### PR TITLE
fix: use merge instead of intersection

### DIFF
--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.spec.ts
@@ -7,15 +7,15 @@ describe("zod-schema-builder", () => {
     const {input, file} = await unitTestInput()
     const schema = input.schema({$ref: `${file}#components/schemas/OneOf`})
 
-    const builder = new ZodBuilder("zod", input)
+    const builder = new ZodBuilder("z", input)
 
     const actual = builder.fromModel(schema, true)
 
     expect(actual).toMatchInlineSnapshot(`
-      "zod.union([
-      zod.object({"strs": zod.array(zod.coerce.string())}),
-      zod.array(zod.coerce.string()),
-      zod.coerce.string(),
+      "z.union([
+      z.object({"strs": z.array(z.coerce.string())}),
+      z.array(z.coerce.string()),
+      z.coerce.string(),
       ])"
     `)
   })
@@ -24,15 +24,13 @@ describe("zod-schema-builder", () => {
     const {input, file} = await unitTestInput()
     const schema = input.schema({$ref: `${file}#components/schemas/AllOf`})
 
-    const builder = new ZodBuilder("zod", input)
+    const builder = new ZodBuilder("z", input)
 
     const actual = builder.fromModel(schema, true)
 
     expect(actual).toMatchInlineSnapshot(`
-      "zod.intersection([
-      zod.object({"name": zod.coerce.string(),"breed": zod.coerce.string().optional()}),
-      zod.object({"id": zod.coerce.number()}),
-      ])"
+      "z.object({"name": z.coerce.string(),"breed": z.coerce.string().optional()})
+      .merge(z.object({"id": z.coerce.number()}))"
     `)
   })
 })

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/schema-builders/zod-schema-builder.ts
@@ -24,12 +24,9 @@ export class ZodBuilder extends AbstractSchemaBuilder {
 
 
   protected intersect(schemas: string[]): string {
-    return [
-      this.zod,
-      `intersection([\n${
-        schemas.map(it => it + ",").join("\n")
-      }\n])`
-    ].filter(isDefined).join(".")
+    return schemas.filter(isDefined).reduce((acc, it) => {
+      return `${acc}\n.merge(${it})`
+    })
   }
 
   protected union(schemas: string[]): string {


### PR DESCRIPTION
intersection actually takes a `left` and `right` parameter, rather than an array.

additionally from the docs:
> Though in many cases, it is recommended to use A.merge(B) to merge two objects. The .merge method returns a new ZodObject instance, whereas A.and(B) returns a less useful ZodIntersection instance that lacks common object methods like pick and omit.
