### PR TITLE
fix(typescript-fetch): omit optional query params

### DIFF
--- a/integration-tests/typescript-fetch/src/api.github.com.json/client.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.json/client.ts
@@ -17,7 +17,16 @@ export interface Res<StatusCode, Body> {
 export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
-  private headers(
+  private _query(
+    params: Record<string, string | number | undefined | null>
+  ): string {
+    const filtered = Object.fromEntries(
+      Object.entries(params).filter(([k, v]) => v !== undefined)
+    )
+    return qs.stringify(filtered)
+  }
+
+  private _headers(
     headers: Record<string, string | undefined>
   ): Record<string, string> {
     return Object.fromEntries(
@@ -69,7 +78,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/app`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -121,7 +130,7 @@ export class ApiClient {
       this.config.basePath + `/app-manifests/${p["code"]}/conversions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -173,13 +182,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/app/installations?${qs.stringify({
+        `/app/installations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -232,7 +241,7 @@ export class ApiClient {
       this.config.basePath + `/app/installations/${p["installationId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -250,7 +259,7 @@ export class ApiClient {
       this.config.basePath + `/app/installations/${p["installationId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -397,7 +406,7 @@ export class ApiClient {
         `/app/installations/${p["installationId"]}/access_tokens`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -417,7 +426,7 @@ export class ApiClient {
         `/app/installations/${p["installationId"]}/suspended`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -436,7 +445,7 @@ export class ApiClient {
         `/app/installations/${p["installationId"]}/suspended`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -469,13 +478,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/applications/grants?${qs.stringify({
+        `/applications/grants?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -509,7 +518,7 @@ export class ApiClient {
       this.config.basePath + `/applications/grants/${p["grantId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -527,7 +536,7 @@ export class ApiClient {
       this.config.basePath + `/applications/grants/${p["grantId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -551,7 +560,7 @@ export class ApiClient {
       this.config.basePath + `/applications/${p["clientId"]}/grant`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -572,7 +581,7 @@ export class ApiClient {
         `/applications/${p["clientId"]}/grants/${p["accessToken"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -638,7 +647,7 @@ export class ApiClient {
       this.config.basePath + `/applications/${p["clientId"]}/token`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -705,7 +714,7 @@ export class ApiClient {
       this.config.basePath + `/applications/${p["clientId"]}/token`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -730,7 +739,7 @@ export class ApiClient {
       this.config.basePath + `/applications/${p["clientId"]}/token`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -793,7 +802,7 @@ export class ApiClient {
         `/applications/${p["clientId"]}/tokens/${p["accessToken"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -855,7 +864,7 @@ export class ApiClient {
         `/applications/${p["clientId"]}/tokens/${p["accessToken"]}`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -875,7 +884,7 @@ export class ApiClient {
         `/applications/${p["clientId"]}/tokens/${p["accessToken"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -924,7 +933,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/apps/${p["appSlug"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -962,13 +971,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/authorizations?${qs.stringify({
+        `/authorizations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1016,7 +1025,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/authorizations`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -1087,7 +1096,7 @@ export class ApiClient {
       this.config.basePath + `/authorizations/clients/${p["clientId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -1160,7 +1169,7 @@ export class ApiClient {
         `/authorizations/clients/${p["clientId"]}/${p["fingerprint"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -1201,7 +1210,7 @@ export class ApiClient {
       this.config.basePath + `/authorizations/${p["authorizationId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1252,7 +1261,7 @@ export class ApiClient {
       this.config.basePath + `/authorizations/${p["authorizationId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -1271,7 +1280,7 @@ export class ApiClient {
       this.config.basePath + `/authorizations/${p["authorizationId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1293,7 +1302,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/codes_of_conduct`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -1320,7 +1329,7 @@ export class ApiClient {
       this.config.basePath + `/codes_of_conduct/${p["key"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1355,7 +1364,7 @@ export class ApiClient {
         `/content_references/${p["contentReferenceId"]}/attachments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -1369,7 +1378,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/emojis`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -1385,10 +1394,10 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/events?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        `/events?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1449,7 +1458,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/feeds`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -1511,14 +1520,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/gists?${qs.stringify({
+        `/gists?${this._query({
           since: p["since"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1644,7 +1653,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/gists`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -1707,14 +1716,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/gists/public?${qs.stringify({
+        `/gists/public?${this._query({
           since: p["since"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1777,14 +1786,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/gists/starred?${qs.stringify({
+        `/gists/starred?${this._query({
           since: p["since"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -1898,7 +1907,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/gists/${p["gistId"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -2023,7 +2032,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/gists/${p["gistId"]}`, {
       method: "PATCH",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -2039,7 +2048,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/gists/${p["gistId"]}`, {
       method: "DELETE",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -2088,13 +2097,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/gists/${p["gistId"]}/comments?${qs.stringify({
+        `/gists/${p["gistId"]}/comments?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2150,7 +2159,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/comments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -2202,7 +2211,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/comments/${p["commentId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2259,7 +2268,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/comments/${p["commentId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -2279,7 +2288,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/comments/${p["commentId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2331,13 +2340,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/gists/${p["gistId"]}/commits?${qs.stringify({
+        `/gists/${p["gistId"]}/commits?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2397,7 +2406,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/forks`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2445,13 +2454,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/gists/${p["gistId"]}/forks?${qs.stringify({
+        `/gists/${p["gistId"]}/forks?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2469,7 +2478,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/star`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2487,7 +2496,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/star`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2505,7 +2514,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/star`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2625,7 +2634,7 @@ export class ApiClient {
       this.config.basePath + `/gists/${p["gistId"]}/${p["sha"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2640,7 +2649,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/gitignore/templates`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -2662,7 +2671,7 @@ export class ApiClient {
       this.config.basePath + `/gitignore/templates/${p["name"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2787,13 +2796,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/installation/repositories?${qs.stringify({
+        `/installation/repositories?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -2808,7 +2817,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/installation/token`, {
       method: "DELETE",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -3072,7 +3081,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/issues?${qs.stringify({
+        `/issues?${this._query({
           filter: p["filter"],
           state: p["state"],
           labels: p["labels"],
@@ -3084,7 +3093,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3108,7 +3117,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/licenses`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -3141,7 +3150,7 @@ export class ApiClient {
       this.config.basePath + `/licenses/${p["license"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3164,7 +3173,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/markdown`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -3185,7 +3194,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/markdown/raw`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -3259,7 +3268,7 @@ export class ApiClient {
       this.config.basePath + `/marketplace_listing/accounts/${p["accountId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3295,13 +3304,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/marketplace_listing/plans?${qs.stringify({
+        `/marketplace_listing/plans?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3376,7 +3385,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/marketplace_listing/plans/${p["planId"]}/accounts?${qs.stringify({
+        `/marketplace_listing/plans/${p["planId"]}/accounts?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           per_page: p["perPage"],
@@ -3384,7 +3393,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3459,7 +3468,7 @@ export class ApiClient {
         `/marketplace_listing/stubbed/accounts/${p["accountId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3495,13 +3504,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/marketplace_listing/stubbed/plans?${qs.stringify({
+        `/marketplace_listing/stubbed/plans?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3578,7 +3587,7 @@ export class ApiClient {
       this.config.basePath +
         `/marketplace_listing/stubbed/plans/${
           p["planId"]
-        }/accounts?${qs.stringify({
+        }/accounts?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           per_page: p["perPage"],
@@ -3586,7 +3595,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3618,7 +3627,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/meta`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -3636,13 +3645,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/networks/${p["owner"]}/${p["repo"]}/events?${qs.stringify({
+        `/networks/${p["owner"]}/${p["repo"]}/events?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3749,7 +3758,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/notifications?${qs.stringify({
+        `/notifications?${this._query({
           all: p["all"],
           participating: p["participating"],
           since: p["since"],
@@ -3759,7 +3768,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3780,7 +3789,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/notifications`, {
       method: "PUT",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -3881,7 +3890,7 @@ export class ApiClient {
       this.config.basePath + `/notifications/threads/${p["threadId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3899,7 +3908,7 @@ export class ApiClient {
       this.config.basePath + `/notifications/threads/${p["threadId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3930,7 +3939,7 @@ export class ApiClient {
         `/notifications/threads/${p["threadId"]}/subscription`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -3967,7 +3976,7 @@ export class ApiClient {
         `/notifications/threads/${p["threadId"]}/subscription`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -3987,7 +3996,7 @@ export class ApiClient {
         `/notifications/threads/${p["threadId"]}/subscription`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4018,10 +4027,10 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/organizations?${qs.stringify({ since: p["since"] })}`,
+        `/organizations?${this._query({ since: p["since"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4086,7 +4095,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/orgs/${p["org"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -4173,7 +4182,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/orgs/${p["org"]}`, {
       method: "PATCH",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -4204,13 +4213,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/actions/runners?${qs.stringify({
+        `/orgs/${p["org"]}/actions/runners?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4238,7 +4247,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/actions/runners/downloads`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4265,7 +4274,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/runners/registration-token`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4291,7 +4300,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/actions/runners/remove-token`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4321,7 +4330,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4341,7 +4350,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4373,13 +4382,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/actions/secrets?${qs.stringify({
+        `/orgs/${p["org"]}/actions/secrets?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4402,7 +4411,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/actions/secrets/public-key`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4433,7 +4442,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4462,7 +4471,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -4483,7 +4492,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4578,7 +4587,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4604,7 +4613,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -4626,7 +4635,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4647,7 +4656,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4684,7 +4693,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/orgs/${p["org"]}/blocks`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -4702,7 +4711,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4721,7 +4730,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4740,7 +4749,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4770,7 +4779,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/credential-authorizations`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4790,7 +4799,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/credential-authorizations/${p["credentialId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4808,13 +4817,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/events?${qs.stringify({
+        `/orgs/${p["org"]}/events?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4850,13 +4859,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/hooks?${qs.stringify({
+        `/orgs/${p["org"]}/hooks?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4904,7 +4913,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/orgs/${p["org"]}/hooks`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -4941,7 +4950,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -4991,7 +5000,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -5011,7 +5020,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5030,7 +5039,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}/pings`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5088,7 +5097,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/installation`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5153,13 +5162,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/installations?${qs.stringify({
+        `/orgs/${p["org"]}/installations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5186,7 +5195,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/interaction-limits`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5219,7 +5228,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/interaction-limits`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -5238,7 +5247,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/interaction-limits`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5289,13 +5298,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/invitations?${qs.stringify({
+        `/orgs/${p["org"]}/invitations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5355,7 +5364,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/invitations`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -5393,12 +5402,12 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/invitations/${
-          p["invitationId"]
-        }/teams?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        `/orgs/${p["org"]}/invitations/${p["invitationId"]}/teams?${this._query(
+          { per_page: p["perPage"], page: p["page"] }
+        )}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5664,7 +5673,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/issues?${qs.stringify({
+        `/orgs/${p["org"]}/issues?${this._query({
           filter: p["filter"],
           state: p["state"],
           labels: p["labels"],
@@ -5676,7 +5685,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5721,7 +5730,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/members?${qs.stringify({
+        `/orgs/${p["org"]}/members?${this._query({
           filter: p["filter"],
           role: p["role"],
           per_page: p["perPage"],
@@ -5729,7 +5738,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5748,7 +5757,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/members/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5767,7 +5776,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/members/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5830,7 +5839,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/memberships/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -5899,7 +5908,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/memberships/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -5919,7 +5928,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/memberships/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6079,7 +6088,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/migrations`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -6232,13 +6241,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/migrations?${qs.stringify({
+        `/orgs/${p["org"]}/migrations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6391,7 +6400,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/migrations/${p["migrationId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6411,7 +6420,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/migrations/${p["migrationId"]}/archive`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6431,7 +6440,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/migrations/${p["migrationId"]}/archive`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6452,7 +6461,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/migrations/${p["migrationId"]}/repos/${p["repoName"]}/lock`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6587,13 +6596,13 @@ export class ApiClient {
       this.config.basePath +
         `/orgs/${p["org"]}/migrations/${
           p["migrationId"]
-        }/repositories?${qs.stringify({
+        }/repositories?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6636,14 +6645,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/outside_collaborators?${qs.stringify({
+        `/orgs/${p["org"]}/outside_collaborators?${this._query({
           filter: p["filter"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6672,7 +6681,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/outside_collaborators/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6701,7 +6710,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/outside_collaborators/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6758,14 +6767,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/projects?${qs.stringify({
+        `/orgs/${p["org"]}/projects?${this._query({
           state: p["state"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6828,7 +6837,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/projects`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -6871,13 +6880,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/public_members?${qs.stringify({
+        `/orgs/${p["org"]}/public_members?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6897,7 +6906,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/public_members/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6917,7 +6926,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/public_members/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -6937,7 +6946,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/public_members/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7079,7 +7088,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/repos?${qs.stringify({
+        `/orgs/${p["org"]}/repos?${this._query({
           type: p["type"],
           sort: p["sort"],
           direction: p["direction"],
@@ -7088,7 +7097,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7236,7 +7245,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/orgs/${p["org"]}/repos`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -7265,13 +7274,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/team-sync/groups?${qs.stringify({
+        `/orgs/${p["org"]}/team-sync/groups?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7307,13 +7316,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams?${qs.stringify({
+        `/orgs/${p["org"]}/teams?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7393,7 +7402,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/orgs/${p["org"]}/teams`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -7464,7 +7473,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7545,7 +7554,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -7565,7 +7574,7 @@ export class ApiClient {
       this.config.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7637,14 +7646,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions?${qs.stringify({
+        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions?${this._query({
           direction: p["direction"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7724,7 +7733,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -7798,7 +7807,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7878,7 +7887,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -7900,7 +7909,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -7970,14 +7979,14 @@ export class ApiClient {
       this.config.basePath +
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${
           p["discussionNumber"]
-        }/comments?${qs.stringify({
+        }/comments?${this._query({
           direction: p["direction"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8051,7 +8060,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -8121,7 +8130,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8196,7 +8205,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -8219,7 +8228,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8281,14 +8290,14 @@ export class ApiClient {
       this.config.basePath +
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${
           p["discussionNumber"]
-        }/comments/${p["commentNumber"]}/reactions?${qs.stringify({
+        }/comments/${p["commentNumber"]}/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8354,7 +8363,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -8378,7 +8387,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8439,14 +8448,14 @@ export class ApiClient {
       this.config.basePath +
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${
           p["discussionNumber"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8511,7 +8520,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -8534,7 +8543,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8586,13 +8595,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/invitations?${qs.stringify({
+        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/invitations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8636,14 +8645,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/members?${qs.stringify({
+        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/members?${this._query({
           role: p["role"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8674,7 +8683,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8722,7 +8731,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -8744,7 +8753,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8808,13 +8817,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects?${qs.stringify({
+        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8881,7 +8890,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -8917,7 +8926,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -8939,7 +8948,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9072,13 +9081,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos?${qs.stringify({
+        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9347,7 +9356,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9375,7 +9384,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9398,7 +9407,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9429,7 +9438,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/team-sync/group-mappings`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9470,7 +9479,7 @@ export class ApiClient {
         `/orgs/${p["org"]}/teams/${p["teamSlug"]}/team-sync/group-mappings`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9519,13 +9528,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/teams?${qs.stringify({
+        `/orgs/${p["org"]}/teams/${p["teamSlug"]}/teams?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9576,7 +9585,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/cards/${p["cardId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9637,7 +9646,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/cards/${p["cardId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9656,7 +9665,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/cards/${p["cardId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9681,7 +9690,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/cards/${p["cardId"]}/moves`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9711,7 +9720,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/${p["columnId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9749,7 +9758,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/${p["columnId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9768,7 +9777,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/${p["columnId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9823,14 +9832,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/projects/columns/${p["columnId"]}/cards?${qs.stringify({
+        `/projects/columns/${p["columnId"]}/cards?${this._query({
           archived_state: p["archivedState"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -9892,7 +9901,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/${p["columnId"]}/cards`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9917,7 +9926,7 @@ export class ApiClient {
       this.config.basePath + `/projects/columns/${p["columnId"]}/moves`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -9971,7 +9980,7 @@ export class ApiClient {
       this.config.basePath + `/projects/${p["projectId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10038,7 +10047,7 @@ export class ApiClient {
       this.config.basePath + `/projects/${p["projectId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -10057,7 +10066,7 @@ export class ApiClient {
       this.config.basePath + `/projects/${p["projectId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10100,14 +10109,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/projects/${p["projectId"]}/collaborators?${qs.stringify({
+        `/projects/${p["projectId"]}/collaborators?${this._query({
           affiliation: p["affiliation"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10133,7 +10142,7 @@ export class ApiClient {
         `/projects/${p["projectId"]}/collaborators/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -10154,7 +10163,7 @@ export class ApiClient {
         `/projects/${p["projectId"]}/collaborators/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10201,7 +10210,7 @@ export class ApiClient {
         `/projects/${p["projectId"]}/collaborators/${p["username"]}/permission`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10233,13 +10242,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/projects/${p["projectId"]}/columns?${qs.stringify({
+        `/projects/${p["projectId"]}/columns?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10277,7 +10286,7 @@ export class ApiClient {
       this.config.basePath + `/projects/${p["projectId"]}/columns`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -10324,7 +10333,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/rate_limit`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -10341,7 +10350,7 @@ export class ApiClient {
       this.config.basePath + `/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -10707,7 +10716,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11090,7 +11099,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -11119,7 +11128,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11156,13 +11165,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11198,7 +11207,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts/${p["artifactId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11219,7 +11228,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts/${p["artifactId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11241,7 +11250,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts/${p["artifactId"]}/${p["archiveFormat"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11289,7 +11298,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/jobs/${p["jobId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11310,7 +11319,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/jobs/${p["jobId"]}/logs`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11342,13 +11351,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/actions/runners?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/actions/runners?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11378,7 +11387,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runners/downloads`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11406,7 +11415,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runners/registration-token`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11434,7 +11443,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runners/remove-token`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11465,7 +11474,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11486,7 +11495,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11690,7 +11699,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/actions/runs?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/actions/runs?${this._query({
           actor: p["actor"],
           branch: p["branch"],
           event: p["event"],
@@ -11700,7 +11709,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11899,7 +11908,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11939,13 +11948,13 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${
           p["runId"]
-        }/artifacts?${qs.stringify({
+        }/artifacts?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -11966,7 +11975,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/cancel`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12019,14 +12028,14 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${
           p["runId"]
-        }/jobs?${qs.stringify({
+        }/jobs?${this._query({
           filter: p["filter"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12047,7 +12056,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/logs`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12068,7 +12077,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/logs`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12089,7 +12098,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/rerun`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12131,7 +12140,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/timing`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12162,13 +12171,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/actions/secrets?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/actions/secrets?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12196,7 +12205,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/public-key`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12226,7 +12235,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12254,7 +12263,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -12276,7 +12285,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12314,13 +12323,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/actions/workflows?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/actions/workflows?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12357,7 +12366,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12564,7 +12573,7 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${
           p["workflowId"]
-        }/runs?${qs.stringify({
+        }/runs?${this._query({
           actor: p["actor"],
           branch: p["branch"],
           event: p["event"],
@@ -12574,7 +12583,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12612,7 +12621,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}/timing`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12655,13 +12664,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/assignees?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/assignees?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12682,7 +12691,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/assignees/${p["assignee"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12702,7 +12711,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/automated-security-fixes`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12722,7 +12731,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/automated-security-fixes`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12762,14 +12771,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/branches?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/branches?${this._query({
           protected: p["protected"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -12857,7 +12866,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13021,7 +13030,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13212,7 +13221,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -13234,7 +13243,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13263,7 +13272,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/enforce_admins`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13292,7 +13301,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/enforce_admins`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13313,7 +13322,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/enforce_admins`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13383,7 +13392,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13465,7 +13474,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -13487,7 +13496,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13516,7 +13525,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_signatures`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13545,7 +13554,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_signatures`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13566,7 +13575,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_signatures`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13597,7 +13606,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13635,7 +13644,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -13657,7 +13666,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13678,7 +13687,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13703,7 +13712,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -13729,7 +13738,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -13755,7 +13764,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -13853,7 +13862,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13874,7 +13883,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13931,7 +13940,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -13992,7 +14001,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14054,7 +14063,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14116,7 +14125,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14156,7 +14165,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -14199,7 +14208,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14243,7 +14252,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14287,7 +14296,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14333,7 +14342,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -14382,7 +14391,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14432,7 +14441,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14482,7 +14491,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14629,7 +14638,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/check-runs`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14779,7 +14788,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -14884,7 +14893,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -14921,13 +14930,13 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/check-runs/${
           p["checkRunId"]
-        }/annotations?${qs.stringify({
+        }/annotations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15108,7 +15117,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/check-suites`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -15256,7 +15265,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/check-suites/preferences`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -15434,7 +15443,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/check-suites/${p["checkSuiteId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15545,7 +15554,7 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/check-suites/${
           p["checkSuiteId"]
-        }/check-runs?${qs.stringify({
+        }/check-runs?${this._query({
           check_name: p["checkName"],
           status: p["status"],
           filter: p["filter"],
@@ -15554,7 +15563,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15575,7 +15584,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/check-suites/${p["checkSuiteId"]}/rerequest`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15611,13 +15620,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts?${this._query({
           state: p["state"],
           ref: p["ref"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15654,7 +15663,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15703,14 +15712,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/collaborators?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/collaborators?${this._query({
           affiliation: p["affiliation"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15731,7 +15740,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15878,7 +15887,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -15900,7 +15909,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -15948,7 +15957,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}/permission`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16004,13 +16013,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/comments?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/comments?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16068,7 +16077,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16132,7 +16141,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -16154,7 +16163,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16215,14 +16224,14 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/comments/${
           p["commentId"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16287,7 +16296,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -16310,7 +16319,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16414,7 +16423,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/commits?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/commits?${this._query({
           sha: p["sha"],
           path: p["path"],
           author: p["author"],
@@ -16425,7 +16434,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16458,7 +16467,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/branches-where-head`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16517,13 +16526,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/commits/${
           p["commitSha"]
-        }/comments?${qs.stringify({
-          per_page: p["perPage"],
-          page: p["page"],
-        })}`,
+        }/comments?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -16590,7 +16596,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/comments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -17072,10 +17078,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/commits/${
           p["commitSha"]
-        }/pulls?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/pulls?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17191,7 +17197,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17302,7 +17308,7 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/commits/${
           p["ref"]
-        }/check-runs?${qs.stringify({
+        }/check-runs?${this._query({
           check_name: p["checkName"],
           status: p["status"],
           filter: p["filter"],
@@ -17311,7 +17317,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17494,7 +17500,7 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/commits/${
           p["ref"]
-        }/check-suites?${qs.stringify({
+        }/check-suites?${this._query({
           app_id: p["appId"],
           check_name: p["checkName"],
           per_page: p["perPage"],
@@ -17502,7 +17508,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17614,7 +17620,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}/status`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17672,13 +17678,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/commits/${
           p["ref"]
-        }/statuses?${qs.stringify({
-          per_page: p["perPage"],
-          page: p["page"],
-        })}`,
+        }/statuses?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17708,7 +17711,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/community/code_of_conduct`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -17769,7 +17772,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/community/profile`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18046,7 +18049,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/compare/${p["base"]}...${p["head"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18087,12 +18090,12 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}?${qs.stringify(
-          { ref: p["ref"] }
-        )}`,
+        `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}?${this._query({
+          ref: p["ref"],
+        })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18237,7 +18240,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -18314,7 +18317,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -18361,14 +18364,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/contributors?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/contributors?${this._query({
           anon: p["anon"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18435,7 +18438,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/deployments?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/deployments?${this._query({
           sha: p["sha"],
           ref: p["ref"],
           task: p["task"],
@@ -18445,7 +18448,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18534,7 +18537,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/deployments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -18600,7 +18603,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18621,7 +18624,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18682,13 +18685,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/deployments/${
           p["deploymentId"]
-        }/statuses?${qs.stringify({
-          per_page: p["perPage"],
-          page: p["page"],
-        })}`,
+        }/statuses?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18767,7 +18767,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -18829,7 +18829,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses/${p["statusId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -18857,7 +18857,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/dispatches`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -18877,13 +18877,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/events?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/events?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19017,14 +19017,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/forks?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/forks?${this._query({
           sort: p["sort"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19159,7 +19159,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/forks`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19194,7 +19194,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/blobs`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19227,7 +19227,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/git/blobs/${p["fileSha"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19299,7 +19299,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/commits`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19355,7 +19355,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/git/commits/${p["commitSha"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19391,10 +19391,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/git/matching-refs/${
           p["ref"]
-        }?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19429,7 +19429,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/git/ref/${p["ref"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19469,7 +19469,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/refs`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19512,7 +19512,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/git/refs/${p["ref"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19534,7 +19534,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/git/refs/${p["ref"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19594,7 +19594,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/tags`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19643,7 +19643,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/git/tags/${p["tagSha"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19691,7 +19691,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/trees`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19730,10 +19730,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/git/trees/${
           p["treeSha"]
-        }?${qs.stringify({ recursive: p["recursive"] })}`,
+        }?${this._query({ recursive: p["recursive"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19778,13 +19778,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/hooks?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/hooks?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19843,7 +19843,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/hooks`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19891,7 +19891,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19953,7 +19953,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -19975,7 +19975,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -19996,7 +19996,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/pings`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20017,7 +20017,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/tests`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20067,7 +20067,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -20106,7 +20106,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20146,7 +20146,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -20166,7 +20166,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20197,12 +20197,12 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/import/authors?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/import/authors?${this._query({
           since: p["since"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20243,7 +20243,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/import/authors/${p["authorId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -20274,7 +20274,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/import/large_files`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20318,7 +20318,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/import/lfs`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -20381,7 +20381,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/installation`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20410,7 +20410,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20445,7 +20445,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -20466,7 +20466,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20604,13 +20604,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/invitations?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/invitations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20631,7 +20631,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/invitations/${p["invitationId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -20777,7 +20777,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/invitations/${p["invitationId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -20942,7 +20942,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/issues?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/issues?${this._query({
           milestone: p["milestone"],
           state: p["state"],
           assignee: p["assignee"],
@@ -20957,7 +20957,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21143,7 +21143,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/issues`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -21199,7 +21199,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/issues/comments?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/issues/comments?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           since: p["since"],
@@ -21208,7 +21208,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21262,7 +21262,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21322,7 +21322,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -21344,7 +21344,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21405,14 +21405,14 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${
           p["commentId"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21477,7 +21477,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -21500,7 +21500,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21684,13 +21684,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/issues/events?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/issues/events?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -21876,7 +21876,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/events/${p["eventId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22053,7 +22053,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22242,7 +22242,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22406,7 +22406,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22570,7 +22570,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22627,14 +22627,14 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/issues/${
           p["issueNumber"]
-        }/comments?${qs.stringify({
+        }/comments?${this._query({
           since: p["since"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22694,7 +22694,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/comments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22750,10 +22750,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/issues/${
           p["issueNumber"]
-        }/events?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/events?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22788,10 +22788,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/issues/${
           p["issueNumber"]
-        }/labels?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/labels?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22831,7 +22831,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22872,7 +22872,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22894,7 +22894,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22929,7 +22929,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels/${p["name"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -22956,7 +22956,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/lock`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -22978,7 +22978,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/lock`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23039,14 +23039,14 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/issues/${
           p["issueNumber"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23111,7 +23111,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23134,7 +23134,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23189,13 +23189,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/issues/${
           p["issueNumber"]
-        }/timeline?${qs.stringify({
-          per_page: p["perPage"],
-          page: p["page"],
-        })}`,
+        }/timeline?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23227,13 +23224,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/keys?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/keys?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23273,7 +23270,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/keys`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23308,7 +23305,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/keys/${p["keyId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23329,7 +23326,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/keys/${p["keyId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23361,13 +23358,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/labels?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/labels?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23407,7 +23404,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/labels`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23442,7 +23439,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23484,7 +23481,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23506,7 +23503,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23533,7 +23530,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/languages`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23581,7 +23578,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/license`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23700,7 +23697,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/merges`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23764,7 +23761,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/milestones?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/milestones?${this._query({
           state: p["state"],
           sort: p["sort"],
           direction: p["direction"],
@@ -23773,7 +23770,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23842,7 +23839,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/milestones`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23905,7 +23902,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -23976,7 +23973,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -23998,7 +23995,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24033,10 +24030,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/milestones/${
           p["milestoneNumber"]
-        }/labels?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/labels?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24145,7 +24142,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/notifications?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/notifications?${this._query({
           all: p["all"],
           participating: p["participating"],
           since: p["since"],
@@ -24155,7 +24152,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24180,7 +24177,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/notifications`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -24215,7 +24212,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24258,7 +24255,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -24278,7 +24275,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24304,7 +24301,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -24332,7 +24329,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages/builds`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24386,13 +24383,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/pages/builds?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/pages/builds?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24447,7 +24444,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pages/builds/latest`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24503,7 +24500,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pages/builds/${p["buildId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24561,14 +24558,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/projects?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/projects?${this._query({
           state: p["state"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -24632,7 +24629,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/projects`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -25116,7 +25113,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/pulls?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/pulls?${this._query({
           state: p["state"],
           head: p["head"],
           base: p["base"],
@@ -25127,7 +25124,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -25647,7 +25644,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/pulls`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -25730,7 +25727,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/pulls/comments?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/pulls/comments?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           since: p["since"],
@@ -25739,7 +25736,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -25820,7 +25817,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -25907,7 +25904,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -25929,7 +25926,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -25990,14 +25987,14 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${
           p["commentId"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -26062,7 +26059,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -26085,7 +26082,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}/reactions/${p["reactionId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -26596,7 +26593,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -27117,7 +27114,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -27203,7 +27200,7 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${
           p["pullNumber"]
-        }/comments?${qs.stringify({
+        }/comments?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           since: p["since"],
@@ -27212,7 +27209,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -27306,7 +27303,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/comments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -27395,7 +27392,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/comments/${p["commentId"]}/replies`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -27498,10 +27495,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${
           p["pullNumber"]
-        }/commits?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/commits?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -27539,10 +27536,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${
           p["pullNumber"]
-        }/files?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/files?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -27563,7 +27560,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/merge`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -27616,7 +27613,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/merge`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -27679,13 +27676,13 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${
           p["pullNumber"]
-        }/requested_reviewers?${qs.stringify({
+        }/requested_reviewers?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -28173,7 +28170,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28202,7 +28199,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28267,10 +28264,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${
           p["pullNumber"]
-        }/reviews?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/reviews?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -28346,7 +28343,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28411,7 +28408,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -28474,7 +28471,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -28544,7 +28541,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28622,13 +28619,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${
           p["reviewId"]
-        }/comments?${qs.stringify({
-          per_page: p["perPage"],
-          page: p["page"],
-        })}`,
+        }/comments?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -28698,7 +28692,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/dismissals`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28770,7 +28764,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/events`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28806,7 +28800,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/update-branch`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -28847,12 +28841,12 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/readme?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/readme?${this._query({
           ref: p["ref"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -28947,13 +28941,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/releases?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/releases?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29028,7 +29022,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/releases`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -29088,7 +29082,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29154,7 +29148,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -29176,7 +29170,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29272,7 +29266,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/latest`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29369,7 +29363,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/tags/${p["tag"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29466,7 +29460,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29574,7 +29568,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -29596,7 +29590,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29656,10 +29650,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/releases/${
           p["releaseId"]
-        }/assets?${qs.stringify({ per_page: p["perPage"], page: p["page"] })}`,
+        }/assets?${this._query({ per_page: p["perPage"], page: p["page"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29727,10 +29721,10 @@ export class ApiClient {
       this.config.basePath +
         `/repos/${p["owner"]}/${p["repo"]}/releases/${
           p["releaseId"]
-        }/assets?${qs.stringify({ name: p["name"], label: p["label"] })}`,
+        }/assets?${this._query({ name: p["name"], label: p["label"] })}`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -29777,13 +29771,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/stargazers?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/stargazers?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29803,7 +29797,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/stats/code_frequency`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29832,7 +29826,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/stats/commit_activity`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29885,7 +29879,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/stats/contributors`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29913,7 +29907,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/stats/participation`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29933,7 +29927,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/stats/punch_card`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -29999,7 +29993,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/statuses/${p["sha"]}`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -30043,13 +30037,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/subscribers?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/subscribers?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30081,7 +30075,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30119,7 +30113,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -30139,7 +30133,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30171,13 +30165,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/tags?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/tags?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30214,13 +30208,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/teams?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/teams?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30246,7 +30240,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/topics`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30278,7 +30272,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/topics`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -30310,12 +30304,12 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/traffic/clones?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/traffic/clones?${this._query({
           per: p["per"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30345,7 +30339,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/traffic/popular/paths`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30374,7 +30368,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/traffic/popular/referrers`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30405,12 +30399,12 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repos/${p["owner"]}/${p["repo"]}/traffic/views?${qs.stringify({
+        `/repos/${p["owner"]}/${p["repo"]}/traffic/views?${this._query({
           per: p["per"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30546,7 +30540,7 @@ export class ApiClient {
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/transfer`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -30567,7 +30561,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/vulnerability-alerts`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30587,7 +30581,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/vulnerability-alerts`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30607,7 +30601,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/vulnerability-alerts`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30629,7 +30623,7 @@ export class ApiClient {
         `/repos/${p["owner"]}/${p["repo"]}/${p["archiveFormat"]}/${p["ref"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -30873,7 +30867,7 @@ export class ApiClient {
         `/repos/${p["templateOwner"]}/${p["templateRepo"]}/generate`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -30959,10 +30953,10 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/repositories?${qs.stringify({ since: p["since"] })}`,
+        `/repositories?${this._query({ since: p["since"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31013,14 +31007,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/scim/v2/organizations/${p["org"]}/Users?${qs.stringify({
+        `/scim/v2/organizations/${p["org"]}/Users?${this._query({
           startIndex: p["startIndex"],
           count: p["count"],
           filter: p["filter"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31064,7 +31058,7 @@ export class ApiClient {
       this.config.basePath + `/scim/v2/organizations/${p["org"]}/Users`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31110,7 +31104,7 @@ export class ApiClient {
         `/scim/v2/organizations/${p["org"]}/Users/${p["scimUserId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31156,7 +31150,7 @@ export class ApiClient {
         `/scim/v2/organizations/${p["org"]}/Users/${p["scimUserId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31202,7 +31196,7 @@ export class ApiClient {
         `/scim/v2/organizations/${p["org"]}/Users/${p["scimUserId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31222,7 +31216,7 @@ export class ApiClient {
         `/scim/v2/organizations/${p["org"]}/Users/${p["scimUserId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31324,7 +31318,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/search/code?${qs.stringify({
+        `/search/code?${this._query({
           q: p["q"],
           sort: p["sort"],
           order: p["order"],
@@ -31333,7 +31327,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31499,7 +31493,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/search/commits?${qs.stringify({
+        `/search/commits?${this._query({
           q: p["q"],
           sort: p["sort"],
           order: p["order"],
@@ -31508,7 +31502,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31599,7 +31593,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/search/issues?${qs.stringify({
+        `/search/issues?${this._query({
           q: p["q"],
           sort: p["sort"],
           order: p["order"],
@@ -31608,7 +31602,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31645,7 +31639,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/search/labels?${qs.stringify({
+        `/search/labels?${this._query({
           repository_id: p["repositoryId"],
           q: p["q"],
           sort: p["sort"],
@@ -31653,7 +31647,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31715,7 +31709,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/search/repositories?${qs.stringify({
+        `/search/repositories?${this._query({
           q: p["q"],
           sort: p["sort"],
           order: p["order"],
@@ -31724,7 +31718,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31757,10 +31751,10 @@ export class ApiClient {
     const headers: Record<string, string | undefined> = { accept: p["accept"] }
 
     const res = await fetch(
-      this.config.basePath + `/search/topics?${qs.stringify({ q: p["q"] })}`,
+      this.config.basePath + `/search/topics?${this._query({ q: p["q"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31804,7 +31798,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/search/users?${qs.stringify({
+        `/search/users?${this._query({
           q: p["q"],
           sort: p["sort"],
           order: p["order"],
@@ -31813,7 +31807,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -31878,7 +31872,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/teams/${p["teamId"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -31955,7 +31949,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/teams/${p["teamId"]}`, {
       method: "PATCH",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -31971,7 +31965,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/teams/${p["teamId"]}`, {
       method: "DELETE",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -32041,14 +32035,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/teams/${p["teamId"]}/discussions?${qs.stringify({
+        `/teams/${p["teamId"]}/discussions?${this._query({
           direction: p["direction"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32126,7 +32120,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/discussions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -32199,7 +32193,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32278,7 +32272,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -32299,7 +32293,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32368,14 +32362,14 @@ export class ApiClient {
       this.config.basePath +
         `/teams/${p["teamId"]}/discussions/${
           p["discussionNumber"]
-        }/comments?${qs.stringify({
+        }/comments?${this._query({
           direction: p["direction"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32448,7 +32442,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -32517,7 +32511,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32591,7 +32585,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -32613,7 +32607,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32674,14 +32668,14 @@ export class ApiClient {
       this.config.basePath +
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${
           p["commentNumber"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32746,7 +32740,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -32807,14 +32801,14 @@ export class ApiClient {
       this.config.basePath +
         `/teams/${p["teamId"]}/discussions/${
           p["discussionNumber"]
-        }/reactions?${qs.stringify({
+        }/reactions?${this._query({
           content: p["content"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32878,7 +32872,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/reactions`,
       {
         method: "POST",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -32930,13 +32924,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/teams/${p["teamId"]}/invitations?${qs.stringify({
+        `/teams/${p["teamId"]}/invitations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -32979,14 +32973,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/teams/${p["teamId"]}/members?${qs.stringify({
+        `/teams/${p["teamId"]}/members?${this._query({
           role: p["role"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33005,7 +32999,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/members/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33038,7 +33032,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/members/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33057,7 +33051,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/members/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33086,7 +33080,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/memberships/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33133,7 +33127,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/memberships/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -33154,7 +33148,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/memberships/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33217,13 +33211,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/teams/${p["teamId"]}/projects?${qs.stringify({
+        `/teams/${p["teamId"]}/projects?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33288,7 +33282,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/projects/${p["projectId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33322,7 +33316,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/projects/${p["projectId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -33342,7 +33336,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/projects/${p["projectId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33474,13 +33468,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/teams/${p["teamId"]}/repos?${qs.stringify({
+        `/teams/${p["teamId"]}/repos?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33748,7 +33742,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33775,7 +33769,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -33797,7 +33791,7 @@ export class ApiClient {
         `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33826,7 +33820,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/team-sync/group-mappings`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33865,7 +33859,7 @@ export class ApiClient {
       this.config.basePath + `/teams/${p["teamId"]}/team-sync/group-mappings`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -33913,13 +33907,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/teams/${p["teamId"]}/teams?${qs.stringify({
+        `/teams/${p["teamId"]}/teams?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -33982,7 +33976,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -34059,7 +34053,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user`, {
       method: "PATCH",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -34096,7 +34090,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/blocks`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -34113,7 +34107,7 @@ export class ApiClient {
       this.config.basePath + `/user/blocks/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34131,7 +34125,7 @@ export class ApiClient {
       this.config.basePath + `/user/blocks/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34149,7 +34143,7 @@ export class ApiClient {
       this.config.basePath + `/user/blocks/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34181,7 +34175,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/email/visibility`, {
       method: "PATCH",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -34208,13 +34202,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/emails?${qs.stringify({
+        `/user/emails?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34245,7 +34239,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/emails`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -34266,7 +34260,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/emails`, {
       method: "DELETE",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -34307,13 +34301,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/followers?${qs.stringify({
+        `/user/followers?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34354,13 +34348,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/following?${qs.stringify({
+        `/user/following?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34378,7 +34372,7 @@ export class ApiClient {
       this.config.basePath + `/user/following/${p["username"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34396,7 +34390,7 @@ export class ApiClient {
       this.config.basePath + `/user/following/${p["username"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34414,7 +34408,7 @@ export class ApiClient {
       this.config.basePath + `/user/following/${p["username"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34469,13 +34463,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/gpg_keys?${qs.stringify({
+        `/user/gpg_keys?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34534,7 +34528,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/gpg_keys`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -34590,7 +34584,7 @@ export class ApiClient {
       this.config.basePath + `/user/gpg_keys/${p["gpgKeyId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34608,7 +34602,7 @@ export class ApiClient {
       this.config.basePath + `/user/gpg_keys/${p["gpgKeyId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34673,13 +34667,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/installations?${qs.stringify({
+        `/user/installations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34810,12 +34804,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/installations/${p["installationId"]}/repositories?${qs.stringify(
-          { per_page: p["perPage"], page: p["page"] }
-        )}`,
+        `/user/installations/${p["installationId"]}/repositories?${this._query({
+          per_page: p["perPage"],
+          page: p["page"],
+        })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34835,7 +34830,7 @@ export class ApiClient {
         `/user/installations/${p["installationId"]}/repositories/${p["repositoryId"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -34855,7 +34850,7 @@ export class ApiClient {
         `/user/installations/${p["installationId"]}/repositories/${p["repositoryId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35120,7 +35115,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/issues?${qs.stringify({
+        `/user/issues?${this._query({
           filter: p["filter"],
           state: p["state"],
           labels: p["labels"],
@@ -35132,7 +35127,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35157,13 +35152,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/keys?${qs.stringify({
+        `/user/keys?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35193,7 +35188,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/keys`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -35217,7 +35212,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/keys/${p["keyId"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -35232,7 +35227,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/keys/${p["keyId"]}`, {
       method: "DELETE",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -35283,13 +35278,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/marketplace_purchases?${qs.stringify({
+        `/user/marketplace_purchases?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35341,13 +35336,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/marketplace_purchases/stubbed?${qs.stringify({
+        `/user/marketplace_purchases/stubbed?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35409,14 +35404,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/memberships/orgs?${qs.stringify({
+        `/user/memberships/orgs?${this._query({
           state: p["state"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35478,7 +35473,7 @@ export class ApiClient {
       this.config.basePath + `/user/memberships/orgs/${p["org"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -35546,7 +35541,7 @@ export class ApiClient {
       this.config.basePath + `/user/memberships/orgs/${p["org"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
         body: JSON.stringify(p.requestBody),
       }
     )
@@ -35710,7 +35705,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/migrations`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -35867,13 +35862,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/migrations?${qs.stringify({
+        `/user/migrations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36031,7 +36026,7 @@ export class ApiClient {
       this.config.basePath + `/user/migrations/${p["migrationId"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36049,7 +36044,7 @@ export class ApiClient {
       this.config.basePath + `/user/migrations/${p["migrationId"]}/archive`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36067,7 +36062,7 @@ export class ApiClient {
       this.config.basePath + `/user/migrations/${p["migrationId"]}/archive`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36087,7 +36082,7 @@ export class ApiClient {
         `/user/migrations/${p["migrationId"]}/repos/${p["repoName"]}/lock`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36122,13 +36117,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/orgs?${qs.stringify({
+        `/user/orgs?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36188,7 +36183,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/projects`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -36215,13 +36210,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/public_emails?${qs.stringify({
+        `/user/public_emails?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36243,7 +36238,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/repos?${qs.stringify({
+        `/user/repos?${this._query({
           visibility: p["visibility"],
           affiliation: p["affiliation"],
           type: p["type"],
@@ -36254,7 +36249,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36401,7 +36396,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/user/repos`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -36537,13 +36532,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/repository_invitations?${qs.stringify({
+        `/user/repository_invitations?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36562,7 +36557,7 @@ export class ApiClient {
         `/user/repository_invitations/${p["invitationId"]}`,
       {
         method: "PATCH",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36581,7 +36576,7 @@ export class ApiClient {
         `/user/repository_invitations/${p["invitationId"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36713,7 +36708,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/starred?${qs.stringify({
+        `/user/starred?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           per_page: p["perPage"],
@@ -36721,7 +36716,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36740,7 +36735,7 @@ export class ApiClient {
       this.config.basePath + `/user/starred/${p["owner"]}/${p["repo"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36759,7 +36754,7 @@ export class ApiClient {
       this.config.basePath + `/user/starred/${p["owner"]}/${p["repo"]}`,
       {
         method: "PUT",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36778,7 +36773,7 @@ export class ApiClient {
       this.config.basePath + `/user/starred/${p["owner"]}/${p["repo"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36909,13 +36904,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/subscriptions?${qs.stringify({
+        `/user/subscriptions?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -36984,13 +36979,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/teams?${qs.stringify({
+        `/user/teams?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37122,13 +37117,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/user/${p["migrationId"]}/repositories?${qs.stringify({
+        `/user/${p["migrationId"]}/repositories?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37164,10 +37159,10 @@ export class ApiClient {
     const headers: Record<string, string | undefined> = { accept: p["accept"] }
 
     const res = await fetch(
-      this.config.basePath + `/users?${qs.stringify({ since: p["since"] })}`,
+      this.config.basePath + `/users?${this._query({ since: p["since"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37218,7 +37213,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/users/${p["username"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -37235,13 +37230,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/events?${qs.stringify({
+        `/users/${p["username"]}/events?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37260,13 +37255,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/events/orgs/${p["org"]}?${qs.stringify({
+        `/users/${p["username"]}/events/orgs/${p["org"]}?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37284,13 +37279,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/events/public?${qs.stringify({
+        `/users/${p["username"]}/events/public?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37332,13 +37327,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/followers?${qs.stringify({
+        `/users/${p["username"]}/followers?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37380,13 +37375,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/following?${qs.stringify({
+        `/users/${p["username"]}/following?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37406,7 +37401,7 @@ export class ApiClient {
         `/users/${p["username"]}/following/${p["targetUser"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37470,14 +37465,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/gists?${qs.stringify({
+        `/users/${p["username"]}/gists?${this._query({
           since: p["since"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37533,13 +37528,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/gpg_keys?${qs.stringify({
+        `/users/${p["username"]}/gpg_keys?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37567,13 +37562,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/hovercard?${qs.stringify({
+        `/users/${p["username"]}/hovercard?${this._query({
           subject_type: p["subjectType"],
           subject_id: p["subjectId"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37634,7 +37629,7 @@ export class ApiClient {
       this.config.basePath + `/users/${p["username"]}/installation`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37660,13 +37655,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/keys?${qs.stringify({
+        `/users/${p["username"]}/keys?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37702,13 +37697,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/orgs?${qs.stringify({
+        `/users/${p["username"]}/orgs?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37765,14 +37760,14 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/projects?${qs.stringify({
+        `/users/${p["username"]}/projects?${this._query({
           state: p["state"],
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37790,13 +37785,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/received_events?${qs.stringify({
+        `/users/${p["username"]}/received_events?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37814,13 +37809,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/received_events/public?${qs.stringify({
+        `/users/${p["username"]}/received_events/public?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37841,7 +37836,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/repos?${qs.stringify({
+        `/users/${p["username"]}/repos?${this._query({
           type: p["type"],
           sort: p["sort"],
           direction: p["direction"],
@@ -37850,7 +37845,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -37983,7 +37978,7 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/starred?${qs.stringify({
+        `/users/${p["username"]}/starred?${this._query({
           sort: p["sort"],
           direction: p["direction"],
           per_page: p["perPage"],
@@ -37991,7 +37986,7 @@ export class ApiClient {
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -38123,13 +38118,13 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/users/${p["username"]}/subscriptions?${qs.stringify({
+        `/users/${p["username"]}/subscriptions?${this._query({
           per_page: p["perPage"],
           page: p["page"],
         })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 

--- a/integration-tests/typescript-fetch/src/api.github.com.json/client.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.json/client.ts
@@ -18,11 +18,12 @@ export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
   private _query(
-    params: Record<string, string | number | undefined | null>
+    params: Record<string, string | number | boolean | undefined | null>
   ): string {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([k, v]) => v !== undefined)
     )
+
     return qs.stringify(filtered)
   }
 

--- a/integration-tests/typescript-fetch/src/api.github.com.json/client.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.json/client.ts
@@ -18,7 +18,10 @@ export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
   private _query(
-    params: Record<string, string | number | boolean | undefined | null>
+    params: Record<
+      string,
+      string | number | boolean | string[] | undefined | null
+    >
   ): string {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([k, v]) => v !== undefined)

--- a/integration-tests/typescript-fetch/src/petstore-expanded.yml/client.ts
+++ b/integration-tests/typescript-fetch/src/petstore-expanded.yml/client.ts
@@ -18,7 +18,16 @@ export interface Res<StatusCode, Body> {
 export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
-  private headers(
+  private _query(
+    params: Record<string, string | number | undefined | null>
+  ): string {
+    const filtered = Object.fromEntries(
+      Object.entries(params).filter(([k, v]) => v !== undefined)
+    )
+    return qs.stringify(filtered)
+  }
+
+  private _headers(
     headers: Record<string, string | undefined>
   ): Record<string, string> {
     return Object.fromEntries(
@@ -36,10 +45,10 @@ export class ApiClient {
 
     const res = await fetch(
       this.config.basePath +
-        `/pets?${qs.stringify({ tags: p["tags"], limit: p["limit"] })}`,
+        `/pets?${this._query({ tags: p["tags"], limit: p["limit"] })}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -56,7 +65,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/pets`, {
       method: "POST",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -74,7 +83,7 @@ export class ApiClient {
       this.config.basePath + `/pets/${p["id"]}/${p["species"]}`,
       {
         method: "GET",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 
@@ -92,7 +101,7 @@ export class ApiClient {
       this.config.basePath + `/pets/${p["id"]}/${p["species"]}`,
       {
         method: "DELETE",
-        headers: this.headers(headers),
+        headers: this._headers(headers),
       }
     )
 

--- a/integration-tests/typescript-fetch/src/petstore-expanded.yml/client.ts
+++ b/integration-tests/typescript-fetch/src/petstore-expanded.yml/client.ts
@@ -19,7 +19,10 @@ export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
   private _query(
-    params: Record<string, string | number | boolean | undefined | null>
+    params: Record<
+      string,
+      string | number | boolean | string[] | undefined | null
+    >
   ): string {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([k, v]) => v !== undefined)

--- a/integration-tests/typescript-fetch/src/petstore-expanded.yml/client.ts
+++ b/integration-tests/typescript-fetch/src/petstore-expanded.yml/client.ts
@@ -19,11 +19,12 @@ export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
   private _query(
-    params: Record<string, string | number | undefined | null>
+    params: Record<string, string | number | boolean | undefined | null>
   ): string {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([k, v]) => v !== undefined)
     )
+
     return qs.stringify(filtered)
   }
 

--- a/integration-tests/typescript-fetch/src/todo-lists.yml/client.ts
+++ b/integration-tests/typescript-fetch/src/todo-lists.yml/client.ts
@@ -19,7 +19,10 @@ export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
   private _query(
-    params: Record<string, string | number | boolean | undefined | null>
+    params: Record<
+      string,
+      string | number | boolean | string[] | undefined | null
+    >
   ): string {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([k, v]) => v !== undefined)

--- a/integration-tests/typescript-fetch/src/todo-lists.yml/client.ts
+++ b/integration-tests/typescript-fetch/src/todo-lists.yml/client.ts
@@ -19,11 +19,12 @@ export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
   private _query(
-    params: Record<string, string | number | undefined | null>
+    params: Record<string, string | number | boolean | undefined | null>
   ): string {
     const filtered = Object.fromEntries(
       Object.entries(params).filter(([k, v]) => v !== undefined)
     )
+
     return qs.stringify(filtered)
   }
 

--- a/integration-tests/typescript-fetch/src/todo-lists.yml/client.ts
+++ b/integration-tests/typescript-fetch/src/todo-lists.yml/client.ts
@@ -18,7 +18,16 @@ export interface Res<StatusCode, Body> {
 export class ApiClient {
   constructor(private readonly config: ApiClientConfig) {}
 
-  private headers(
+  private _query(
+    params: Record<string, string | number | undefined | null>
+  ): string {
+    const filtered = Object.fromEntries(
+      Object.entries(params).filter(([k, v]) => v !== undefined)
+    )
+    return qs.stringify(filtered)
+  }
+
+  private _headers(
     headers: Record<string, string | undefined>
   ): Record<string, string> {
     return Object.fromEntries(
@@ -35,7 +44,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/list/${p["listId"]}`, {
       method: "GET",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption
@@ -52,7 +61,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/list/${p["listId"]}`, {
       method: "PUT",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
       body: JSON.stringify(p.requestBody),
     })
 
@@ -67,7 +76,7 @@ export class ApiClient {
 
     const res = await fetch(this.config.basePath + `/list/${p["listId"]}`, {
       method: "DELETE",
-      headers: this.headers(headers),
+      headers: this._headers(headers),
     })
 
     // TODO: this is a poor assumption

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
@@ -79,7 +79,7 @@ export interface Res<StatusCode, Body> {
 export class ${ clientName } {
   constructor(private readonly config: ${ clientName }Config) {}
 
-  private _query(params: Record<string, string|number|undefined|null>): string {
+  private _query(params: Record<string, string|number|boolean|undefined|null>): string {
     const filtered = Object.fromEntries(
         Object.entries(params)
             .filter(([k,v])=> v !== undefined)

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
@@ -29,7 +29,9 @@ export class TypescriptFetchClientBuilder extends TypescriptClientBuilder {
             })
             .join(' | ')
 
-        const url = '`' + routeToTemplateString(route) + (queryString ? "?${qs.stringify({" + queryString + "})}" : "") + '`'
+
+
+        const url = '`' + routeToTemplateString(route) + (queryString ? "?${this._query({" + queryString + "})}" : "") + '`'
         const body = `
 
 const headers: Record<string,string|undefined> = {${
@@ -45,7 +47,7 @@ const headers: Record<string,string|undefined> = {${
 const res = await fetch(this.config.basePath + ${ url },
     {
     method: "${ method }",
-    headers: this.headers(headers),
+    headers: this._headers(headers),
     ${ requestBodyParameter ? `body: JSON.stringify(p.requestBody),` : '' }
     })
 
@@ -77,7 +79,16 @@ export interface Res<StatusCode, Body> {
 export class ${ clientName } {
   constructor(private readonly config: ${ clientName }Config) {}
 
-  private headers(headers: Record<string, string|undefined>): Record<string, string> {
+  private _query(params: Record<string, string|number|undefined|null>): string {
+    const filtered = Object.fromEntries(
+        Object.entries(params)
+            .filter(([k,v])=> v !== undefined)
+    )
+
+    return qs.stringify(filtered)
+  }
+
+  private _headers(headers: Record<string, string|undefined>): Record<string, string> {
     return Object.fromEntries(
         Object.entries({...this.config.defaultHeaders, ...headers})
             .filter((it): it is [string,string] => it[1] !== undefined)

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
@@ -79,7 +79,7 @@ export interface Res<StatusCode, Body> {
 export class ${ clientName } {
   constructor(private readonly config: ${ clientName }Config) {}
 
-  private _query(params: Record<string, string|number|boolean|undefined|null>): string {
+  private _query(params: Record<string, string | number | boolean | string[] | undefined | null>): string {
     const filtered = Object.fromEntries(
         Object.entries(params)
             .filter(([k,v])=> v !== undefined)


### PR DESCRIPTION
filter out query parameters passed as undefined, unstead of passing them in the url as `name=`

explicit null values will still be passed to the server

prefix private methods with `_` to reduce change of naming collisions with the generated public interface