### PR TITLE
refactor: simplify

### DIFF
--- a/integration-tests/typescript-angular/src/app/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/app/api.github.com.yaml/client.service.ts
@@ -890,7 +890,7 @@ export class ApiClient {
       files: {
         [key: string]: unknown
       }
-      public?: boolean | ("true" | "false")
+      public?: boolean | "true" | "false"
     }
   }): Observable<
     t_gist_simple | void | t_basic_error | t_basic_error | t_validation_error

--- a/integration-tests/typescript-angular/src/app/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/app/api.github.com.yaml/models.ts
@@ -5967,7 +5967,7 @@ export type t_validation_error = {
     index?: number
     message?: string
     resource?: string
-    value?: (string | null) | (number | null) | string[]
+    value?: string | null | number | string[]
   }[]
   message: string
 }

--- a/integration-tests/typescript-fetch/src/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.yaml/client.ts
@@ -806,7 +806,7 @@ export class ApiClient extends AbstractFetchClient {
       files: {
         [key: string]: unknown
       }
-      public?: boolean | ("true" | "false")
+      public?: boolean | "true" | "false"
     }
   }): Promise<
     | Response<201, t_gist_simple>

--- a/integration-tests/typescript-fetch/src/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.yaml/models.ts
@@ -5967,7 +5967,7 @@ export type t_validation_error = {
     index?: number
     message?: string
     resource?: string
-    value?: (string | null) | (number | null) | string[]
+    value?: string | null | number | string[]
   }[]
   message: string
 }

--- a/integration-tests/typescript-koa/src/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/api.github.com.yaml/models.ts
@@ -5878,7 +5878,7 @@ export type t_validation_error = {
     index?: number
     message?: string
     resource?: string
-    value?: (string | null) | (number | null) | string[]
+    value?: string | null | number | string[]
   }[]
   message: string
 }
@@ -8498,7 +8498,7 @@ export type t_GistsCreateBodySchema = {
   files: {
     [key: string]: unknown
   }
-  public?: boolean | ("true" | "false")
+  public?: boolean | "true" | "false"
 }
 
 export type t_GistsCreateCommentBodySchema = {

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.ts
@@ -3,24 +3,27 @@ import {Input} from "../../core/input"
 import {Reference} from "../../core/openapi-types"
 import {getNameFromRef, isRef} from "../../core/openapi-utils"
 import {ImportBuilder} from "./import-builder"
-import {intersect, objectProperty, union} from "./type-utils"
+import {
+  array,
+  intersect,
+  object,
+  objectProperty,
+  quotedValue,
+  toString,
+  union,
+} from "./type-utils"
 
 export class TypeBuilder {
-
   private constructor(
     public readonly filename: string,
     private readonly input: Input,
     private readonly referenced = new Set<string>(),
-    private readonly imports?: ImportBuilder) {
+    private readonly imports?: ImportBuilder
+  ) {
   }
 
   withImports(imports: ImportBuilder): TypeBuilder {
-    return new TypeBuilder(
-      this.filename,
-      this.input,
-      this.referenced,
-      imports,
-    )
+    return new TypeBuilder(this.filename, this.input, this.referenced, imports)
   }
 
   private add({$ref}: Reference): string {
@@ -36,9 +39,10 @@ export class TypeBuilder {
   }
 
   toString(): string {
-    const generate = () => Array.from(this.referenced.values())
-      .sort()
-      .map(($ref) => this.generateModelFromRef($ref))
+    const generate = () =>
+      Array.from(this.referenced.values())
+        .sort()
+        .map(($ref) => this.generateModelFromRef($ref))
 
     // Super lazy way of discovering sub-references for generation easily...
     // could obviously be optimized but in most cases is plenty fast enough.
@@ -50,8 +54,7 @@ export class TypeBuilder {
       next = generate()
     }
 
-    return next
-      .join("\n\n")
+    return next.join("\n\n")
   }
 
   private generateModelFromRef($ref: string): string {
@@ -67,7 +70,6 @@ export class TypeBuilder {
   }
 
   readonly schemaObjectToTypes = (schemaObject: MaybeIRModel): string[] => {
-
     if (isRef(schemaObject)) {
       return [this.add(schemaObject)]
     }
@@ -85,7 +87,7 @@ export class TypeBuilder {
     if (result.length === 0) {
       switch (schemaObject.type) {
         case "array": {
-          result.push(`${this.schemaObjectToType(schemaObject.items)}[]`)
+          result.push(array(this.schemaObjectToType(schemaObject.items)))
           break
         }
 
@@ -95,23 +97,21 @@ export class TypeBuilder {
         }
 
         case "string": {
-          result.push(...(schemaObject.enum?.filter(it => typeof it === "string")
-            .map(it => `"${it}"`) ?? ["string"]))
+          result.push(...(schemaObject.enum?.map(quotedValue) ?? ["string"]))
           break
         }
 
         case "number": {
           // todo support bigint as string
-          result.push(...(schemaObject.enum?.filter(it => typeof it === "number")
-            .map(it => `${it}`) ?? ["number"]))
+          result.push(...(schemaObject.enum?.map(toString) ?? ["number"]))
           break
         }
 
         case "object": {
           const properties = Object.entries(schemaObject.properties)
-            .sort(([a], [b]) => a < b ? -1 : 1)
+            .sort(([a], [b]) => (a < b ? -1 : 1))
             .map(([name, definition]) => {
-              const isRequired = schemaObject.required.some(it => it === name)
+              const isRequired = schemaObject.required.some((it) => it === name)
               const type = this.schemaObjectToType(definition)
 
               const isReadonly = isRef(definition) ? false : definition.readOnly
@@ -120,20 +120,24 @@ export class TypeBuilder {
                 name,
                 type,
                 isReadonly,
-                isRequired
+                isRequired,
               })
             })
 
           // TODO better support
-          const additionalProperties = schemaObject.additionalProperties || properties.length === 0 ?
-            "[key: string]: unknown" : ""
+          const additionalProperties =
+            schemaObject.additionalProperties || properties.length === 0
+              ? "[key: string]: unknown"
+              : ""
 
-          result.push("{\n" + [...properties, additionalProperties].filter(Boolean).join("\n") + "\n}")
+          result.push(object([...properties, additionalProperties]))
           break
         }
 
         default: {
-          throw new Error(`unsupported type '${JSON.stringify(schemaObject, undefined, 2)}'`)
+          throw new Error(
+            `unsupported type '${JSON.stringify(schemaObject, undefined, 2)}'`
+          )
         }
       }
     }

--- a/packages/openapi-code-generator/src/typescript/common/type-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-utils.ts
@@ -1,9 +1,9 @@
-function wrapForArrayOrRestParameters<T, U>(fn: (arg: T[]) => U): {
+function wrap<T, U>(
+  fn: (arg: T[]) => U
+): {
   (...arg: T[] | T[][]): U
 } {
-
   return (...args: T[] | T[][]) => {
-
     if ((args as unknown[]).every((it) => Array.isArray(it))) {
       return fn((args as T[][]).reduce((acc, it) => acc.concat(it), [] as T[]))
     }
@@ -17,13 +17,13 @@ function unique(types: (string | undefined | null)[]) {
   return Array.from(
     types
       .filter((it): it is string => Boolean(it))
-      .filter(it => seen.has(it) ? false : seen.add(it) && true)
+      .filter((it) => (seen.has(it) ? false : seen.add(it) && true))
   )
 }
 
 type MaybeString = string | undefined | null
 
-export const union = wrapForArrayOrRestParameters(function (types: MaybeString[]): string {
+export const union = wrap((types: MaybeString[]): string => {
   const distinctTypes = unique(types)
 
   if (!distinctTypes.length) {
@@ -35,7 +35,7 @@ export const union = wrapForArrayOrRestParameters(function (types: MaybeString[]
   return `(${distinctTypes.join("\n | ")})`
 })
 
-export const intersect = wrapForArrayOrRestParameters(function (types: MaybeString[]): string {
+export const intersect = wrap((types: MaybeString[]): string => {
   const distinctTypes = unique(types)
 
   if (!distinctTypes.length) {
@@ -47,15 +47,33 @@ export const intersect = wrapForArrayOrRestParameters(function (types: MaybeStri
   return `(${distinctTypes.join(" & ")})`
 })
 
-export const objectProperty = ({name, type, isReadonly, isRequired}: {
-  name: string,
-  type: string,
-  isReadonly: boolean,
+export type ObjectPropertyDefinition = {
+  name: string
+  type: string
+  isReadonly: boolean
   isRequired: boolean
-}) => {
+}
+
+export const objectProperty = ({
+  name,
+  type,
+  isReadonly,
+  isRequired,
+}: ObjectPropertyDefinition): string => {
   return [
     isReadonly ? "readonly" : "",
     `"${name}"` + (isRequired ? ":" : "?:"),
     type,
-  ].filter(Boolean).join(" ") + ""
+  ]
+    .filter(Boolean)
+    .join(" ")
 }
+
+export const object = (properties: string[]): string =>
+  "{\n" + properties.filter(Boolean).join("\n") + "\n}"
+
+export const array = (type: string): string => `(${type})[]`
+
+export const toString = (it: string | number): string => it.toString()
+
+export const quotedValue = (it: string): string => `"${it}"`


### PR DESCRIPTION
- consolidates several redundant / similar code paths
- unifies handling of `nullable`
- avoids redundant unions