### PR TITLE
fix: don't coerce strings

### DIFF
--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -20,12 +20,12 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       "import { z } from "zod"
 
       export const s_SimpleObject = z.object({
-        str: z.coerce.string(),
+        str: z.string(),
         num: z.coerce.number(),
-        date: z.coerce.string(),
-        datetime: z.coerce.string().datetime({ offset: true }),
-        optional_str: z.coerce.string().optional(),
-        required_nullable: z.coerce.string().nullable(),
+        date: z.string(),
+        datetime: z.string().datetime({ offset: true }),
+        optional_str: z.string().optional(),
+        required_nullable: z.string().nullable(),
       })
       "
     `)
@@ -42,9 +42,9 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       "import { z } from "zod"
 
       export const s_OneOf = z.union([
-        z.object({ strs: z.array(z.coerce.string()) }),
-        z.array(z.coerce.string()),
-        z.coerce.string(),
+        z.object({ strs: z.array(z.string()) }),
+        z.array(z.string()),
+        z.string(),
       ])
       "
     `)
@@ -60,7 +60,7 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
     expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
-      export const s_AnyOf = z.union([z.coerce.number(), z.coerce.string()])
+      export const s_AnyOf = z.union([z.coerce.number(), z.string()])
       "
     `)
   })
@@ -76,8 +76,8 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       "import { z } from "zod"
 
       export const s_Base = z.object({
-        name: z.coerce.string(),
-        breed: z.coerce.string().optional(),
+        name: z.string(),
+        breed: z.string().optional(),
       })
 
       export const s_AllOf = s_Base.merge(z.object({ id: z.coerce.number() }))
@@ -113,10 +113,10 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
     expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
-      export const s_AOrdering = z.object({ name: z.coerce.string().optional() })
+      export const s_AOrdering = z.object({ name: z.string().optional() })
 
       export const s_ZOrdering = z.object({
-        name: z.coerce.string().optional(),
+        name: z.string().optional(),
         dependency1: s_AOrdering,
       })
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -126,7 +126,7 @@ export class ZodBuilder extends AbstractSchemaBuilder {
 
     return [
       this.zod,
-      "coerce.string()",
+      "string()",
       model.format === "date-time" ? "datetime({offset:true})" : undefined,
       model.format === "email" ? "email()" : undefined,
       required ? undefined : "optional()",


### PR DESCRIPTION
coercing strings causes issues with objects like `{foo: undefined}` as it coerces `undefined` to `"undefined"` rather than leaving it as `undefined` / throwing an error if the property is not optional.

coercing numbers doesn't seem to suffer the same issue, and is needed for parameters from route params / query strings since these always start as a string.

the schema builder should probably become aware of when to expect to receive a parsed JSON value rather than a string and adjust it's use of coerce accordingly, but this will improve things in the meantime.