### PR TITLE
style: comma-dangle always-multiline

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     indent: "off",
     "linebreak-style": ["error", "unix"],
     quotes: ["error", "double", {avoidEscape: true}],
+    "comma-dangle": ["error", "always-multiline"],
     semi: ["error", "never"],
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
@@ -29,21 +30,21 @@ module.exports = {
         minimumDescriptionLength: 3,
       },
     ],
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
   },
   overrides: [
     {
       files: "**/*.spec.ts",
       extends: [
         "plugin:jest/recommended",
-        "plugin:jest/style"
+        "plugin:jest/style",
       ],
       env: {
-        jest: true
+        jest: true,
       },
       rules: {
-        "prefer-arrow-callback": "error"
-      }
-    }
+        "prefer-arrow-callback": "error",
+      },
+    },
   ],
 }

--- a/jest.base.js
+++ b/jest.base.js
@@ -7,7 +7,7 @@ const config = {
     "^.+\\.(t|j)sx?$": "@swc/jest",
   },
   resetMocks: true,
-  testMatch: ["**/*.spec.ts"]
+  testMatch: ["**/*.spec.ts"],
 }
 
 module.exports = config

--- a/packages/openapi-code-generator/jest.config.js
+++ b/packages/openapi-code-generator/jest.config.js
@@ -8,7 +8,7 @@ const {name: displayName} = require("./package.json")
  */
 const config = {
   ...base,
-  displayName
+  displayName,
 }
 
 module.exports = config

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -31,7 +31,7 @@ import {logger} from "./logger"
 
 export class Input {
   constructor(
-    readonly loader: OpenapiLoader
+    readonly loader: OpenapiLoader,
   ) {
   }
 
@@ -73,7 +73,7 @@ export class Input {
           responses: this.normalizeResponsesObject(definition.responses),
           summary: definition.summary,
           description: definition.description,
-          deprecated: definition.deprecated ?? false
+          deprecated: definition.deprecated ?? false,
         })
       }
     }
@@ -134,8 +134,8 @@ export class Input {
         {
           headers: {},
           description: response.description,
-          content: normalizeMediaType(response.content)
-        }
+          content: normalizeMediaType(response.content),
+        },
       ]
     }))
   }
@@ -159,7 +159,7 @@ function normalizeRequestBodyObject(requestBodyObject: RequestBody): IRRequestBo
   return {
     description: requestBodyObject.description,
     required: requestBodyObject.required ?? true,
-    content: normalizeMediaType(requestBodyObject.content)
+    content: normalizeMediaType(requestBodyObject.content),
   }
 }
 
@@ -172,8 +172,8 @@ function normalizeMediaType(mediaTypes: {[contentType: string]: MediaType} = {})
       contentType,
       {
         schema: normalizeSchemaObject(mediaType.schema),
-        encoding: mediaType.encoding
-      }
+        encoding: mediaType.encoding,
+      },
     ]
   }))
 }
@@ -186,7 +186,7 @@ function normalizeParameterObject(parameterObject: Parameter): IRParameter {
     description: parameterObject.description,
     required: parameterObject.required ?? false,
     deprecated: parameterObject.deprecated ?? false,
-    allowEmptyValue: parameterObject.allowEmptyValue ?? false
+    allowEmptyValue: parameterObject.allowEmptyValue ?? false,
   }
 }
 
@@ -197,7 +197,7 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
 
   const base: IRModelBase = {
     nullable: schemaObject.nullable || false,
-    readOnly: schemaObject.readOnly || false
+    readOnly: schemaObject.readOnly || false,
   }
 
   switch (schemaObject.type) {
@@ -228,7 +228,7 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         anyOf,
         required,
         properties,
-        additionalProperties
+        additionalProperties,
       } satisfies IRModelObject
     }
     case "array": {
@@ -242,7 +242,7 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
       return {
         ...base,
         type: schemaObject.type,
-        items: normalizeSchemaObject(items)
+        items: normalizeSchemaObject(items),
       } satisfies IRModelArray
     }
     case "number":
@@ -254,7 +254,7 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         type: "number",
         // todo: https://github.com/mnahkies/openapi-code-generator/issues/51
         format: schemaObject.format as any,
-        enum: enumValues.length ? enumValues : undefined
+        enum: enumValues.length ? enumValues : undefined,
       } satisfies IRModelNumeric
     }
     case "string": {
@@ -264,13 +264,13 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
         ...base,
         type: schemaObject.type,
         format: schemaObject.format as any,
-        enum: enumValues.length ? enumValues : undefined
+        enum: enumValues.length ? enumValues : undefined,
       } satisfies IRModelString
     }
     case "boolean":
       return {
         ...base,
-        type: schemaObject.type
+        type: schemaObject.type,
       } satisfies IRModelBoolean
     default:
       throw new Error(`unsupported type '${schemaObject.type}'`)

--- a/packages/openapi-code-generator/src/test/input.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/input.test-utils.ts
@@ -20,7 +20,7 @@ export async function unitTestInput(skipValidation = false) {
 
 export async function createTestInputFromYamlString(
   str: string,
-  skipValidation = true
+  skipValidation = true,
 ): Promise<Input> {
   const spec = yaml.load(str)
 

--- a/packages/openapi-code-generator/src/typescript/common/client-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/client-operation-builder.ts
@@ -86,7 +86,7 @@ export class ClientOperationBuilder {
       .map(it => {
         return {
           statusType: statusStringToType(it.status),
-          responseType: it.definition ? models.schemaObjectToType(it.definition) : "void"
+          responseType: it.definition ? models.schemaObjectToType(it.definition) : "void",
         }
       })
   }

--- a/packages/openapi-code-generator/src/typescript/common/typescript-common.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-common.ts
@@ -31,7 +31,7 @@ export function combineParams(parameters: MethodParameterDefinition[], name = "p
     }
     }`,
     required: true, // avoid "TS1015: Parameter cannot have question mark and initializer."
-    default: !required ? "{}" : undefined
+    default: !required ? "{}" : undefined,
   }
 }
 
@@ -51,7 +51,7 @@ export function combineAndDestructureParams(parameters: MethodParameterDefinitio
     ${
       params(parameters)
     }
-    }`
+    }`,
   }
 }
 
@@ -123,8 +123,8 @@ export function requestBodyAsParameter(operation: IROperation): {
         required: requestBody.required,
         schema: definition.schema,
         allowEmptyValue: false,
-        deprecated: false
-      }
+        deprecated: false,
+      },
     }
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/angular-service-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/angular-service-builder.ts
@@ -59,7 +59,7 @@ return this.httpClient.request<any>(
         [
             queryString ? "params," : "",
             headers ? "headers," : "",
-            requestBodyParameter ? "body," : ""
+            requestBodyParameter ? "body," : "",
         ]
             .filter(Boolean)
             .join("\n")

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
@@ -54,7 +54,7 @@ const url = this.basePath + \`${routeToTemplateString(route)}\`
         `method: "${method}",`,
         headers ? "headers," : "",
         requestBodyParameter ? "body," : "",
-        "...(opts ?? {})"
+        "...(opts ?? {})",
       ]
         .filter(Boolean)
         .join("\n")

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -28,7 +28,7 @@ function reduceParamsToOpenApiSchema(parameters: IRParameter[]): IRModelObject {
     anyOf: [],
     additionalProperties: false,
     nullable: false,
-    readOnly: false
+    readOnly: false,
   } as IRModelObject)
 }
 
@@ -138,11 +138,11 @@ export class ServerBuilder {
 ) => Promise<${
           [
             ...responseSchemas.specific.map(it => `Response<${it.statusType}, ${it.type}>`),
-            responseSchemas.defaultResponse && `Response<StatusCode, ${responseSchemas.defaultResponse.type}>`
+            responseSchemas.defaultResponse && `Response<StatusCode, ${responseSchemas.defaultResponse.type}>`,
           ]
             .filter(isDefined).join(" | ")
         }>`,
-        kind: "type"
+        kind: "type",
       })
 
     this.statements.push([
@@ -184,7 +184,7 @@ ${Object.values(this.operationTypeMap).join("\n\n")}
 ${buildExport({
       name: "Implementation",
       value: object(Object.keys(this.operationTypeMap).map((key) => `${key}: ${titleCase(key)}`).join(",")),
-      kind: "type"
+      kind: "type",
     })}
 
 export function bootstrap(implementation: Implementation, config: Omit<ServerConfig, "router">){
@@ -225,7 +225,7 @@ export async function generateTypescriptKoa(config: OpenapiGeneratorConfig): Pro
     imports,
     types,
     schemaBuilder,
-    loadExistingImplementations(await loadPreviousResult(config.dest, {filename: "index.ts"}))
+    loadExistingImplementations(await loadPreviousResult(config.dest, {filename: "index.ts"})),
   )
 
   input.allOperations()

--- a/packages/typescript-fetch-runtime/jest.config.js
+++ b/packages/typescript-fetch-runtime/jest.config.js
@@ -8,7 +8,7 @@ const {name: displayName} = require("./package.json")
  */
 const config = {
   ...base,
-  displayName
+  displayName,
 }
 
 module.exports = config

--- a/packages/typescript-fetch-runtime/src/main.spec.ts
+++ b/packages/typescript-fetch-runtime/src/main.spec.ts
@@ -21,7 +21,7 @@ describe("main", () => {
 
     it("returns the defined params in a simple case", () => {
       expect(
-        client.query({ foo: undefined, bar: "baz", foobar: "value" })
+        client.query({ foo: undefined, bar: "baz", foobar: "value" }),
       ).toBe("?bar=baz&foobar=value")
     })
 
@@ -31,7 +31,7 @@ describe("main", () => {
 
     it("handles objects", () => {
       expect(client.query({ foo: { bar: "baz" } })).toBe(
-        `?${encodeURIComponent("foo[bar]")}=baz`
+        `?${encodeURIComponent("foo[bar]")}=baz`,
       )
     })
 
@@ -45,13 +45,13 @@ describe("main", () => {
           limit: 10,
           undefined: undefined,
           includeSomething: false,
-        })
+        }),
       ).toBe(
         `?${encodeURIComponent("foo[prop1]")}=one&${encodeURIComponent(
-          "foo[prop2]"
+          "foo[prop2]",
         )}=two&${encodeURIComponent("foo[prop1]")}=foo&${encodeURIComponent(
-          "foo[prop2]"
-        )}=bar&limit=10&includeSomething=false`
+          "foo[prop2]",
+        )}=bar&limit=10&includeSomething=false`,
       )
     })
   })

--- a/packages/typescript-koa-runtime/jest.config.js
+++ b/packages/typescript-koa-runtime/jest.config.js
@@ -8,7 +8,7 @@ const {name: displayName} = require("./package.json")
  */
 const config = {
   ...base,
-  displayName
+  displayName,
 }
 
 module.exports = config

--- a/packages/typescript-koa-runtime/src/joi.ts
+++ b/packages/typescript-koa-runtime/src/joi.ts
@@ -14,7 +14,7 @@ export function parseRequestInput(
 ): undefined;
 export function parseRequestInput<Schema extends JoiSchema>(
   schema: Schema | undefined,
-  input: unknown
+  input: unknown,
 ): any {
 
   if (!schema) {

--- a/packages/typescript-koa-runtime/src/zod.ts
+++ b/packages/typescript-koa-runtime/src/zod.ts
@@ -12,7 +12,7 @@ export function parseRequestInput(
 ): undefined;
 export function parseRequestInput<Schema extends z.ZodTypeAny>(
   schema: Schema | undefined,
-  input: unknown
+  input: unknown,
 ): z.infer<Schema> | undefined {
   return schema?.parse(input)
 }


### PR DESCRIPTION
enables https://eslint.org/docs/latest/rules/comma-dangle to force trailing commas on multi-line statements.