### PR TITLE
fix: dependency graph handles oneOf allOf nesting

### DIFF
--- a/packages/openapi-code-generator/src/core/dependency-graph.spec.ts
+++ b/packages/openapi-code-generator/src/core/dependency-graph.spec.ts
@@ -33,6 +33,14 @@ describe("core/dependency-graph", () => {
       graph.order.indexOf("s_Base"),
     )
 
+    expect(graph.order.indexOf("s_OneOfAllOf")).toBeGreaterThan(
+      graph.order.indexOf("s_ZOrdering"),
+    )
+
+    expect(graph.order.indexOf("s_OneOfAllOf")).toBeGreaterThan(
+      graph.order.indexOf("s_AOrdering"),
+    )
+
     expect(graph.order.indexOf("s_Recursive")).toBe(-1)
 
     expect(graph.circular).toEqual(new Set(["s_Recursive"]))

--- a/packages/openapi-code-generator/src/core/dependency-graph.ts
+++ b/packages/openapi-code-generator/src/core/dependency-graph.ts
@@ -36,19 +36,26 @@ const getDependenciesFromSchema = (
     if (isRef(it)) {
       acc.add(getNameForRef(it))
     } else if (it.type === "object") {
-      Object.values(it.properties).forEach((prop) => {
-        if (isRef(prop)) {
-          acc.add(getNameForRef(prop))
-        } else if (prop.type === "object") {
-          intersect(acc, getDependenciesFromSchema(prop, getNameForRef))
-        } else if (prop.type === "array") {
-          if (isRef(prop.items)) {
-            acc.add(getNameForRef(prop.items))
-          } else {
-            intersect(acc, getDependenciesFromSchema(prop.items, getNameForRef))
+      Object.values(it.properties)
+        .concat(Reflect.get(schema, "oneOf") ?? [])
+        .concat(Reflect.get(schema, "allOf") ?? [])
+        .concat(Reflect.get(schema, "anyOf") ?? [])
+        .forEach((prop) => {
+          if (isRef(prop)) {
+            acc.add(getNameForRef(prop))
+          } else if (prop.type === "object") {
+            intersect(acc, getDependenciesFromSchema(prop, getNameForRef))
+          } else if (prop.type === "array") {
+            if (isRef(prop.items)) {
+              acc.add(getNameForRef(prop.items))
+            } else {
+              intersect(
+                acc,
+                getDependenciesFromSchema(prop.items, getNameForRef),
+              )
+            }
           }
-        }
-      })
+        })
     }
 
     return acc

--- a/packages/openapi-code-generator/src/test/unit-test-inputs.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs.yaml
@@ -126,4 +126,11 @@ components:
         child:
           $ref: "#/components/schemas/Recursive"
 
+    OneOfAllOf:
+      type: object
+      oneOf:
+        - allOf:
+            - $ref: '#/components/schemas/AOrdering'
+            - $ref: '#/components/schemas/ZOrdering'
+
   parameters: { }


### PR DESCRIPTION
the latest github api definitions (https://github.com/mnahkies/openapi-code-generator/pull/72) include structures like:
```
    repository-rule-detailed:
      title: Repository Rule
      type: object
      description: A repository rule with ruleset details.
      oneOf:
      - allOf:
        - "$ref": "#/components/schemas/repository-rule-creation"
        - "$ref": "#/components/schemas/repository-rule-ruleset-info"
      - allOf:
        - "$ref": "#/components/schemas/repository-rule-update"
        - "$ref": "#/components/schemas/repository-rule-ruleset-info"
```

which weren't being considered by the dependency graph correctly, causing use before define errors to be emitted.