### PR TITLE
fix: switch to qs and add tests for query string

### DIFF
--- a/packages/openapi-code-generator/src/typescript/common/client-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/client-operation-builder.ts
@@ -46,6 +46,7 @@ export class ClientOperationBuilder {
   queryString(): string {
     const {parameters} = this.operation
 
+    // todo: consider style / explode / allowReserved etc here
     return parameters.filter(it => it.in === "query")
       .map(it => "'" + it.name + "': " + this.paramName(it.name))
       .join(",\n")

--- a/packages/typescript-fetch-runtime/package.json
+++ b/packages/typescript-fetch-runtime/package.json
@@ -11,5 +11,11 @@
   "scripts": {
     "build": "tsc -p ./tsconfig.json",
     "test": "jest"
+  },
+  "dependencies": {
+    "qs": "^6.11.1"
+  },
+  "devDependencies": {
+    "@types/qs": "^6.9.7"
   }
 }

--- a/packages/typescript-fetch-runtime/src/main.spec.ts
+++ b/packages/typescript-fetch-runtime/src/main.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect } from "@jest/globals"
+import { AbstractFetchClient, QueryParams } from "./main"
+
+class ConcreteFetchClient extends AbstractFetchClient {
+  constructor() {
+    super({ basePath: "", defaultHeaders: {} })
+  }
+
+  query(params: QueryParams) {
+    return this._query(params)
+  }
+}
+
+describe("main", () => {
+  const client = new ConcreteFetchClient()
+
+  describe("_query", () => {
+    it("returns an empty string when all params are undefined", () => {
+      expect(client.query({ foo: undefined, bar: undefined })).toBe("")
+    })
+
+    it("returns the defined params in a simple case", () => {
+      expect(
+        client.query({ foo: undefined, bar: "baz", foobar: "value" })
+      ).toBe("?bar=baz&foobar=value")
+    })
+
+    it("repeats array params", () => {
+      expect(client.query({ foo: ["bar", "baz"] })).toBe("?foo=bar&foo=baz")
+    })
+
+    it("handles objects", () => {
+      expect(client.query({ foo: { bar: "baz" } })).toBe(
+        `?${encodeURIComponent("foo[bar]")}=baz`
+      )
+    })
+
+    it("handles arrays of objects with multiple properties", () => {
+      expect(
+        client.query({
+          foo: [
+            { prop1: "one", prop2: "two" },
+            { prop1: "foo", prop2: "bar" },
+          ],
+          limit: 10,
+          undefined: undefined,
+          includeSomething: false,
+        })
+      ).toBe(
+        `?${encodeURIComponent("foo[prop1]")}=one&${encodeURIComponent(
+          "foo[prop2]"
+        )}=two&${encodeURIComponent("foo[prop1]")}=foo&${encodeURIComponent(
+          "foo[prop2]"
+        )}=bar&limit=10&includeSomething=false`
+      )
+    })
+  })
+})

--- a/packages/typescript-fetch-runtime/src/main.ts
+++ b/packages/typescript-fetch-runtime/src/main.ts
@@ -1,58 +1,83 @@
-import qs from "node:querystring"
+import qs from "qs"
 
 // from https://stackoverflow.com/questions/39494689/is-it-possible-to-restrict-number-to-a-certain-range
-type Enumerate<N extends number, Acc extends number[] = []> = Acc["length"] extends N
+type Enumerate<
+  N extends number,
+  Acc extends number[] = []
+> = Acc["length"] extends N
   ? Acc[number]
   : Enumerate<N, [...Acc, Acc["length"]]>
 
-type IntRange<F extends number, T extends number> = F extends T ?
-  F :
-  Exclude<Enumerate<T>, Enumerate<F>> extends never ?
-    never :
-    Exclude<Enumerate<T>, Enumerate<F>> | T
+type IntRange<F extends number, T extends number> = F extends T
+  ? F
+  : Exclude<Enumerate<T>, Enumerate<F>> extends never
+  ? never
+  : Exclude<Enumerate<T>, Enumerate<F>> | T
 
 export type StatusCode1xx = IntRange<100, 199>
 export type StatusCode2xx = IntRange<200, 299>
 export type StatusCode3xx = IntRange<300, 399>
 export type StatusCode4xx = IntRange<400, 499>
 export type StatusCode5xx = IntRange<500, 599>
-export type StatusCode = StatusCode1xx | StatusCode2xx | StatusCode3xx | StatusCode4xx | StatusCode5xx
+export type StatusCode =
+  | StatusCode1xx
+  | StatusCode2xx
+  | StatusCode3xx
+  | StatusCode4xx
+  | StatusCode5xx
 
-export type Response<Status extends StatusCode, Type> = { status: Status, body: Type }
+export type Response<Status extends StatusCode, Type> = {
+  status: Status
+  body: Type
+}
 
 export interface AbstractFetchClientConfig {
   basePath: string
   defaultHeaders: Record<string, string>
 }
 
+export type QueryParams = {
+  [name: string]:
+    | string
+    | number
+    | boolean
+    | string[]
+    | undefined
+    | null
+    | QueryParams
+    | QueryParams[]
+}
+
+export type HeaderParams = Record<string, string | undefined>
+
 export abstract class AbstractFetchClient {
   protected readonly basePath: string
   protected readonly defaultHeaders: Record<string, string>
 
-  protected constructor(
-    config: AbstractFetchClientConfig
-  ) {
+  protected constructor(config: AbstractFetchClientConfig) {
     this.basePath = config.basePath
     this.defaultHeaders = config.defaultHeaders
   }
 
-  protected _query(params: Record<string, string | number | boolean | string[] | undefined | null>): string {
-    const definedParams = Object.entries(params)
-      .filter(([, v]) => v !== undefined)
+  protected _query(params: QueryParams): string {
+    const definedParams = Object.entries(params).filter(
+      ([, v]) => v !== undefined
+    )
 
     if (!definedParams.length) {
       return ""
     }
 
-    return "?" + qs.stringify(Object.fromEntries(
-      definedParams
-    ))
+    return (
+      "?" + qs.stringify(Object.fromEntries(definedParams), { indices: false })
+    )
   }
 
-  protected _headers(headers: Record<string, string | undefined>): Record<string, string> {
+  protected _headers(headers: HeaderParams): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({...this.defaultHeaders, ...headers})
-        .filter((it): it is [string, string] => it[1] !== undefined)
+      Object.entries({ ...this.defaultHeaders, ...headers }).filter(
+        (it): it is [string, string] => it[1] !== undefined
+      )
     )
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2509,6 +2509,9 @@ __metadata:
 "@nahkies/typescript-fetch-runtime@0.0.1, @nahkies/typescript-fetch-runtime@workspace:packages/typescript-fetch-runtime":
   version: 0.0.0-use.local
   resolution: "@nahkies/typescript-fetch-runtime@workspace:packages/typescript-fetch-runtime"
+  dependencies:
+    "@types/qs": ^6.9.7
+    qs: ^6.11.1
   languageName: unknown
   linkType: soft
 
@@ -3606,7 +3609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*":
+"@types/qs@npm:*, @types/qs@npm:^6.9.7":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
@@ -12356,7 +12359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.11.0, qs@npm:^6.5.2":
+"qs@npm:^6.11.0, qs@npm:^6.11.1, qs@npm:^6.5.2":
   version: 6.11.1
   resolution: "qs@npm:6.11.1"
   dependencies:


### PR DESCRIPTION
- switch to qs package as this advertises support for arrays/objects more so than the built-in node:querystring library

- add tests for query string serialization

I'm not 100% sure that this is actually what we want, or at least what we always want. It could well be that we need to provide configuration to control how arrays/objects are handled for serialization, as I suspect different API's will have different opinions on this.

Currently it's also ignoring the serialization hint parameters like style/explode - just adding a todo for now.