### PR TITLE
feat: better support for additional properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - run: yarn ci-build
     - run: yarn ci-test
     - run: yarn ci-lint
+    - run: yarn ci-format
     - run: yarn integration:generate
     - run: yarn integration:validate
     - run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -112,3 +112,7 @@ dist
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+*.json
+*.yaml
+integration-tests

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,3 +2,4 @@ semi: false
 arrowParens: always
 bracketSpacing: false
 requirePragma: true
+trailingComma: all

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,4 @@
+semi: false
+arrowParens: always
+bracketSpacing: false
+requirePragma: true

--- a/integration-tests/typescript-angular/src/app/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/app/api.github.com.yaml/client.service.ts
@@ -334,13 +334,18 @@ export class ApiClient {
   }
 
   appsCreateFromManifest(p: { code: string }): Observable<
-    | (t_integration & {
-        client_id: string
-        client_secret: string
-        pem: string
-        webhook_secret: string | null
-        [key: string]: unknown
-      })
+    | (t_integration &
+        (
+          | {
+              client_id: string
+              client_secret: string
+              pem: string
+              webhook_secret: string | null
+            }
+          | {
+              [key: string]: unknown
+            }
+        ))
     | t_basic_error
     | t_validation_error_simple
   > {
@@ -728,7 +733,7 @@ export class ApiClient {
   }
 
   emojisGet(): Observable<{
-    [key: string]: unknown
+    [key: string]: string
   } | void> {
     return this.httpClient.request<any>(
       "GET",
@@ -900,7 +905,9 @@ export class ApiClient {
     requestBody: {
       description?: string
       files: {
-        [key: string]: unknown
+        [key: string]: {
+          content: string
+        }
       }
       public?: boolean | "true" | "false"
     }
@@ -999,7 +1006,9 @@ export class ApiClient {
     requestBody: {
       description?: string
       files?: {
-        [key: string]: unknown
+        [key: string]: {
+          [key: string]: never
+        } | null
       }
     } | null
   }): Observable<t_gist_simple | t_basic_error | t_validation_error> {
@@ -9127,13 +9136,14 @@ export class ApiClient {
           status: {
             [key: string]: never
           }
+        }
+      | {
           [key: string]: unknown
         }
       | {
           status?: {
             [key: string]: never
           }
-          [key: string]: unknown
         }
   }): Observable<t_check_run> {
     const headers = this._headers({ "Content-Type": "application/json" })

--- a/integration-tests/typescript-angular/src/app/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/app/api.github.com.yaml/client.service.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import {
+  EmptyObject,
   t_actions_billing_usage,
   t_actions_cache_list,
   t_actions_cache_usage_by_repository,
@@ -430,13 +431,9 @@ export class ApiClient {
     )
   }
 
-  appsRedeliverWebhookDelivery(p: { deliveryId: number }): Observable<
-    | {
-        [key: string]: never
-      }
-    | t_scim_error
-    | t_validation_error
-  > {
+  appsRedeliverWebhookDelivery(p: {
+    deliveryId: number
+  }): Observable<EmptyObject | t_scim_error | t_validation_error> {
     return this.httpClient.request<any>(
       "POST",
       this.config.basePath + `/app/hook/deliveries/${p["deliveryId"]}/attempts`,
@@ -1006,9 +1003,7 @@ export class ApiClient {
     requestBody: {
       description?: string
       files?: {
-        [key: string]: {
-          [key: string]: never
-        } | null
+        [key: string]: EmptyObject | null
       }
     } | null
   }): Observable<t_gist_simple | t_basic_error | t_validation_error> {
@@ -1199,14 +1194,9 @@ export class ApiClient {
     )
   }
 
-  gistsCheckIsStarred(p: { gistId: string }): Observable<
-    | void
-    | void
-    | t_basic_error
-    | {
-        [key: string]: never
-      }
-  > {
+  gistsCheckIsStarred(p: {
+    gistId: string
+  }): Observable<void | void | t_basic_error | EmptyObject> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/gists/${p["gistId"]}/star`,
@@ -1840,9 +1830,7 @@ export class ApiClient {
       reason?: string | null
     }
   }): Observable<
-    | {
-        [key: string]: never
-      }
+    | EmptyObject
     | t_basic_error
     | t_basic_error
     | t_validation_error
@@ -1964,9 +1952,7 @@ export class ApiClient {
       pat_ids: number[]
     }
   }): Observable<
-    | {
-        [key: string]: never
-      }
+    | EmptyObject
     | t_basic_error
     | t_basic_error
     | t_validation_error
@@ -2102,13 +2088,9 @@ export class ApiClient {
     )
   }
 
-  orgsDelete(p: { org: string }): Observable<
-    | {
-        [key: string]: never
-      }
-    | t_basic_error
-    | t_basic_error
-  > {
+  orgsDelete(p: {
+    org: string
+  }): Observable<EmptyObject | t_basic_error | t_basic_error> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/orgs/${p["org"]}`,
@@ -3974,13 +3956,7 @@ export class ApiClient {
     org: string
     hookId: number
     deliveryId: number
-  }): Observable<
-    | {
-        [key: string]: never
-      }
-    | t_scim_error
-    | t_validation_error
-  > {
+  }): Observable<EmptyObject | t_scim_error | t_validation_error> {
     return this.httpClient.request<any>(
       "POST",
       this.config.basePath +
@@ -4041,12 +4017,9 @@ export class ApiClient {
     )
   }
 
-  interactionsGetRestrictionsForOrg(p: { org: string }): Observable<
-    | t_interaction_limit_response
-    | {
-        [key: string]: never
-      }
-  > {
+  interactionsGetRestrictionsForOrg(p: {
+    org: string
+  }): Observable<t_interaction_limit_response | EmptyObject> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath + `/orgs/${p["org"]}/interaction-limits`,
@@ -4311,9 +4284,7 @@ export class ApiClient {
     username: string
     codespaceName: string
   }): Observable<
-    | {
-        [key: string]: never
-      }
+    | EmptyObject
     | void
     | t_basic_error
     | t_basic_error
@@ -4572,14 +4543,7 @@ export class ApiClient {
     requestBody?: {
       async?: boolean
     }
-  }): Observable<
-    | {
-        [key: string]: never
-      }
-    | void
-    | void
-    | t_basic_error
-  > {
+  }): Observable<EmptyObject | void | void | t_basic_error> {
     const headers = this._headers({ "Content-Type": "application/json" })
     const body = p["requestBody"]
 
@@ -6056,9 +6020,7 @@ export class ApiClient {
       position: string
     }
   }): Observable<
-    | {
-        [key: string]: never
-      }
+    | EmptyObject
     | void
     | t_basic_error
     | {
@@ -6216,9 +6178,7 @@ export class ApiClient {
       position: string
     }
   }): Observable<
-    | {
-        [key: string]: never
-      }
+    | EmptyObject
     | void
     | t_basic_error
     | t_basic_error
@@ -9133,17 +9093,13 @@ export class ApiClient {
     repo: string
     requestBody:
       | {
-          status: {
-            [key: string]: never
-          }
+          status: EmptyObject
         }
       | {
           [key: string]: unknown
         }
       | {
-          status?: {
-            [key: string]: never
-          }
+          status?: EmptyObject
         }
   }): Observable<t_check_run> {
     const headers = this._headers({ "Content-Type": "application/json" })
@@ -12176,13 +12132,7 @@ export class ApiClient {
     repo: string
     hookId: number
     deliveryId: number
-  }): Observable<
-    | {
-        [key: string]: never
-      }
-    | t_scim_error
-    | t_validation_error
-  > {
+  }): Observable<EmptyObject | t_scim_error | t_validation_error> {
     return this.httpClient.request<any>(
       "POST",
       this.config.basePath +
@@ -12406,12 +12356,7 @@ export class ApiClient {
   interactionsGetRestrictionsForRepo(p: {
     owner: string
     repo: string
-  }): Observable<
-    | t_interaction_limit_response
-    | {
-        [key: string]: never
-      }
-  > {
+  }): Observable<t_interaction_limit_response | EmptyObject> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -13515,9 +13460,10 @@ export class ApiClient {
     )
   }
 
-  reposEnableLfsForRepo(p: { owner: string; repo: string }): Observable<{
-    [key: string]: never
-  } | void> {
+  reposEnableLfsForRepo(p: {
+    owner: string
+    repo: string
+  }): Observable<EmptyObject | void> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/lfs`,
@@ -15669,13 +15615,10 @@ export class ApiClient {
     )
   }
 
-  reposGetCodeFrequencyStats(p: { owner: string; repo: string }): Observable<
-    | t_code_frequency_stat[]
-    | {
-        [key: string]: never
-      }
-    | void
-  > {
+  reposGetCodeFrequencyStats(p: {
+    owner: string
+    repo: string
+  }): Observable<t_code_frequency_stat[] | EmptyObject | void> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -15687,13 +15630,10 @@ export class ApiClient {
     )
   }
 
-  reposGetCommitActivityStats(p: { owner: string; repo: string }): Observable<
-    | t_commit_activity[]
-    | {
-        [key: string]: never
-      }
-    | void
-  > {
+  reposGetCommitActivityStats(p: {
+    owner: string
+    repo: string
+  }): Observable<t_commit_activity[] | EmptyObject | void> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -15705,13 +15645,10 @@ export class ApiClient {
     )
   }
 
-  reposGetContributorsStats(p: { owner: string; repo: string }): Observable<
-    | t_contributor_activity[]
-    | {
-        [key: string]: never
-      }
-    | void
-  > {
+  reposGetContributorsStats(p: {
+    owner: string
+    repo: string
+  }): Observable<t_contributor_activity[] | EmptyObject | void> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -17795,9 +17732,7 @@ export class ApiClient {
   codespacesDeleteForAuthenticatedUser(p: {
     codespaceName: string
   }): Observable<
-    | {
-        [key: string]: never
-      }
+    | EmptyObject
     | void
     | t_basic_error
     | t_basic_error
@@ -18326,13 +18261,7 @@ export class ApiClient {
   }
 
   interactionsGetRestrictionsForAuthenticatedUser(): Observable<
-    | (
-        | t_interaction_limit_response
-        | {
-            [key: string]: never
-          }
-      )
-    | void
+    (t_interaction_limit_response | EmptyObject) | void
   > {
     return this.httpClient.request<any>(
       "GET",

--- a/integration-tests/typescript-angular/src/app/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/app/api.github.com.yaml/models.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export type EmptyObject = { [key: string]: never }
+
 export type t_actions_billing_usage = {
   included_minutes: number
   minutes_used_breakdown: {
@@ -246,9 +248,7 @@ export type t_assigned_issue_event = {
 
 export type t_authentication_token = {
   expires_at: string
-  permissions?: {
-    [key: string]: never
-  }
+  permissions?: EmptyObject
   repositories?: t_repository[]
   repository_selection?: "all" | "selected"
   single_file?: string | null
@@ -316,15 +316,11 @@ export type t_base_gist = {
       type?: string
     }
   }
-  forks?: {
-    [key: string]: never
-  }[]
+  forks?: EmptyObject[]
   forks_url: string
   git_pull_url: string
   git_push_url: string
-  history?: {
-    [key: string]: never
-  }[]
+  history?: EmptyObject[]
   html_url: string
   id: string
   node_id: string
@@ -1671,9 +1667,7 @@ export type t_email = {
   visibility: string | null
 }
 
-export type t_empty_object = {
-  [key: string]: never
-}
+export type t_empty_object = EmptyObject
 
 export type t_enabled_repositories = "all" | "none" | "selected"
 
@@ -2019,15 +2013,11 @@ export type t_gist_simple = {
         type?: string
       }
     }
-    forks?: {
-      [key: string]: never
-    }[]
+    forks?: EmptyObject[]
     forks_url: string
     git_pull_url: string
     git_push_url: string
-    history?: {
-      [key: string]: never
-    }[]
+    history?: EmptyObject[]
     html_url: string
     id: string
     node_id: string
@@ -2179,9 +2169,7 @@ export type t_gpg_key = {
     public_key?: string
     raw_key?: string | null
     revoked?: boolean
-    subkeys?: {
-      [key: string]: never
-    }[]
+    subkeys?: EmptyObject[]
   }[]
 }
 

--- a/integration-tests/typescript-angular/src/app/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/app/api.github.com.yaml/models.ts
@@ -308,7 +308,13 @@ export type t_base_gist = {
   created_at: string
   description: string | null
   files: {
-    [key: string]: unknown
+    [key: string]: {
+      filename?: string
+      language?: string
+      raw_url?: string
+      size?: number
+      type?: string
+    }
   }
   forks?: {
     [key: string]: never
@@ -1478,6 +1484,14 @@ export type t_dependabot_secret = {
   updated_at: string
 }
 
+export type t_dependency = {
+  dependencies?: string[]
+  metadata?: t_metadata
+  package_url?: string
+  relationship?: "direct" | "indirect"
+  scope?: "runtime" | "development"
+}
+
 export type t_dependency_graph_diff = {
   change_type: "added" | "removed"
   ecosystem: string
@@ -1980,7 +1994,15 @@ export type t_gist_simple = {
   created_at?: string
   description?: string | null
   files?: {
-    [key: string]: unknown
+    [key: string]: {
+      content?: string
+      filename?: string
+      language?: string
+      raw_url?: string
+      size?: number
+      truncated?: boolean
+      type?: string
+    } | null
   }
   fork_of?: {
     comments: number
@@ -1989,7 +2011,13 @@ export type t_gist_simple = {
     created_at: string
     description: string | null
     files: {
-      [key: string]: unknown
+      [key: string]: {
+        filename?: string
+        language?: string
+        raw_url?: string
+        size?: number
+        type?: string
+      }
     }
     forks?: {
       [key: string]: never
@@ -2334,14 +2362,17 @@ export type t_integration = {
   node_id: string
   owner: t_nullable_simple_user
   pem?: string
-  permissions: {
-    checks?: string
-    contents?: string
-    deployments?: string
-    issues?: string
-    metadata?: string
-    [key: string]: unknown
-  }
+  permissions:
+    | {
+        checks?: string
+        contents?: string
+        deployments?: string
+        issues?: string
+        metadata?: string
+      }
+    | {
+        [key: string]: string
+      }
   slug?: string
   updated_at: string
   webhook_secret?: string | null
@@ -2668,7 +2699,7 @@ export type t_labeled_issue_event = {
 }
 
 export type t_language = {
-  [key: string]: unknown
+  [key: string]: number
 }
 
 export type t_license = {
@@ -2738,6 +2769,17 @@ export type t_locked_issue_event = {
   url: string
 }
 
+export type t_manifest = {
+  file?: {
+    source_location?: string
+  }
+  metadata?: t_metadata
+  name: string
+  resolved?: {
+    [key: string]: t_dependency
+  }
+}
+
 export type t_marketplace_account = {
   email?: string | null
   id: number
@@ -2797,7 +2839,7 @@ export type t_merged_upstream = {
 }
 
 export type t_metadata = {
-  [key: string]: unknown
+  [key: string]: string | number | boolean | null
 }
 
 export type t_migration = {
@@ -3052,14 +3094,17 @@ export type t_nullable_integration = {
   node_id: string
   owner: t_nullable_simple_user
   pem?: string
-  permissions: {
-    checks?: string
-    contents?: string
-    deployments?: string
-    issues?: string
-    metadata?: string
-    [key: string]: unknown
-  }
+  permissions:
+    | {
+        checks?: string
+        contents?: string
+        deployments?: string
+        issues?: string
+        metadata?: string
+      }
+    | {
+        [key: string]: string
+      }
   slug?: string
   updated_at: string
   webhook_secret?: string | null
@@ -3689,13 +3734,13 @@ export type t_organization_programmatic_access_grant = {
   owner: t_simple_user
   permissions: {
     organization?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     other?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     repository?: {
-      [key: string]: unknown
+      [key: string]: string
     }
   }
   repositories_url: string
@@ -3711,13 +3756,13 @@ export type t_organization_programmatic_access_grant_request = {
   owner: t_simple_user
   permissions: {
     organization?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     other?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     repository?: {
-      [key: string]: unknown
+      [key: string]: string
     }
   }
   reason: string | null
@@ -5965,7 +6010,7 @@ export type t_snapshot = {
     id: string
   }
   manifests?: {
-    [key: string]: unknown
+    [key: string]: t_manifest
   }
   metadata?: t_metadata
   ref: string

--- a/integration-tests/typescript-fetch/src/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.yaml/client.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import {
+  EmptyObject,
   t_actions_billing_usage,
   t_actions_cache_list,
   t_actions_cache_usage_by_repository,
@@ -398,13 +399,10 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async appsRedeliverWebhookDelivery(p: { deliveryId: number }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+  async appsRedeliverWebhookDelivery(p: {
+    deliveryId: number
+  }): Promise<
+    | Response<202, EmptyObject>
     | Response<400, t_scim_error>
     | Response<422, t_validation_error>
   > {
@@ -921,9 +919,7 @@ export class ApiClient extends AbstractFetchClient {
     requestBody: {
       description?: string
       files?: {
-        [key: string]: {
-          [key: string]: never
-        } | null
+        [key: string]: EmptyObject | null
       }
     } | null
   }): Promise<
@@ -1108,16 +1104,13 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async gistsCheckIsStarred(p: { gistId: string }): Promise<
+  async gistsCheckIsStarred(p: {
+    gistId: string
+  }): Promise<
     | Response<204, void>
     | Response<304, void>
     | Response<403, t_basic_error>
-    | Response<
-        404,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<404, EmptyObject>
   > {
     const url = this.basePath + `/gists/${p["gistId"]}/star`
 
@@ -1709,12 +1702,7 @@ export class ApiClient extends AbstractFetchClient {
       reason?: string | null
     }
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<403, t_basic_error>
     | Response<404, t_basic_error>
     | Response<422, t_validation_error>
@@ -1821,12 +1809,7 @@ export class ApiClient extends AbstractFetchClient {
       pat_ids: number[]
     }
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<403, t_basic_error>
     | Response<404, t_basic_error>
     | Response<422, t_validation_error>
@@ -1947,13 +1930,10 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async orgsDelete(p: { org: string }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+  async orgsDelete(p: {
+    org: string
+  }): Promise<
+    | Response<202, EmptyObject>
     | Response<403, t_basic_error>
     | Response<404, t_basic_error>
   > {
@@ -3622,12 +3602,7 @@ export class ApiClient extends AbstractFetchClient {
     hookId: number
     deliveryId: number
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<400, t_scim_error>
     | Response<422, t_validation_error>
   > {
@@ -3685,15 +3660,9 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async interactionsGetRestrictionsForOrg(p: { org: string }): Promise<
-    Response<
-      200,
-      | t_interaction_limit_response
-      | {
-          [key: string]: never
-        }
-    >
-  > {
+  async interactionsGetRestrictionsForOrg(p: {
+    org: string
+  }): Promise<Response<200, t_interaction_limit_response | EmptyObject>> {
     const url = this.basePath + `/orgs/${p["org"]}/interaction-limits`
 
     const res = await fetch(url, { method: "GET" })
@@ -3923,12 +3892,7 @@ export class ApiClient extends AbstractFetchClient {
     username: string
     codespaceName: string
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<304, void>
     | Response<401, t_basic_error>
     | Response<403, t_basic_error>
@@ -4162,12 +4126,7 @@ export class ApiClient extends AbstractFetchClient {
       async?: boolean
     }
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<204, void>
     | Response<403, void>
     | Response<404, t_basic_error>
@@ -5494,12 +5453,7 @@ export class ApiClient extends AbstractFetchClient {
       position: string
     }
   }): Promise<
-    | Response<
-        201,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<201, EmptyObject>
     | Response<304, void>
     | Response<401, t_basic_error>
     | Response<
@@ -5658,12 +5612,7 @@ export class ApiClient extends AbstractFetchClient {
       position: string
     }
   }): Promise<
-    | Response<
-        201,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<201, EmptyObject>
     | Response<304, void>
     | Response<401, t_basic_error>
     | Response<403, t_basic_error>
@@ -8337,17 +8286,13 @@ export class ApiClient extends AbstractFetchClient {
     repo: string
     requestBody:
       | {
-          status: {
-            [key: string]: never
-          }
+          status: EmptyObject
         }
       | {
           [key: string]: unknown
         }
       | {
-          status?: {
-            [key: string]: never
-          }
+          status?: EmptyObject
         }
   }): Promise<Response<201, t_check_run>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/check-runs`
@@ -11121,12 +11066,7 @@ export class ApiClient extends AbstractFetchClient {
     hookId: number
     deliveryId: number
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<400, t_scim_error>
     | Response<422, t_validation_error>
   > {
@@ -11339,15 +11279,7 @@ export class ApiClient extends AbstractFetchClient {
   async interactionsGetRestrictionsForRepo(p: {
     owner: string
     repo: string
-  }): Promise<
-    Response<
-      200,
-      | t_interaction_limit_response
-      | {
-          [key: string]: never
-        }
-    >
-  > {
+  }): Promise<Response<200, t_interaction_limit_response | EmptyObject>> {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`
 
@@ -12342,15 +12274,10 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async reposEnableLfsForRepo(p: { owner: string; repo: string }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
-    | Response<403, void>
-  > {
+  async reposEnableLfsForRepo(p: {
+    owner: string
+    repo: string
+  }): Promise<Response<202, EmptyObject> | Response<403, void>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/lfs`
 
     const res = await fetch(url, { method: "PUT" })
@@ -14313,14 +14240,12 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async reposGetCodeFrequencyStats(p: { owner: string; repo: string }): Promise<
+  async reposGetCodeFrequencyStats(p: {
+    owner: string
+    repo: string
+  }): Promise<
     | Response<200, t_code_frequency_stat[]>
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<204, void>
   > {
     const url =
@@ -14337,12 +14262,7 @@ export class ApiClient extends AbstractFetchClient {
     repo: string
   }): Promise<
     | Response<200, t_commit_activity[]>
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<204, void>
   > {
     const url =
@@ -14354,14 +14274,12 @@ export class ApiClient extends AbstractFetchClient {
     return { status: res.status as any, body: (await res.json()) as any }
   }
 
-  async reposGetContributorsStats(p: { owner: string; repo: string }): Promise<
+  async reposGetContributorsStats(p: {
+    owner: string
+    repo: string
+  }): Promise<
     | Response<200, t_contributor_activity[]>
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<204, void>
   > {
     const url =
@@ -16245,12 +16163,7 @@ export class ApiClient extends AbstractFetchClient {
   async codespacesDeleteForAuthenticatedUser(p: {
     codespaceName: string
   }): Promise<
-    | Response<
-        202,
-        {
-          [key: string]: never
-        }
-      >
+    | Response<202, EmptyObject>
     | Response<304, void>
     | Response<401, t_basic_error>
     | Response<403, t_basic_error>
@@ -16742,13 +16655,7 @@ export class ApiClient extends AbstractFetchClient {
   }
 
   async interactionsGetRestrictionsForAuthenticatedUser(): Promise<
-    | Response<
-        200,
-        | t_interaction_limit_response
-        | {
-            [key: string]: never
-          }
-      >
+    | Response<200, t_interaction_limit_response | EmptyObject>
     | Response<204, void>
   > {
     const url = this.basePath + `/user/interaction-limits`

--- a/integration-tests/typescript-fetch/src/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.yaml/client.ts
@@ -310,13 +310,18 @@ export class ApiClient extends AbstractFetchClient {
   async appsCreateFromManifest(p: { code: string }): Promise<
     | Response<
         201,
-        t_integration & {
-          client_id: string
-          client_secret: string
-          pem: string
-          webhook_secret: string | null
-          [key: string]: unknown
-        }
+        t_integration &
+          (
+            | {
+                client_id: string
+                client_secret: string
+                pem: string
+                webhook_secret: string | null
+              }
+            | {
+                [key: string]: unknown
+              }
+          )
       >
     | Response<404, t_basic_error>
     | Response<422, t_validation_error_simple>
@@ -658,7 +663,7 @@ export class ApiClient extends AbstractFetchClient {
     | Response<
         200,
         {
-          [key: string]: unknown
+          [key: string]: string
         }
       >
     | Response<304, void>
@@ -816,7 +821,9 @@ export class ApiClient extends AbstractFetchClient {
     requestBody: {
       description?: string
       files: {
-        [key: string]: unknown
+        [key: string]: {
+          content: string
+        }
       }
       public?: boolean | "true" | "false"
     }
@@ -914,7 +921,9 @@ export class ApiClient extends AbstractFetchClient {
     requestBody: {
       description?: string
       files?: {
-        [key: string]: unknown
+        [key: string]: {
+          [key: string]: never
+        } | null
       }
     } | null
   }): Promise<
@@ -8331,13 +8340,14 @@ export class ApiClient extends AbstractFetchClient {
           status: {
             [key: string]: never
           }
+        }
+      | {
           [key: string]: unknown
         }
       | {
           status?: {
             [key: string]: never
           }
-          [key: string]: unknown
         }
   }): Promise<Response<201, t_check_run>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/check-runs`

--- a/integration-tests/typescript-fetch/src/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.yaml/models.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export type EmptyObject = { [key: string]: never }
+
 export type t_actions_billing_usage = {
   included_minutes: number
   minutes_used_breakdown: {
@@ -246,9 +248,7 @@ export type t_assigned_issue_event = {
 
 export type t_authentication_token = {
   expires_at: string
-  permissions?: {
-    [key: string]: never
-  }
+  permissions?: EmptyObject
   repositories?: t_repository[]
   repository_selection?: "all" | "selected"
   single_file?: string | null
@@ -316,15 +316,11 @@ export type t_base_gist = {
       type?: string
     }
   }
-  forks?: {
-    [key: string]: never
-  }[]
+  forks?: EmptyObject[]
   forks_url: string
   git_pull_url: string
   git_push_url: string
-  history?: {
-    [key: string]: never
-  }[]
+  history?: EmptyObject[]
   html_url: string
   id: string
   node_id: string
@@ -1671,9 +1667,7 @@ export type t_email = {
   visibility: string | null
 }
 
-export type t_empty_object = {
-  [key: string]: never
-}
+export type t_empty_object = EmptyObject
 
 export type t_enabled_repositories = "all" | "none" | "selected"
 
@@ -2019,15 +2013,11 @@ export type t_gist_simple = {
         type?: string
       }
     }
-    forks?: {
-      [key: string]: never
-    }[]
+    forks?: EmptyObject[]
     forks_url: string
     git_pull_url: string
     git_push_url: string
-    history?: {
-      [key: string]: never
-    }[]
+    history?: EmptyObject[]
     html_url: string
     id: string
     node_id: string
@@ -2179,9 +2169,7 @@ export type t_gpg_key = {
     public_key?: string
     raw_key?: string | null
     revoked?: boolean
-    subkeys?: {
-      [key: string]: never
-    }[]
+    subkeys?: EmptyObject[]
   }[]
 }
 

--- a/integration-tests/typescript-fetch/src/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/api.github.com.yaml/models.ts
@@ -308,7 +308,13 @@ export type t_base_gist = {
   created_at: string
   description: string | null
   files: {
-    [key: string]: unknown
+    [key: string]: {
+      filename?: string
+      language?: string
+      raw_url?: string
+      size?: number
+      type?: string
+    }
   }
   forks?: {
     [key: string]: never
@@ -1478,6 +1484,14 @@ export type t_dependabot_secret = {
   updated_at: string
 }
 
+export type t_dependency = {
+  dependencies?: string[]
+  metadata?: t_metadata
+  package_url?: string
+  relationship?: "direct" | "indirect"
+  scope?: "runtime" | "development"
+}
+
 export type t_dependency_graph_diff = {
   change_type: "added" | "removed"
   ecosystem: string
@@ -1980,7 +1994,15 @@ export type t_gist_simple = {
   created_at?: string
   description?: string | null
   files?: {
-    [key: string]: unknown
+    [key: string]: {
+      content?: string
+      filename?: string
+      language?: string
+      raw_url?: string
+      size?: number
+      truncated?: boolean
+      type?: string
+    } | null
   }
   fork_of?: {
     comments: number
@@ -1989,7 +2011,13 @@ export type t_gist_simple = {
     created_at: string
     description: string | null
     files: {
-      [key: string]: unknown
+      [key: string]: {
+        filename?: string
+        language?: string
+        raw_url?: string
+        size?: number
+        type?: string
+      }
     }
     forks?: {
       [key: string]: never
@@ -2334,14 +2362,17 @@ export type t_integration = {
   node_id: string
   owner: t_nullable_simple_user
   pem?: string
-  permissions: {
-    checks?: string
-    contents?: string
-    deployments?: string
-    issues?: string
-    metadata?: string
-    [key: string]: unknown
-  }
+  permissions:
+    | {
+        checks?: string
+        contents?: string
+        deployments?: string
+        issues?: string
+        metadata?: string
+      }
+    | {
+        [key: string]: string
+      }
   slug?: string
   updated_at: string
   webhook_secret?: string | null
@@ -2668,7 +2699,7 @@ export type t_labeled_issue_event = {
 }
 
 export type t_language = {
-  [key: string]: unknown
+  [key: string]: number
 }
 
 export type t_license = {
@@ -2738,6 +2769,17 @@ export type t_locked_issue_event = {
   url: string
 }
 
+export type t_manifest = {
+  file?: {
+    source_location?: string
+  }
+  metadata?: t_metadata
+  name: string
+  resolved?: {
+    [key: string]: t_dependency
+  }
+}
+
 export type t_marketplace_account = {
   email?: string | null
   id: number
@@ -2797,7 +2839,7 @@ export type t_merged_upstream = {
 }
 
 export type t_metadata = {
-  [key: string]: unknown
+  [key: string]: string | number | boolean | null
 }
 
 export type t_migration = {
@@ -3052,14 +3094,17 @@ export type t_nullable_integration = {
   node_id: string
   owner: t_nullable_simple_user
   pem?: string
-  permissions: {
-    checks?: string
-    contents?: string
-    deployments?: string
-    issues?: string
-    metadata?: string
-    [key: string]: unknown
-  }
+  permissions:
+    | {
+        checks?: string
+        contents?: string
+        deployments?: string
+        issues?: string
+        metadata?: string
+      }
+    | {
+        [key: string]: string
+      }
   slug?: string
   updated_at: string
   webhook_secret?: string | null
@@ -3689,13 +3734,13 @@ export type t_organization_programmatic_access_grant = {
   owner: t_simple_user
   permissions: {
     organization?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     other?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     repository?: {
-      [key: string]: unknown
+      [key: string]: string
     }
   }
   repositories_url: string
@@ -3711,13 +3756,13 @@ export type t_organization_programmatic_access_grant_request = {
   owner: t_simple_user
   permissions: {
     organization?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     other?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     repository?: {
-      [key: string]: unknown
+      [key: string]: string
     }
   }
   reason: string | null
@@ -5965,7 +6010,7 @@ export type t_snapshot = {
     id: string
   }
   manifests?: {
-    [key: string]: unknown
+    [key: string]: t_manifest
   }
   metadata?: t_metadata
   ref: string

--- a/integration-tests/typescript-koa/src/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/api.github.com.yaml/generated.ts
@@ -1414,6 +1414,7 @@ import {
   t_dependabot_alert_with_repository,
   t_dependabot_public_key,
   t_dependabot_secret,
+  t_dependency,
   t_dependency_graph_diff,
   t_dependency_graph_spdx_sbom,
   t_deploy_key,
@@ -1481,6 +1482,7 @@ import {
   t_link,
   t_link_with_type,
   t_locked_issue_event,
+  t_manifest,
   t_marketplace_account,
   t_marketplace_listing_plan,
   t_marketplace_purchase,
@@ -1987,13 +1989,18 @@ export type AppsCreateFromManifest = (
 ) => Promise<
   | Response<
       201,
-      t_integration & {
-        client_id: string
-        client_secret: string
-        pem: string
-        webhook_secret: string | null
-        [key: string]: unknown
-      }
+      t_integration &
+        (
+          | {
+              client_id: string
+              client_secret: string
+              pem: string
+              webhook_secret: string | null
+            }
+          | {
+              [key: string]: unknown
+            }
+        )
     >
   | Response<404, t_basic_error>
   | Response<422, t_validation_error_simple>
@@ -2167,7 +2174,7 @@ export type EmojisGet = (
   | Response<
       200,
       {
-        [key: string]: unknown
+        [key: string]: string
       }
     >
   | Response<304, void>

--- a/integration-tests/typescript-koa/src/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/api.github.com.yaml/generated.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import {
+  EmptyObject,
   t_ActionsAddCustomLabelsToSelfHostedRunnerForOrgBodySchema,
   t_ActionsAddCustomLabelsToSelfHostedRunnerForOrgParamSchema,
   t_ActionsAddCustomLabelsToSelfHostedRunnerForRepoBodySchema,
@@ -2038,12 +2039,7 @@ export type AppsRedeliverWebhookDelivery = (
   params: Params<t_AppsRedeliverWebhookDeliveryParamSchema, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<400, t_scim_error>
   | Response<422, t_validation_error>
 >
@@ -2431,12 +2427,7 @@ export type GistsCheckIsStarred = (
   | Response<204, void>
   | Response<304, void>
   | Response<403, t_basic_error>
-  | Response<
-      404,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<404, EmptyObject>
 >
 
 export type GistsStar = (
@@ -2746,12 +2737,7 @@ export type OrgsReviewPatGrantRequestsInBulk = (
   >,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<403, t_basic_error>
   | Response<404, t_basic_error>
   | Response<422, t_validation_error>
@@ -2810,12 +2796,7 @@ export type OrgsUpdatePatAccesses = (
   >,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<403, t_basic_error>
   | Response<404, t_basic_error>
   | Response<422, t_validation_error>
@@ -2873,12 +2854,7 @@ export type OrgsDelete = (
   params: Params<t_OrgsDeleteParamSchema, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<403, t_basic_error>
   | Response<404, t_basic_error>
 >
@@ -3842,12 +3818,7 @@ export type OrgsRedeliverWebhookDelivery = (
   params: Params<t_OrgsRedeliverWebhookDeliveryParamSchema, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<400, t_scim_error>
   | Response<422, t_validation_error>
 >
@@ -3882,15 +3853,7 @@ export type OrgsListAppInstallations = (
 export type InteractionsGetRestrictionsForOrg = (
   params: Params<t_InteractionsGetRestrictionsForOrgParamSchema, void, void>,
   ctx: Context
-) => Promise<
-  Response<
-    200,
-    | t_interaction_limit_response
-    | {
-        [key: string]: never
-      }
-  >
->
+) => Promise<Response<200, t_interaction_limit_response | EmptyObject>>
 
 export type InteractionsSetRestrictionsForOrg = (
   params: Params<
@@ -4005,12 +3968,7 @@ export type CodespacesDeleteFromOrganization = (
   params: Params<t_CodespacesDeleteFromOrganizationParamSchema, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<304, void>
   | Response<401, t_basic_error>
   | Response<403, t_basic_error>
@@ -4135,12 +4093,7 @@ export type OrgsConvertMemberToOutsideCollaborator = (
   >,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<204, void>
   | Response<403, void>
   | Response<404, t_basic_error>
@@ -4770,12 +4723,7 @@ export type ProjectsMoveCard = (
   >,
   ctx: Context
 ) => Promise<
-  | Response<
-      201,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<201, EmptyObject>
   | Response<304, void>
   | Response<401, t_basic_error>
   | Response<
@@ -4890,12 +4838,7 @@ export type ProjectsMoveColumn = (
   >,
   ctx: Context
 ) => Promise<
-  | Response<
-      201,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<201, EmptyObject>
   | Response<304, void>
   | Response<401, t_basic_error>
   | Response<403, t_basic_error>
@@ -7552,12 +7495,7 @@ export type ReposRedeliverWebhookDelivery = (
   params: Params<t_ReposRedeliverWebhookDeliveryParamSchema, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<400, t_scim_error>
   | Response<422, t_validation_error>
 >
@@ -7668,15 +7606,7 @@ export type AppsGetRepoInstallation = (
 export type InteractionsGetRestrictionsForRepo = (
   params: Params<t_InteractionsGetRestrictionsForRepoParamSchema, void, void>,
   ctx: Context
-) => Promise<
-  Response<
-    200,
-    | t_interaction_limit_response
-    | {
-        [key: string]: never
-      }
-  >
->
+) => Promise<Response<200, t_interaction_limit_response | EmptyObject>>
 
 export type InteractionsSetRestrictionsForRepo = (
   params: Params<
@@ -8136,15 +8066,7 @@ export type ReposListLanguages = (
 export type ReposEnableLfsForRepo = (
   params: Params<t_ReposEnableLfsForRepoParamSchema, void, void>,
   ctx: Context
-) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
-  | Response<403, void>
->
+) => Promise<Response<202, EmptyObject> | Response<403, void>>
 
 export type ReposDisableLfsForRepo = (
   params: Params<t_ReposDisableLfsForRepoParamSchema, void, void>,
@@ -9124,12 +9046,7 @@ export type ReposGetCodeFrequencyStats = (
   ctx: Context
 ) => Promise<
   | Response<200, t_code_frequency_stat[]>
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<204, void>
 >
 
@@ -9138,12 +9055,7 @@ export type ReposGetCommitActivityStats = (
   ctx: Context
 ) => Promise<
   | Response<200, t_commit_activity[]>
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<204, void>
 >
 
@@ -9152,12 +9064,7 @@ export type ReposGetContributorsStats = (
   ctx: Context
 ) => Promise<
   | Response<200, t_contributor_activity[]>
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<204, void>
 >
 
@@ -10137,12 +10044,7 @@ export type CodespacesDeleteForAuthenticatedUser = (
   params: Params<t_CodespacesDeleteForAuthenticatedUserParamSchema, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      202,
-      {
-        [key: string]: never
-      }
-    >
+  | Response<202, EmptyObject>
   | Response<304, void>
   | Response<401, t_basic_error>
   | Response<403, t_basic_error>
@@ -10481,13 +10383,7 @@ export type InteractionsGetRestrictionsForAuthenticatedUser = (
   params: Params<void, void, void>,
   ctx: Context
 ) => Promise<
-  | Response<
-      200,
-      | t_interaction_limit_response
-      | {
-          [key: string]: never
-        }
-    >
+  | Response<200, t_interaction_limit_response | EmptyObject>
   | Response<204, void>
 >
 

--- a/integration-tests/typescript-koa/src/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/api.github.com.yaml/models.ts
@@ -303,7 +303,13 @@ export type t_base_gist = {
   created_at: string
   description: string | null
   files: {
-    [key: string]: unknown
+    [key: string]: {
+      filename?: string
+      language?: string
+      raw_url?: string
+      size?: number
+      type?: string
+    }
   }
   forks?: {
     [key: string]: never
@@ -1468,6 +1474,14 @@ export type t_dependabot_secret = {
   updated_at: string
 }
 
+export type t_dependency = {
+  dependencies?: string[]
+  metadata?: t_metadata
+  package_url?: string
+  relationship?: "direct" | "indirect"
+  scope?: "runtime" | "development"
+}
+
 export type t_dependency_graph_diff = {
   change_type: "added" | "removed"
   ecosystem: string
@@ -1966,7 +1980,15 @@ export type t_gist_simple = {
   created_at?: string
   description?: string | null
   files?: {
-    [key: string]: unknown
+    [key: string]: {
+      content?: string
+      filename?: string
+      language?: string
+      raw_url?: string
+      size?: number
+      truncated?: boolean
+      type?: string
+    } | null
   }
   fork_of?: {
     comments: number
@@ -1975,7 +1997,13 @@ export type t_gist_simple = {
     created_at: string
     description: string | null
     files: {
-      [key: string]: unknown
+      [key: string]: {
+        filename?: string
+        language?: string
+        raw_url?: string
+        size?: number
+        type?: string
+      }
     }
     forks?: {
       [key: string]: never
@@ -2320,14 +2348,17 @@ export type t_integration = {
   node_id: string
   owner: t_nullable_simple_user
   pem?: string
-  permissions: {
-    checks?: string
-    contents?: string
-    deployments?: string
-    issues?: string
-    metadata?: string
-    [key: string]: unknown
-  }
+  permissions:
+    | {
+        checks?: string
+        contents?: string
+        deployments?: string
+        issues?: string
+        metadata?: string
+      }
+    | {
+        [key: string]: string
+      }
   slug?: string
   updated_at: string
   webhook_secret?: string | null
@@ -2649,7 +2680,7 @@ export type t_labeled_issue_event = {
 }
 
 export type t_language = {
-  [key: string]: unknown
+  [key: string]: number
 }
 
 export type t_license = {
@@ -2719,6 +2750,17 @@ export type t_locked_issue_event = {
   url: string
 }
 
+export type t_manifest = {
+  file?: {
+    source_location?: string
+  }
+  metadata?: t_metadata
+  name: string
+  resolved?: {
+    [key: string]: t_dependency
+  }
+}
+
 export type t_marketplace_account = {
   email?: string | null
   id: number
@@ -2778,7 +2820,7 @@ export type t_merged_upstream = {
 }
 
 export type t_metadata = {
-  [key: string]: unknown
+  [key: string]: string | number | boolean | null
 }
 
 export type t_migration = {
@@ -3033,14 +3075,17 @@ export type t_nullable_integration = {
   node_id: string
   owner: t_nullable_simple_user
   pem?: string
-  permissions: {
-    checks?: string
-    contents?: string
-    deployments?: string
-    issues?: string
-    metadata?: string
-    [key: string]: unknown
-  }
+  permissions:
+    | {
+        checks?: string
+        contents?: string
+        deployments?: string
+        issues?: string
+        metadata?: string
+      }
+    | {
+        [key: string]: string
+      }
   slug?: string
   updated_at: string
   webhook_secret?: string | null
@@ -3670,13 +3715,13 @@ export type t_organization_programmatic_access_grant = {
   owner: t_simple_user
   permissions: {
     organization?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     other?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     repository?: {
-      [key: string]: unknown
+      [key: string]: string
     }
   }
   repositories_url: string
@@ -3692,13 +3737,13 @@ export type t_organization_programmatic_access_grant_request = {
   owner: t_simple_user
   permissions: {
     organization?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     other?: {
-      [key: string]: unknown
+      [key: string]: string
     }
     repository?: {
-      [key: string]: unknown
+      [key: string]: string
     }
   }
   reason: string | null
@@ -8249,13 +8294,14 @@ export type t_ChecksCreateBodySchema =
       status: {
         [key: string]: never
       }
+    }
+  | {
       [key: string]: unknown
     }
   | {
       status?: {
         [key: string]: never
       }
-      [key: string]: unknown
     }
 
 export type t_ChecksCreateParamSchema = {
@@ -9129,7 +9175,7 @@ export type t_DependencyGraphCreateRepositorySnapshotBodySchema = {
     id: string
   }
   manifests?: {
-    [key: string]: unknown
+    [key: string]: t_manifest
   }
   metadata?: t_metadata
   ref: string
@@ -9165,7 +9211,9 @@ export type t_GistsCheckIsStarredParamSchema = {
 export type t_GistsCreateBodySchema = {
   description?: string
   files: {
-    [key: string]: unknown
+    [key: string]: {
+      content: string
+    }
   }
   public?: boolean | "true" | "false"
 }
@@ -9271,7 +9319,9 @@ export type t_GistsUnstarParamSchema = {
 export type t_GistsUpdateBodySchema = {
   description?: string
   files?: {
-    [key: string]: unknown
+    [key: string]: {
+      [key: string]: never
+    } | null
   }
 } | null
 

--- a/integration-tests/typescript-koa/src/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/api.github.com.yaml/models.ts
@@ -2,6 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export type EmptyObject = { [key: string]: never }
+
 export type t_actions_billing_usage = {
   included_minutes: number
   minutes_used_breakdown: {
@@ -241,9 +243,7 @@ export type t_assigned_issue_event = {
 
 export type t_authentication_token = {
   expires_at: string
-  permissions?: {
-    [key: string]: never
-  }
+  permissions?: EmptyObject
   repositories?: t_repository[]
   repository_selection?: "all" | "selected"
   single_file?: string | null
@@ -311,15 +311,11 @@ export type t_base_gist = {
       type?: string
     }
   }
-  forks?: {
-    [key: string]: never
-  }[]
+  forks?: EmptyObject[]
   forks_url: string
   git_pull_url: string
   git_push_url: string
-  history?: {
-    [key: string]: never
-  }[]
+  history?: EmptyObject[]
   html_url: string
   id: string
   node_id: string
@@ -1657,9 +1653,7 @@ export type t_email = {
   visibility: string | null
 }
 
-export type t_empty_object = {
-  [key: string]: never
-}
+export type t_empty_object = EmptyObject
 
 export type t_enabled_repositories = "all" | "none" | "selected"
 
@@ -2005,15 +1999,11 @@ export type t_gist_simple = {
         type?: string
       }
     }
-    forks?: {
-      [key: string]: never
-    }[]
+    forks?: EmptyObject[]
     forks_url: string
     git_pull_url: string
     git_push_url: string
-    history?: {
-      [key: string]: never
-    }[]
+    history?: EmptyObject[]
     html_url: string
     id: string
     node_id: string
@@ -2165,9 +2155,7 @@ export type t_gpg_key = {
     public_key?: string
     raw_key?: string | null
     revoked?: boolean
-    subkeys?: {
-      [key: string]: never
-    }[]
+    subkeys?: EmptyObject[]
   }[]
 }
 
@@ -8291,17 +8279,13 @@ export type t_BillingGetSharedStorageBillingUserParamSchema = {
 
 export type t_ChecksCreateBodySchema =
   | {
-      status: {
-        [key: string]: never
-      }
+      status: EmptyObject
     }
   | {
       [key: string]: unknown
     }
   | {
-      status?: {
-        [key: string]: never
-      }
+      status?: EmptyObject
     }
 
 export type t_ChecksCreateParamSchema = {
@@ -9319,9 +9303,7 @@ export type t_GistsUnstarParamSchema = {
 export type t_GistsUpdateBodySchema = {
   description?: string
   files?: {
-    [key: string]: {
-      [key: string]: never
-    } | null
+    [key: string]: EmptyObject | null
   }
 } | null
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "refresh": "./scripts/refresh-data.sh",
     "start": "nodemon",
     "lint": "eslint . --cache --report-unused-disable-directives --fix",
+    "format": "prettier --write .",
     "build": "lerna run build --scope '@nahkies/*'",
     "test": "jest",
     "integration:generate": "lerna run generate --stream --concurrency 1",
@@ -16,7 +17,8 @@
     "ci-build": "lerna run build --stream",
     "ci-test": "jest --coverage",
     "ci-lint": "eslint . --cache --report-unused-disable-directives",
-    "ci-pipeline": "yarn ci-build && yarn ci-test && yarn ci-lint && yarn integration:generate && yarn integration:validate"
+    "ci-format": "prettier --list-different .",
+    "ci-pipeline": "yarn ci-build && yarn ci-test && yarn lint && yarn format && yarn integration:generate && yarn integration:validate"
   },
   "author": "Michael Nahkies",
   "license": "MIT",
@@ -46,7 +48,8 @@
   ],
   "lint-staged": {
     "*.{ts,js,tsx,jsx}": [
-      "yarn lint"
+      "yarn lint",
+      "yarn prettier --write"
     ],
     "*.md": [
       "sh -c 'yarn docs:generate'",

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -6,19 +6,25 @@ import {
   Reference,
   RequestBody,
   Responses,
-  Schema
+  Schema,
 } from "./openapi-types"
 import {OpenapiLoader} from "./openapi-loader"
 import {generationLib} from "./generation-lib"
 import {isHttpMethod} from "./utils"
 import {
   IRModel,
-  IRModelArray, IRModelBase, IRModelBoolean, IRModelNumeric, IRModelObject,
+  IRModelArray,
+  IRModelBase,
+  IRModelBoolean,
+  IRModelNumeric,
+  IRModelObject,
   IRModelString,
   IROperation,
-  IRParameter, IRRef,
-  IRRequestBody, IRResponse,
-  MaybeIRModel
+  IRParameter,
+  IRRef,
+  IRRequestBody,
+  IRResponse,
+  MaybeIRModel,
 } from "./openapi-types-normalized"
 import {isRef} from "./openapi-utils"
 import {logger} from "./logger"
@@ -50,7 +56,6 @@ export class Input {
 
       // eslint-disable-next-line prefer-const
       for (let [method, definition] of Object.entries(methods)) {
-
         if (!definition) {
           continue
         }
@@ -74,7 +79,6 @@ export class Input {
     }
 
     return result
-
   }
 
   operationsByFirstTag(): Record<string, IROperation[]> {
@@ -149,7 +153,6 @@ export class Input {
 
     return _.camelCase([method, ...route.split("/")].join("-"))
   }
-
 }
 
 function normalizeRequestBodyObject(requestBodyObject: RequestBody): IRRequestBody | undefined {

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -6,7 +6,7 @@ import {
   Reference,
   RequestBody,
   Responses,
-  Schema,
+  Schema
 } from "./openapi-types"
 import {OpenapiLoader} from "./openapi-loader"
 import {generationLib} from "./generation-lib"
@@ -18,14 +18,14 @@ import {
   IROperation,
   IRParameter, IRRef,
   IRRequestBody, IRResponse,
-  MaybeIRModel,
+  MaybeIRModel
 } from "./openapi-types-normalized"
 import {isRef} from "./openapi-utils"
 import {logger} from "./logger"
 
 export class Input {
   constructor(
-    readonly loader: OpenapiLoader,
+    readonly loader: OpenapiLoader
   ) {
   }
 
@@ -68,7 +68,7 @@ export class Input {
           responses: this.normalizeResponsesObject(definition.responses),
           summary: definition.summary,
           description: definition.description,
-          deprecated: definition.deprecated ?? false,
+          deprecated: definition.deprecated ?? false
         })
       }
     }
@@ -117,7 +117,7 @@ export class Input {
     return normalizeRequestBodyObject(this.loader.requestBody(requestBody))
   }
 
-  private normalizeResponsesObject(responses?: Responses): { [statusCode: string]: IRResponse } | undefined {
+  private normalizeResponsesObject(responses?: Responses): {[statusCode: string]: IRResponse} | undefined {
     if (!responses) {
       return undefined
     }
@@ -130,8 +130,8 @@ export class Input {
         {
           headers: {},
           description: response.description,
-          content: normalizeMediaType(response.content),
-        },
+          content: normalizeMediaType(response.content)
+        }
       ]
     }))
   }
@@ -156,18 +156,18 @@ function normalizeRequestBodyObject(requestBodyObject: RequestBody): IRRequestBo
   return {
     description: requestBodyObject.description,
     required: requestBodyObject.required ?? true,
-    content: normalizeMediaType(requestBodyObject.content),
+    content: normalizeMediaType(requestBodyObject.content)
   }
 }
 
-function normalizeMediaType(mediaTypes: { [contentType: string]: MediaType } = {}) {
+function normalizeMediaType(mediaTypes: {[contentType: string]: MediaType} = {}) {
   return Object.fromEntries(Object.entries(mediaTypes).map(([contentType, mediaType]) => {
     return [
       contentType,
       {
         schema: normalizeSchemaObject(mediaType.schema),
-        encoding: mediaType.encoding,
-      },
+        encoding: mediaType.encoding
+      }
     ]
   }))
 }
@@ -180,18 +180,18 @@ function normalizeParameterObject(parameterObject: Parameter): IRParameter {
     description: parameterObject.description,
     required: parameterObject.required ?? false,
     deprecated: parameterObject.deprecated ?? false,
-    allowEmptyValue: parameterObject.allowEmptyValue ?? false,
+    allowEmptyValue: parameterObject.allowEmptyValue ?? false
   }
 }
 
 function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
   if (isRef(schemaObject)) {
-    return type<IRRef>(schemaObject)
+    return schemaObject satisfies IRRef
   }
 
   const base: IRModelBase = {
     nullable: schemaObject.nullable || false,
-    readOnly: schemaObject.readOnly || false,
+    readOnly: schemaObject.readOnly || false
   }
 
   switch (schemaObject.type) {
@@ -212,14 +212,9 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         return include
       })
 
-      let additionalProperties = schemaObject.additionalProperties || false
+      const additionalProperties = normalizeAdditionalProperties(schemaObject.additionalProperties)
 
-      if (typeof additionalProperties !== "boolean") {
-        logger.error("skipping object additionalProperties as not yet supported")
-        additionalProperties = true
-      }
-
-      return type<IRModelObject>({
+      return {
         ...base,
         type: "object",
         allOf,
@@ -227,8 +222,8 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         anyOf,
         required,
         properties,
-        additionalProperties,
-      })
+        additionalProperties
+      } satisfies IRModelObject
     }
     case "array": {
       let items = schemaObject.items
@@ -238,45 +233,41 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         items = {$ref: generationLib.UnknownObject$Ref}
       }
 
-      return type<IRModelArray>({
+      return {
         ...base,
         type: schemaObject.type,
-        items: normalizeSchemaObject(items),
-      })
+        items: normalizeSchemaObject(items)
+      } satisfies IRModelArray
     }
     case "number":
     case "integer": {
       const enumValues = ((schemaObject.enum ?? []) as any[])
         .filter((it): it is number => isFinite(it))
-      return type<IRModelNumeric>({
+      return {
         ...base,
         type: "number",
         // todo: https://github.com/mnahkies/openapi-code-generator/issues/51
         format: schemaObject.format as any,
-        enum: enumValues.length ? enumValues : undefined,
-      })
+        enum: enumValues.length ? enumValues : undefined
+      } satisfies IRModelNumeric
     }
     case "string": {
       const enumValues = ((schemaObject.enum ?? []) as any[])
         .map((it) => String(it))
-      return type<IRModelString>({
+      return {
         ...base,
         type: schemaObject.type,
         format: schemaObject.format as any,
-        enum: enumValues.length ? enumValues : undefined,
-      })
+        enum: enumValues.length ? enumValues : undefined
+      } satisfies IRModelString
     }
     case "boolean":
-      return type<IRModelBoolean>({
+      return {
         ...base,
-        type: schemaObject.type,
-      })
+        type: schemaObject.type
+      } satisfies IRModelBoolean
     default:
       throw new Error(`unsupported type '${schemaObject.type}'`)
-  }
-
-  function type<T>(it: T) {
-    return it
   }
 
   function normalizeProperties(properties: Schema["properties"] = {}): Record<string, MaybeIRModel> {
@@ -286,6 +277,14 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         result[name] = normalizeSchemaObject(schemaObject)
         return result
       }, {} as Record<string, MaybeIRModel>)
+  }
+
+  function normalizeAdditionalProperties(additionalProperties: Schema["additionalProperties"] = false): boolean | MaybeIRModel {
+    if (typeof additionalProperties === "boolean") {
+      return additionalProperties
+    }
+
+    return normalizeSchemaObject(additionalProperties)
   }
 
   function normalizeAllOf(allOf: Schema["allOf"] = []): MaybeIRModel[] {

--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -1,3 +1,7 @@
+/**
+ * @prettier
+ */
+
 export interface IRRef {
   $ref: string
 }
@@ -14,7 +18,13 @@ export interface IRModelNumeric extends IRModelBase {
   enum?: number[]
 }
 
-export type IRModelStringFormat = "byte" | "binary" | "date" | "date-time" | "password" | "email"
+export type IRModelStringFormat =
+  | "byte"
+  | "binary"
+  | "date"
+  | "date-time"
+  | "password"
+  | "email"
 
 export interface IRModelString extends IRModelBase {
   type: "string"
@@ -33,8 +43,8 @@ export interface IRModelObject extends IRModelBase {
 
   type: "object"
   required: string[]
-  properties: { [propertyName: string]: MaybeIRModel }
-  additionalProperties: boolean /* | IRObject */
+  properties: {[propertyName: string]: MaybeIRModel}
+  additionalProperties: boolean | MaybeIRModel
 }
 
 export interface IRModelArray extends IRModelBase {
@@ -42,7 +52,12 @@ export interface IRModelArray extends IRModelBase {
   items: MaybeIRModel
 }
 
-export type IRModel = IRModelNumeric | IRModelString | IRModelBoolean | IRModelObject | IRModelArray
+export type IRModel =
+  | IRModelNumeric
+  | IRModelString
+  | IRModelBoolean
+  | IRModelObject
+  | IRModelArray
 export type MaybeIRModel = IRModel | IRRef
 
 export interface IRParameter {

--- a/packages/openapi-code-generator/src/test/unit-test-inputs.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs.yaml
@@ -108,4 +108,16 @@ components:
         name:
           type: string
 
+    AdditionalPropertiesBool:
+      type: object
+      additionalProperties: true
+
+    AdditionalPropertiesSchema:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties:
+        $ref: "#/components/schemas/NamedNullableStringEnum"
+
   parameters: { }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -125,7 +125,7 @@ export abstract class AbstractSchemaBuilder {
         ], required)
         break
       case "object":
-
+        // todo: additionalProperties support
         if (model.allOf.length) {
           result = this.intersect(model.allOf.map(it => this.fromModel(it, true)))
         } else if (model.oneOf.length) {

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @prettier
+ */
+
 import {describe, it, expect} from "@jest/globals"
 import {unitTestInput} from "../../test/input.test-utils"
 import {TypeBuilder} from "./type-builder"
@@ -88,9 +92,7 @@ describe("typescript/common/type-builder", () => {
   })
 
   it("can build a type for a oneOf correctly", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/OneOf"
-    )
+    const {type, schemas, imports} = await getActual("components/schemas/OneOf")
 
     expect(type).toMatchInlineSnapshot(`
       "const x: t_OneOf
@@ -114,9 +116,7 @@ describe("typescript/common/type-builder", () => {
   })
 
   it("can build a type for a anyOf correctly", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/AnyOf"
-    )
+    const {type, schemas, imports} = await getActual("components/schemas/AnyOf")
 
     expect(type).toMatchInlineSnapshot(`
       "const x: t_AnyOf
@@ -135,9 +135,7 @@ describe("typescript/common/type-builder", () => {
   })
 
   it("can build a type for a allOf correctly", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/AllOf"
-    )
+    const {type, schemas, imports} = await getActual("components/schemas/AllOf")
 
     expect(type).toMatchInlineSnapshot(`
       "const x: t_AllOf
@@ -158,6 +156,58 @@ describe("typescript/common/type-builder", () => {
 
     expect(imports).toMatchInlineSnapshot(`
       "import { t_AllOf, t_Base } from "models"
+      "
+    `)
+  })
+
+  it("handles additionalProperties set to true", async () => {
+    const {type, schemas, imports} = await getActual(
+      "components/schemas/AdditionalPropertiesBool"
+    )
+
+    expect(type).toMatchInlineSnapshot(`
+      "const x: t_AdditionalPropertiesBool
+      "
+    `)
+
+    expect(schemas).toMatchInlineSnapshot(`
+      "export type t_AdditionalPropertiesBool = {
+        [key: string]: unknown
+      }
+      "
+    `)
+
+    expect(imports).toMatchInlineSnapshot(`
+      "import { t_AdditionalPropertiesBool } from "models"
+      "
+    `)
+  })
+
+  it("handles additionalProperties specifying a schema", async () => {
+    const {type, schemas, imports} = await getActual(
+      "components/schemas/AdditionalPropertiesSchema"
+    )
+
+    expect(type).toMatchInlineSnapshot(`
+      "const x: t_AdditionalPropertiesSchema
+      "
+    `)
+
+    expect(schemas).toMatchInlineSnapshot(`
+      "export type t_NamedNullableStringEnum = "" | "one" | "two" | "three" | null
+
+      export type t_AdditionalPropertiesSchema =
+        | {
+            name?: string
+          }
+        | {
+            [key: string]: t_NamedNullableStringEnum
+          }
+      "
+    `)
+
+    expect(imports).toMatchInlineSnapshot(`
+      "import { t_AdditionalPropertiesSchema, t_NamedNullableStringEnum } from "models"
       "
     `)
   })

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -11,7 +11,7 @@ import {formatOutput} from "./output-utils"
 describe("typescript/common/type-builder", () => {
   it("can build a type for a simple object correctly", async () => {
     const {type, schemas, imports} = await getActual(
-      "components/schemas/SimpleObject"
+      "components/schemas/SimpleObject",
     )
 
     expect(type).toMatchInlineSnapshot(`
@@ -39,7 +39,7 @@ describe("typescript/common/type-builder", () => {
 
   it("can build a type for an object that references other objects correctly", async () => {
     const {type, schemas, imports} = await getActual(
-      "components/schemas/ObjectWithRefs"
+      "components/schemas/ObjectWithRefs",
     )
 
     expect(type).toMatchInlineSnapshot(`
@@ -72,7 +72,7 @@ describe("typescript/common/type-builder", () => {
 
   it("can build a type for a named nullable string enum", async () => {
     const {type, schemas, imports} = await getActual(
-      "components/schemas/NamedNullableStringEnum"
+      "components/schemas/NamedNullableStringEnum",
     )
 
     expect(type).toMatchInlineSnapshot(`
@@ -162,7 +162,7 @@ describe("typescript/common/type-builder", () => {
 
   it("handles additionalProperties set to true", async () => {
     const {type, schemas, imports} = await getActual(
-      "components/schemas/AdditionalPropertiesBool"
+      "components/schemas/AdditionalPropertiesBool",
     )
 
     expect(type).toMatchInlineSnapshot(`
@@ -185,7 +185,7 @@ describe("typescript/common/type-builder", () => {
 
   it("handles additionalProperties specifying a schema", async () => {
     const {type, schemas, imports} = await getActual(
-      "components/schemas/AdditionalPropertiesSchema"
+      "components/schemas/AdditionalPropertiesSchema",
     )
 
     expect(type).toMatchInlineSnapshot(`
@@ -219,7 +219,7 @@ describe("typescript/common/type-builder", () => {
     const imports = new ImportBuilder()
 
     const builder = TypeBuilder.fromInput("models.ts", input).withImports(
-      imports
+      imports,
     )
 
     const type = builder.schemaObjectToType(schema)

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.ts
@@ -1,3 +1,7 @@
+/**
+ * @prettier
+ */
+
 import {MaybeIRModel} from "../../core/openapi-types-normalized"
 import {Input} from "../../core/input"
 import {Reference} from "../../core/openapi-types"
@@ -19,8 +23,7 @@ export class TypeBuilder {
     private readonly input: Input,
     private readonly referenced = new Set<string>(),
     private readonly imports?: ImportBuilder
-  ) {
-  }
+  ) {}
 
   withImports(imports: ImportBuilder): TypeBuilder {
     return new TypeBuilder(this.filename, this.input, this.referenced, imports)
@@ -129,14 +132,27 @@ export class TypeBuilder {
             })
 
           // todo: https://github.com/mnahkies/openapi-code-generator/issues/44
-          const additionalProperties =
-            schemaObject.additionalProperties
-              ? "[key: string]: unknown"
+
+          const additionalPropertiesType = schemaObject.additionalProperties
+            ? typeof schemaObject.additionalProperties === "boolean"
+              ? "unknown"
+              : this.schemaObjectToType(schemaObject.additionalProperties)
+            : ""
+
+          const additionalProperties = additionalPropertiesType
+            ? `[key: string]: ${additionalPropertiesType}`
+            : ""
+
+          const emptyObject =
+            !additionalProperties && properties.length === 0
+              ? "[key: string]:  never"
               : ""
 
-          const emptyObject = !additionalProperties && properties.length === 0 ? "[key: string]:  never" : ""
-
-          result.push(object([...properties, additionalProperties, emptyObject]))
+          result.push(
+            object(properties),
+            object(additionalProperties),
+            object(emptyObject)
+          )
           break
         }
 

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.ts
@@ -29,7 +29,7 @@ export class TypeBuilder {
     private readonly input: Input,
     private readonly referenced = new Set<string>(),
     private readonly referencedStaticTypes = new Set<StaticType>(),
-    private readonly imports?: ImportBuilder
+    private readonly imports?: ImportBuilder,
   ) {}
 
   withImports(imports: ImportBuilder): TypeBuilder {
@@ -38,7 +38,7 @@ export class TypeBuilder {
       this.input,
       this.referenced,
       this.referencedStaticTypes,
-      imports
+      imports,
     )
   }
 
@@ -75,7 +75,7 @@ export class TypeBuilder {
       return this.staticTypes().concat(
         Array.from(this.referenced.values())
           .sort()
-          .map(($ref) => this.generateModelFromRef($ref))
+          .map(($ref) => this.generateModelFromRef($ref)),
       )
     }
 
@@ -183,14 +183,14 @@ export class TypeBuilder {
           result.push(
             object(properties),
             object(additionalProperties),
-            emptyObject
+            emptyObject,
           )
           break
         }
 
         default: {
           throw new Error(
-            `unsupported type '${JSON.stringify(schemaObject, undefined, 2)}'`
+            `unsupported type '${JSON.stringify(schemaObject, undefined, 2)}'`,
           )
         }
       }

--- a/packages/openapi-code-generator/src/typescript/common/type-utils.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-utils.spec.ts
@@ -1,10 +1,12 @@
+/**
+ * @prettier
+ */
+
 import {describe, expect} from "@jest/globals"
-import {intersect, objectProperty, union} from "./type-utils"
+import {intersect, object, objectProperty, union} from "./type-utils"
 
 describe("typescript/common/type-utils", () => {
-
   describe("union", () => {
-
     it("handles an empty array", () => {
       expect(union([])).toBe("")
     })
@@ -19,7 +21,9 @@ describe("typescript/common/type-utils", () => {
     })
 
     it("skips empty strings and falsy values", () => {
-      expect(union(["1", "", "2", undefined, "3", null])).toBe("(1\n | 2\n | 3)")
+      const actual = union(["1", "", "2", undefined, "3", null])
+
+      expect(actual).toBe("(1\n | 2\n | 3)")
     })
 
     it("accepts an array", () => {
@@ -29,11 +33,9 @@ describe("typescript/common/type-utils", () => {
     it("accepts rest parameters", () => {
       expect(union("1", "2", "3")).toBe("(1\n | 2\n | 3)")
     })
-
   })
 
   describe("intersect", () => {
-
     it("handles an empty array", () => {
       expect(intersect([])).toBe("")
     })
@@ -48,7 +50,9 @@ describe("typescript/common/type-utils", () => {
     })
 
     it("skips empty strings and falsy values", () => {
-      expect(intersect(["1", "", "2", undefined, "3", null])).toBe("(1 & 2 & 3)")
+      const actual = intersect(["1", "", "2", undefined, "3", null])
+
+      expect(actual).toBe("(1 & 2 & 3)")
     })
 
     it("accepts an array", () => {
@@ -58,29 +62,70 @@ describe("typescript/common/type-utils", () => {
     it("accepts rest parameters", () => {
       expect(intersect("1", "2", "3")).toBe("(1 & 2 & 3)")
     })
-
   })
 
   describe("objectProperty", () => {
     it("returns a mutable required property", () => {
-      expect(objectProperty({name: "foo", type: "number", isRequired: true, isReadonly: false}))
-        .toBe('"foo": number')
+      const actual = objectProperty({
+        name: "foo",
+        type: "number",
+        isRequired: true,
+        isReadonly: false,
+      })
+
+      expect(actual).toBe('"foo": number')
     })
 
     it("returns a mutable optional property", () => {
-      expect(objectProperty({name: "foo", type: "number", isRequired: false, isReadonly: false}))
-        .toBe('"foo"?: number')
+      const actual = objectProperty({
+        name: "foo",
+        type: "number",
+        isRequired: false,
+        isReadonly: false,
+      })
+
+      expect(actual).toBe('"foo"?: number')
     })
 
     it("returns a readonly required property", () => {
-      expect(objectProperty({name: "foo", type: "number", isRequired: true, isReadonly: true}))
-        .toBe('readonly "foo": number')
+      const actual = objectProperty({
+        name: "foo",
+        type: "number",
+        isRequired: true,
+        isReadonly: true,
+      })
+
+      expect(actual).toBe('readonly "foo": number')
     })
 
     it("returns a readonly optional property", () => {
-      expect(objectProperty({name: "foo", type: "number", isRequired: false, isReadonly: true}))
-        .toBe('readonly "foo"?: number')
+      const actual = objectProperty({
+        name: "foo",
+        type: "number",
+        isRequired: false,
+        isReadonly: true,
+      })
+
+      expect(actual).toBe('readonly "foo"?: number')
     })
   })
 
+  describe("object", () => {
+    it("returns an empty string when no defined properties", () => {
+      expect(object([""])).toBe("")
+    })
+
+    it("returns an object when there are defined properties", () => {
+      const property = objectProperty({
+        name: "foo",
+        type: "string",
+        isReadonly: false,
+        isRequired: true,
+      })
+
+      const actual = object(property, "")
+
+      expect(actual).toBe('{\n"foo": string\n}')
+    })
+  })
 })

--- a/packages/openapi-code-generator/src/typescript/common/type-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-utils.ts
@@ -3,7 +3,7 @@
  */
 
 function wrap<T, U>(
-  fn: (arg: T[]) => U
+  fn: (arg: T[]) => U,
 ): {
   (...arg: T[] | T[][]): U
 } {
@@ -21,7 +21,7 @@ function unique(types: (string | undefined | null)[]) {
   return Array.from(
     types
       .filter((it): it is string => Boolean(it))
-      .filter((it) => (seen.has(it) ? false : seen.add(it) && true))
+      .filter((it) => (seen.has(it) ? false : seen.add(it) && true)),
   )
 }
 

--- a/packages/openapi-code-generator/src/typescript/common/type-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-utils.ts
@@ -1,3 +1,7 @@
+/**
+ * @prettier
+ */
+
 function wrap<T, U>(
   fn: (arg: T[]) => U
 ): {
@@ -69,9 +73,15 @@ export const objectProperty = ({
     .join(" ")
 }
 
-export const object = (properties: string[]): string =>
-  "{\n" + properties.filter(Boolean).join("\n") + "\n}"
+export const object = wrap((properties: MaybeString[]): string => {
+  const definedProperties = properties.filter(Boolean)
 
+  if (!definedProperties.length) {
+    return ""
+  }
+
+  return "{\n" + definedProperties.join("\n") + "\n}"
+})
 export const array = (type: string): string => `(${type})[]`
 
 export const toString = (it: string | number): string => it.toString()


### PR DESCRIPTION
- adjust normalization of `additionalProperties` on input to support
  schemas

- adjust type builder to output a union when `additionalProperties` is
  declared, where the type remains unknown when set to true, but uses
  the schema type otherwise. The union is required since otherwise the 
  index type might conflict with other declared properties

- begin incremental adoption of prettier in the codebase, I've been
  putting it off to try and keep diff's more readable, but think it's
  time

- replace inline `{[key: string]: never }` type with a static `EmptyObject` type to 
  better communicate the intention

mostly solves https://github.com/mnahkies/openapi-code-generator/issues/44 although currently the schema builder completely ignores `additionalProperties` meaning that they won't work correctly for the `koa` template yet