### PR TITLE
feat!: more flexible koa server creation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -109,5 +109,5 @@ dist
 .yarn/*
 
 *.json
-*.yaml
-integration-tests
+integration-tests-definitions/
+integration-tests-definitions-shared/

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -12428,11 +12428,7 @@ export type Implementation = {
   metaGetZen: MetaGetZen
 }
 
-export function bootstrap(
-  implementation: Implementation,
-  config: Omit<ServerConfig, "router">,
-) {
-  // ApiClient
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const metaRootResponseValidator = responseValidationFactory(
@@ -49639,9 +49635,10 @@ export function bootstrap(
     return next()
   })
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port,
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ApiClient
+  return startServer(config)
 }

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -363,11 +363,7 @@ export type Implementation = {
   getProfileSchema: GetProfileSchema
 }
 
-export function bootstrap(
-  implementation: Implementation,
-  config: Omit<ServerConfig, "router">,
-) {
-  // ApiClient
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const createAppAuthenticatorEnrollmentBodySchema =
@@ -1107,9 +1103,10 @@ export function bootstrap(
     },
   )
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port,
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ApiClient
+  return startServer(config)
 }

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
@@ -440,11 +440,7 @@ export type Implementation = {
   userinfoCustomAs: UserinfoCustomAs
 }
 
-export function bootstrap(
-  implementation: Implementation,
-  config: Omit<ServerConfig, "router">,
-) {
-  // ApiClient
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const getWellKnownOpenIdConfigurationQuerySchema = z.object({
@@ -1402,9 +1398,10 @@ export function bootstrap(
     },
   )
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port,
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ApiClient
+  return startServer(config)
 }

--- a/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
@@ -62,11 +62,7 @@ export type Implementation = {
   deletePet: DeletePet
 }
 
-export function bootstrap(
-  implementation: Implementation,
-  config: Omit<ServerConfig, "router">,
-) {
-  // ApiClient
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const findPetsQuerySchema = z.object({
@@ -156,9 +152,10 @@ export function bootstrap(
     return next()
   })
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port,
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ApiClient
+  return startServer(config)
 }

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -7977,11 +7977,7 @@ export type Implementation = {
   postWebhookEndpointsWebhookEndpoint: PostWebhookEndpointsWebhookEndpoint
 }
 
-export function bootstrap(
-  implementation: Implementation,
-  config: Omit<ServerConfig, "router">,
-) {
-  // ApiClient
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const getAccountQuerySchema = z.object({
@@ -46585,9 +46581,10 @@ export function bootstrap(
     },
   )
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port,
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ApiClient
+  return startServer(config)
 }

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -78,11 +78,7 @@ export type Implementation = {
   deleteTodoListById: DeleteTodoListById
 }
 
-export function bootstrap(
-  implementation: Implementation,
-  config: Omit<ServerConfig, "router">,
-) {
-  // ApiClient
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const getTodoListsQuerySchema = z.object({
@@ -183,9 +179,10 @@ export function bootstrap(
     return next()
   })
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port,
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ApiClient
+  return startServer(config)
 }

--- a/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
+++ b/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
@@ -57,7 +57,7 @@ async function main() {
       addPet: notImplemented,
       deletePet: notImplemented,
     }),
-    port: 3000,
+    port: {port: 3000, host: "127.0.0.1"},
   })
 
   console.info(`listening on ${address.address}:${address.port}`)

--- a/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
+++ b/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
@@ -1,7 +1,13 @@
 /**
  * @prettier
  */
-import { bootstrap, createRouter, FindPetById } from "./generated/petstore-expanded.yaml/generated"
+import {
+  bootstrap,
+  createRouter,
+  FindPetById,
+} from "./generated/petstore-expanded.yaml/generated"
+import {add} from "husky"
+import {s_review} from "./generated/stripe.yaml/schemas"
 
 const notImplemented = async () => {
   return {
@@ -43,12 +49,28 @@ const findPetById: FindPetById = async ({params}, ctx) => {
   }
 }
 
-bootstrap({
-  router: createRouter({
-    findPets: notImplemented,
-    findPetById,
-    addPet: notImplemented,
-    deletePet: notImplemented,
-  }),
-  port: 3000,
-})
+async function main() {
+  const {server, address} = await bootstrap({
+    router: createRouter({
+      findPets: notImplemented,
+      findPetById,
+      addPet: notImplemented,
+      deletePet: notImplemented,
+    }),
+    port: 3000,
+  })
+
+  console.info(`listening on ${address.address}:${address.port}`)
+
+  process.on("SIGTERM", () => {
+    console.info("sigterm received, closing server")
+    server.close()
+  })
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("unhandled exception", err)
+    process.exit(1)
+  })
+}

--- a/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
+++ b/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
@@ -1,13 +1,16 @@
-import { bootstrap, FindPetById } from "./generated/petstore-expanded.yaml/generated"
+/**
+ * @prettier
+ */
+import { bootstrap, createRouter, FindPetById } from "./generated/petstore-expanded.yaml/generated"
 
 const notImplemented = async () => {
   return {
     status: 501 as const,
-    body: { code: 1, message: "not implemented" },
+    body: {code: 1, message: "not implemented"},
   }
 }
 
-const findPetById: FindPetById = async ({ params }, ctx) => {
+const findPetById: FindPetById = async ({params}, ctx) => {
   switch (params.id) {
     case 1:
       return {
@@ -40,12 +43,12 @@ const findPetById: FindPetById = async ({ params }, ctx) => {
   }
 }
 
-bootstrap(
-  {
+bootstrap({
+  router: createRouter({
     findPets: notImplemented,
     findPetById,
     addPet: notImplemented,
     deletePet: notImplemented,
-  },
-  { port: 3000 }
-)
+  }),
+  port: 3000,
+})

--- a/packages/openapi-code-generator/README.md
+++ b/packages/openapi-code-generator/README.md
@@ -289,8 +289,8 @@ bootstrap({
 
 #### Custom Koa app / configuration
 
-The provided `bootstrap` function has a limited range of options. For more advanced use-cases, eg: `https`, or binding to a
-specific ip address you will need to construct your own Koa `app`.
+The provided `bootstrap` function has a limited range of options. For more advanced use-cases,
+such as `https` you will need to construct your own Koa `app`.
 
 The only real requirement is that you provide a body parsing middleware before the `router` that places a parsed request body
 on the `ctx.body` property.
@@ -300,6 +300,7 @@ Eg:
 ```typescript
 import {createRouter} from "../generated"
 import KoaBody from "koa-body"
+import https from "https"
 
 // ...implement routes where
 
@@ -313,9 +314,14 @@ const router = createRouter({getTodoLists, createTodoList})
 app.use(router.allowedMethods())
 app.use(router.routes())
 
-app.listen(8080, '127.0.0.1', () => {
-  console.info("listening")
-})
+https
+  .createServer({
+      key: "...",
+      cert: "...",
+    },
+    app.callback(),
+  )
+  .listen(433)
 ```
 
 ## More information / contributing

--- a/packages/openapi-code-generator/README.md
+++ b/packages/openapi-code-generator/README.md
@@ -229,7 +229,7 @@ Will output three files into `./src`:
 Once generated usage should look something like this:
 
 ```typescript
-import {bootstrap, CreateTodoList, GetTodoLists} from "../generated"
+import {bootstrap, createRouter, CreateTodoList, GetTodoLists} from "../generated"
 
 // Define your route implementations as async functions implementing the types
 // exported from generated.ts
@@ -254,7 +254,10 @@ const getTodoLists: GetTodoLists = async ({query}) => {
 }
 
 // Starts a server listening on `port`
-bootstrap({getTodoLists, createTodoList}, {port: port})
+bootstrap({
+  router: createRouter({getTodoLists, createTodoList}),
+  port: 8080
+})
 ```
 
 ## More information / contributing

--- a/packages/openapi-code-generator/README.md
+++ b/packages/openapi-code-generator/README.md
@@ -1,4 +1,5 @@
 # @nahkies/openapi-code-generator
+
 ![CI/CD](https://github.com/mnahkies/openapi-code-generator/actions/workflows/ci.yml/badge.svg)
 [![npm](https://img.shields.io/npm/v/@nahkies/openapi-code-generator.svg)](https://www.npmjs.com/package/@nahkies/openapi-code-generator)
 
@@ -16,11 +17,13 @@ generating a strongly typed client for large/complex definitions like the GitHub
   - [Typescript Angular](#typescript-angular)
 - [Server Examples](#server-examples)
   - [Typescript Koa](#typescript-koa)
+    - [Custom Koa app / configuration](#custom-koa-app--configuration)
 - [More information / contributing](#more-information--contributing)
 
 <!-- tocstop -->
 
 ## Project Goal
+
 To make it fun, easy and productive to generate both client and server "glue"
 code from openapi 3 definitions. This is code that is tedious and error prone to maintain by hand,
 by automating it we can reduce toil and frustration.
@@ -39,6 +42,7 @@ The initial focus on `typescript`, with an intention to later support other lang
 most likely candidate for a second language.
 
 ## Usage
+
 Install as a `devDependency` in the consuming project, or execute using `npx`
 
 ```shell
@@ -46,35 +50,44 @@ yarn add --dev @nahkies/openapi-code-generator
 ```
 
 See available options using:
+
 ```shell
 yarn openapi-code-generator --help
 ```
-Or looking at the code defining them in [index.ts](./src/index.ts). 
+
+Or looking at the code defining them in [index.ts](./src/index.ts).
 All options can be provided as either cli arguments or environment variables.
 
 Example usage:
+
 ```shell
 yarn openapi-code-generator --input="./openapi.yaml" --out="./src/" --template=typescript-koa
 ```
 
 Where template is one of:
+
 - typescript-angular
 - typescript-fetch
 - typescript-koa
 
 There is an optional parameter `schema-builder` for choosing between:
+
 - [zod](https://zod.dev/) (default)
 - [joi](https://joi.dev/)
 
 For runtime phrasing / validation of schemas (eg: responses, parameters).
 
 ## Client Examples
+
 There are two client templates:
+
 - `typescript-fetch`
 - `typescript-angular`
 
 ### Typescript Fetch
+
 The `typescript-fetch` template outputs a client SDK based on the [fetch api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) that gives the following:
+
 - Typed methods to call each endpoint
 - Support for passing a `timeout`, abort signals are still respected
 
@@ -83,12 +96,15 @@ It does not yet support runtime validation/parsing - compile time type safety on
 See [integration-tests/typescript-fetch](../../integration-tests/typescript-fetch) for more samples.
 
 Dependencies:
+
 ```shell
 yarn add @nahkies/typescript-fetch-runtime
 ```
+
 If you're using a version of NodeJS that doesn't include the `fetch` API, you may need a polyfill like [node-fetch](https://www.npmjs.com/package/node-fetch)
 
 Running:
+
 ```shell
 yarn openapi-code-generator \
   --input ./openapi.yaml \
@@ -97,6 +113,7 @@ yarn openapi-code-generator \
 ```
 
 Will output these files into `./src/clients/some-service`:
+
 - `./client.ts`: exports a class `ApiClient` that implements methods for calling each endpoint
 - `./models.ts`: exports typescript types
 
@@ -130,9 +147,11 @@ console.log(`id is: ${body.id}`)
 ```
 
 ### Typescript Angular
+
 **Note: this is the least battle tested of the templates and most likely to have critical bugs**
 
 The `typescript-angular` template outputs a client SDK based on the [Angular HttpClient](https://angular.io/api/common/http/HttpClient) that gives the following:
+
 - Typed methods to call each endpoint returning an [RxJS Observable](https://rxjs.dev/guide/observable)
 
 It does not yet support runtime validation/parsing - compile time type safety only at this stage.
@@ -140,6 +159,7 @@ It does not yet support runtime validation/parsing - compile time type safety on
 See [integration-tests/typescript-angular](../../integration-tests/typescript-angular) for more samples.
 
 Running:
+
 ```shell
 yarn openapi-code-generator \
   --input ./openapi.yaml \
@@ -148,6 +168,7 @@ yarn openapi-code-generator \
 ```
 
 Will output these files into `./src/app/clients/some-service`:
+
 - `./api.module.ts`: exports a class `ApiModule` as an `NgModule`
 - `./client.service.ts`: exports a class `ApiClient` as injectable Angular service
 - `./models.ts`: exports typescript types
@@ -183,7 +204,7 @@ export class AppComponent {
 
     client.updateTodoListById({listId: "1", requestBody: {name: "Foo"}})
       .subscribe(next => {
-        if(next.status === 200){
+        if (next.status === 200) {
           // TODO: body is currently incorrectly `unknown` here
           console.log(next.body.id)
         }
@@ -193,26 +214,31 @@ export class AppComponent {
 ```
 
 ## Server Examples
+
 Currently, there is a single server template: `typescript-koa`
 
 Support for `express` or other frameworks may be added in future.
 
 ### Typescript Koa
+
 The `typescript-koa` template outputs scaffolding code that handles the following:
+
 - Building a [@koa/router](https://www.npmjs.com/package/@koa/router) instance with all routes in the openapi specification
 - Generating types and runtime schema parsers for all request parameters/bodies and response bodies
 - Generating types for route handlers that receive validated inputs, and have return types that are additionally validated at runtime prior to sending the response
-- Actually starting the server and binding to a port
+- (Optionally) Actually starting the server and binding to a port
 
 See [integration-tests/typescript-koa](../../integration-tests/typescript-koa) for more samples.
 
 Dependencies:
+
 ```shell
 yarn add @nahkies/typescript-koa-runtime @koa/cors @koa/router koa koa-body zod
 yarn add --dev @types/koa @types/koa__router
 ```
 
 Running:
+
 ```shell
 yarn openapi-code-generator \
   --input ./openapi.yaml \
@@ -222,8 +248,9 @@ yarn openapi-code-generator \
 ```
 
 Will output three files into `./src`:
-- `generated.ts` - exports a single function `bootstrap` and associated types used to start your server
-- `models.ts` - exports typescript types
+
+- `generated.ts` - exports a `createRouter` and `bootstrap` function, along with associated types used to create your server
+- `models.ts` - exports typescript types for schemas
 - `schemas.ts` - exports runtime schema validators
 
 Once generated usage should look something like this:
@@ -260,5 +287,37 @@ bootstrap({
 })
 ```
 
+#### Custom Koa app / configuration
+
+The provided `bootstrap` function has a limited range of options. For more advanced use-cases, eg: `https`, or binding to a
+specific ip address you will need to construct your own Koa `app`.
+
+The only real requirement is that you provide a body parsing middleware before the `router` that places a parsed request body
+on the `ctx.body` property.
+
+Eg:
+
+```typescript
+import {createRouter} from "../generated"
+import KoaBody from "koa-body"
+
+// ...implement routes where
+
+const app = new Koa()
+
+// it doesn't have to be koa-body, but it does need to put the parsed body on `ctx.body`
+app.use(KoaBody())
+
+// mount the generated router
+const router = createRouter({getTodoLists, createTodoList})
+app.use(router.allowedMethods())
+app.use(router.routes())
+
+app.listen(8080, '127.0.0.1', () => {
+  console.info("listening")
+})
+```
+
 ## More information / contributing
+
 Refer to top level [README.md](../../README.md) / [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -187,7 +187,7 @@ ${buildExport({
       kind: "type",
     })}
 
-export function createRouter(implementation: Implementation) {
+export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   ${routes.join("\n\n")}

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -187,17 +187,17 @@ ${buildExport({
       kind: "type",
     })}
 
-export function bootstrap(implementation: Implementation, config: Omit<ServerConfig, "router">){
-  // ${clientName}
+export function createRouter(implementation: Implementation) {
   const router = new KoaRouter()
 
   ${routes.join("\n\n")}
 
-  return startServer({
-    middleware: config.middleware,
-    router,
-    port: config.port
-  })
+  return router
+}
+
+export async function bootstrap(config: ServerConfig) {
+  // ${clientName}
+  return startServer(config)
 }
 `
   }

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -97,15 +97,23 @@ export async function startServer({
   app.use(router.allowedMethods())
   app.use(router.routes())
 
-  return new Promise((resolve) => {
-    const server = app.listen(port, () => {
-      const address = server.address()
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        try {
+          const address = server.address()
 
-      if (!address || typeof address !== "object") {
-        throw new Error("failed to bind port")
-      }
+          if (!address || typeof address !== "object") {
+            throw new Error("failed to bind port")
+          }
 
-      resolve({app, server, address})
-    })
+          resolve({app, server, address})
+        } catch (err) {
+          reject(err)
+        }
+      })
+    } catch (err) {
+      reject(err)
+    }
   })
 }

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -42,19 +42,19 @@ export type Response<Status extends StatusCode, Type> = {
 }
 
 export type ServerConfig = {
-  /** set to false to disable cors middleware, pass undefined for defaults */
-  cors?: false | Cors.Options | undefined
+  /** set to "disabled" to disable cors middleware, omit or pass undefined for defaults */
+  cors?: "disabled" | Cors.Options | undefined
 
   /**
-   * set to false to disable body parsing middleware, pass undefined for defaults.
+   * set to "disabled" to disable body parsing middleware, omit or pass undefined for defaults.
    *
    * if disabling, ensure you pass a body parsing middlware that places the parsed
    * body on `ctx.body` for request body processing to work.
    **/
-  body?: false | KoaBodyMiddlewareOptions | undefined
+  body?: "disabled" | KoaBodyMiddlewareOptions | undefined
 
   /**
-   * optional array of arbitrary middleware to be mounted before the Router,
+   *
    * useful for mounting logging, alternative body parsers, etc
    */
   middleware?: Middleware[]
@@ -71,6 +71,15 @@ export type ServerConfig = {
   port?: number
 }
 
+/**
+ * Starts a Koa server and listens on `port` or a randomly allocated port if none provided.
+ * Enables CORS and body parsing by default. It's recommended to customize the CORS options
+ * for production usage.
+ *
+ * If you need more control over your Koa server you should avoid calling this function,
+ * and instead mount the router from your generated codes `createRouter` call directly
+ * onto a server you have constructed.
+ */
 export async function startServer({
   middleware = [],
   cors = undefined,
@@ -84,11 +93,11 @@ export async function startServer({
 }> {
   const app = new Koa()
 
-  if (cors !== false) {
+  if (cors !== "disabled") {
     app.use(Cors(cors))
   }
 
-  if (body !== false) {
+  if (body !== "disabled") {
     app.use(KoaBody(body))
   }
 

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -1,51 +1,113 @@
-import cors from "@koa/cors"
+/**
+ * @prettier
+ */
+
+import Cors from "@koa/cors"
 import Koa, {Middleware} from "koa"
-import koaBody from "koa-body"
+import KoaBody from "koa-body"
 import Router from "@koa/router"
 import {Server} from "http"
+import {KoaBodyMiddlewareOptions} from "koa-body/lib/types"
+import {AddressInfo} from "node:net"
 
 // from https://stackoverflow.com/questions/39494689/is-it-possible-to-restrict-number-to-a-certain-range
-type Enumerate<N extends number, Acc extends number[] = []> = Acc["length"] extends N
+type Enumerate<
+  N extends number,
+  Acc extends number[] = [],
+> = Acc["length"] extends N
   ? Acc[number]
   : Enumerate<N, [...Acc, Acc["length"]]>
 
-type IntRange<F extends number, T extends number> = F extends T ?
-  F :
-  Exclude<Enumerate<T>, Enumerate<F>> extends never ?
-    never :
-    Exclude<Enumerate<T>, Enumerate<F>> | T
+type IntRange<F extends number, T extends number> = F extends T
+  ? F
+  : Exclude<Enumerate<T>, Enumerate<F>> extends never
+  ? never
+  : Exclude<Enumerate<T>, Enumerate<F>> | T
 
 export type StatusCode1xx = IntRange<100, 199> // `1${number}${number}`
 export type StatusCode2xx = IntRange<200, 299> // `2${number}${number}`
 export type StatusCode3xx = IntRange<300, 399> // `3${number}${number}`
 export type StatusCode4xx = IntRange<400, 499> // `4${number}${number}`
 export type StatusCode5xx = IntRange<500, 599> // `5${number}${number}`
-export type StatusCode = StatusCode1xx | StatusCode2xx | StatusCode3xx | StatusCode4xx | StatusCode5xx
+export type StatusCode =
+  | StatusCode1xx
+  | StatusCode2xx
+  | StatusCode3xx
+  | StatusCode4xx
+  | StatusCode5xx
 
-export type Response<Status extends StatusCode, Type> = { status: Status, body: Type }
-
-export type ServerConfig = {
-  middleware?: Middleware[]
-  router: Router
-  port: number
+export type Response<Status extends StatusCode, Type> = {
+  status: Status
+  body: Type
 }
 
-export function startServer(config: ServerConfig): Server {
+export type ServerConfig = {
+  /** set to false to disable cors middleware, pass undefined for defaults */
+  cors?: false | Cors.Options | undefined
+
+  /**
+   * set to false to disable body parsing middleware, pass undefined for defaults.
+   *
+   * if disabling, ensure you pass a body parsing middlware that places the parsed
+   * body on `ctx.body` for request body processing to work.
+   **/
+  body?: false | KoaBodyMiddlewareOptions | undefined
+
+  /**
+   * optional array of arbitrary middleware to be mounted before the Router,
+   * useful for mounting logging, alternative body parsers, etc
+   */
+  middleware?: Middleware[]
+
+  /**
+   * the router to use, normally obtained by calling the generated `createRouter`
+   * function
+   */
+  router: Router
+
+  /**
+   * the port to listen on, a randomly allocated port will be used if none passed
+   */
+  port?: number
+}
+
+export async function startServer({
+  middleware = [],
+  cors = undefined,
+  body = undefined,
+  port = 0,
+  router,
+}: ServerConfig): Promise<{
+  app: Koa
+  server: Server
+  address: AddressInfo
+}> {
   const app = new Koa()
 
-  app.use(cors())
-  app.use(koaBody())
+  if (cors !== false) {
+    app.use(Cors(cors))
+  }
 
-  const middleware = config.middleware ?? []
-  middleware.forEach(it => app.use(it))
+  if (body !== false) {
+    app.use(KoaBody(body))
+  }
 
-  app.use(config.router.allowedMethods())
-  app.use(config.router.routes())
+  middleware.forEach((it) => app.use(it))
 
-  const server = app.listen(config.port, () => {
-    const address = server.address()
-    console.info("server listening", {address})
+  app.use(router.allowedMethods())
+  app.use(router.routes())
+
+  return new Promise((resolve) => {
+    const server = app.listen(port, () => {
+      const address = server.address()
+
+      if (!address || typeof address !== "object") {
+        throw new Error("failed to bind port")
+      }
+
+      console.info("server listening", {address})
+
+      resolve({app, server, address})
+    })
   })
-
-  return server
 }

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -105,8 +105,6 @@ export async function startServer({
         throw new Error("failed to bind port")
       }
 
-      console.info("server listening", {address})
-
       resolve({app, server, address})
     })
   })

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -9,6 +9,7 @@ import Router from "@koa/router"
 import {Server} from "http"
 import {KoaBodyMiddlewareOptions} from "koa-body/lib/types"
 import {AddressInfo} from "node:net"
+import {ListenOptions} from "net"
 
 // from https://stackoverflow.com/questions/39494689/is-it-possible-to-restrict-number-to-a-certain-range
 type Enumerate<
@@ -67,8 +68,10 @@ export type ServerConfig = {
 
   /**
    * the port to listen on, a randomly allocated port will be used if none passed
+   * alternatively ListenOptions can be passed to control the network interface
+   * bound to.
    */
-  port?: number
+  port?: number | ListenOptions
 }
 
 /**

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -111,7 +111,9 @@ export async function startServer({
 
   return new Promise((resolve, reject) => {
     try {
-      const server = app.listen(port, () => {
+      const server = app.listen(port)
+
+      server.once("listening", () => {
         try {
           const address = server.address()
 
@@ -123,6 +125,10 @@ export async function startServer({
         } catch (err) {
           reject(err)
         }
+      })
+
+      server.once("error", (err) => {
+        reject(err)
       })
     } catch (err) {
       reject(err)


### PR DESCRIPTION
- split out a generated `createRouter` function that only creates
  the koa router, making use of the `bootstrap` / `startServer`
  functions optional

- allow passing options to the `cors` / `koa-body` middlewares, or
  disabling these completely

- support passing a `ListenOptions` instead of `port` number, allowing
  to bind to a specific network interface

- return the koa `app` and the `AddressInfo` from `startServer` /
  `bootstrap`

- make `startServer` an `async` function that rejects if `app.listen`
  fails

**this is a breaking change**, and probably not the last to this interface.
whilst the prior iteration was far too inflexible, this doesn't feel quite right still:
- `startServer` still pretty inflexible/simple, and doesn't support all options
- but also now flexible enough to shoot yourself in the foot, eg: `body: "disable"` and no suitable alternative provided
- `bootstrap` function basically redundant now as well, though that may not remain true so can stay for the moment

closes #94