### PR TITLE
fix: remove broken functionality

### DIFF
--- a/packages/openapi-code-generator/README.md
+++ b/packages/openapi-code-generator/README.md
@@ -76,8 +76,7 @@ There are two client templates:
 ### Typescript Fetch
 The `typescript-fetch` template outputs a client SDK based on the [fetch api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) that gives the following:
 - Typed methods to call each endpoint
-- Support for passing a `timeout`
-- ~~Support for cancelling in-flight requests~~ (the types aren't working correctly to destructure to get the `cancelRequest` `AbortController` yet)
+- Support for passing a `timeout`, abort signals are still respected
 
 It does not yet support runtime validation/parsing - compile time type safety only at this stage.
 
@@ -115,7 +114,7 @@ const client = new ApiClient({
 const res = await client.createTodoListItem({
   listId: list.id,
   requestBody: {content: "test item"},
-  // optionally pass a timeout (ms), or any arbitrary fetch options
+  // optionally pass a timeout (ms), or any arbitrary fetch options (eg: an abort signal)
   // timeout?: number,
   // opts?: RequestInit
 })

--- a/packages/typescript-fetch-runtime/src/main.ts
+++ b/packages/typescript-fetch-runtime/src/main.ts
@@ -37,10 +37,7 @@ export type Res<Status extends StatusCode, Type> = {
 
 export type TypedFetchResponse<R extends Res<any, any>> = Promise<
   Omit<Response, "json" | "status"> & R
-> & {
-  res: Promise<Omit<Response, "json" | "status"> & R>
-  cancelRequest: AbortController
-}
+>
 
 export interface AbstractFetchClientConfig {
   basePath: string
@@ -73,7 +70,7 @@ export abstract class AbstractFetchClient {
     this.defaultTimeout = config.defaultTimeout
   }
 
-  protected _fetch<R extends Res<any, any>>(
+  protected async _fetch<R extends Res<any, any>>(
     url: string,
     opts: RequestInit,
     timeout: number | undefined = this.defaultTimeout,
@@ -100,7 +97,7 @@ export abstract class AbstractFetchClient {
 
     const headers = opts.headers ?? this._headers({})
 
-    const res = fetch(url, {
+    return fetch(url, {
       ...opts,
       headers,
       signal: cancelRequest.signal,
@@ -112,17 +109,7 @@ export abstract class AbstractFetchClient {
       }
       // if not aborted just throw
       throw err
-    })
-
-    // decorate the Promise with itself and the AbortController, this allows the
-    // caller to choose between:
-    // - await the Promise and ignore the AbortController
-    // - destructure the Promise to get the Promise and the AbortController
-    // @ts-ignore decorating with itself
-    res.res = res
-    // @ts-ignore decorating with abort controller
-    res.cancelRequest = cancelRequest
-    return res as any
+    }) as any
   }
 
   protected _query(params: QueryParams): string {


### PR DESCRIPTION
the promise returned from _fetch gets wrapped by the caller with new promises preventing the user from being able to destructure for the abort controller

equivilant functionality is available if the caller passes their own AbortSignal as the `signal` property of `opts`