### PR TITLE
feat: move static code to normal files

### DIFF
--- a/integration-tests/typescript-koa/package.json
+++ b/integration-tests/typescript-koa/package.json
@@ -13,6 +13,7 @@
     "@hapi/joi": "^17.1.1",
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.0",
+    "@nahkies/typescript-koa-runtime": "0.0.1",
     "@types/hapi__joi": "^17.1.9",
     "koa": "^2.14.1",
     "koa-body": "^6.0.1",
@@ -22,7 +23,6 @@
     "@types/koa": "^2.13.6",
     "@types/koa__cors": "^4.0.0",
     "@types/koa__router": "^12.0.0",
-    "koa-body": "^6.0.1",
     "typescript": "~4.9.5"
   }
 }

--- a/integration-tests/typescript-koa/src/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/api.github.com.yaml/generated.ts
@@ -1260,60 +1260,17 @@ import {
 } from "./models"
 import cors from "@koa/cors"
 import KoaRouter from "@koa/router"
+import {
+  bodyValidationFactory,
+  paramValidationFactory,
+  queryValidationFactory,
+} from "@nahkies/typescript-koa-runtime/zod"
 import Koa, { Context, Middleware, Next } from "koa"
 import koaBody from "koa-body"
 import { ZodSchema, z } from "zod"
 
 //region safe-edit-region-header
 //endregion safe-edit-region-header
-
-function paramValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ params: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.params)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.params = result.data
-
-    return next()
-  }
-}
-
-function queryValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ query: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.query)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.query = result.data
-
-    return next()
-  }
-}
-
-function bodyValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ body: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.request.body)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.body = result.data
-
-    return next()
-  }
-}
 
 type Params<Params, Query, Body> = { params: Params; query: Query; body: Body }
 

--- a/integration-tests/typescript-koa/src/petstore-expanded.yml/generated.ts
+++ b/integration-tests/typescript-koa/src/petstore-expanded.yml/generated.ts
@@ -10,60 +10,17 @@ import {
 } from "./models"
 import cors from "@koa/cors"
 import KoaRouter from "@koa/router"
+import {
+  bodyValidationFactory,
+  paramValidationFactory,
+  queryValidationFactory,
+} from "@nahkies/typescript-koa-runtime/zod"
 import Koa, { Context, Middleware, Next } from "koa"
 import koaBody from "koa-body"
 import { ZodSchema, z } from "zod"
 
 //region safe-edit-region-header
 //endregion safe-edit-region-header
-
-function paramValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ params: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.params)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.params = result.data
-
-    return next()
-  }
-}
-
-function queryValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ query: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.query)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.query = result.data
-
-    return next()
-  }
-}
-
-function bodyValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ body: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.request.body)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.body = result.data
-
-    return next()
-  }
-}
 
 type Params<Params, Query, Body> = { params: Params; query: Query; body: Body }
 

--- a/integration-tests/typescript-koa/src/todo-lists.yml/generated.ts
+++ b/integration-tests/typescript-koa/src/todo-lists.yml/generated.ts
@@ -11,60 +11,17 @@ import {
 } from "./models"
 import cors from "@koa/cors"
 import KoaRouter from "@koa/router"
+import {
+  bodyValidationFactory,
+  paramValidationFactory,
+  queryValidationFactory,
+} from "@nahkies/typescript-koa-runtime/dist/zod"
 import Koa, { Context, Middleware, Next } from "koa"
 import koaBody from "koa-body"
 import { ZodSchema, z } from "zod"
 
 //region safe-edit-region-header
 //endregion safe-edit-region-header
-
-function paramValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ params: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.params)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.params = result.data
-
-    return next()
-  }
-}
-
-function queryValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ query: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.query)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.query = result.data
-
-    return next()
-  }
-}
-
-function bodyValidationFactory<Type>(
-  schema: ZodSchema
-): Middleware<{ body: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.request.body)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.body = result.data
-
-    return next()
-  }
-}
 
 type Params<Params, Query, Body> = { params: Params; query: Query; body: Body }
 

--- a/integration-tests/typescript-koa/src/todo-lists.yml/generated.ts
+++ b/integration-tests/typescript-koa/src/todo-lists.yml/generated.ts
@@ -15,7 +15,7 @@ import {
   bodyValidationFactory,
   paramValidationFactory,
   queryValidationFactory,
-} from "@nahkies/typescript-koa-runtime/dist/zod"
+} from "@nahkies/typescript-koa-runtime/zod"
 import Koa, { Context, Middleware, Next } from "koa"
 import koaBody from "koa-body"
 import { ZodSchema, z } from "zod"

--- a/jest.base.ts
+++ b/jest.base.ts
@@ -1,9 +1,10 @@
-import type { JestConfigWithTsJest } from "ts-jest"
+import type {JestConfigWithTsJest} from "ts-jest"
 
 const config: JestConfigWithTsJest = {
-    preset: "ts-jest",
-    testEnvironment: "node",
-    resetMocks: true,
+  preset: "ts-jest",
+  testEnvironment: "node",
+  resetMocks: true,
+  testMatch: ["**/*.spec.ts"]
 }
 
 module.exports = config

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci-build": "lerna run build --stream",
     "ci-test": "jest --coverage",
     "ci-lint": "eslint . --cache --report-unused-disable-directives",
-    "ci-pipeline": " yarn ci-build && yarn ci-test && yarn ci-lint && yarn integration:generate && yarn integration:validate"
+    "ci-pipeline": "yarn ci-build && yarn ci-test && yarn ci-lint && yarn integration:generate && yarn integration:validate"
   },
   "author": "Michael Nahkies",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "refresh": "./scripts/refresh-data.sh",
     "start": "nodemon",
     "lint": "eslint . --cache --report-unused-disable-directives --fix",
-    "build": "lerna run build --scope 'openapi-code-generator'",
+    "build": "lerna run build --scope '@nahkies/*'",
     "test": "jest",
     "integration:generate": "lerna run generate --stream --concurrency 1",
     "integration:validate": "lerna run validate --stream",

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "openapi-code-generator",
+  "name": "@nahkies/openapi-code-generator",
   "version": "0.0.1",
   "description": "",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p ./tsconfig.json",
     "test": "jest"
@@ -27,14 +28,5 @@
     "prettier": "^2.8.7",
     "source-map-support": "^0.5.21",
     "tslib": "^2.5.0"
-  },
-  "nyc": {
-    "extends": "@istanbuljs/nyc-config-typescript",
-    "reporter": [
-      "lcov",
-      "teamcity",
-      "text"
-    ],
-    "all": true
   }
 }

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/joi-schema-builder.ts
@@ -1,8 +1,8 @@
-import { Input } from "../../../core/input"
-import { IRModelObject, IRParameter, MaybeIRModel } from "../../../core/openapi-types-normalized"
-import { isDefined } from "../../../core/utils"
-import { SchemaBuilder } from "./schema-builder"
-import { ImportBuilder } from "../../common/import-builder"
+import {Input} from "../../../core/input"
+import {IRModelString} from "../../../core/openapi-types-normalized"
+import {isDefined} from "../../../core/utils"
+import {SchemaBuilder} from "./schema-builder"
+import {ImportBuilder} from "../../common/import-builder"
 
 enum JoiFn {
   Object = "object()",
@@ -13,85 +13,38 @@ enum JoiFn {
   Required = "required()"
 }
 
-export class JoiBuilder implements SchemaBuilder {
+export class JoiBuilder extends SchemaBuilder {
   constructor(
     private readonly joi = "joi",
-    private readonly input: Input,
+    input: Input,
   ) {
+    super(input)
   }
-
 
   importHelpers(importBuilder: ImportBuilder) {
     importBuilder.from("@nahkies/typescript-koa-runtime/joi")
       .add("queryValidationFactory", "paramValidationFactory", "bodyValidationFactory")
   }
 
-  fromParameters(parameters: IRParameter[]): string {
-    const model: IRModelObject = {
-      type: "object",
-      required: [],
-      properties: {},
-      allOf: [],
-      readOnly: false,
-      nullable: false,
-      additionalProperties: false,
-    }
-
-    parameters.forEach(parameter => {
-      if (parameter.required) {
-        model.required.push(parameter.name)
-      }
-      model.properties[parameter.name] = parameter.schema
-    })
-
-    return this.fromModel(model, true)
-  }
-
-  fromModel(maybeModel: MaybeIRModel, required: boolean): string {
-    const model = this.input.schema(maybeModel)
-
-    switch (model.type) {
-      case "string":
-        return this.string(required)
-      case "number":
-        return this.number(required)
-      case "boolean":
-        return this.boolean(required)
-      case "array":
-        return this.array([
-          this.fromModel(this.input.schema(model.items), false),
-        ], required)
-      case "object":
-        return this.object(
-          Object.fromEntries(
-            Object.entries(model.properties)
-              .map(([key, value]) => {
-                return [key, this.fromModel(this.input.schema(value), model.required.includes(key))]
-              }),
-          ), required,
-        )
-    }
-  }
-
-  private object(keys: Record<string, string>, required: boolean): string {
+  protected object(keys: Record<string, string>, required: boolean): string {
     return [
       this.joi,
       JoiFn.Object,
-      `keys({${ Object.entries(keys).map(([key, value]) => `"${ key }": ${ value }`).join(",") } })`,
+      `keys({${Object.entries(keys).map(([key, value]) => `"${key}": ${value}`).join(",")} })`,
       required ? JoiFn.Required : undefined,
     ].filter(isDefined).join(".")
   }
 
-  private array(items: string[], required: boolean): string {
+  protected array(items: string[], required: boolean): string {
     return [
       this.joi,
       JoiFn.Array,
-      `items(${ items.join(",") })`,
+      `items(${items.join(",")})`,
       required ? JoiFn.Required : undefined,
     ].filter(isDefined).join(".")
   }
 
-  private number(required: boolean) {
+  protected number(required: boolean) {
     return [
       this.joi,
       JoiFn.Number,
@@ -99,7 +52,9 @@ export class JoiBuilder implements SchemaBuilder {
     ].filter(isDefined).join(".")
   }
 
-  private string(required: boolean) {
+  protected string(model: IRModelString, required: boolean) {
+    // TODO: enum support
+
     return [
       this.joi,
       JoiFn.String,
@@ -107,7 +62,7 @@ export class JoiBuilder implements SchemaBuilder {
     ].filter(isDefined).join(".")
   }
 
-  private boolean(required: boolean) {
+  protected boolean(required: boolean) {
     return [
       this.joi,
       JoiFn.Boolean,

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/joi-schema-builder.ts
@@ -22,7 +22,7 @@ export class JoiBuilder implements SchemaBuilder {
 
 
   importHelpers(importBuilder: ImportBuilder) {
-    importBuilder.from("@nahkies/typescript-koa-runtime/dist/joi")
+    importBuilder.from("@nahkies/typescript-koa-runtime/joi")
       .add("queryValidationFactory", "paramValidationFactory", "bodyValidationFactory")
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/joi-schema-builder.ts
@@ -2,6 +2,7 @@ import { Input } from "../../../core/input"
 import { IRModelObject, IRParameter, MaybeIRModel } from "../../../core/openapi-types-normalized"
 import { isDefined } from "../../../core/utils"
 import { SchemaBuilder } from "./schema-builder"
+import { ImportBuilder } from "../../common/import-builder"
 
 enum JoiFn {
   Object = "object()",
@@ -19,50 +20,10 @@ export class JoiBuilder implements SchemaBuilder {
   ) {
   }
 
-  staticHelpers(): string {
-    return `
-function paramValidationFactory<Type>(schema: joi.Schema): Middleware<{ params: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.validate(ctx.params, { stripUnknown: true })
 
-    if (result.error) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.params = result.value
-
-    return next()
-  }
-}
-
-function queryValidationFactory<Type>(schema: joi.Schema): Middleware<{ query: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.validate(ctx.query, { stripUnknown: true })
-
-    if (result.error) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.query = result.value
-
-    return next()
-  }
-}
-
-function bodyValidationFactory<Type>(schema: joi.Schema): Middleware<{ body: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.validate(ctx.request.body, { stripUnknown: true })
-
-    if (result.error) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.body = result.value
-
-    return next()
-  }
-}
-`
+  importHelpers(importBuilder: ImportBuilder) {
+    importBuilder.from("@nahkies/typescript-koa-runtime/dist/joi")
+      .add("queryValidationFactory", "paramValidationFactory", "bodyValidationFactory")
   }
 
   fromParameters(parameters: IRParameter[]): string {

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/schema-builder.ts
@@ -1,10 +1,69 @@
-import { IRParameter, MaybeIRModel } from "../../../core/openapi-types-normalized"
-import { ImportBuilder } from "../../common/import-builder"
+import {IRModelObject, IRModelString, IRParameter, MaybeIRModel} from "../../../core/openapi-types-normalized"
+import {ImportBuilder} from "../../common/import-builder"
+import {Input} from "../../../core/input"
 
-export interface SchemaBuilder {
-  importHelpers(importBuilder: ImportBuilder): void
+export abstract class SchemaBuilder {
 
-  fromParameters(parameters: IRParameter[]): string
+  protected constructor(private readonly input: Input) {
+  }
 
-  fromModel(maybeModel: MaybeIRModel, required: boolean): string
+
+  abstract importHelpers(importBuilder: ImportBuilder): void
+
+  fromParameters(parameters: IRParameter[]): string {
+    const model: IRModelObject = {
+      type: "object",
+      required: [],
+      properties: {},
+      allOf: [],
+      readOnly: false,
+      nullable: false,
+      additionalProperties: false,
+    }
+
+    parameters.forEach(parameter => {
+      if (parameter.required) {
+        model.required.push(parameter.name)
+      }
+      model.properties[parameter.name] = parameter.schema
+    })
+
+    return this.fromModel(model, true)
+  }
+
+  fromModel(maybeModel: MaybeIRModel, required: boolean): string {
+    const model = this.input.schema(maybeModel)
+
+    switch (model.type) {
+      case "string":
+        return this.string(model, required)
+      case "number":
+        return this.number(required)
+      case "boolean":
+        return this.boolean(required)
+      case "array":
+        return this.array([
+          this.fromModel(this.input.schema(model.items), false),
+        ], required)
+      case "object":
+        return this.object(
+          Object.fromEntries(
+            Object.entries(model.properties)
+              .map(([key, value]) => {
+                return [key, this.fromModel(this.input.schema(value), model.required.includes(key))]
+              }),
+          ), required,
+        )
+    }
+  }
+
+  protected abstract object(keys: Record<string, string>, required: boolean): string
+
+  protected abstract array(items: string[], required: boolean): string
+
+  protected abstract number(required: boolean): string
+
+  protected abstract string(model: IRModelString, required: boolean): string
+
+  protected abstract boolean(required: boolean): string
 }

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/schema-builder.ts
@@ -1,7 +1,8 @@
 import { IRParameter, MaybeIRModel } from "../../../core/openapi-types-normalized"
+import { ImportBuilder } from "../../common/import-builder"
 
 export interface SchemaBuilder {
-  staticHelpers(): string
+  importHelpers(importBuilder: ImportBuilder): void
 
   fromParameters(parameters: IRParameter[]): string
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
@@ -17,7 +17,7 @@ export class ZodBuilder implements SchemaBuilder {
   }
 
   importHelpers(importBuilder: ImportBuilder) {
-    importBuilder.from("@nahkies/typescript-koa-runtime/dist/zod")
+    importBuilder.from("@nahkies/typescript-koa-runtime/zod")
       .add("queryValidationFactory", "paramValidationFactory", "bodyValidationFactory")
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
@@ -1,19 +1,17 @@
-import { Input } from "../../../core/input"
+import {Input} from "../../../core/input"
 import {
-  IRModelObject,
   IRModelString,
-  IRParameter,
-  MaybeIRModel,
 } from "../../../core/openapi-types-normalized"
-import { isDefined } from "../../../core/utils"
-import { SchemaBuilder } from "./schema-builder"
-import { ImportBuilder } from "../../common/import-builder"
+import {isDefined} from "../../../core/utils"
+import {SchemaBuilder} from "./schema-builder"
+import {ImportBuilder} from "../../common/import-builder"
 
-export class ZodBuilder implements SchemaBuilder {
+export class ZodBuilder extends SchemaBuilder {
   constructor(
     private readonly zod = "z",
-    private readonly input: Input,
+    input: Input,
   ) {
+    super(input)
   }
 
   importHelpers(importBuilder: ImportBuilder) {
@@ -21,70 +19,23 @@ export class ZodBuilder implements SchemaBuilder {
       .add("queryValidationFactory", "paramValidationFactory", "bodyValidationFactory")
   }
 
-  fromParameters(parameters: IRParameter[]): string {
-    const model: IRModelObject = {
-      type: "object",
-      required: [],
-      properties: {},
-      allOf: [],
-      readOnly: false,
-      nullable: false,
-      additionalProperties: false,
-    }
-
-    parameters.forEach(parameter => {
-      if (parameter.required) {
-        model.required.push(parameter.name)
-      }
-      model.properties[parameter.name] = parameter.schema
-    })
-
-    return this.fromModel(model, true)
-  }
-
-  fromModel(maybeModel: MaybeIRModel, required: boolean): string {
-    const model = this.input.schema(maybeModel)
-
-    switch (model.type) {
-      case "string":
-        return this.string(model, required)
-      case "number":
-        return this.number(required)
-      case "boolean":
-        return this.boolean(required)
-      case "array":
-        return this.array([
-          this.fromModel(this.input.schema(model.items), false),
-        ], required)
-      case "object":
-        return this.object(
-          Object.fromEntries(
-            Object.entries(model.properties)
-              .map(([key, value]) => {
-                return [key, this.fromModel(this.input.schema(value), model.required.includes(key))]
-              }),
-          ), required,
-        )
-    }
-  }
-
-  private object(keys: Record<string, string>, required: boolean): string {
+  protected object(keys: Record<string, string>, required: boolean): string {
     return [
       this.zod,
-      `object({${ Object.entries(keys).map(([key, value]) => `"${ key }": ${ value }`).join(",") }})`,
+      `object({${Object.entries(keys).map(([key, value]) => `"${key}": ${value}`).join(",")}})`,
       required ? undefined : "optional()",
     ].filter(isDefined).join(".")
   }
 
-  private array(items: string[], required: boolean): string {
+  protected array(items: string[], required: boolean): string {
     return [
       this.zod,
-      `array(${ items.join(",") })`,
+      `array(${items.join(",")})`,
       required ? undefined : "optional()",
     ].filter(isDefined).join(".")
   }
 
-  private number(required: boolean) {
+  protected number(required: boolean) {
     return [
       this.zod,
       "coerce.number()",
@@ -92,7 +43,7 @@ export class ZodBuilder implements SchemaBuilder {
     ].filter(isDefined).join(".")
   }
 
-  private string(model: IRModelString, required: boolean) {
+  protected string(model: IRModelString, required: boolean) {
     if (model.enum) {
       return this.enum(model, required)
     }
@@ -106,19 +57,19 @@ export class ZodBuilder implements SchemaBuilder {
     ].filter(isDefined).join(".")
   }
 
-  private enum(model: IRModelString, required: boolean) {
+  protected enum(model: IRModelString, required: boolean) {
     if (!model.enum) {
       throw new Error("model is not an enum")
     }
 
     return [
       this.zod,
-      `enum([${ model.enum.map(it => `"${ it }"`).join(",") }])`,
+      `enum([${model.enum.map(it => `"${it}"`).join(",")}])`,
       required ? undefined : "optional()",
     ].filter(isDefined).join(".")
   }
 
-  private boolean(required: boolean) {
+  protected boolean(required: boolean) {
     return [
       this.zod,
       // TODO: this would mean the literal string "false" as a query parameter is coerced to true

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../core/openapi-types-normalized"
 import { isDefined } from "../../../core/utils"
 import { SchemaBuilder } from "./schema-builder"
+import { ImportBuilder } from "../../common/import-builder"
 
 export class ZodBuilder implements SchemaBuilder {
   constructor(
@@ -15,50 +16,9 @@ export class ZodBuilder implements SchemaBuilder {
   ) {
   }
 
-  staticHelpers(): string {
-    return `
-function paramValidationFactory<Type>(schema: ZodSchema): Middleware<{ params: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.params)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.params = result.data
-
-    return next()
-  }
-}
-
-function queryValidationFactory<Type>(schema: ZodSchema): Middleware<{ query: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.query)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.query = result.data
-
-    return next()
-  }
-}
-
-function bodyValidationFactory<Type>(schema: ZodSchema): Middleware<{ body: Type }> {
-  return async function (ctx: Context, next: Next) {
-    const result = schema.safeParse(ctx.request.body)
-
-    if (!result.success) {
-      throw new Error("validation error")
-    }
-
-    ctx.state.body = result.data
-
-    return next()
-  }
-}
-`
+  importHelpers(importBuilder: ImportBuilder) {
+    importBuilder.from("@nahkies/typescript-koa-runtime/dist/zod")
+      .add("queryValidationFactory", "paramValidationFactory", "bodyValidationFactory")
   }
 
   fromParameters(parameters: IRParameter[]): string {

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -56,25 +56,26 @@ export class ServerBuilder {
       }
     }
 
-
+    this.schemaBuilder.importHelpers(this.imports)
     this.models = models.withImports(this.imports)
   }
 
   add(operation: IROperation): void {
     const models = this.models
-    const joiBuilder = this.schemaBuilder
+    const schemaBuilder = this.schemaBuilder
 
     const pathParams = operation.parameters.filter(it => it.in === "path")
-    const paramSchema = pathParams.length ? joiBuilder.fromParameters(pathParams) : undefined
-    let pathParamsType = "void"
+
+    const paramSchema = pathParams.length ? schemaBuilder.fromParameters(pathParams) : undefined
+    let pathParamsType = 'void'
 
     const queryParams = operation.parameters.filter(it => it.in === "query")
-    const querySchema = queryParams.length ? joiBuilder.fromParameters(queryParams) : undefined
-    let queryParamsType = "void"
+    const querySchema = queryParams.length ? schemaBuilder.fromParameters(queryParams) : undefined
+    let queryParamsType = 'void'
 
     const { requestBodyParameter } = this.requestBodyAsParameter(operation)
-    const bodyParamSchema = requestBodyParameter ? joiBuilder.fromModel(requestBodyParameter.schema, requestBodyParameter.required) : undefined
-    let bodyParamsType = "void"
+    const bodyParamSchema = requestBodyParameter ? schemaBuilder.fromModel(requestBodyParameter.schema, requestBodyParameter.required) : undefined
+    let bodyParamsType = 'void'
 
     if (paramSchema) {
       const name = `${ operation.operationId }ParamSchema`
@@ -158,8 +159,6 @@ ${ imports.toString() }
 
 //region safe-edit-region-header
 //endregion safe-edit-region-header
-
-${this.schemaBuilder.staticHelpers()}
 
 type Params<Params, Query, Body> = {params: Params, query: Query, body: Body}
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -67,15 +67,15 @@ export class ServerBuilder {
     const pathParams = operation.parameters.filter(it => it.in === "path")
 
     const paramSchema = pathParams.length ? schemaBuilder.fromParameters(pathParams) : undefined
-    let pathParamsType = 'void'
+    let pathParamsType = "void"
 
     const queryParams = operation.parameters.filter(it => it.in === "query")
     const querySchema = queryParams.length ? schemaBuilder.fromParameters(queryParams) : undefined
-    let queryParamsType = 'void'
+    let queryParamsType = "void"
 
     const { requestBodyParameter } = this.requestBodyAsParameter(operation)
     const bodyParamSchema = requestBodyParameter ? schemaBuilder.fromModel(requestBodyParameter.schema, requestBodyParameter.required) : undefined
-    let bodyParamsType = 'void'
+    let bodyParamsType = "void"
 
     if (paramSchema) {
       const name = `${ operation.operationId }ParamSchema`

--- a/packages/typescript-koa-runtime/jest.config.ts
+++ b/packages/typescript-koa-runtime/jest.config.ts
@@ -1,0 +1,10 @@
+import base = require( "../../jest.base")
+import {JestConfigWithTsJest} from "ts-jest"
+import {name as displayName} from "./package.json"
+
+const config: JestConfigWithTsJest = {
+  ...base,
+  displayName
+}
+
+module.exports = config

--- a/packages/typescript-koa-runtime/package.json
+++ b/packages/typescript-koa-runtime/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@nahkies/typescript-koa-runtime",
   "version": "0.0.1",
+  "exports": {
+    "./joi": {
+      "require": "./dist/joi.js",
+      "import": "./dist/joi.js",
+      "types": "./dist/joi.d.ts"
+    },
+    "./zod": {
+      "require": "./dist/zod.js",
+      "import": "./dist/zod.js",
+      "types": "./dist/joi.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p ./tsconfig.json",
     "test": "jest"

--- a/packages/typescript-koa-runtime/package.json
+++ b/packages/typescript-koa-runtime/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@nahkies/typescript-koa-runtime",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "@hapi/joi": "^17.1.1",
+    "koa": "^2.14.1",
+    "zod": "^3.20.6"
+  },
+  "devDependencies": {
+    "@hapi/joi": "^17.1.1",
+    "@types/koa": "^2.13.5",
+    "@types/koa__router": "^12.0.0",
+    "koa": "^2.14.1",
+    "zod": "^3.20.6"
+  }
+}

--- a/packages/typescript-koa-runtime/src/joi.ts
+++ b/packages/typescript-koa-runtime/src/joi.ts
@@ -1,5 +1,6 @@
 import type {Schema} from "@hapi/joi"
 import type { Context, Middleware, Next } from "koa"
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type koaBody from "koa-body"
 
 export function paramValidationFactory<Type>(schema: Schema): Middleware<{ params: Type }> {

--- a/packages/typescript-koa-runtime/src/joi.ts
+++ b/packages/typescript-koa-runtime/src/joi.ts
@@ -1,0 +1,45 @@
+import type {Schema} from "@hapi/joi"
+import type { Context, Middleware, Next } from "koa"
+import type koaBody from "koa-body"
+
+export function paramValidationFactory<Type>(schema: Schema): Middleware<{ params: Type }> {
+  return async function (ctx: Context, next: Next) {
+    const result = schema.validate(ctx.params, { stripUnknown: true })
+
+    if (result.error) {
+      throw new Error("validation error")
+    }
+
+    ctx.state.params = result.value
+
+    return next()
+  }
+}
+
+export function queryValidationFactory<Type>(schema: Schema): Middleware<{ query: Type }> {
+  return async function (ctx: Context, next: Next) {
+    const result = schema.validate(ctx.query, { stripUnknown: true })
+
+    if (result.error) {
+      throw new Error("validation error")
+    }
+
+    ctx.state.query = result.value
+
+    return next()
+  }
+}
+
+export function bodyValidationFactory<Type>(schema: Schema): Middleware<{ body: Type }> {
+  return async function (ctx: Context, next: Next) {
+    const result = schema.validate(ctx.request.body, { stripUnknown: true })
+
+    if (result.error) {
+      throw new Error("validation error")
+    }
+
+    ctx.state.body = result.value
+
+    return next()
+  }
+}

--- a/packages/typescript-koa-runtime/src/zod.spec.ts
+++ b/packages/typescript-koa-runtime/src/zod.spec.ts
@@ -1,5 +1,0 @@
-import { describe, it } from "@jest/globals"
-
-describe("zod", () =>{
-  it.todo("works")
-})

--- a/packages/typescript-koa-runtime/src/zod.spec.ts
+++ b/packages/typescript-koa-runtime/src/zod.spec.ts
@@ -1,0 +1,5 @@
+import { describe } from "node:test"
+
+describe("zod", function(){
+  it("works")
+})

--- a/packages/typescript-koa-runtime/src/zod.spec.ts
+++ b/packages/typescript-koa-runtime/src/zod.spec.ts
@@ -1,5 +1,5 @@
-import { describe } from "node:test"
+import { describe, it } from "@jest/globals"
 
-describe("zod", function(){
-  it("works")
+describe("zod", () =>{
+  it.todo("works")
 })

--- a/packages/typescript-koa-runtime/src/zod.ts
+++ b/packages/typescript-koa-runtime/src/zod.ts
@@ -1,0 +1,44 @@
+import type { ZodSchema } from "zod"
+import type { Context, Middleware, Next } from "koa"
+
+export function paramValidationFactory<Type>(schema: ZodSchema): Middleware<{ params: Type }> {
+  return async function (ctx: Context, next: Next) {
+    const result = schema.safeParse(ctx.params)
+
+    if (!result.success) {
+      throw new Error("validation error")
+    }
+
+    ctx.state.params = result.data
+
+    return next()
+  }
+}
+
+export function queryValidationFactory<Type>(schema: ZodSchema): Middleware<{ query: Type }> {
+  return async function (ctx: Context, next: Next) {
+    const result = schema.safeParse(ctx.query)
+
+    if (!result.success) {
+      throw new Error("validation error")
+    }
+
+    ctx.state.query = result.data
+
+    return next()
+  }
+}
+
+export function bodyValidationFactory<Type>(schema: ZodSchema): Middleware<{ body: Type }> {
+  return async function (ctx: Context, next: Next) {
+    const result = schema.safeParse(ctx.request.body)
+
+    if (!result.success) {
+      throw new Error("validation error")
+    }
+
+    ctx.state.body = result.data
+
+    return next()
+  }
+}

--- a/packages/typescript-koa-runtime/tsconfig.json
+++ b/packages/typescript-koa-runtime/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "resolveJsonModule": true,
-    "types": ["@types/mocha"]
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/typescript-koa-runtime/tsconfig.json
+++ b/packages/typescript-koa-runtime/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
+    "types": ["@types/mocha"]
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,11 @@
     "declaration": true,
     "sourceMap": true,
     "importHelpers": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "@nahkies/*": [
+        "./packages/*/src"
+      ]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "importHelpers": true,
     "resolveJsonModule": true,
+    "moduleResolution": "Node16",
     "paths": {
       "@nahkies/*": [
         "./packages/*/src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2483,6 +2483,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nahkies/openapi-code-generator@workspace:packages/openapi-code-generator":
+  version: 0.0.0-use.local
+  resolution: "@nahkies/openapi-code-generator@workspace:packages/openapi-code-generator"
+  dependencies:
+    "@types/convict": ^6.1.1
+    "@types/js-yaml": ^4.0.5
+    "@types/lodash": ^4.14.192
+    "@types/prettier": ^2.7.2
+    ajv: ^8.12.0
+    ajv-formats: ^2.1.1
+    convict: ^6.2.4
+    js-yaml: ^4.1.0
+    lodash: ^4.17.21
+    nodemon: 2.0.22
+    prettier: ^2.8.7
+    source-map-support: ^0.5.21
+    ts-node: 10.9.1
+    tslib: ^2.5.0
+    typescript: ~4.9.5
+  languageName: unknown
+  linkType: soft
+
+"@nahkies/typescript-koa-runtime@0.0.1, @nahkies/typescript-koa-runtime@workspace:packages/typescript-koa-runtime":
+  version: 0.0.0-use.local
+  resolution: "@nahkies/typescript-koa-runtime@workspace:packages/typescript-koa-runtime"
+  dependencies:
+    "@hapi/joi": ^17.1.1
+    "@types/koa": ^2.13.5
+    "@types/koa__router": ^12.0.0
+    koa: ^2.14.1
+    zod: ^3.20.6
+  peerDependencies:
+    "@hapi/joi": ^17.1.1
+    koa: ^2.14.1
+    zod: ^3.20.6
+  languageName: unknown
+  linkType: soft
+
 "@ngtools/webpack@npm:15.2.4":
   version: 15.2.4
   resolution: "@ngtools/webpack@npm:15.2.4"
@@ -7210,14 +7248,14 @@ __metadata:
   linkType: hard
 
 "formidable@npm:^2.0.1":
-  version: 2.1.1
-  resolution: "formidable@npm:2.1.1"
+  version: 2.1.2
+  resolution: "formidable@npm:2.1.2"
   dependencies:
     dezalgo: ^1.0.4
     hexoid: ^1.0.0
     once: ^1.4.0
     qs: ^6.11.0
-  checksum: b407bf89abf0dc40e00efe20edd80aa60ff7e7f4928b3a7048b630d3bb61012f316b69cd3350ccc9aab2d4c682516fea917bc31aef3479d4a652ed97cf8ba9aa
+  checksum: 81c8e5d89f5eb873e992893468f0de22c01678ca3d315db62be0560f9de1c77d4faefc9b1f4575098eb2263b3c81ba1024833a9fc3206297ddbac88a4f69b7a8
   languageName: node
   linkType: hard
 
@@ -11445,28 +11483,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"openapi-code-generator@workspace:packages/openapi-code-generator":
-  version: 0.0.0-use.local
-  resolution: "openapi-code-generator@workspace:packages/openapi-code-generator"
-  dependencies:
-    "@types/convict": ^6.1.1
-    "@types/js-yaml": ^4.0.5
-    "@types/lodash": ^4.14.192
-    "@types/prettier": ^2.7.2
-    ajv: ^8.12.0
-    ajv-formats: ^2.1.1
-    convict: ^6.2.4
-    js-yaml: ^4.1.0
-    lodash: ^4.17.21
-    nodemon: 2.0.22
-    prettier: ^2.8.7
-    source-map-support: ^0.5.21
-    ts-node: 10.9.1
-    tslib: ^2.5.0
-    typescript: ~4.9.5
-  languageName: unknown
-  linkType: soft
-
 "optionator@npm:^0.9.1":
   version: 0.9.1
   resolution: "optionator@npm:0.9.1"
@@ -14295,6 +14311,7 @@ __metadata:
     "@hapi/joi": ^17.1.1
     "@koa/cors": ^4.0.0
     "@koa/router": ^12.0.0
+    "@nahkies/typescript-koa-runtime": 0.0.1
     "@types/hapi__joi": ^17.1.9
     "@types/koa": ^2.13.6
     "@types/koa__cors": ^4.0.0
@@ -15160,7 +15177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.19.1, zod@npm:^3.21.4":
+"zod@npm:^3.19.1, zod@npm:^3.20.6, zod@npm:^3.21.4":
   version: 3.21.4
   resolution: "zod@npm:3.21.4"
   checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f


### PR DESCRIPTION
- splits out a runtime package to host static koa code
- changes koa template to import from this
- factor out abstract `SchemaBuilder` class to reduce code duplication

this makes it easier to unit test the static helpers in future, and reduces the amount of code-in-code