### PR TITLE
feat: add script consuming github fetch client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 coverage
 .eslintcache
 yarn-error.log
+.env

--- a/integration-tests/typescript-fetch/package.json
+++ b/integration-tests/typescript-fetch/package.json
@@ -9,6 +9,9 @@
     "generate": "./generate.sh",
     "validate": "tsc -p ./tsconfig.json"
   },
+  "dependencies": {
+    "dotenv": "^16.0.3"
+  },
   "devDependencies": {
     "@types/node": "^18.11.18",
     "typescript": "~4.9.4"

--- a/integration-tests/typescript-fetch/src/uniform-github-repositories/uniform-github-repositories.ts
+++ b/integration-tests/typescript-fetch/src/uniform-github-repositories/uniform-github-repositories.ts
@@ -1,0 +1,69 @@
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+import {ApiClient} from "../api.github.com.yaml/client";
+import {t_repository} from "../api.github.com.yaml/models";
+
+const client = new ApiClient({
+  basePath: 'https://api.github.com',
+  defaultHeaders: {'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`},
+})
+
+async function main() {
+  console.info(client)
+  await checkAuth()
+
+  const repos = await getAllRepos()
+
+  const sourceAndAdminRepos = repos.filter(it => !it.fork && it.permissions?.admin)
+
+  for (const repo of sourceAndAdminRepos) {
+    console.info("updating: " + repo.full_name)
+    await updateRepoConfig(repo.owner.login, repo.name)
+  }
+}
+
+async function checkAuth() {
+  const res = await client.usersGetAuthenticated()
+
+  if (res.status !== 200) {
+    console.info(res)
+    throw new Error("invalid auth!")
+  }
+}
+
+async function getAllRepos(page = 1): Promise<t_repository[]> {
+  const perPage = 100
+  const res = await client.reposListForAuthenticatedUser({perPage, page})
+
+  if (res.status !== 200) {
+    console.info(res)
+    throw new Error("failed to fetch repositories, page: " + page)
+  }
+
+  if (res.body.length >= perPage) {
+    return res.body.concat(await getAllRepos(page + 1))
+  }
+
+  return res.body
+}
+
+async function updateRepoConfig(owner: string, repo: string) {
+  const res = await client.reposUpdate({
+    owner,
+    repo,
+    requestBody: {
+      allow_auto_merge: true,
+      allow_merge_commit: false,
+      allow_update_branch: true,
+      delete_branch_on_merge: true,
+    }
+  })
+
+  if(res.status >= 300){
+    console.info(res)
+  }
+}
+
+main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,6 +4554,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"


### PR DESCRIPTION
adds a small script that uses the github `typescript-fetch` client to enumerate the authenticated users source (owned) repo's and apply an opinionated config to them