### PR TITLE
fix: try using wildcard version to work around lerna publish bug

### DIFF
--- a/integration-tests/typescript-fetch/package.json
+++ b/integration-tests/typescript-fetch/package.json
@@ -11,7 +11,7 @@
     "validate": "tsc -p ./tsconfig.json"
   },
   "dependencies": {
-    "@nahkies/typescript-fetch-runtime": "0.0.0",
+    "@nahkies/typescript-fetch-runtime": "*",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/integration-tests/typescript-koa/package.json
+++ b/integration-tests/typescript-koa/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@koa/router": "^12.0.0",
-    "@nahkies/typescript-koa-runtime": "0.0.0",
+    "@nahkies/typescript-koa-runtime": "*",
     "@types/hapi__joi": "^17.1.11",
     "koa": "^2.14.2",
     "zod": "^3.22.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,7 +2732,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nahkies/typescript-fetch-runtime@0.0.0, @nahkies/typescript-fetch-runtime@workspace:packages/typescript-fetch-runtime":
+"@nahkies/typescript-fetch-runtime@*, @nahkies/typescript-fetch-runtime@workspace:packages/typescript-fetch-runtime":
   version: 0.0.0-use.local
   resolution: "@nahkies/typescript-fetch-runtime@workspace:packages/typescript-fetch-runtime"
   dependencies:
@@ -2741,7 +2741,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nahkies/typescript-koa-runtime@0.0.0, @nahkies/typescript-koa-runtime@workspace:packages/typescript-koa-runtime":
+"@nahkies/typescript-koa-runtime@*, @nahkies/typescript-koa-runtime@workspace:packages/typescript-koa-runtime":
   version: 0.0.0-use.local
   resolution: "@nahkies/typescript-koa-runtime@workspace:packages/typescript-koa-runtime"
   dependencies:
@@ -14546,7 +14546,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "typescript-fetch@workspace:integration-tests/typescript-fetch"
   dependencies:
-    "@nahkies/typescript-fetch-runtime": 0.0.0
+    "@nahkies/typescript-fetch-runtime": "*"
     "@types/node": ^20.6.2
     dotenv: ^16.3.1
     typescript: ~5.1.6
@@ -14559,7 +14559,7 @@ __metadata:
   dependencies:
     "@hapi/joi": ^17.1.1
     "@koa/router": ^12.0.0
-    "@nahkies/typescript-koa-runtime": 0.0.0
+    "@nahkies/typescript-koa-runtime": "*"
     "@types/hapi__joi": ^17.1.11
     "@types/koa": ^2.13.9
     "@types/koa__router": ^12.0.1


### PR DESCRIPTION
Trying to publish `0.0.1` resulted in this error:
```
lerna ERR! Error: Command failed with exit code 1: yarn install --mode update-lockfile
lerna ERR! ➤ YN0000: ┌ Resolution step
lerna ERR! ➤ YN0001: │ Error: @nahkies/typescript-fetch-runtime@npm:0.0.0: No candidates found
```

As far as I could see, `lerna` had failed to update the requested version in these files from `0.0.0` to `0.0.1` causing the issue. By using a wildcard this shouldn't be an issue.