### PR TITLE
feat!: throw discriminable errors indicating point of failure

### DIFF
--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -2126,6 +2126,10 @@ import {
 } from "./schemas"
 import KoaRouter from "@koa/router"
 import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
+import {
   Response,
   ServerConfig,
   StatusCode,
@@ -12574,7 +12578,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.metaRoot(input, ctx)
+    const { status, body } = await implementation
+      .metaRoot(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = metaRootResponseValidator(status, body)
     ctx.status = status
@@ -12636,12 +12644,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           securityAdvisoriesListGlobalAdvisoriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesListGlobalAdvisories(input, ctx)
+      const { status, body } = await implementation
+        .securityAdvisoriesListGlobalAdvisories(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesListGlobalAdvisoriesResponseValidator(
         status,
@@ -12673,13 +12685,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesGetGlobalAdvisoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesGetGlobalAdvisory(input, ctx)
+      const { status, body } = await implementation
+        .securityAdvisoriesGetGlobalAdvisory(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesGetGlobalAdvisoryResponseValidator(
         status,
@@ -12702,10 +12718,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.appsGetAuthenticated(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .appsGetAuthenticated(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = appsGetAuthenticatedResponseValidator(status, body)
     ctx.status = status
@@ -12741,15 +12758,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsCreateFromManifestParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsCreateFromManifest(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsCreateFromManifest(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsCreateFromManifestResponseValidator(status, body)
       ctx.status = status
@@ -12772,10 +12791,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsGetWebhookConfigForApp(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsGetWebhookConfigForApp(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetWebhookConfigForAppResponseValidator(status, body)
       ctx.status = status
@@ -12803,11 +12823,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           appsUpdateWebhookConfigForAppBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.appsUpdateWebhookConfigForApp(input, ctx)
+      const { status, body } = await implementation
+        .appsUpdateWebhookConfigForApp(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsUpdateWebhookConfigForAppResponseValidator(status, body)
       ctx.status = status
@@ -12839,14 +12863,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           appsListWebhookDeliveriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsListWebhookDeliveries(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsListWebhookDeliveries(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListWebhookDeliveriesResponseValidator(status, body)
       ctx.status = status
@@ -12875,15 +12901,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsGetWebhookDeliveryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsGetWebhookDelivery(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsGetWebhookDelivery(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetWebhookDeliveryResponseValidator(status, body)
       ctx.status = status
@@ -12913,13 +12941,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsRedeliverWebhookDeliveryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsRedeliverWebhookDelivery(input, ctx)
+      const { status, body } = await implementation
+        .appsRedeliverWebhookDelivery(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsRedeliverWebhookDeliveryResponseValidator(status, body)
       ctx.status = status
@@ -12951,15 +12983,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           appsListInstallationRequestsForAuthenticatedAppQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListInstallationRequestsForAuthenticatedApp(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsListInstallationRequestsForAuthenticatedApp(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         appsListInstallationRequestsForAuthenticatedAppResponseValidator(
@@ -12989,14 +13022,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(appsListInstallationsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          appsListInstallationsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsListInstallations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsListInstallations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListInstallationsResponseValidator(status, body)
       ctx.status = status
@@ -13021,15 +13059,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/app/installations/:installationId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(appsGetInstallationParamSchema, ctx.params),
+        params: parseRequestInput(
+          appsGetInstallationParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsGetInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsGetInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetInstallationResponseValidator(status, body)
       ctx.status = status
@@ -13057,15 +13100,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsDeleteInstallationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsDeleteInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsDeleteInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsDeleteInstallationResponseValidator(status, body)
       ctx.status = status
@@ -13105,16 +13150,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsCreateInstallationAccessTokenParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           appsCreateInstallationAccessTokenBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.appsCreateInstallationAccessToken(input, ctx)
+      const { status, body } = await implementation
+        .appsCreateInstallationAccessToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsCreateInstallationAccessTokenResponseValidator(
         status,
@@ -13145,15 +13195,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsSuspendInstallationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsSuspendInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsSuspendInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsSuspendInstallationResponseValidator(status, body)
       ctx.status = status
@@ -13181,15 +13233,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsUnsuspendInstallationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsUnsuspendInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsUnsuspendInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsUnsuspendInstallationResponseValidator(status, body)
       ctx.status = status
@@ -13219,18 +13273,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsDeleteAuthorizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           appsDeleteAuthorizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.appsDeleteAuthorization(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsDeleteAuthorization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsDeleteAuthorizationResponseValidator(status, body)
       ctx.status = status
@@ -13256,12 +13313,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/applications/:clientId/token",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(appsCheckTokenParamSchema, ctx.params),
+        params: parseRequestInput(
+          appsCheckTokenParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(appsCheckTokenBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          appsCheckTokenBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.appsCheckToken(input, ctx)
+      const { status, body } = await implementation
+        .appsCheckToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsCheckTokenResponseValidator(status, body)
       ctx.status = status
@@ -13286,12 +13355,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/applications/:clientId/token",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(appsResetTokenParamSchema, ctx.params),
+        params: parseRequestInput(
+          appsResetTokenParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(appsResetTokenBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          appsResetTokenBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.appsResetToken(input, ctx)
+      const { status, body } = await implementation
+        .appsResetToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsResetTokenResponseValidator(status, body)
       ctx.status = status
@@ -13316,12 +13397,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/applications/:clientId/token",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(appsDeleteTokenParamSchema, ctx.params),
+        params: parseRequestInput(
+          appsDeleteTokenParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(appsDeleteTokenBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          appsDeleteTokenBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.appsDeleteToken(input, ctx)
+      const { status, body } = await implementation
+        .appsDeleteToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsDeleteTokenResponseValidator(status, body)
       ctx.status = status
@@ -13356,12 +13449,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/applications/:clientId/token/scoped",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(appsScopeTokenParamSchema, ctx.params),
+        params: parseRequestInput(
+          appsScopeTokenParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(appsScopeTokenBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          appsScopeTokenBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.appsScopeToken(input, ctx)
+      const { status, body } = await implementation
+        .appsScopeToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsScopeTokenResponseValidator(status, body)
       ctx.status = status
@@ -13382,12 +13487,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("appsGetBySlug", "/apps/:appSlug", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(appsGetBySlugParamSchema, ctx.params),
+      params: parseRequestInput(
+        appsGetBySlugParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.appsGetBySlug(input, ctx)
+    const { status, body } = await implementation
+      .appsGetBySlug(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = appsGetBySlugResponseValidator(status, body)
     ctx.status = status
@@ -13414,15 +13527,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           classroomGetAnAssignmentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.classroomGetAnAssignment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .classroomGetAnAssignment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = classroomGetAnAssignmentResponseValidator(status, body)
       ctx.status = status
@@ -13453,19 +13568,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           classroomListAcceptedAssigmentsForAnAssignmentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           classroomListAcceptedAssigmentsForAnAssignmentQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.classroomListAcceptedAssigmentsForAnAssignment(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .classroomListAcceptedAssigmentsForAnAssignment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         classroomListAcceptedAssigmentsForAnAssignmentResponseValidator(
@@ -13498,13 +13615,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           classroomGetAssignmentGradesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.classroomGetAssignmentGrades(input, ctx)
+      const { status, body } = await implementation
+        .classroomGetAssignmentGrades(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = classroomGetAssignmentGradesResponseValidator(status, body)
       ctx.status = status
@@ -13525,14 +13646,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("classroomListClassrooms", "/classrooms", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(classroomListClassroomsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        classroomListClassroomsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.classroomListClassrooms(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .classroomListClassrooms(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = classroomListClassroomsResponseValidator(status, body)
     ctx.status = status
@@ -13559,15 +13685,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           classroomGetAClassroomParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.classroomGetAClassroom(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .classroomGetAClassroom(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = classroomGetAClassroomResponseValidator(status, body)
       ctx.status = status
@@ -13598,16 +13726,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           classroomListAssignmentsForAClassroomParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           classroomListAssignmentsForAClassroomQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.classroomListAssignmentsForAClassroom(input, ctx)
+      const { status, body } = await implementation
+        .classroomListAssignmentsForAClassroom(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = classroomListAssignmentsForAClassroomResponseValidator(
         status,
@@ -13637,8 +13770,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codesOfConductGetAllCodesOfConduct(input, ctx)
+      const { status, body } = await implementation
+        .codesOfConductGetAllCodesOfConduct(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codesOfConductGetAllCodesOfConductResponseValidator(
         status,
@@ -13669,13 +13805,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codesOfConductGetConductCodeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codesOfConductGetConductCode(input, ctx)
+      const { status, body } = await implementation
+        .codesOfConductGetConductCode(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codesOfConductGetConductCodeResponseValidator(status, body)
       ctx.status = status
@@ -13698,7 +13838,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.emojisGet(input, ctx)
+    const { status, body } = await implementation
+      .emojisGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = emojisGetResponseValidator(status, body)
     ctx.status = status
@@ -13744,16 +13888,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotListAlertsForEnterpriseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependabotListAlertsForEnterpriseQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.dependabotListAlertsForEnterprise(input, ctx)
+      const { status, body } = await implementation
+        .dependabotListAlertsForEnterprise(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotListAlertsForEnterpriseResponseValidator(
         status,
@@ -13804,16 +13953,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           secretScanningListAlertsForEnterpriseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           secretScanningListAlertsForEnterpriseQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.secretScanningListAlertsForEnterprise(input, ctx)
+      const { status, body } = await implementation
+        .secretScanningListAlertsForEnterprise(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = secretScanningListAlertsForEnterpriseResponseValidator(
         status,
@@ -13849,14 +14003,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("activityListPublicEvents", "/events", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(activityListPublicEventsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        activityListPublicEventsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.activityListPublicEvents(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .activityListPublicEvents(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = activityListPublicEventsResponseValidator(status, body)
     ctx.status = status
@@ -13875,7 +14034,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.activityGetFeeds(input, ctx)
+    const { status, body } = await implementation
+      .activityGetFeeds(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = activityGetFeedsResponseValidator(status, body)
     ctx.status = status
@@ -13900,11 +14063,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("gistsList", "/gists", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(gistsListQuerySchema, ctx.query),
+      query: parseRequestInput(
+        gistsListQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsList(input, ctx)
+    const { status, body } = await implementation
+      .gistsList(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsListResponseValidator(status, body)
     ctx.status = status
@@ -13932,10 +14103,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(gistsCreateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        gistsCreateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.gistsCreate(input, ctx)
+    const { status, body } = await implementation
+      .gistsCreate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsCreateResponseValidator(status, body)
     ctx.status = status
@@ -13961,11 +14140,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("gistsListPublic", "/gists/public", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(gistsListPublicQuerySchema, ctx.query),
+      query: parseRequestInput(
+        gistsListPublicQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsListPublic(input, ctx)
+    const { status, body } = await implementation
+      .gistsListPublic(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsListPublicResponseValidator(status, body)
     ctx.status = status
@@ -13991,11 +14178,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("gistsListStarred", "/gists/starred", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(gistsListStarredQuerySchema, ctx.query),
+      query: parseRequestInput(
+        gistsListStarredQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsListStarred(input, ctx)
+    const { status, body } = await implementation
+      .gistsListStarred(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsListStarredResponseValidator(status, body)
     ctx.status = status
@@ -14029,12 +14224,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("gistsGet", "/gists/:gistId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsGetParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsGetParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsGet(input, ctx)
+    const { status, body } = await implementation
+      .gistsGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsGetResponseValidator(status, body)
     ctx.status = status
@@ -14061,12 +14264,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.patch("gistsUpdate", "/gists/:gistId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsUpdateParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsUpdateParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(gistsUpdateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        gistsUpdateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.gistsUpdate(input, ctx)
+    const { status, body } = await implementation
+      .gistsUpdate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsUpdateResponseValidator(status, body)
     ctx.status = status
@@ -14087,12 +14302,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("gistsDelete", "/gists/:gistId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsDeleteParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsDeleteParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsDelete(input, ctx)
+    const { status, body } = await implementation
+      .gistsDelete(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsDeleteResponseValidator(status, body)
     ctx.status = status
@@ -14121,15 +14344,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/comments",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsListCommentsParamSchema, ctx.params),
-        query: parseRequestInput(gistsListCommentsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          gistsListCommentsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          gistsListCommentsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.gistsListComments(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gistsListComments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsListCommentsResponseValidator(status, body)
       ctx.status = status
@@ -14156,15 +14388,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/comments",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsCreateCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          gistsCreateCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gistsCreateCommentBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gistsCreateCommentBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gistsCreateComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gistsCreateComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsCreateCommentResponseValidator(status, body)
       ctx.status = status
@@ -14205,12 +14446,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsGetCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          gistsGetCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gistsGetComment(input, ctx)
+      const { status, body } = await implementation
+        .gistsGetComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsGetCommentResponseValidator(status, body)
       ctx.status = status
@@ -14238,15 +14487,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsUpdateCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          gistsUpdateCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gistsUpdateCommentBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gistsUpdateCommentBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gistsUpdateComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gistsUpdateComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsUpdateCommentResponseValidator(status, body)
       ctx.status = status
@@ -14274,15 +14532,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsDeleteCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          gistsDeleteCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gistsDeleteComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gistsDeleteComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsDeleteCommentResponseValidator(status, body)
       ctx.status = status
@@ -14312,12 +14575,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/commits",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsListCommitsParamSchema, ctx.params),
-        query: parseRequestInput(gistsListCommitsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          gistsListCommitsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          gistsListCommitsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.gistsListCommits(input, ctx)
+      const { status, body } = await implementation
+        .gistsListCommits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsListCommitsResponseValidator(status, body)
       ctx.status = status
@@ -14344,12 +14619,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("gistsListForks", "/gists/:gistId/forks", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsListForksParamSchema, ctx.params),
-      query: parseRequestInput(gistsListForksQuerySchema, ctx.query),
+      params: parseRequestInput(
+        gistsListForksParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        gistsListForksQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsListForks(input, ctx)
+    const { status, body } = await implementation
+      .gistsListForks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsListForksResponseValidator(status, body)
     ctx.status = status
@@ -14371,12 +14658,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("gistsFork", "/gists/:gistId/forks", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsForkParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsForkParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsFork(input, ctx)
+    const { status, body } = await implementation
+      .gistsFork(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsForkResponseValidator(status, body)
     ctx.status = status
@@ -14400,15 +14695,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gists/:gistId/star",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsCheckIsStarredParamSchema, ctx.params),
+        params: parseRequestInput(
+          gistsCheckIsStarredParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gistsCheckIsStarred(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gistsCheckIsStarred(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsCheckIsStarredResponseValidator(status, body)
       ctx.status = status
@@ -14430,12 +14730,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.put("gistsStar", "/gists/:gistId/star", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsStarParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsStarParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsStar(input, ctx)
+    const { status, body } = await implementation
+      .gistsStar(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsStarResponseValidator(status, body)
     ctx.status = status
@@ -14456,12 +14764,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("gistsUnstar", "/gists/:gistId/star", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsUnstarParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsUnstarParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsUnstar(input, ctx)
+    const { status, body } = await implementation
+      .gistsUnstar(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsUnstarResponseValidator(status, body)
     ctx.status = status
@@ -14485,12 +14801,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("gistsGetRevision", "/gists/:gistId/:sha", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(gistsGetRevisionParamSchema, ctx.params),
+      params: parseRequestInput(
+        gistsGetRevisionParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.gistsGetRevision(input, ctx)
+    const { status, body } = await implementation
+      .gistsGetRevision(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = gistsGetRevisionResponseValidator(status, body)
     ctx.status = status
@@ -14515,10 +14839,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitignoreGetAllTemplates(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gitignoreGetAllTemplates(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitignoreGetAllTemplatesResponseValidator(status, body)
       ctx.status = status
@@ -14541,15 +14866,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/gitignore/templates/:name",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitignoreGetTemplateParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitignoreGetTemplateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitignoreGetTemplate(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gitignoreGetTemplate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitignoreGetTemplateResponseValidator(status, body)
       ctx.status = status
@@ -14589,12 +14919,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           appsListReposAccessibleToInstallationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListReposAccessibleToInstallation(input, ctx)
+      const { status, body } = await implementation
+        .appsListReposAccessibleToInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListReposAccessibleToInstallationResponseValidator(
         status,
@@ -14618,8 +14952,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsRevokeInstallationAccessToken(input, ctx)
+      const { status, body } = await implementation
+        .appsRevokeInstallationAccessToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsRevokeInstallationAccessTokenResponseValidator(
         status,
@@ -14660,11 +14997,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("issuesList", "/issues", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(issuesListQuerySchema, ctx.query),
+      query: parseRequestInput(
+        issuesListQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.issuesList(input, ctx)
+    const { status, body } = await implementation
+      .issuesList(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = issuesListResponseValidator(status, body)
     ctx.status = status
@@ -14691,14 +15036,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
       query: parseRequestInput(
         licensesGetAllCommonlyUsedQuerySchema,
         ctx.query,
+        RequestInputType.QueryString,
       ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.licensesGetAllCommonlyUsed(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .licensesGetAllCommonlyUsed(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = licensesGetAllCommonlyUsedResponseValidator(status, body)
     ctx.status = status
@@ -14719,12 +15066,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("licensesGet", "/licenses/:license", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(licensesGetParamSchema, ctx.params),
+      params: parseRequestInput(
+        licensesGetParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.licensesGet(input, ctx)
+    const { status, body } = await implementation
+      .licensesGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = licensesGetResponseValidator(status, body)
     ctx.status = status
@@ -14749,10 +15104,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(markdownRenderBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        markdownRenderBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.markdownRender(input, ctx)
+    const { status, body } = await implementation
+      .markdownRender(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = markdownRenderResponseValidator(status, body)
     ctx.status = status
@@ -14773,10 +15136,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(markdownRenderRawBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        markdownRenderRawBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.markdownRenderRaw(input, ctx)
+    const { status, body } = await implementation
+      .markdownRenderRaw(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = markdownRenderRawResponseValidator(status, body)
     ctx.status = status
@@ -14805,13 +15176,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsGetSubscriptionPlanForAccountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsGetSubscriptionPlanForAccount(input, ctx)
+      const { status, body } = await implementation
+        .appsGetSubscriptionPlanForAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetSubscriptionPlanForAccountResponseValidator(
         status,
@@ -14842,11 +15217,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(appsListPlansQuerySchema, ctx.query),
+        query: parseRequestInput(
+          appsListPlansQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsListPlans(input, ctx)
+      const { status, body } = await implementation
+        .appsListPlans(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListPlansResponseValidator(status, body)
       ctx.status = status
@@ -14883,15 +15266,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsListAccountsForPlanParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(appsListAccountsForPlanQuerySchema, ctx.query),
+        query: parseRequestInput(
+          appsListAccountsForPlanQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsListAccountsForPlan(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsListAccountsForPlan(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListAccountsForPlanResponseValidator(status, body)
       ctx.status = status
@@ -14921,16 +15310,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsGetSubscriptionPlanForAccountStubbedParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsGetSubscriptionPlanForAccountStubbed(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsGetSubscriptionPlanForAccountStubbed(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetSubscriptionPlanForAccountStubbedResponseValidator(
         status,
@@ -14960,14 +15350,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(appsListPlansStubbedQuerySchema, ctx.query),
+        query: parseRequestInput(
+          appsListPlansStubbedQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsListPlansStubbed(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsListPlansStubbed(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListPlansStubbedResponseValidator(status, body)
       ctx.status = status
@@ -15003,16 +15398,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsListAccountsForPlanStubbedParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           appsListAccountsForPlanStubbedQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListAccountsForPlanStubbed(input, ctx)
+      const { status, body } = await implementation
+        .appsListAccountsForPlanStubbed(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListAccountsForPlanStubbedResponseValidator(status, body)
       ctx.status = status
@@ -15035,7 +15435,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.metaGet(input, ctx)
+    const { status, body } = await implementation
+      .metaGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = metaGetResponseValidator(status, body)
     ctx.status = status
@@ -15072,16 +15476,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListPublicEventsForRepoNetworkParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListPublicEventsForRepoNetworkQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListPublicEventsForRepoNetwork(input, ctx)
+      const { status, body } = await implementation
+        .activityListPublicEventsForRepoNetwork(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListPublicEventsForRepoNetworkResponseValidator(
         status,
@@ -15122,15 +15531,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           activityListNotificationsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListNotificationsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityListNotificationsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListNotificationsForAuthenticatedUserResponseValidator(
         status,
@@ -15170,11 +15580,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           activityMarkNotificationsAsReadBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.activityMarkNotificationsAsRead(input, ctx)
+      const { status, body } = await implementation
+        .activityMarkNotificationsAsRead(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityMarkNotificationsAsReadResponseValidator(status, body)
       ctx.status = status
@@ -15201,15 +15615,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/notifications/threads/:threadId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(activityGetThreadParamSchema, ctx.params),
+        params: parseRequestInput(
+          activityGetThreadParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.activityGetThread(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activityGetThread(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityGetThreadResponseValidator(status, body)
       ctx.status = status
@@ -15238,15 +15657,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityMarkThreadAsReadParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.activityMarkThreadAsRead(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activityMarkThreadAsRead(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityMarkThreadAsReadResponseValidator(status, body)
       ctx.status = status
@@ -15277,16 +15698,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityGetThreadSubscriptionForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityGetThreadSubscriptionForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityGetThreadSubscriptionForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         activityGetThreadSubscriptionForAuthenticatedUserResponseValidator(
@@ -15325,16 +15747,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activitySetThreadSubscriptionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           activitySetThreadSubscriptionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.activitySetThreadSubscription(input, ctx)
+      const { status, body } = await implementation
+        .activitySetThreadSubscription(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activitySetThreadSubscriptionResponseValidator(status, body)
       ctx.status = status
@@ -15365,13 +15792,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityDeleteThreadSubscriptionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityDeleteThreadSubscription(input, ctx)
+      const { status, body } = await implementation
+        .activityDeleteThreadSubscription(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityDeleteThreadSubscriptionResponseValidator(status, body)
       ctx.status = status
@@ -15389,11 +15820,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("metaGetOctocat", "/octocat", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(metaGetOctocatQuerySchema, ctx.query),
+      query: parseRequestInput(
+        metaGetOctocatQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.metaGetOctocat(input, ctx)
+    const { status, body } = await implementation
+      .metaGetOctocat(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = metaGetOctocatResponseValidator(status, body)
     ctx.status = status
@@ -15416,11 +15855,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("orgsList", "/organizations", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(orgsListQuerySchema, ctx.query),
+      query: parseRequestInput(
+        orgsListQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsList(input, ctx)
+    const { status, body } = await implementation
+      .orgsList(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsListResponseValidator(status, body)
     ctx.status = status
@@ -15439,12 +15886,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("orgsGet", "/orgs/:org", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsGetParamSchema, ctx.params),
+      params: parseRequestInput(
+        orgsGetParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsGet(input, ctx)
+    const { status, body } = await implementation
+      .orgsGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsGetResponseValidator(status, body)
     ctx.status = status
@@ -15516,12 +15971,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.patch("orgsUpdate", "/orgs/:org", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsUpdateParamSchema, ctx.params),
+      params: parseRequestInput(
+        orgsUpdateParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(orgsUpdateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        orgsUpdateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.orgsUpdate(input, ctx)
+    const { status, body } = await implementation
+      .orgsUpdate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsUpdateResponseValidator(status, body)
     ctx.status = status
@@ -15541,12 +16008,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("orgsDelete", "/orgs/:org", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsDeleteParamSchema, ctx.params),
+      params: parseRequestInput(
+        orgsDeleteParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsDelete(input, ctx)
+    const { status, body } = await implementation
+      .orgsDelete(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsDeleteResponseValidator(status, body)
     ctx.status = status
@@ -15571,13 +16046,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetActionsCacheUsageForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetActionsCacheUsageForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetActionsCacheUsageForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetActionsCacheUsageForOrgResponseValidator(
         status,
@@ -15621,16 +16100,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetActionsCacheUsageByRepoForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsGetActionsCacheUsageByRepoForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetActionsCacheUsageByRepoForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetActionsCacheUsageByRepoForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetActionsCacheUsageByRepoForOrgResponseValidator(
         status,
@@ -15656,13 +16140,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           oidcGetOidcCustomSubTemplateForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.oidcGetOidcCustomSubTemplateForOrg(input, ctx)
+      const { status, body } = await implementation
+        .oidcGetOidcCustomSubTemplateForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = oidcGetOidcCustomSubTemplateForOrgResponseValidator(
         status,
@@ -15697,16 +16185,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           oidcUpdateOidcCustomSubTemplateForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           oidcUpdateOidcCustomSubTemplateForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.oidcUpdateOidcCustomSubTemplateForOrg(input, ctx)
+      const { status, body } = await implementation
+        .oidcUpdateOidcCustomSubTemplateForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = oidcUpdateOidcCustomSubTemplateForOrgResponseValidator(
         status,
@@ -15735,16 +16228,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetGithubActionsPermissionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetGithubActionsPermissionsOrganization(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsGetGithubActionsPermissionsOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsGetGithubActionsPermissionsOrganizationResponseValidator(
@@ -15776,19 +16270,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetGithubActionsPermissionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetGithubActionsPermissionsOrganizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetGithubActionsPermissionsOrganization(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsSetGithubActionsPermissionsOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsSetGithubActionsPermissionsOrganizationResponseValidator(
@@ -15831,19 +16327,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListSelectedRepositoriesEnabledGithubActionsOrganizationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListSelectedRepositoriesEnabledGithubActionsOrganization(
+      const { status, body } = await implementation
+        .actionsListSelectedRepositoriesEnabledGithubActionsOrganization(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsListSelectedRepositoriesEnabledGithubActionsOrganizationResponseValidator(
@@ -15872,19 +16373,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetSelectedRepositoriesEnabledGithubActionsOrganization(
+      const { status, body } = await implementation
+        .actionsSetSelectedRepositoriesEnabledGithubActionsOrganization(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationResponseValidator(
@@ -15910,16 +16416,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsEnableSelectedRepositoryGithubActionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsEnableSelectedRepositoryGithubActionsOrganization(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsEnableSelectedRepositoryGithubActionsOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsEnableSelectedRepositoryGithubActionsOrganizationResponseValidator(
@@ -15945,16 +16452,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDisableSelectedRepositoryGithubActionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDisableSelectedRepositoryGithubActionsOrganization(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsDisableSelectedRepositoryGithubActionsOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsDisableSelectedRepositoryGithubActionsOrganizationResponseValidator(
@@ -15981,13 +16489,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetAllowedActionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetAllowedActionsOrganization(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetAllowedActionsOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetAllowedActionsOrganizationResponseValidator(
         status,
@@ -16016,16 +16528,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetAllowedActionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetAllowedActionsOrganizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetAllowedActionsOrganization(input, ctx)
+      const { status, body } = await implementation
+        .actionsSetAllowedActionsOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetAllowedActionsOrganizationResponseValidator(
         status,
@@ -16053,16 +16570,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetGithubActionsDefaultWorkflowPermissionsOrganization(
+      const { status, body } = await implementation
+        .actionsGetGithubActionsDefaultWorkflowPermissionsOrganization(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsGetGithubActionsDefaultWorkflowPermissionsOrganizationResponseValidator(
@@ -16091,19 +16612,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetGithubActionsDefaultWorkflowPermissionsOrganization(
+      const { status, body } = await implementation
+        .actionsSetGithubActionsDefaultWorkflowPermissionsOrganization(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationResponseValidator(
@@ -16147,16 +16673,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListSelfHostedRunnersForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListSelfHostedRunnersForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListSelfHostedRunnersForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsListSelfHostedRunnersForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListSelfHostedRunnersForOrgResponseValidator(
         status,
@@ -16185,13 +16716,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRunnerApplicationsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListRunnerApplicationsForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsListRunnerApplicationsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRunnerApplicationsForOrgResponseValidator(
         status,
@@ -16231,16 +16766,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGenerateRunnerJitconfigForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsGenerateRunnerJitconfigForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsGenerateRunnerJitconfigForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsGenerateRunnerJitconfigForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGenerateRunnerJitconfigForOrgResponseValidator(
         status,
@@ -16266,13 +16806,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateRegistrationTokenForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsCreateRegistrationTokenForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateRegistrationTokenForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateRegistrationTokenForOrgResponseValidator(
         status,
@@ -16298,13 +16842,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateRemoveTokenForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsCreateRemoveTokenForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateRemoveTokenForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateRemoveTokenForOrgResponseValidator(status, body)
       ctx.status = status
@@ -16328,13 +16876,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetSelfHostedRunnerForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetSelfHostedRunnerForOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetSelfHostedRunnerForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetSelfHostedRunnerForOrgResponseValidator(status, body)
       ctx.status = status
@@ -16358,13 +16910,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteSelfHostedRunnerFromOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteSelfHostedRunnerFromOrg(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteSelfHostedRunnerFromOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteSelfHostedRunnerFromOrgResponseValidator(
         status,
@@ -16403,16 +16959,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListLabelsForSelfHostedRunnerForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListLabelsForSelfHostedRunnerForOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsListLabelsForSelfHostedRunnerForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListLabelsForSelfHostedRunnerForOrgResponseValidator(
         status,
@@ -16456,19 +17013,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsAddCustomLabelsToSelfHostedRunnerForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsAddCustomLabelsToSelfHostedRunnerForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsAddCustomLabelsToSelfHostedRunnerForOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsAddCustomLabelsToSelfHostedRunnerForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsAddCustomLabelsToSelfHostedRunnerForOrgResponseValidator(
@@ -16513,19 +17072,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetCustomLabelsForSelfHostedRunnerForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetCustomLabelsForSelfHostedRunnerForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetCustomLabelsForSelfHostedRunnerForOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsSetCustomLabelsForSelfHostedRunnerForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsSetCustomLabelsForSelfHostedRunnerForOrgResponseValidator(
@@ -16563,16 +17124,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgResponseValidator(
@@ -16615,16 +17177,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsRemoveCustomLabelFromSelfHostedRunnerForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsRemoveCustomLabelFromSelfHostedRunnerForOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsRemoveCustomLabelFromSelfHostedRunnerForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsRemoveCustomLabelFromSelfHostedRunnerForOrgResponseValidator(
@@ -16661,15 +17224,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/actions/secrets",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsListOrgSecretsParamSchema, ctx.params),
-        query: parseRequestInput(actionsListOrgSecretsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          actionsListOrgSecretsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          actionsListOrgSecretsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListOrgSecrets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListOrgSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListOrgSecretsResponseValidator(status, body)
       ctx.status = status
@@ -16692,15 +17264,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetOrgPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetOrgPublicKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetOrgPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetOrgPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -16723,15 +17297,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/actions/secrets/:secretName",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsGetOrgSecretParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsGetOrgSecretParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetOrgSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -16768,16 +17347,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateOrUpdateOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateOrUpdateOrgSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsCreateOrUpdateOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateOrUpdateOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateOrUpdateOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -16803,15 +17387,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDeleteOrgSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDeleteOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -16851,16 +17437,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListSelectedReposForOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListSelectedReposForOrgSecretQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListSelectedReposForOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsListSelectedReposForOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListSelectedReposForOrgSecretResponseValidator(
         status,
@@ -16891,16 +17482,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetSelectedReposForOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetSelectedReposForOrgSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetSelectedReposForOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsSetSelectedReposForOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetSelectedReposForOrgSecretResponseValidator(
         status,
@@ -16934,13 +17530,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsAddSelectedRepoToOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsAddSelectedRepoToOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsAddSelectedRepoToOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsAddSelectedRepoToOrgSecretResponseValidator(
         status,
@@ -16974,13 +17574,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsRemoveSelectedRepoFromOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsRemoveSelectedRepoFromOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsRemoveSelectedRepoFromOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsRemoveSelectedRepoFromOrgSecretResponseValidator(
         status,
@@ -17019,15 +17623,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListOrgVariablesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(actionsListOrgVariablesQuerySchema, ctx.query),
+        query: parseRequestInput(
+          actionsListOrgVariablesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListOrgVariables(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListOrgVariables(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListOrgVariablesResponseValidator(status, body)
       ctx.status = status
@@ -17057,18 +17667,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateOrgVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.actionsCreateOrgVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsCreateOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateOrgVariableResponseValidator(status, body)
       ctx.status = status
@@ -17091,15 +17704,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/actions/variables/:name",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsGetOrgVariableParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsGetOrgVariableParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetOrgVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetOrgVariableResponseValidator(status, body)
       ctx.status = status
@@ -17132,18 +17750,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsUpdateOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsUpdateOrgVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.actionsUpdateOrgVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsUpdateOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsUpdateOrgVariableResponseValidator(status, body)
       ctx.status = status
@@ -17169,15 +17790,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDeleteOrgVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDeleteOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteOrgVariableResponseValidator(status, body)
       ctx.status = status
@@ -17218,16 +17841,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListSelectedReposForOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListSelectedReposForOrgVariableQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListSelectedReposForOrgVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsListSelectedReposForOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListSelectedReposForOrgVariableResponseValidator(
         status,
@@ -17264,16 +17892,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetSelectedReposForOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetSelectedReposForOrgVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetSelectedReposForOrgVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsSetSelectedReposForOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetSelectedReposForOrgVariableResponseValidator(
         status,
@@ -17307,13 +17940,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsAddSelectedRepoToOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsAddSelectedRepoToOrgVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsAddSelectedRepoToOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsAddSelectedRepoToOrgVariableResponseValidator(
         status,
@@ -17347,16 +17984,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsRemoveSelectedRepoFromOrgVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsRemoveSelectedRepoFromOrgVariable(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsRemoveSelectedRepoFromOrgVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsRemoveSelectedRepoFromOrgVariableResponseValidator(
         status,
@@ -17381,15 +18019,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("orgsListBlockedUsers", "/orgs/:org/blocks", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsListBlockedUsersParamSchema, ctx.params),
-      query: parseRequestInput(orgsListBlockedUsersQuerySchema, ctx.query),
+      params: parseRequestInput(
+        orgsListBlockedUsersParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        orgsListBlockedUsersQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsListBlockedUsers(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .orgsListBlockedUsers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsListBlockedUsersResponseValidator(status, body)
     ctx.status = status
@@ -17414,15 +18061,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/blocks/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsCheckBlockedUserParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsCheckBlockedUserParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsCheckBlockedUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsCheckBlockedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsCheckBlockedUserResponseValidator(status, body)
       ctx.status = status
@@ -17448,12 +18100,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/blocks/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsBlockUserParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsBlockUserParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsBlockUser(input, ctx)
+      const { status, body } = await implementation
+        .orgsBlockUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsBlockUserResponseValidator(status, body)
       ctx.status = status
@@ -17476,12 +18136,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/blocks/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsUnblockUserParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsUnblockUserParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsUnblockUser(input, ctx)
+      const { status, body } = await implementation
+        .orgsUnblockUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsUnblockUserResponseValidator(status, body)
       ctx.status = status
@@ -17529,16 +18197,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningListAlertsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codeScanningListAlertsForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codeScanningListAlertsForOrg(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningListAlertsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningListAlertsForOrgResponseValidator(status, body)
       ctx.status = status
@@ -17580,16 +18253,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListInOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesListInOrganizationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListInOrganization(input, ctx)
+      const { status, body } = await implementation
+        .codespacesListInOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesListInOrganizationResponseValidator(status, body)
       ctx.status = status
@@ -17630,16 +18308,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesSetCodespacesAccessParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesSetCodespacesAccessBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesSetCodespacesAccess(input, ctx)
+      const { status, body } = await implementation
+        .codespacesSetCodespacesAccess(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesSetCodespacesAccessResponseValidator(status, body)
       ctx.status = status
@@ -17676,16 +18359,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesSetCodespacesAccessUsersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesSetCodespacesAccessUsersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesSetCodespacesAccessUsers(input, ctx)
+      const { status, body } = await implementation
+        .codespacesSetCodespacesAccessUsers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesSetCodespacesAccessUsersResponseValidator(
         status,
@@ -17725,16 +18413,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesDeleteCodespacesAccessUsersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesDeleteCodespacesAccessUsersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesDeleteCodespacesAccessUsers(input, ctx)
+      const { status, body } = await implementation
+        .codespacesDeleteCodespacesAccessUsers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesDeleteCodespacesAccessUsersResponseValidator(
         status,
@@ -17773,18 +18466,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListOrgSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesListOrgSecretsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesListOrgSecrets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesListOrgSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesListOrgSecretsResponseValidator(status, body)
       ctx.status = status
@@ -17807,15 +18503,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetOrgPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesGetOrgPublicKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesGetOrgPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetOrgPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -17841,15 +18539,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesGetOrgSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesGetOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -17888,16 +18588,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesCreateOrUpdateOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesCreateOrUpdateOrgSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesCreateOrUpdateOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .codespacesCreateOrUpdateOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesCreateOrUpdateOrgSecretResponseValidator(
         status,
@@ -17929,15 +18634,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesDeleteOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesDeleteOrgSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesDeleteOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesDeleteOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -17978,16 +18685,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListSelectedReposForOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesListSelectedReposForOrgSecretQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListSelectedReposForOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .codespacesListSelectedReposForOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesListSelectedReposForOrgSecretResponseValidator(
         status,
@@ -18025,16 +18737,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesSetSelectedReposForOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesSetSelectedReposForOrgSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesSetSelectedReposForOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .codespacesSetSelectedReposForOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesSetSelectedReposForOrgSecretResponseValidator(
         status,
@@ -18070,13 +18787,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesAddSelectedRepoToOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesAddSelectedRepoToOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .codespacesAddSelectedRepoToOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesAddSelectedRepoToOrgSecretResponseValidator(
         status,
@@ -18112,16 +18833,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesRemoveSelectedRepoFromOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesRemoveSelectedRepoFromOrgSecret(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesRemoveSelectedRepoFromOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesRemoveSelectedRepoFromOrgSecretResponseValidator(
         status,
@@ -18156,13 +18878,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotGetCopilotOrganizationDetailsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.copilotGetCopilotOrganizationDetails(input, ctx)
+      const { status, body } = await implementation
+        .copilotGetCopilotOrganizationDetails(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotGetCopilotOrganizationDetailsResponseValidator(
         status,
@@ -18205,15 +18931,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotListCopilotSeatsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(copilotListCopilotSeatsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          copilotListCopilotSeatsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.copilotListCopilotSeats(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .copilotListCopilotSeats(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotListCopilotSeatsResponseValidator(status, body)
       ctx.status = status
@@ -18250,19 +18982,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotAddCopilotForBusinessSeatsForTeamsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           copilotAddCopilotForBusinessSeatsForTeamsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.copilotAddCopilotForBusinessSeatsForTeams(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .copilotAddCopilotForBusinessSeatsForTeams(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotAddCopilotForBusinessSeatsForTeamsResponseValidator(
         status,
@@ -18302,19 +19036,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotCancelCopilotSeatAssignmentForTeamsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           copilotCancelCopilotSeatAssignmentForTeamsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.copilotCancelCopilotSeatAssignmentForTeams(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .copilotCancelCopilotSeatAssignmentForTeams(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotCancelCopilotSeatAssignmentForTeamsResponseValidator(
         status,
@@ -18354,19 +19090,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotAddCopilotForBusinessSeatsForUsersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           copilotAddCopilotForBusinessSeatsForUsersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.copilotAddCopilotForBusinessSeatsForUsers(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .copilotAddCopilotForBusinessSeatsForUsers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotAddCopilotForBusinessSeatsForUsersResponseValidator(
         status,
@@ -18406,19 +19144,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotCancelCopilotSeatAssignmentForUsersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           copilotCancelCopilotSeatAssignmentForUsersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.copilotCancelCopilotSeatAssignmentForUsers(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .copilotCancelCopilotSeatAssignmentForUsers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotCancelCopilotSeatAssignmentForUsersResponseValidator(
         status,
@@ -18466,18 +19206,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotListAlertsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependabotListAlertsForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotListAlertsForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotListAlertsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotListAlertsForOrgResponseValidator(status, body)
       ctx.status = status
@@ -18513,18 +19256,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotListOrgSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependabotListOrgSecretsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotListOrgSecrets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotListOrgSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotListOrgSecretsResponseValidator(status, body)
       ctx.status = status
@@ -18547,15 +19293,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotGetOrgPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotGetOrgPublicKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotGetOrgPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotGetOrgPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -18581,15 +19329,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotGetOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotGetOrgSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotGetOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotGetOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -18626,16 +19376,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotCreateOrUpdateOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           dependabotCreateOrUpdateOrgSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.dependabotCreateOrUpdateOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .dependabotCreateOrUpdateOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotCreateOrUpdateOrgSecretResponseValidator(
         status,
@@ -18664,15 +19419,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotDeleteOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotDeleteOrgSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotDeleteOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotDeleteOrgSecretResponseValidator(status, body)
       ctx.status = status
@@ -18712,16 +19469,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotListSelectedReposForOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependabotListSelectedReposForOrgSecretQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.dependabotListSelectedReposForOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .dependabotListSelectedReposForOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotListSelectedReposForOrgSecretResponseValidator(
         status,
@@ -18752,16 +19514,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotSetSelectedReposForOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           dependabotSetSelectedReposForOrgSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.dependabotSetSelectedReposForOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .dependabotSetSelectedReposForOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotSetSelectedReposForOrgSecretResponseValidator(
         status,
@@ -18795,13 +19562,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotAddSelectedRepoToOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.dependabotAddSelectedRepoToOrgSecret(input, ctx)
+      const { status, body } = await implementation
+        .dependabotAddSelectedRepoToOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotAddSelectedRepoToOrgSecretResponseValidator(
         status,
@@ -18835,16 +19606,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotRemoveSelectedRepoFromOrgSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.dependabotRemoveSelectedRepoFromOrgSecret(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .dependabotRemoveSelectedRepoFromOrgSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotRemoveSelectedRepoFromOrgSecretResponseValidator(
         status,
@@ -18876,16 +19648,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesListDockerMigrationConflictingPackagesForOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesListDockerMigrationConflictingPackagesForOrganization(
+      const { status, body } = await implementation
+        .packagesListDockerMigrationConflictingPackagesForOrganization(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesListDockerMigrationConflictingPackagesForOrganizationResponseValidator(
@@ -18915,18 +19691,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListPublicOrgEventsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListPublicOrgEventsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.activityListPublicOrgEvents(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activityListPublicOrgEvents(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListPublicOrgEventsResponseValidator(status, body)
       ctx.status = status
@@ -18957,18 +19736,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListFailedInvitationsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListFailedInvitationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListFailedInvitations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListFailedInvitations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListFailedInvitationsResponseValidator(status, body)
       ctx.status = status
@@ -18993,12 +19775,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("orgsListWebhooks", "/orgs/:org/hooks", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsListWebhooksParamSchema, ctx.params),
-      query: parseRequestInput(orgsListWebhooksQuerySchema, ctx.query),
+      params: parseRequestInput(
+        orgsListWebhooksParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        orgsListWebhooksQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsListWebhooks(input, ctx)
+    const { status, body } = await implementation
+      .orgsListWebhooks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsListWebhooksResponseValidator(status, body)
     ctx.status = status
@@ -19032,12 +19826,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("orgsCreateWebhook", "/orgs/:org/hooks", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsCreateWebhookParamSchema, ctx.params),
+      params: parseRequestInput(
+        orgsCreateWebhookParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(orgsCreateWebhookBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        orgsCreateWebhookBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.orgsCreateWebhook(input, ctx)
+    const { status, body } = await implementation
+      .orgsCreateWebhook(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsCreateWebhookResponseValidator(status, body)
     ctx.status = status
@@ -19062,12 +19868,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/hooks/:hookId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsGetWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsGetWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsGetWebhook(input, ctx)
+      const { status, body } = await implementation
+        .orgsGetWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsGetWebhookResponseValidator(status, body)
       ctx.status = status
@@ -19110,15 +19924,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/hooks/:hookId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsUpdateWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsUpdateWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(orgsUpdateWebhookBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          orgsUpdateWebhookBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.orgsUpdateWebhook(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsUpdateWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsUpdateWebhookResponseValidator(status, body)
       ctx.status = status
@@ -19144,15 +19967,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/hooks/:hookId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsDeleteWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsDeleteWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsDeleteWebhook(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsDeleteWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsDeleteWebhookResponseValidator(status, body)
       ctx.status = status
@@ -19178,15 +20006,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsGetWebhookConfigForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsGetWebhookConfigForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsGetWebhookConfigForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsGetWebhookConfigForOrgResponseValidator(status, body)
       ctx.status = status
@@ -19219,16 +20049,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsUpdateWebhookConfigForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsUpdateWebhookConfigForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.orgsUpdateWebhookConfigForOrg(input, ctx)
+      const { status, body } = await implementation
+        .orgsUpdateWebhookConfigForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsUpdateWebhookConfigForOrgResponseValidator(status, body)
       ctx.status = status
@@ -19264,18 +20099,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListWebhookDeliveriesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListWebhookDeliveriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListWebhookDeliveries(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListWebhookDeliveries(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListWebhookDeliveriesResponseValidator(status, body)
       ctx.status = status
@@ -19306,15 +20144,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsGetWebhookDeliveryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsGetWebhookDelivery(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsGetWebhookDelivery(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsGetWebhookDeliveryResponseValidator(status, body)
       ctx.status = status
@@ -19346,13 +20186,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsRedeliverWebhookDeliveryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsRedeliverWebhookDelivery(input, ctx)
+      const { status, body } = await implementation
+        .orgsRedeliverWebhookDelivery(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsRedeliverWebhookDeliveryResponseValidator(status, body)
       ctx.status = status
@@ -19378,12 +20222,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/hooks/:hookId/pings",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsPingWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsPingWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsPingWebhook(input, ctx)
+      const { status, body } = await implementation
+        .orgsPingWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsPingWebhookResponseValidator(status, body)
       ctx.status = status
@@ -19406,15 +20258,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsGetOrgInstallationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsGetOrgInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsGetOrgInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetOrgInstallationResponseValidator(status, body)
       ctx.status = status
@@ -19450,18 +20304,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListAppInstallationsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListAppInstallationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListAppInstallations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListAppInstallations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListAppInstallationsResponseValidator(status, body)
       ctx.status = status
@@ -19487,13 +20344,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           interactionsGetRestrictionsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.interactionsGetRestrictionsForOrg(input, ctx)
+      const { status, body } = await implementation
+        .interactionsGetRestrictionsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = interactionsGetRestrictionsForOrgResponseValidator(
         status,
@@ -19527,16 +20388,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           interactionsSetRestrictionsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           interactionsSetRestrictionsForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.interactionsSetRestrictionsForOrg(input, ctx)
+      const { status, body } = await implementation
+        .interactionsSetRestrictionsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = interactionsSetRestrictionsForOrgResponseValidator(
         status,
@@ -19562,13 +20428,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           interactionsRemoveRestrictionsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.interactionsRemoveRestrictionsForOrg(input, ctx)
+      const { status, body } = await implementation
+        .interactionsRemoveRestrictionsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = interactionsRemoveRestrictionsForOrgResponseValidator(
         status,
@@ -19612,18 +20482,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListPendingInvitationsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListPendingInvitationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListPendingInvitations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListPendingInvitations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListPendingInvitationsResponseValidator(status, body)
       ctx.status = status
@@ -19656,18 +20529,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/invitations",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsCreateInvitationParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsCreateInvitationParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           orgsCreateInvitationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.orgsCreateInvitation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsCreateInvitation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsCreateInvitationResponseValidator(status, body)
       ctx.status = status
@@ -19694,15 +20573,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/invitations/:invitationId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsCancelInvitationParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsCancelInvitationParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsCancelInvitation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsCancelInvitation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsCancelInvitationResponseValidator(status, body)
       ctx.status = status
@@ -19736,15 +20620,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListInvitationTeamsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(orgsListInvitationTeamsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          orgsListInvitationTeamsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListInvitationTeams(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListInvitationTeams(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListInvitationTeamsResponseValidator(status, body)
       ctx.status = status
@@ -19777,12 +20667,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("issuesListForOrg", "/orgs/:org/issues", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(issuesListForOrgParamSchema, ctx.params),
-      query: parseRequestInput(issuesListForOrgQuerySchema, ctx.query),
+      params: parseRequestInput(
+        issuesListForOrgParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        issuesListForOrgQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.issuesListForOrg(input, ctx)
+    const { status, body } = await implementation
+      .issuesListForOrg(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = issuesListForOrgResponseValidator(status, body)
     ctx.status = status
@@ -19808,12 +20710,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("orgsListMembers", "/orgs/:org/members", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsListMembersParamSchema, ctx.params),
-      query: parseRequestInput(orgsListMembersQuerySchema, ctx.query),
+      params: parseRequestInput(
+        orgsListMembersParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        orgsListMembersQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsListMembers(input, ctx)
+    const { status, body } = await implementation
+      .orgsListMembers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsListMembersResponseValidator(status, body)
     ctx.status = status
@@ -19842,15 +20756,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsCheckMembershipForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsCheckMembershipForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsCheckMembershipForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsCheckMembershipForUserResponseValidator(status, body)
       ctx.status = status
@@ -19876,12 +20792,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/members/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsRemoveMemberParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsRemoveMemberParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsRemoveMember(input, ctx)
+      const { status, body } = await implementation
+        .orgsRemoveMember(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsRemoveMemberResponseValidator(status, body)
       ctx.status = status
@@ -19926,16 +20850,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetCodespacesForUserInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesGetCodespacesForUserInOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesGetCodespacesForUserInOrg(input, ctx)
+      const { status, body } = await implementation
+        .codespacesGetCodespacesForUserInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetCodespacesForUserInOrgResponseValidator(
         status,
@@ -19973,13 +20902,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesDeleteFromOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesDeleteFromOrganization(input, ctx)
+      const { status, body } = await implementation
+        .codespacesDeleteFromOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesDeleteFromOrganizationResponseValidator(status, body)
       ctx.status = status
@@ -20014,13 +20947,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesStopInOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesStopInOrganization(input, ctx)
+      const { status, body } = await implementation
+        .codespacesStopInOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesStopInOrganizationResponseValidator(status, body)
       ctx.status = status
@@ -20054,16 +20991,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           copilotGetCopilotSeatAssignmentDetailsForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.copilotGetCopilotSeatAssignmentDetailsForUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .copilotGetCopilotSeatAssignmentDetailsForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = copilotGetCopilotSeatAssignmentDetailsForUserResponseValidator(
         status,
@@ -20096,15 +21034,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsGetMembershipForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsGetMembershipForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsGetMembershipForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsGetMembershipForUserResponseValidator(status, body)
       ctx.status = status
@@ -20138,18 +21078,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsSetMembershipForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsSetMembershipForUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.orgsSetMembershipForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsSetMembershipForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsSetMembershipForUserResponseValidator(status, body)
       ctx.status = status
@@ -20180,15 +21123,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsRemoveMembershipForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsRemoveMembershipForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsRemoveMembershipForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsRemoveMembershipForUserResponseValidator(status, body)
       ctx.status = status
@@ -20214,15 +21159,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/migrations",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(migrationsListForOrgParamSchema, ctx.params),
-        query: parseRequestInput(migrationsListForOrgQuerySchema, ctx.query),
+        params: parseRequestInput(
+          migrationsListForOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          migrationsListForOrgQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsListForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsListForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsListForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20258,18 +21212,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/migrations",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(migrationsStartForOrgParamSchema, ctx.params),
+        params: parseRequestInput(
+          migrationsStartForOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           migrationsStartForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.migrationsStartForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsStartForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsStartForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20302,18 +21262,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsGetStatusForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           migrationsGetStatusForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsGetStatusForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsGetStatusForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsGetStatusForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20343,13 +21306,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsDownloadArchiveForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsDownloadArchiveForOrg(input, ctx)
+      const { status, body } = await implementation
+        .migrationsDownloadArchiveForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsDownloadArchiveForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20379,13 +21346,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsDeleteArchiveForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsDeleteArchiveForOrg(input, ctx)
+      const { status, body } = await implementation
+        .migrationsDeleteArchiveForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsDeleteArchiveForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20415,15 +21386,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsUnlockRepoForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsUnlockRepoForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsUnlockRepoForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsUnlockRepoForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20457,18 +21430,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsListReposForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           migrationsListReposForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsListReposForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsListReposForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsListReposForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20495,16 +21471,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListOutsideCollaboratorsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListOutsideCollaboratorsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsListOutsideCollaborators(input, ctx)
+      const { status, body } = await implementation
+        .orgsListOutsideCollaborators(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListOutsideCollaboratorsResponseValidator(status, body)
       ctx.status = status
@@ -20540,16 +21521,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsConvertMemberToOutsideCollaboratorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsConvertMemberToOutsideCollaboratorBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.orgsConvertMemberToOutsideCollaborator(input, ctx)
+      const { status, body } = await implementation
+        .orgsConvertMemberToOutsideCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsConvertMemberToOutsideCollaboratorResponseValidator(
         status,
@@ -20588,13 +21574,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsRemoveOutsideCollaboratorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsRemoveOutsideCollaborator(input, ctx)
+      const { status, body } = await implementation
+        .orgsRemoveOutsideCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsRemoveOutsideCollaboratorResponseValidator(status, body)
       ctx.status = status
@@ -20639,16 +21629,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesListPackagesForOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesListPackagesForOrganizationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesListPackagesForOrganization(input, ctx)
+      const { status, body } = await implementation
+        .packagesListPackagesForOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesListPackagesForOrganizationResponseValidator(
         status,
@@ -20683,13 +21678,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetPackageForOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetPackageForOrganization(input, ctx)
+      const { status, body } = await implementation
+        .packagesGetPackageForOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesGetPackageForOrganizationResponseValidator(
         status,
@@ -20732,15 +21731,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesDeletePackageForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.packagesDeletePackageForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .packagesDeletePackageForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesDeletePackageForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20784,16 +21785,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesRestorePackageForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesRestorePackageForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesRestorePackageForOrg(input, ctx)
+      const { status, body } = await implementation
+        .packagesRestorePackageForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesRestorePackageForOrgResponseValidator(status, body)
       ctx.status = status
@@ -20843,19 +21849,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetAllPackageVersionsForPackageOwnedByOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesGetAllPackageVersionsForPackageOwnedByOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetAllPackageVersionsForPackageOwnedByOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesGetAllPackageVersionsForPackageOwnedByOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesGetAllPackageVersionsForPackageOwnedByOrgResponseValidator(
@@ -20892,16 +21900,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetPackageVersionForOrganizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetPackageVersionForOrganization(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesGetPackageVersionForOrganization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesGetPackageVersionForOrganizationResponseValidator(
         status,
@@ -20945,13 +21954,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesDeletePackageVersionForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesDeletePackageVersionForOrg(input, ctx)
+      const { status, body } = await implementation
+        .packagesDeletePackageVersionForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesDeletePackageVersionForOrgResponseValidator(
         status,
@@ -20995,13 +22008,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesRestorePackageVersionForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesRestorePackageVersionForOrg(input, ctx)
+      const { status, body } = await implementation
+        .packagesRestorePackageVersionForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesRestorePackageVersionForOrgResponseValidator(
         status,
@@ -21045,18 +22062,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListPatGrantRequestsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListPatGrantRequestsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListPatGrantRequests(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListPatGrantRequests(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListPatGrantRequestsResponseValidator(status, body)
       ctx.status = status
@@ -21094,16 +22114,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsReviewPatGrantRequestsInBulkParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsReviewPatGrantRequestsInBulkBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.orgsReviewPatGrantRequestsInBulk(input, ctx)
+      const { status, body } = await implementation
+        .orgsReviewPatGrantRequestsInBulk(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsReviewPatGrantRequestsInBulkResponseValidator(status, body)
       ctx.status = status
@@ -21140,18 +22165,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsReviewPatGrantRequestParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsReviewPatGrantRequestBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.orgsReviewPatGrantRequest(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsReviewPatGrantRequest(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsReviewPatGrantRequestResponseValidator(status, body)
       ctx.status = status
@@ -21188,16 +22216,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListPatGrantRequestRepositoriesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListPatGrantRequestRepositoriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsListPatGrantRequestRepositories(input, ctx)
+      const { status, body } = await implementation
+        .orgsListPatGrantRequestRepositories(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListPatGrantRequestRepositoriesResponseValidator(
         status,
@@ -21238,15 +22271,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/personal-access-tokens",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsListPatGrantsParamSchema, ctx.params),
-        query: parseRequestInput(orgsListPatGrantsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          orgsListPatGrantsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          orgsListPatGrantsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListPatGrants(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListPatGrants(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListPatGrantsResponseValidator(status, body)
       ctx.status = status
@@ -21277,18 +22319,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/personal-access-tokens",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsUpdatePatAccessesParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsUpdatePatAccessesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           orgsUpdatePatAccessesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.orgsUpdatePatAccesses(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsUpdatePatAccesses(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsUpdatePatAccessesResponseValidator(status, body)
       ctx.status = status
@@ -21319,18 +22367,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/personal-access-tokens/:patId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsUpdatePatAccessParamSchema, ctx.params),
+        params: parseRequestInput(
+          orgsUpdatePatAccessParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           orgsUpdatePatAccessBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.orgsUpdatePatAccess(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsUpdatePatAccess(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsUpdatePatAccessResponseValidator(status, body)
       ctx.status = status
@@ -21367,16 +22421,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListPatGrantRepositoriesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           orgsListPatGrantRepositoriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsListPatGrantRepositories(input, ctx)
+      const { status, body } = await implementation
+        .orgsListPatGrantRepositories(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListPatGrantRepositoriesResponseValidator(status, body)
       ctx.status = status
@@ -21402,12 +22461,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("projectsListForOrg", "/orgs/:org/projects", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(projectsListForOrgParamSchema, ctx.params),
-      query: parseRequestInput(projectsListForOrgQuerySchema, ctx.query),
+      params: parseRequestInput(
+        projectsListForOrgParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        projectsListForOrgQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.projectsListForOrg(input, ctx)
+    const { status, body } = await implementation
+      .projectsListForOrg(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = projectsListForOrgResponseValidator(status, body)
     ctx.status = status
@@ -21438,18 +22509,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/projects",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsCreateForOrgParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsCreateForOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           projectsCreateForOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.projectsCreateForOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsCreateForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsCreateForOrgResponseValidator(status, body)
       ctx.status = status
@@ -21474,15 +22551,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/public_members",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(orgsListPublicMembersParamSchema, ctx.params),
-        query: parseRequestInput(orgsListPublicMembersQuerySchema, ctx.query),
+        params: parseRequestInput(
+          orgsListPublicMembersParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          orgsListPublicMembersQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsListPublicMembers(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsListPublicMembers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListPublicMembersResponseValidator(status, body)
       ctx.status = status
@@ -21512,13 +22598,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsCheckPublicMembershipForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsCheckPublicMembershipForUser(input, ctx)
+      const { status, body } = await implementation
+        .orgsCheckPublicMembershipForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsCheckPublicMembershipForUserResponseValidator(status, body)
       ctx.status = status
@@ -21548,16 +22638,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsSetPublicMembershipForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsSetPublicMembershipForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .orgsSetPublicMembershipForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsSetPublicMembershipForAuthenticatedUserResponseValidator(
         status,
@@ -21584,16 +22675,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsRemovePublicMembershipForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsRemovePublicMembershipForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .orgsRemovePublicMembershipForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         orgsRemovePublicMembershipForAuthenticatedUserResponseValidator(
@@ -21624,12 +22716,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("reposListForOrg", "/orgs/:org/repos", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposListForOrgParamSchema, ctx.params),
-      query: parseRequestInput(reposListForOrgQuerySchema, ctx.query),
+      params: parseRequestInput(
+        reposListForOrgParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        reposListForOrgQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.reposListForOrg(input, ctx)
+    const { status, body } = await implementation
+      .reposListForOrg(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposListForOrgResponseValidator(status, body)
     ctx.status = status
@@ -21680,12 +22784,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("reposCreateInOrg", "/orgs/:org/repos", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposCreateInOrgParamSchema, ctx.params),
+      params: parseRequestInput(
+        reposCreateInOrgParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(reposCreateInOrgBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        reposCreateInOrgBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.reposCreateInOrg(input, ctx)
+    const { status, body } = await implementation
+      .reposCreateInOrg(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposCreateInOrgResponseValidator(status, body)
     ctx.status = status
@@ -21713,15 +22829,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/rulesets",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetOrgRulesetsParamSchema, ctx.params),
-        query: parseRequestInput(reposGetOrgRulesetsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetOrgRulesetsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetOrgRulesetsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetOrgRulesets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetOrgRulesets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetOrgRulesetsResponseValidator(status, body)
       ctx.status = status
@@ -21754,18 +22879,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/rulesets",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateOrgRulesetParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateOrgRulesetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposCreateOrgRulesetBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateOrgRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateOrgRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateOrgRulesetResponseValidator(status, body)
       ctx.status = status
@@ -21792,15 +22923,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/rulesets/:rulesetId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetOrgRulesetParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetOrgRulesetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetOrgRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetOrgRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetOrgRulesetResponseValidator(status, body)
       ctx.status = status
@@ -21838,18 +22974,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/rulesets/:rulesetId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposUpdateOrgRulesetParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposUpdateOrgRulesetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateOrgRulesetBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUpdateOrgRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateOrgRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateOrgRulesetResponseValidator(status, body)
       ctx.status = status
@@ -21876,15 +23018,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/rulesets/:rulesetId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteOrgRulesetParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteOrgRulesetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteOrgRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteOrgRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteOrgRulesetResponseValidator(status, body)
       ctx.status = status
@@ -21933,16 +23080,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           secretScanningListAlertsForOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           secretScanningListAlertsForOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.secretScanningListAlertsForOrg(input, ctx)
+      const { status, body } = await implementation
+        .secretScanningListAlertsForOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = secretScanningListAlertsForOrgResponseValidator(status, body)
       ctx.status = status
@@ -21981,19 +23133,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesListOrgRepositoryAdvisoriesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           securityAdvisoriesListOrgRepositoryAdvisoriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesListOrgRepositoryAdvisories(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .securityAdvisoriesListOrgRepositoryAdvisories(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesListOrgRepositoryAdvisoriesResponseValidator(
         status,
@@ -22017,13 +23171,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsListSecurityManagerTeamsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsListSecurityManagerTeams(input, ctx)
+      const { status, body } = await implementation
+        .orgsListSecurityManagerTeams(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListSecurityManagerTeamsResponseValidator(status, body)
       ctx.status = status
@@ -22052,15 +23210,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsAddSecurityManagerTeamParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.orgsAddSecurityManagerTeam(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .orgsAddSecurityManagerTeam(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsAddSecurityManagerTeamResponseValidator(status, body)
       ctx.status = status
@@ -22084,13 +23244,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsRemoveSecurityManagerTeamParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsRemoveSecurityManagerTeam(input, ctx)
+      const { status, body } = await implementation
+        .orgsRemoveSecurityManagerTeam(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsRemoveSecurityManagerTeamResponseValidator(status, body)
       ctx.status = status
@@ -22113,13 +23277,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           billingGetGithubActionsBillingOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.billingGetGithubActionsBillingOrg(input, ctx)
+      const { status, body } = await implementation
+        .billingGetGithubActionsBillingOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = billingGetGithubActionsBillingOrgResponseValidator(
         status,
@@ -22145,13 +23313,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           billingGetGithubPackagesBillingOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.billingGetGithubPackagesBillingOrg(input, ctx)
+      const { status, body } = await implementation
+        .billingGetGithubPackagesBillingOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = billingGetGithubPackagesBillingOrgResponseValidator(
         status,
@@ -22177,13 +23349,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           billingGetSharedStorageBillingOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.billingGetSharedStorageBillingOrg(input, ctx)
+      const { status, body } = await implementation
+        .billingGetSharedStorageBillingOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = billingGetSharedStorageBillingOrgResponseValidator(
         status,
@@ -22211,12 +23387,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("teamsList", "/orgs/:org/teams", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(teamsListParamSchema, ctx.params),
-      query: parseRequestInput(teamsListQuerySchema, ctx.query),
+      params: parseRequestInput(
+        teamsListParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        teamsListQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.teamsList(input, ctx)
+    const { status, body } = await implementation
+      .teamsList(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = teamsListResponseValidator(status, body)
     ctx.status = status
@@ -22249,12 +23437,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("teamsCreate", "/orgs/:org/teams", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(teamsCreateParamSchema, ctx.params),
+      params: parseRequestInput(
+        teamsCreateParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(teamsCreateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        teamsCreateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.teamsCreate(input, ctx)
+    const { status, body } = await implementation
+      .teamsCreate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = teamsCreateResponseValidator(status, body)
     ctx.status = status
@@ -22279,12 +23479,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsGetByNameParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsGetByNameParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsGetByName(input, ctx)
+      const { status, body } = await implementation
+        .teamsGetByName(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetByNameResponseValidator(status, body)
       ctx.status = status
@@ -22326,12 +23534,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsUpdateInOrgParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsUpdateInOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(teamsUpdateInOrgBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          teamsUpdateInOrgBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.teamsUpdateInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsUpdateInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsUpdateInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22354,12 +23574,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsDeleteInOrgParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsDeleteInOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsDeleteInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsDeleteInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsDeleteInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22392,18 +23620,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListDiscussionsInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           teamsListDiscussionsInOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListDiscussionsInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListDiscussionsInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListDiscussionsInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22435,18 +23666,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCreateDiscussionInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsCreateDiscussionInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.teamsCreateDiscussionInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsCreateDiscussionInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCreateDiscussionInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22473,15 +23707,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsGetDiscussionInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsGetDiscussionInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsGetDiscussionInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetDiscussionInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22512,18 +23748,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsUpdateDiscussionInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsUpdateDiscussionInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.teamsUpdateDiscussionInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsUpdateDiscussionInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsUpdateDiscussionInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22550,15 +23789,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsDeleteDiscussionInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsDeleteDiscussionInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsDeleteDiscussionInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsDeleteDiscussionInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22592,16 +23833,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListDiscussionCommentsInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           teamsListDiscussionCommentsInOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsListDiscussionCommentsInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsListDiscussionCommentsInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListDiscussionCommentsInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22630,16 +23876,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCreateDiscussionCommentInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsCreateDiscussionCommentInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsCreateDiscussionCommentInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsCreateDiscussionCommentInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCreateDiscussionCommentInOrgResponseValidator(
         status,
@@ -22668,13 +23919,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsGetDiscussionCommentInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsGetDiscussionCommentInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsGetDiscussionCommentInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetDiscussionCommentInOrgResponseValidator(status, body)
       ctx.status = status
@@ -22704,16 +23959,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsUpdateDiscussionCommentInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsUpdateDiscussionCommentInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsUpdateDiscussionCommentInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsUpdateDiscussionCommentInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsUpdateDiscussionCommentInOrgResponseValidator(
         status,
@@ -22742,13 +24002,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsDeleteDiscussionCommentInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsDeleteDiscussionCommentInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsDeleteDiscussionCommentInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsDeleteDiscussionCommentInOrgResponseValidator(
         status,
@@ -22794,19 +24058,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForTeamDiscussionCommentInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForTeamDiscussionCommentInOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForTeamDiscussionCommentInOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reactionsListForTeamDiscussionCommentInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForTeamDiscussionCommentInOrgResponseValidator(
         status,
@@ -22854,19 +24120,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForTeamDiscussionCommentInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForTeamDiscussionCommentInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForTeamDiscussionCommentInOrg(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reactionsCreateForTeamDiscussionCommentInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForTeamDiscussionCommentInOrgResponseValidator(
         status,
@@ -22896,13 +24164,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForTeamDiscussionCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsDeleteForTeamDiscussionComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsDeleteForTeamDiscussionComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForTeamDiscussionCommentResponseValidator(
         status,
@@ -22947,16 +24219,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForTeamDiscussionInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForTeamDiscussionInOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForTeamDiscussionInOrg(input, ctx)
+      const { status, body } = await implementation
+        .reactionsListForTeamDiscussionInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForTeamDiscussionInOrgResponseValidator(
         status,
@@ -23003,16 +24280,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForTeamDiscussionInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForTeamDiscussionInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForTeamDiscussionInOrg(input, ctx)
+      const { status, body } = await implementation
+        .reactionsCreateForTeamDiscussionInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForTeamDiscussionInOrgResponseValidator(
         status,
@@ -23041,13 +24323,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForTeamDiscussionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsDeleteForTeamDiscussion(input, ctx)
+      const { status, body } = await implementation
+        .reactionsDeleteForTeamDiscussion(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForTeamDiscussionResponseValidator(status, body)
       ctx.status = status
@@ -23079,16 +24365,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListPendingInvitationsInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           teamsListPendingInvitationsInOrgQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsListPendingInvitationsInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsListPendingInvitationsInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListPendingInvitationsInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23117,15 +24408,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug/members",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsListMembersInOrgParamSchema, ctx.params),
-        query: parseRequestInput(teamsListMembersInOrgQuerySchema, ctx.query),
+        params: parseRequestInput(
+          teamsListMembersInOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          teamsListMembersInOrgQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListMembersInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListMembersInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListMembersInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23156,13 +24456,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsGetMembershipForUserInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsGetMembershipForUserInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsGetMembershipForUserInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetMembershipForUserInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23198,16 +24502,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsAddOrUpdateMembershipForUserInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsAddOrUpdateMembershipForUserInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsAddOrUpdateMembershipForUserInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsAddOrUpdateMembershipForUserInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddOrUpdateMembershipForUserInOrgResponseValidator(
         status,
@@ -23241,13 +24550,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsRemoveMembershipForUserInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsRemoveMembershipForUserInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsRemoveMembershipForUserInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveMembershipForUserInOrgResponseValidator(
         status,
@@ -23281,15 +24594,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListProjectsInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(teamsListProjectsInOrgQuerySchema, ctx.query),
+        query: parseRequestInput(
+          teamsListProjectsInOrgQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListProjectsInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListProjectsInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListProjectsInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23320,13 +24639,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCheckPermissionsForProjectInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsCheckPermissionsForProjectInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsCheckPermissionsForProjectInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCheckPermissionsForProjectInOrgResponseValidator(
         status,
@@ -23371,16 +24694,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsAddOrUpdateProjectPermissionsInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsAddOrUpdateProjectPermissionsInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsAddOrUpdateProjectPermissionsInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsAddOrUpdateProjectPermissionsInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddOrUpdateProjectPermissionsInOrgResponseValidator(
         status,
@@ -23410,15 +24738,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsRemoveProjectInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsRemoveProjectInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsRemoveProjectInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveProjectInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23446,15 +24776,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug/repos",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsListReposInOrgParamSchema, ctx.params),
-        query: parseRequestInput(teamsListReposInOrgQuerySchema, ctx.query),
+        params: parseRequestInput(
+          teamsListReposInOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          teamsListReposInOrgQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListReposInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListReposInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListReposInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23487,13 +24826,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCheckPermissionsForRepoInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsCheckPermissionsForRepoInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsCheckPermissionsForRepoInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCheckPermissionsForRepoInOrgResponseValidator(
         status,
@@ -23526,16 +24869,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsAddOrUpdateRepoPermissionsInOrgParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsAddOrUpdateRepoPermissionsInOrgBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsAddOrUpdateRepoPermissionsInOrg(input, ctx)
+      const { status, body } = await implementation
+        .teamsAddOrUpdateRepoPermissionsInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddOrUpdateRepoPermissionsInOrgResponseValidator(
         status,
@@ -23563,15 +24911,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug/repos/:owner/:repo",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsRemoveRepoInOrgParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsRemoveRepoInOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsRemoveRepoInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsRemoveRepoInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveRepoInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23599,15 +24952,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/orgs/:org/teams/:teamSlug/teams",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsListChildInOrgParamSchema, ctx.params),
-        query: parseRequestInput(teamsListChildInOrgQuerySchema, ctx.query),
+        params: parseRequestInput(
+          teamsListChildInOrgParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          teamsListChildInOrgQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListChildInOrg(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListChildInOrg(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListChildInOrgResponseValidator(status, body)
       ctx.status = status
@@ -23650,19 +25012,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsEnableOrDisableSecurityProductOnAllOrgReposParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsEnableOrDisableSecurityProductOnAllOrgReposBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.orgsEnableOrDisableSecurityProductOnAllOrgRepos(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .orgsEnableOrDisableSecurityProductOnAllOrgRepos(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         orgsEnableOrDisableSecurityProductOnAllOrgReposResponseValidator(
@@ -23692,12 +25056,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/cards/:cardId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsGetCardParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsGetCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsGetCard(input, ctx)
+      const { status, body } = await implementation
+        .projectsGetCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsGetCardResponseValidator(status, body)
       ctx.status = status
@@ -23731,15 +25103,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/cards/:cardId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsUpdateCardParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsUpdateCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(projectsUpdateCardBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          projectsUpdateCardBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.projectsUpdateCard(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsUpdateCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsUpdateCardResponseValidator(status, body)
       ctx.status = status
@@ -23772,15 +25153,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/cards/:cardId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsDeleteCardParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsDeleteCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsDeleteCard(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsDeleteCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsDeleteCardResponseValidator(status, body)
       ctx.status = status
@@ -23843,12 +25229,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/cards/:cardId/moves",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsMoveCardParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsMoveCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(projectsMoveCardBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          projectsMoveCardBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.projectsMoveCard(input, ctx)
+      const { status, body } = await implementation
+        .projectsMoveCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsMoveCardResponseValidator(status, body)
       ctx.status = status
@@ -23876,15 +25274,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/:columnId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsGetColumnParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsGetColumnParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsGetColumn(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsGetColumn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsGetColumnResponseValidator(status, body)
       ctx.status = status
@@ -23913,18 +25316,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/:columnId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsUpdateColumnParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsUpdateColumnParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           projectsUpdateColumnBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.projectsUpdateColumn(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsUpdateColumn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsUpdateColumnResponseValidator(status, body)
       ctx.status = status
@@ -23951,15 +25360,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/:columnId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsDeleteColumnParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsDeleteColumnParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsDeleteColumn(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsDeleteColumn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsDeleteColumnResponseValidator(status, body)
       ctx.status = status
@@ -23992,15 +25406,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/:columnId/cards",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsListCardsParamSchema, ctx.params),
-        query: parseRequestInput(projectsListCardsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          projectsListCardsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          projectsListCardsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsListCards(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsListCards(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsListCardsResponseValidator(status, body)
       ctx.status = status
@@ -24049,15 +25472,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/:columnId/cards",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsCreateCardParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsCreateCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(projectsCreateCardBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          projectsCreateCardBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.projectsCreateCard(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsCreateCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsCreateCardResponseValidator(status, body)
       ctx.status = status
@@ -24087,15 +25519,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/columns/:columnId/moves",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsMoveColumnParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsMoveColumnParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(projectsMoveColumnBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          projectsMoveColumnBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.projectsMoveColumn(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsMoveColumn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsMoveColumnResponseValidator(status, body)
       ctx.status = status
@@ -24117,12 +25558,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("projectsGet", "/projects/:projectId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(projectsGetParamSchema, ctx.params),
+      params: parseRequestInput(
+        projectsGetParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.projectsGet(input, ctx)
+    const { status, body } = await implementation
+      .projectsGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = projectsGetResponseValidator(status, body)
     ctx.status = status
@@ -24165,12 +25614,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.patch("projectsUpdate", "/projects/:projectId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(projectsUpdateParamSchema, ctx.params),
+      params: parseRequestInput(
+        projectsUpdateParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(projectsUpdateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        projectsUpdateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.projectsUpdate(input, ctx)
+    const { status, body } = await implementation
+      .projectsUpdate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = projectsUpdateResponseValidator(status, body)
     ctx.status = status
@@ -24200,12 +25661,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("projectsDelete", "/projects/:projectId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(projectsDeleteParamSchema, ctx.params),
+      params: parseRequestInput(
+        projectsDeleteParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.projectsDelete(input, ctx)
+    const { status, body } = await implementation
+      .projectsDelete(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = projectsDeleteResponseValidator(status, body)
     ctx.status = status
@@ -24242,18 +25711,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           projectsListCollaboratorsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           projectsListCollaboratorsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsListCollaborators(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsListCollaborators(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsListCollaboratorsResponseValidator(status, body)
       ctx.status = status
@@ -24291,18 +25763,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           projectsAddCollaboratorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           projectsAddCollaboratorBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.projectsAddCollaborator(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsAddCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsAddCollaboratorResponseValidator(status, body)
       ctx.status = status
@@ -24335,15 +25810,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           projectsRemoveCollaboratorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsRemoveCollaborator(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsRemoveCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsRemoveCollaboratorResponseValidator(status, body)
       ctx.status = status
@@ -24377,13 +25854,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           projectsGetPermissionForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.projectsGetPermissionForUser(input, ctx)
+      const { status, body } = await implementation
+        .projectsGetPermissionForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsGetPermissionForUserResponseValidator(status, body)
       ctx.status = status
@@ -24415,15 +25896,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/:projectId/columns",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsListColumnsParamSchema, ctx.params),
-        query: parseRequestInput(projectsListColumnsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          projectsListColumnsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          projectsListColumnsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsListColumns(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsListColumns(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsListColumnsResponseValidator(status, body)
       ctx.status = status
@@ -24453,18 +25943,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/projects/:projectId/columns",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsCreateColumnParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsCreateColumnParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           projectsCreateColumnBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.projectsCreateColumn(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsCreateColumn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsCreateColumnResponseValidator(status, body)
       ctx.status = status
@@ -24488,7 +25984,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.rateLimitGet(input, ctx)
+    const { status, body } = await implementation
+      .rateLimitGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = rateLimitGetResponseValidator(status, body)
     ctx.status = status
@@ -24509,12 +26009,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("reposGet", "/repos/:owner/:repo", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposGetParamSchema, ctx.params),
+      params: parseRequestInput(
+        reposGetParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.reposGet(input, ctx)
+    const { status, body } = await implementation
+      .reposGet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposGetResponseValidator(status, body)
     ctx.status = status
@@ -24586,12 +26094,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.patch("reposUpdate", "/repos/:owner/:repo", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposUpdateParamSchema, ctx.params),
+      params: parseRequestInput(
+        reposUpdateParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(reposUpdateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        reposUpdateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.reposUpdate(input, ctx)
+    const { status, body } = await implementation
+      .reposUpdate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposUpdateResponseValidator(status, body)
     ctx.status = status
@@ -24621,12 +26141,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("reposDelete", "/repos/:owner/:repo", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposDeleteParamSchema, ctx.params),
+      params: parseRequestInput(
+        reposDeleteParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.reposDelete(input, ctx)
+    const { status, body } = await implementation
+      .reposDelete(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposDeleteResponseValidator(status, body)
     ctx.status = status
@@ -24666,18 +26194,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListArtifactsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListArtifactsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListArtifactsForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListArtifactsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListArtifactsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -24701,15 +26232,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/artifacts/:artifactId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsGetArtifactParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsGetArtifactParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetArtifact(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetArtifact(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetArtifactResponseValidator(status, body)
       ctx.status = status
@@ -24733,15 +26269,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/artifacts/:artifactId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsDeleteArtifactParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsDeleteArtifactParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDeleteArtifact(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDeleteArtifact(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteArtifactResponseValidator(status, body)
       ctx.status = status
@@ -24772,15 +26313,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDownloadArtifactParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDownloadArtifact(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDownloadArtifact(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDownloadArtifactResponseValidator(status, body)
       ctx.status = status
@@ -24807,15 +26350,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetActionsCacheUsageParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetActionsCacheUsage(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetActionsCacheUsage(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetActionsCacheUsageResponseValidator(status, body)
       ctx.status = status
@@ -24852,18 +26397,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetActionsCacheListParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsGetActionsCacheListQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetActionsCacheList(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetActionsCacheList(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetActionsCacheListResponseValidator(status, body)
       ctx.status = status
@@ -24892,16 +26440,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteActionsCacheByKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsDeleteActionsCacheByKeyQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteActionsCacheByKey(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteActionsCacheByKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteActionsCacheByKeyResponseValidator(status, body)
       ctx.status = status
@@ -24926,13 +26479,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteActionsCacheByIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteActionsCacheById(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteActionsCacheById(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteActionsCacheByIdResponseValidator(status, body)
       ctx.status = status
@@ -24957,15 +26514,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetJobForWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetJobForWorkflowRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetJobForWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetJobForWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -24990,13 +26549,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDownloadJobLogsForWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDownloadJobLogsForWorkflowRun(input, ctx)
+      const { status, body } = await implementation
+        .actionsDownloadJobLogsForWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDownloadJobLogsForWorkflowRunResponseValidator(
         status,
@@ -25035,16 +26598,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsReRunJobForWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsReRunJobForWorkflowRunBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsReRunJobForWorkflowRun(input, ctx)
+      const { status, body } = await implementation
+        .actionsReRunJobForWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsReRunJobForWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -25075,13 +26643,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetCustomOidcSubClaimForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetCustomOidcSubClaimForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetCustomOidcSubClaimForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetCustomOidcSubClaimForRepoResponseValidator(
         status,
@@ -25121,16 +26693,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetCustomOidcSubClaimForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetCustomOidcSubClaimForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetCustomOidcSubClaimForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsSetCustomOidcSubClaimForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetCustomOidcSubClaimForRepoResponseValidator(
         status,
@@ -25173,16 +26750,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRepoOrganizationSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListRepoOrganizationSecretsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListRepoOrganizationSecrets(input, ctx)
+      const { status, body } = await implementation
+        .actionsListRepoOrganizationSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRepoOrganizationSecretsResponseValidator(
         status,
@@ -25225,16 +26807,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRepoOrganizationVariablesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListRepoOrganizationVariablesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListRepoOrganizationVariables(input, ctx)
+      const { status, body } = await implementation
+        .actionsListRepoOrganizationVariables(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRepoOrganizationVariablesResponseValidator(
         status,
@@ -25264,16 +26851,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetGithubActionsPermissionsRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetGithubActionsPermissionsRepository(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsGetGithubActionsPermissionsRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetGithubActionsPermissionsRepositoryResponseValidator(
         status,
@@ -25305,19 +26893,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetGithubActionsPermissionsRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetGithubActionsPermissionsRepositoryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetGithubActionsPermissionsRepository(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsSetGithubActionsPermissionsRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetGithubActionsPermissionsRepositoryResponseValidator(
         status,
@@ -25347,13 +26937,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetWorkflowAccessToRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetWorkflowAccessToRepository(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetWorkflowAccessToRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetWorkflowAccessToRepositoryResponseValidator(
         status,
@@ -25383,16 +26977,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetWorkflowAccessToRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetWorkflowAccessToRepositoryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetWorkflowAccessToRepository(input, ctx)
+      const { status, body } = await implementation
+        .actionsSetWorkflowAccessToRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetWorkflowAccessToRepositoryResponseValidator(
         status,
@@ -25419,13 +27018,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetAllowedActionsRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetAllowedActionsRepository(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetAllowedActionsRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetAllowedActionsRepositoryResponseValidator(
         status,
@@ -25455,16 +27058,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetAllowedActionsRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetAllowedActionsRepositoryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetAllowedActionsRepository(input, ctx)
+      const { status, body } = await implementation
+        .actionsSetAllowedActionsRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsSetAllowedActionsRepositoryResponseValidator(
         status,
@@ -25492,16 +27100,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetGithubActionsDefaultWorkflowPermissionsRepository(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsGetGithubActionsDefaultWorkflowPermissionsRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsGetGithubActionsDefaultWorkflowPermissionsRepositoryResponseValidator(
@@ -25536,19 +27145,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetGithubActionsDefaultWorkflowPermissionsRepository(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsSetGithubActionsDefaultWorkflowPermissionsRepository(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryResponseValidator(
@@ -25593,16 +27204,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListSelfHostedRunnersForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListSelfHostedRunnersForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListSelfHostedRunnersForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsListSelfHostedRunnersForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListSelfHostedRunnersForRepoResponseValidator(
         status,
@@ -25632,13 +27248,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRunnerApplicationsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListRunnerApplicationsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsListRunnerApplicationsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRunnerApplicationsForRepoResponseValidator(
         status,
@@ -25679,16 +27299,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGenerateRunnerJitconfigForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsGenerateRunnerJitconfigForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsGenerateRunnerJitconfigForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsGenerateRunnerJitconfigForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGenerateRunnerJitconfigForRepoResponseValidator(
         status,
@@ -25715,13 +27340,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateRegistrationTokenForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsCreateRegistrationTokenForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateRegistrationTokenForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateRegistrationTokenForRepoResponseValidator(
         status,
@@ -25748,13 +27377,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateRemoveTokenForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsCreateRemoveTokenForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateRemoveTokenForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateRemoveTokenForRepoResponseValidator(status, body)
       ctx.status = status
@@ -25779,13 +27412,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetSelfHostedRunnerForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetSelfHostedRunnerForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetSelfHostedRunnerForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetSelfHostedRunnerForRepoResponseValidator(
         status,
@@ -25813,13 +27450,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteSelfHostedRunnerFromRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteSelfHostedRunnerFromRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteSelfHostedRunnerFromRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteSelfHostedRunnerFromRepoResponseValidator(
         status,
@@ -25859,16 +27500,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListLabelsForSelfHostedRunnerForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListLabelsForSelfHostedRunnerForRepo(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsListLabelsForSelfHostedRunnerForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListLabelsForSelfHostedRunnerForRepoResponseValidator(
         status,
@@ -25913,19 +27555,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsAddCustomLabelsToSelfHostedRunnerForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsAddCustomLabelsToSelfHostedRunnerForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsAddCustomLabelsToSelfHostedRunnerForRepo(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsAddCustomLabelsToSelfHostedRunnerForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsAddCustomLabelsToSelfHostedRunnerForRepoResponseValidator(
@@ -25971,19 +27615,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsSetCustomLabelsForSelfHostedRunnerForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsSetCustomLabelsForSelfHostedRunnerForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsSetCustomLabelsForSelfHostedRunnerForRepo(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsSetCustomLabelsForSelfHostedRunnerForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsSetCustomLabelsForSelfHostedRunnerForRepoResponseValidator(
@@ -26025,16 +27671,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepo(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepoResponseValidator(
@@ -26078,16 +27725,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsRemoveCustomLabelFromSelfHostedRunnerForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsRemoveCustomLabelFromSelfHostedRunnerForRepo(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .actionsRemoveCustomLabelFromSelfHostedRunnerForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         actionsRemoveCustomLabelFromSelfHostedRunnerForRepoResponseValidator(
@@ -26156,16 +27804,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListWorkflowRunsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListWorkflowRunsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListWorkflowRunsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .actionsListWorkflowRunsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListWorkflowRunsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -26193,15 +27846,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/runs/:runId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsGetWorkflowRunParamSchema, ctx.params),
-        query: parseRequestInput(actionsGetWorkflowRunQuerySchema, ctx.query),
+        params: parseRequestInput(
+          actionsGetWorkflowRunParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          actionsGetWorkflowRunQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetWorkflowRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -26228,15 +27890,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDeleteWorkflowRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDeleteWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -26263,15 +27927,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetReviewsForRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetReviewsForRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetReviewsForRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetReviewsForRunResponseValidator(status, body)
       ctx.status = status
@@ -26302,15 +27968,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsApproveWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsApproveWorkflowRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsApproveWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsApproveWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -26352,16 +28020,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListWorkflowRunArtifactsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListWorkflowRunArtifactsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListWorkflowRunArtifacts(input, ctx)
+      const { status, body } = await implementation
+        .actionsListWorkflowRunArtifacts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListWorkflowRunArtifactsResponseValidator(status, body)
       ctx.status = status
@@ -26391,16 +28064,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetWorkflowRunAttemptParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsGetWorkflowRunAttemptQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetWorkflowRunAttempt(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetWorkflowRunAttempt(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetWorkflowRunAttemptResponseValidator(status, body)
       ctx.status = status
@@ -26440,16 +28118,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListJobsForWorkflowRunAttemptParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListJobsForWorkflowRunAttemptQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListJobsForWorkflowRunAttempt(input, ctx)
+      const { status, body } = await implementation
+        .actionsListJobsForWorkflowRunAttempt(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListJobsForWorkflowRunAttemptResponseValidator(
         status,
@@ -26478,13 +28161,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDownloadWorkflowRunAttemptLogsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDownloadWorkflowRunAttemptLogs(input, ctx)
+      const { status, body } = await implementation
+        .actionsDownloadWorkflowRunAttemptLogs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDownloadWorkflowRunAttemptLogsResponseValidator(
         status,
@@ -26517,15 +28204,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCancelWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsCancelWorkflowRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsCancelWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCancelWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -26555,16 +28244,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsReviewCustomGatesForRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsReviewCustomGatesForRunBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsReviewCustomGatesForRun(input, ctx)
+      const { status, body } = await implementation
+        .actionsReviewCustomGatesForRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsReviewCustomGatesForRunResponseValidator(status, body)
       ctx.status = status
@@ -26603,16 +28297,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListJobsForWorkflowRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListJobsForWorkflowRunQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListJobsForWorkflowRun(input, ctx)
+      const { status, body } = await implementation
+        .actionsListJobsForWorkflowRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListJobsForWorkflowRunResponseValidator(status, body)
       ctx.status = status
@@ -26637,13 +28336,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDownloadWorkflowRunLogsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDownloadWorkflowRunLogs(input, ctx)
+      const { status, body } = await implementation
+        .actionsDownloadWorkflowRunLogs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDownloadWorkflowRunLogsResponseValidator(status, body)
       ctx.status = status
@@ -26675,13 +28378,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteWorkflowRunLogsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteWorkflowRunLogs(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteWorkflowRunLogs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteWorkflowRunLogsResponseValidator(status, body)
       ctx.status = status
@@ -26709,13 +28416,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetPendingDeploymentsForRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetPendingDeploymentsForRun(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetPendingDeploymentsForRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetPendingDeploymentsForRunResponseValidator(
         status,
@@ -26749,16 +28460,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsReviewPendingDeploymentsForRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsReviewPendingDeploymentsForRunBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsReviewPendingDeploymentsForRun(input, ctx)
+      const { status, body } = await implementation
+        .actionsReviewPendingDeploymentsForRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsReviewPendingDeploymentsForRunResponseValidator(
         status,
@@ -26790,18 +28506,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/runs/:runId/rerun",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsReRunWorkflowParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsReRunWorkflowParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           actionsReRunWorkflowBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.actionsReRunWorkflow(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsReRunWorkflow(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsReRunWorkflowResponseValidator(status, body)
       ctx.status = status
@@ -26831,16 +28553,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsReRunWorkflowFailedJobsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsReRunWorkflowFailedJobsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsReRunWorkflowFailedJobs(input, ctx)
+      const { status, body } = await implementation
+        .actionsReRunWorkflowFailedJobs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsReRunWorkflowFailedJobsResponseValidator(status, body)
       ctx.status = status
@@ -26867,15 +28594,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetWorkflowRunUsageParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetWorkflowRunUsage(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetWorkflowRunUsage(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetWorkflowRunUsageResponseValidator(status, body)
       ctx.status = status
@@ -26914,15 +28643,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRepoSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(actionsListRepoSecretsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          actionsListRepoSecretsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListRepoSecrets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListRepoSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRepoSecretsResponseValidator(status, body)
       ctx.status = status
@@ -26948,15 +28683,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetRepoPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetRepoPublicKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetRepoPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetRepoPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -26980,15 +28717,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/secrets/:secretName",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsGetRepoSecretParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsGetRepoSecretParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetRepoSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -27024,16 +28766,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateOrUpdateRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateOrUpdateRepoSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsCreateOrUpdateRepoSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateOrUpdateRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateOrUpdateRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -27060,15 +28807,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDeleteRepoSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDeleteRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -27107,18 +28856,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRepoVariablesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListRepoVariablesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListRepoVariables(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListRepoVariables(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRepoVariablesResponseValidator(status, body)
       ctx.status = status
@@ -27149,18 +28901,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateRepoVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateRepoVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.actionsCreateRepoVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsCreateRepoVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateRepoVariableResponseValidator(status, body)
       ctx.status = status
@@ -27187,15 +28942,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetRepoVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetRepoVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetRepoVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetRepoVariableResponseValidator(status, body)
       ctx.status = status
@@ -27227,18 +28984,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsUpdateRepoVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsUpdateRepoVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.actionsUpdateRepoVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsUpdateRepoVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsUpdateRepoVariableResponseValidator(status, body)
       ctx.status = status
@@ -27265,15 +29025,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteRepoVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDeleteRepoVariable(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDeleteRepoVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteRepoVariableResponseValidator(status, body)
       ctx.status = status
@@ -27312,18 +29074,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListRepoWorkflowsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListRepoWorkflowsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListRepoWorkflows(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListRepoWorkflows(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListRepoWorkflowsResponseValidator(status, body)
       ctx.status = status
@@ -27347,15 +29112,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/workflows/:workflowId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsGetWorkflowParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsGetWorkflowParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetWorkflow(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetWorkflow(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetWorkflowResponseValidator(status, body)
       ctx.status = status
@@ -27382,15 +29152,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDisableWorkflowParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsDisableWorkflow(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsDisableWorkflow(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDisableWorkflowResponseValidator(status, body)
       ctx.status = status
@@ -27420,16 +29192,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateWorkflowDispatchParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateWorkflowDispatchBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsCreateWorkflowDispatch(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateWorkflowDispatch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateWorkflowDispatchResponseValidator(status, body)
       ctx.status = status
@@ -27453,15 +29230,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/actions/workflows/:workflowId/enable",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(actionsEnableWorkflowParamSchema, ctx.params),
+        params: parseRequestInput(
+          actionsEnableWorkflowParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsEnableWorkflow(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsEnableWorkflow(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsEnableWorkflowResponseValidator(status, body)
       ctx.status = status
@@ -27526,15 +29308,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListWorkflowRunsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(actionsListWorkflowRunsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          actionsListWorkflowRunsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsListWorkflowRuns(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsListWorkflowRuns(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListWorkflowRunsResponseValidator(status, body)
       ctx.status = status
@@ -27561,15 +29349,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetWorkflowUsageParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetWorkflowUsage(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetWorkflowUsage(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetWorkflowUsageResponseValidator(status, body)
       ctx.status = status
@@ -27615,15 +29405,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/activity",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListActivitiesParamSchema, ctx.params),
-        query: parseRequestInput(reposListActivitiesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListActivitiesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListActivitiesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListActivities(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListActivities(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListActivitiesResponseValidator(status, body)
       ctx.status = status
@@ -27654,15 +29453,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/assignees",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesListAssigneesParamSchema, ctx.params),
-        query: parseRequestInput(issuesListAssigneesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          issuesListAssigneesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          issuesListAssigneesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListAssignees(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListAssignees(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListAssigneesResponseValidator(status, body)
       ctx.status = status
@@ -27693,13 +29501,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesCheckUserCanBeAssignedParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.issuesCheckUserCanBeAssigned(input, ctx)
+      const { status, body } = await implementation
+        .issuesCheckUserCanBeAssigned(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesCheckUserCanBeAssignedResponseValidator(status, body)
       ctx.status = status
@@ -27726,15 +29538,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/autolinks",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListAutolinksParamSchema, ctx.params),
-        query: parseRequestInput(reposListAutolinksQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListAutolinksParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListAutolinksQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListAutolinks(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListAutolinks(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListAutolinksResponseValidator(status, body)
       ctx.status = status
@@ -27766,18 +29587,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/autolinks",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateAutolinkParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateAutolinkParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposCreateAutolinkBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateAutolink(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateAutolink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateAutolinkResponseValidator(status, body)
       ctx.status = status
@@ -27804,12 +29631,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/autolinks/:autolinkId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetAutolinkParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetAutolinkParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetAutolink(input, ctx)
+      const { status, body } = await implementation
+        .reposGetAutolink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAutolinkResponseValidator(status, body)
       ctx.status = status
@@ -27836,15 +29671,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/autolinks/:autolinkId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteAutolinkParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteAutolinkParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteAutolink(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteAutolink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteAutolinkResponseValidator(status, body)
       ctx.status = status
@@ -27874,13 +29714,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCheckAutomatedSecurityFixesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposCheckAutomatedSecurityFixes(input, ctx)
+      const { status, body } = await implementation
+        .reposCheckAutomatedSecurityFixes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCheckAutomatedSecurityFixesResponseValidator(status, body)
       ctx.status = status
@@ -27904,13 +29748,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposEnableAutomatedSecurityFixesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposEnableAutomatedSecurityFixes(input, ctx)
+      const { status, body } = await implementation
+        .reposEnableAutomatedSecurityFixes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposEnableAutomatedSecurityFixesResponseValidator(
         status,
@@ -27937,13 +29785,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDisableAutomatedSecurityFixesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDisableAutomatedSecurityFixes(input, ctx)
+      const { status, body } = await implementation
+        .reposDisableAutomatedSecurityFixes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDisableAutomatedSecurityFixesResponseValidator(
         status,
@@ -27978,15 +29830,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/branches",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListBranchesParamSchema, ctx.params),
-        query: parseRequestInput(reposListBranchesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListBranchesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListBranchesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListBranches(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListBranches(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListBranchesResponseValidator(status, body)
       ctx.status = status
@@ -28014,12 +29875,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/branches/:branch",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetBranchParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetBranchParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetBranch(input, ctx)
+      const { status, body } = await implementation
+        .reposGetBranch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetBranchResponseValidator(status, body)
       ctx.status = status
@@ -28049,15 +29918,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetBranchProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetBranchProtection(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetBranchProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetBranchProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28144,18 +30015,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateBranchProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateBranchProtectionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUpdateBranchProtection(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateBranchProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateBranchProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28186,15 +30060,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteBranchProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteBranchProtection(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteBranchProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteBranchProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28222,13 +30098,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetAdminBranchProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetAdminBranchProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposGetAdminBranchProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAdminBranchProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28256,13 +30136,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposSetAdminBranchProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposSetAdminBranchProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposSetAdminBranchProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposSetAdminBranchProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28293,13 +30177,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteAdminBranchProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDeleteAdminBranchProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposDeleteAdminBranchProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteAdminBranchProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28327,13 +30215,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetPullRequestReviewProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetPullRequestReviewProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposGetPullRequestReviewProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetPullRequestReviewProtectionResponseValidator(
         status,
@@ -28390,16 +30282,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdatePullRequestReviewProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdatePullRequestReviewProtectionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposUpdatePullRequestReviewProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposUpdatePullRequestReviewProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdatePullRequestReviewProtectionResponseValidator(
         status,
@@ -28433,13 +30330,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeletePullRequestReviewProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDeletePullRequestReviewProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposDeletePullRequestReviewProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeletePullRequestReviewProtectionResponseValidator(
         status,
@@ -28473,13 +30374,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCommitSignatureProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetCommitSignatureProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposGetCommitSignatureProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCommitSignatureProtectionResponseValidator(
         status,
@@ -28513,13 +30418,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateCommitSignatureProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposCreateCommitSignatureProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateCommitSignatureProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateCommitSignatureProtectionResponseValidator(
         status,
@@ -28553,13 +30462,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteCommitSignatureProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDeleteCommitSignatureProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposDeleteCommitSignatureProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteCommitSignatureProtectionResponseValidator(
         status,
@@ -28593,13 +30506,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetStatusChecksProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetStatusChecksProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposGetStatusChecksProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetStatusChecksProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28646,16 +30563,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateStatusCheckProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateStatusCheckProtectionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposUpdateStatusCheckProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposUpdateStatusCheckProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateStatusCheckProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28680,13 +30602,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRemoveStatusCheckProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposRemoveStatusCheckProtection(input, ctx)
+      const { status, body } = await implementation
+        .reposRemoveStatusCheckProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRemoveStatusCheckProtectionResponseValidator(status, body)
       ctx.status = status
@@ -28717,13 +30643,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetAllStatusCheckContextsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetAllStatusCheckContexts(input, ctx)
+      const { status, body } = await implementation
+        .reposGetAllStatusCheckContexts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAllStatusCheckContextsResponseValidator(status, body)
       ctx.status = status
@@ -28760,18 +30690,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposAddStatusCheckContextsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposAddStatusCheckContextsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposAddStatusCheckContexts(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposAddStatusCheckContexts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposAddStatusCheckContextsResponseValidator(status, body)
       ctx.status = status
@@ -28807,18 +30740,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposSetStatusCheckContextsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposSetStatusCheckContextsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposSetStatusCheckContexts(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposSetStatusCheckContexts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposSetStatusCheckContextsResponseValidator(status, body)
       ctx.status = status
@@ -28855,16 +30791,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRemoveStatusCheckContextsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposRemoveStatusCheckContextsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposRemoveStatusCheckContexts(input, ctx)
+      const { status, body } = await implementation
+        .reposRemoveStatusCheckContexts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRemoveStatusCheckContextsResponseValidator(status, body)
       ctx.status = status
@@ -28894,15 +30835,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetAccessRestrictions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -28927,13 +30870,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDeleteAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposDeleteAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -28964,13 +30911,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetAppsWithAccessToProtectedBranchParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetAppsWithAccessToProtectedBranch(input, ctx)
+      const { status, body } = await implementation
+        .reposGetAppsWithAccessToProtectedBranch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAppsWithAccessToProtectedBranchResponseValidator(
         status,
@@ -29008,16 +30959,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposAddAppAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposAddAppAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposAddAppAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposAddAppAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposAddAppAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29052,16 +31008,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposSetAppAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposSetAppAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposSetAppAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposSetAppAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposSetAppAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29097,16 +31058,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRemoveAppAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposRemoveAppAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposRemoveAppAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposRemoveAppAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRemoveAppAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29137,16 +31103,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetTeamsWithAccessToProtectedBranchParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetTeamsWithAccessToProtectedBranch(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposGetTeamsWithAccessToProtectedBranch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetTeamsWithAccessToProtectedBranchResponseValidator(
         status,
@@ -29184,16 +31151,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposAddTeamAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposAddTeamAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposAddTeamAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposAddTeamAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposAddTeamAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29228,16 +31200,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposSetTeamAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposSetTeamAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposSetTeamAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposSetTeamAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposSetTeamAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29273,16 +31250,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRemoveTeamAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposRemoveTeamAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposRemoveTeamAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposRemoveTeamAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRemoveTeamAccessRestrictionsResponseValidator(
         status,
@@ -29316,16 +31298,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetUsersWithAccessToProtectedBranchParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetUsersWithAccessToProtectedBranch(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposGetUsersWithAccessToProtectedBranch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetUsersWithAccessToProtectedBranchResponseValidator(
         status,
@@ -29363,16 +31346,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposAddUserAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposAddUserAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposAddUserAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposAddUserAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposAddUserAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29407,16 +31395,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposSetUserAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposSetUserAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposSetUserAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposSetUserAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposSetUserAccessRestrictionsResponseValidator(status, body)
       ctx.status = status
@@ -29452,16 +31445,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRemoveUserAccessRestrictionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposRemoveUserAccessRestrictionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposRemoveUserAccessRestrictions(input, ctx)
+      const { status, body } = await implementation
+        .reposRemoveUserAccessRestrictions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRemoveUserAccessRestrictionsResponseValidator(
         status,
@@ -29495,15 +31493,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/branches/:branch/rename",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposRenameBranchParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposRenameBranchParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposRenameBranchBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposRenameBranchBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposRenameBranch(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposRenameBranch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRenameBranchResponseValidator(status, body)
       ctx.status = status
@@ -29531,12 +31538,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-runs",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksCreateParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksCreateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(checksCreateBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          checksCreateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.checksCreate(input, ctx)
+      const { status, body } = await implementation
+        .checksCreate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksCreateResponseValidator(status, body)
       ctx.status = status
@@ -29560,12 +31579,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-runs/:checkRunId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksGetParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksGetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksGet(input, ctx)
+      const { status, body } = await implementation
+        .checksGet(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksGetResponseValidator(status, body)
       ctx.status = status
@@ -29650,12 +31677,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-runs/:checkRunId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksUpdateParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksUpdateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(checksUpdateBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          checksUpdateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.checksUpdate(input, ctx)
+      const { status, body } = await implementation
+        .checksUpdate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksUpdateResponseValidator(status, body)
       ctx.status = status
@@ -29684,15 +31723,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-runs/:checkRunId/annotations",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksListAnnotationsParamSchema, ctx.params),
-        query: parseRequestInput(checksListAnnotationsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          checksListAnnotationsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          checksListAnnotationsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksListAnnotations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksListAnnotations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksListAnnotationsResponseValidator(status, body)
       ctx.status = status
@@ -29721,15 +31769,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-runs/:checkRunId/rerequest",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksRerequestRunParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksRerequestRunParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksRerequestRun(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksRerequestRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksRerequestRunResponseValidator(status, body)
       ctx.status = status
@@ -29757,15 +31810,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-suites",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksCreateSuiteParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksCreateSuiteParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(checksCreateSuiteBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          checksCreateSuiteBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.checksCreateSuite(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksCreateSuite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksCreateSuiteResponseValidator(status, body)
       ctx.status = status
@@ -29799,18 +31861,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           checksSetSuitesPreferencesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           checksSetSuitesPreferencesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.checksSetSuitesPreferences(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksSetSuitesPreferences(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksSetSuitesPreferencesResponseValidator(status, body)
       ctx.status = status
@@ -29834,12 +31899,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-suites/:checkSuiteId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksGetSuiteParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksGetSuiteParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksGetSuite(input, ctx)
+      const { status, body } = await implementation
+        .checksGetSuite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksGetSuiteResponseValidator(status, body)
       ctx.status = status
@@ -29879,15 +31952,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-suites/:checkSuiteId/check-runs",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksListForSuiteParamSchema, ctx.params),
-        query: parseRequestInput(checksListForSuiteQuerySchema, ctx.query),
+        params: parseRequestInput(
+          checksListForSuiteParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          checksListForSuiteQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksListForSuite(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksListForSuite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksListForSuiteResponseValidator(status, body)
       ctx.status = status
@@ -29911,15 +31993,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/check-suites/:checkSuiteId/rerequest",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksRerequestSuiteParamSchema, ctx.params),
+        params: parseRequestInput(
+          checksRerequestSuiteParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksRerequestSuite(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksRerequestSuite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksRerequestSuiteResponseValidator(status, body)
       ctx.status = status
@@ -29971,16 +32058,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningListAlertsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codeScanningListAlertsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codeScanningListAlertsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningListAlertsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningListAlertsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -30017,15 +32109,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/code-scanning/alerts/:alertNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(codeScanningGetAlertParamSchema, ctx.params),
+        params: parseRequestInput(
+          codeScanningGetAlertParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codeScanningGetAlert(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningGetAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningGetAlertResponseValidator(status, body)
       ctx.status = status
@@ -30070,18 +32167,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningUpdateAlertParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codeScanningUpdateAlertBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.codeScanningUpdateAlert(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningUpdateAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningUpdateAlertResponseValidator(status, body)
       ctx.status = status
@@ -30127,16 +32227,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningListAlertInstancesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codeScanningListAlertInstancesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codeScanningListAlertInstances(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningListAlertInstances(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningListAlertInstancesResponseValidator(status, body)
       ctx.status = status
@@ -30186,16 +32291,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningListRecentAnalysesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codeScanningListRecentAnalysesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codeScanningListRecentAnalyses(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningListRecentAnalyses(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningListRecentAnalysesResponseValidator(status, body)
       ctx.status = status
@@ -30234,15 +32344,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningGetAnalysisParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codeScanningGetAnalysis(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningGetAnalysis(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningGetAnalysisResponseValidator(status, body)
       ctx.status = status
@@ -30286,18 +32398,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningDeleteAnalysisParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codeScanningDeleteAnalysisQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.codeScanningDeleteAnalysis(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningDeleteAnalysis(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningDeleteAnalysisResponseValidator(status, body)
       ctx.status = status
@@ -30336,13 +32451,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningListCodeqlDatabasesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codeScanningListCodeqlDatabases(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningListCodeqlDatabases(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningListCodeqlDatabasesResponseValidator(status, body)
       ctx.status = status
@@ -30383,13 +32502,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningGetCodeqlDatabaseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codeScanningGetCodeqlDatabase(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningGetCodeqlDatabase(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningGetCodeqlDatabaseResponseValidator(status, body)
       ctx.status = status
@@ -30428,15 +32551,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningGetDefaultSetupParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codeScanningGetDefaultSetup(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningGetDefaultSetup(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningGetDefaultSetupResponseValidator(status, body)
       ctx.status = status
@@ -30480,16 +32605,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningUpdateDefaultSetupParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codeScanningUpdateDefaultSetupBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codeScanningUpdateDefaultSetup(input, ctx)
+      const { status, body } = await implementation
+        .codeScanningUpdateDefaultSetup(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningUpdateDefaultSetupResponseValidator(status, body)
       ctx.status = status
@@ -30539,18 +32669,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codeScanningUploadSarifParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codeScanningUploadSarifBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.codeScanningUploadSarif(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningUploadSarif(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningUploadSarifResponseValidator(status, body)
       ctx.status = status
@@ -30586,15 +32719,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/code-scanning/sarifs/:sarifId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(codeScanningGetSarifParamSchema, ctx.params),
+        params: parseRequestInput(
+          codeScanningGetSarifParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codeScanningGetSarif(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codeScanningGetSarif(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codeScanningGetSarifResponseValidator(status, body)
       ctx.status = status
@@ -30624,15 +32762,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/codeowners/errors",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCodeownersErrorsParamSchema, ctx.params),
-        query: parseRequestInput(reposCodeownersErrorsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposCodeownersErrorsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposCodeownersErrorsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposCodeownersErrors(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCodeownersErrors(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCodeownersErrorsResponseValidator(status, body)
       ctx.status = status
@@ -30676,19 +32823,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListInRepositoryForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesListInRepositoryForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListInRepositoryForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesListInRepositoryForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesListInRepositoryForAuthenticatedUserResponseValidator(
@@ -30752,19 +32901,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesCreateWithRepoForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesCreateWithRepoForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesCreateWithRepoForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesCreateWithRepoForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesCreateWithRepoForAuthenticatedUserResponseValidator(
         status,
@@ -30817,19 +32968,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListDevcontainersInRepositoryForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesListDevcontainersInRepositoryForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListDevcontainersInRepositoryForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesListDevcontainersInRepositoryForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesListDevcontainersInRepositoryForAuthenticatedUserResponseValidator(
@@ -30879,19 +33032,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesRepoMachinesForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesRepoMachinesForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesRepoMachinesForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesRepoMachinesForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesRepoMachinesForAuthenticatedUserResponseValidator(
         status,
@@ -30942,19 +33097,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesPreFlightWithRepoForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesPreFlightWithRepoForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesPreFlightWithRepoForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesPreFlightWithRepoForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesPreFlightWithRepoForAuthenticatedUserResponseValidator(
@@ -30997,18 +33154,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListRepoSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           codespacesListRepoSecretsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesListRepoSecrets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesListRepoSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesListRepoSecretsResponseValidator(status, body)
       ctx.status = status
@@ -31034,15 +33194,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetRepoPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesGetRepoPublicKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesGetRepoPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetRepoPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -31069,15 +33231,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesGetRepoSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesGetRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -31113,16 +33277,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesCreateOrUpdateRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesCreateOrUpdateRepoSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesCreateOrUpdateRepoSecret(input, ctx)
+      const { status, body } = await implementation
+        .codespacesCreateOrUpdateRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesCreateOrUpdateRepoSecretResponseValidator(
         status,
@@ -31152,15 +33321,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesDeleteRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.codespacesDeleteRepoSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .codespacesDeleteRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesDeleteRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -31198,15 +33369,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListCollaboratorsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(reposListCollaboratorsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          reposListCollaboratorsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListCollaborators(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListCollaborators(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListCollaboratorsResponseValidator(status, body)
       ctx.status = status
@@ -31236,15 +33413,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCheckCollaboratorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposCheckCollaborator(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCheckCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCheckCollaboratorResponseValidator(status, body)
       ctx.status = status
@@ -31277,18 +33456,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/collaborators/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposAddCollaboratorParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposAddCollaboratorParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposAddCollaboratorBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposAddCollaborator(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposAddCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposAddCollaboratorResponseValidator(status, body)
       ctx.status = status
@@ -31319,15 +33504,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRemoveCollaboratorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposRemoveCollaborator(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposRemoveCollaborator(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRemoveCollaboratorResponseValidator(status, body)
       ctx.status = status
@@ -31358,13 +33545,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCollaboratorPermissionLevelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetCollaboratorPermissionLevel(input, ctx)
+      const { status, body } = await implementation
+        .reposGetCollaboratorPermissionLevel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCollaboratorPermissionLevelResponseValidator(
         status,
@@ -31396,16 +33587,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListCommitCommentsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListCommitCommentsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListCommitCommentsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .reposListCommitCommentsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListCommitCommentsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -31432,15 +33628,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetCommitCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetCommitCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetCommitComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31472,18 +33673,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateCommitCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateCommitCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUpdateCommitComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31513,15 +33717,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteCommitCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteCommitComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31569,16 +33775,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForCommitCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForCommitCommentQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForCommitComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsListForCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31623,16 +33834,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForCommitCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForCommitCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForCommitComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsCreateForCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31658,13 +33874,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForCommitCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsDeleteForCommitComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsDeleteForCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31704,12 +33924,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/commits",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListCommitsParamSchema, ctx.params),
-        query: parseRequestInput(reposListCommitsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListCommitsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListCommitsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListCommits(input, ctx)
+      const { status, body } = await implementation
+        .reposListCommits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListCommitsResponseValidator(status, body)
       ctx.status = status
@@ -31740,13 +33972,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListBranchesForHeadCommitParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListBranchesForHeadCommit(input, ctx)
+      const { status, body } = await implementation
+        .reposListBranchesForHeadCommit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListBranchesForHeadCommitResponseValidator(status, body)
       ctx.status = status
@@ -31778,18 +34014,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListCommentsForCommitParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListCommentsForCommitQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListCommentsForCommit(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListCommentsForCommit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListCommentsForCommitResponseValidator(status, body)
       ctx.status = status
@@ -31827,18 +34066,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateCommitCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateCommitCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateCommitComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateCommitComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateCommitCommentResponseValidator(status, body)
       ctx.status = status
@@ -31871,19 +34113,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListPullRequestsAssociatedWithCommitParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListPullRequestsAssociatedWithCommitQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListPullRequestsAssociatedWithCommit(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposListPullRequestsAssociatedWithCommit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListPullRequestsAssociatedWithCommitResponseValidator(
         status,
@@ -31928,12 +34172,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/commits/:ref",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetCommitParamSchema, ctx.params),
-        query: parseRequestInput(reposGetCommitQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetCommitParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetCommitQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetCommit(input, ctx)
+      const { status, body } = await implementation
+        .reposGetCommit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCommitResponseValidator(status, body)
       ctx.status = status
@@ -31974,12 +34230,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/commits/:ref/check-runs",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(checksListForRefParamSchema, ctx.params),
-        query: parseRequestInput(checksListForRefQuerySchema, ctx.query),
+        params: parseRequestInput(
+          checksListForRefParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          checksListForRefQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksListForRef(input, ctx)
+      const { status, body } = await implementation
+        .checksListForRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksListForRefResponseValidator(status, body)
       ctx.status = status
@@ -32021,15 +34289,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           checksListSuitesForRefParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(checksListSuitesForRefQuerySchema, ctx.query),
+        query: parseRequestInput(
+          checksListSuitesForRefQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.checksListSuitesForRef(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .checksListSuitesForRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = checksListSuitesForRefResponseValidator(status, body)
       ctx.status = status
@@ -32065,16 +34339,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCombinedStatusForRefParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposGetCombinedStatusForRefQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetCombinedStatusForRef(input, ctx)
+      const { status, body } = await implementation
+        .reposGetCombinedStatusForRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCombinedStatusForRefResponseValidator(status, body)
       ctx.status = status
@@ -32110,16 +34389,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListCommitStatusesForRefParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListCommitStatusesForRefQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListCommitStatusesForRef(input, ctx)
+      const { status, body } = await implementation
+        .reposListCommitStatusesForRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListCommitStatusesForRefResponseValidator(status, body)
       ctx.status = status
@@ -32143,13 +34427,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCommunityProfileMetricsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetCommunityProfileMetrics(input, ctx)
+      const { status, body } = await implementation
+        .reposGetCommunityProfileMetrics(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCommunityProfileMetricsResponseValidator(status, body)
       ctx.status = status
@@ -32190,15 +34478,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/compare/:basehead",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCompareCommitsParamSchema, ctx.params),
-        query: parseRequestInput(reposCompareCommitsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposCompareCommitsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposCompareCommitsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposCompareCommits(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCompareCommits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCompareCommitsResponseValidator(status, body)
       ctx.status = status
@@ -32237,12 +34534,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/contents/:path",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetContentParamSchema, ctx.params),
-        query: parseRequestInput(reposGetContentQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetContentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetContentQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetContent(input, ctx)
+      const { status, body } = await implementation
+        .reposGetContent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetContentResponseValidator(status, body)
       ctx.status = status
@@ -32297,16 +34606,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateOrUpdateFileContentsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateOrUpdateFileContentsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposCreateOrUpdateFileContents(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateOrUpdateFileContents(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateOrUpdateFileContentsResponseValidator(status, body)
       ctx.status = status
@@ -32355,12 +34669,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/contents/:path",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteFileParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteFileParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposDeleteFileBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposDeleteFileBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposDeleteFile(input, ctx)
+      const { status, body } = await implementation
+        .reposDeleteFile(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteFileResponseValidator(status, body)
       ctx.status = status
@@ -32394,15 +34720,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/contributors",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListContributorsParamSchema, ctx.params),
-        query: parseRequestInput(reposListContributorsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListContributorsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListContributorsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListContributors(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListContributors(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListContributorsResponseValidator(status, body)
       ctx.status = status
@@ -32453,18 +34788,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotListAlertsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependabotListAlertsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotListAlertsForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotListAlertsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotListAlertsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -32493,15 +34831,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/dependabot/alerts/:alertNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(dependabotGetAlertParamSchema, ctx.params),
+        params: parseRequestInput(
+          dependabotGetAlertParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotGetAlert(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotGetAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotGetAlertResponseValidator(status, body)
       ctx.status = status
@@ -32546,18 +34889,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/dependabot/alerts/:alertNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(dependabotUpdateAlertParamSchema, ctx.params),
+        params: parseRequestInput(
+          dependabotUpdateAlertParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           dependabotUpdateAlertBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.dependabotUpdateAlert(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotUpdateAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotUpdateAlertResponseValidator(status, body)
       ctx.status = status
@@ -32596,18 +34945,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotListRepoSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependabotListRepoSecretsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotListRepoSecrets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotListRepoSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotListRepoSecretsResponseValidator(status, body)
       ctx.status = status
@@ -32633,15 +34985,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotGetRepoPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotGetRepoPublicKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotGetRepoPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotGetRepoPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -32668,15 +35022,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotGetRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotGetRepoSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotGetRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotGetRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -32712,16 +35068,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotCreateOrUpdateRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           dependabotCreateOrUpdateRepoSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.dependabotCreateOrUpdateRepoSecret(input, ctx)
+      const { status, body } = await implementation
+        .dependabotCreateOrUpdateRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotCreateOrUpdateRepoSecretResponseValidator(
         status,
@@ -32751,15 +35112,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependabotDeleteRepoSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependabotDeleteRepoSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependabotDeleteRepoSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependabotDeleteRepoSecretResponseValidator(status, body)
       ctx.status = status
@@ -32794,18 +35157,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependencyGraphDiffRangeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           dependencyGraphDiffRangeQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependencyGraphDiffRange(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependencyGraphDiffRange(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependencyGraphDiffRangeResponseValidator(status, body)
       ctx.status = status
@@ -32835,15 +35201,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependencyGraphExportSbomParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.dependencyGraphExportSbom(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .dependencyGraphExportSbom(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependencyGraphExportSbomResponseValidator(status, body)
       ctx.status = status
@@ -32882,16 +35250,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           dependencyGraphCreateRepositorySnapshotParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           dependencyGraphCreateRepositorySnapshotBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.dependencyGraphCreateRepositorySnapshot(input, ctx)
+      const { status, body } = await implementation
+        .dependencyGraphCreateRepositorySnapshot(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = dependencyGraphCreateRepositorySnapshotResponseValidator(
         status,
@@ -32926,15 +35299,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/deployments",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListDeploymentsParamSchema, ctx.params),
-        query: parseRequestInput(reposListDeploymentsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListDeploymentsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListDeploymentsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListDeployments(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListDeployments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListDeploymentsResponseValidator(status, body)
       ctx.status = status
@@ -32974,18 +35356,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/deployments",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateDeploymentParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateDeploymentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposCreateDeploymentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateDeployment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateDeployment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateDeploymentResponseValidator(status, body)
       ctx.status = status
@@ -33012,15 +35400,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/deployments/:deploymentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetDeploymentParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetDeploymentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetDeployment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetDeployment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetDeploymentResponseValidator(status, body)
       ctx.status = status
@@ -33048,15 +35441,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/deployments/:deploymentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteDeploymentParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteDeploymentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteDeployment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteDeployment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteDeploymentResponseValidator(status, body)
       ctx.status = status
@@ -33092,18 +35490,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListDeploymentStatusesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListDeploymentStatusesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListDeploymentStatuses(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListDeploymentStatuses(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListDeploymentStatusesResponseValidator(status, body)
       ctx.status = status
@@ -33152,18 +35553,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateDeploymentStatusParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateDeploymentStatusBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateDeploymentStatus(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateDeploymentStatus(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateDeploymentStatusResponseValidator(status, body)
       ctx.status = status
@@ -33194,15 +35598,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetDeploymentStatusParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetDeploymentStatus(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetDeploymentStatus(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetDeploymentStatusResponseValidator(status, body)
       ctx.status = status
@@ -33236,18 +35642,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateDispatchEventParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateDispatchEventBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateDispatchEvent(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateDispatchEvent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateDispatchEventResponseValidator(status, body)
       ctx.status = status
@@ -33286,15 +35695,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetAllEnvironmentsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(reposGetAllEnvironmentsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          reposGetAllEnvironmentsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetAllEnvironments(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetAllEnvironments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAllEnvironmentsResponseValidator(status, body)
       ctx.status = status
@@ -33318,15 +35733,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/environments/:environmentName",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetEnvironmentParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetEnvironmentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetEnvironment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetEnvironment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetEnvironmentResponseValidator(status, body)
       ctx.status = status
@@ -33374,16 +35794,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateOrUpdateEnvironmentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateOrUpdateEnvironmentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposCreateOrUpdateEnvironment(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateOrUpdateEnvironment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateOrUpdateEnvironmentResponseValidator(status, body)
       ctx.status = status
@@ -33410,15 +35835,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteAnEnvironmentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteAnEnvironment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteAnEnvironment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteAnEnvironmentResponseValidator(status, body)
       ctx.status = status
@@ -33459,16 +35886,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListDeploymentBranchPoliciesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListDeploymentBranchPoliciesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListDeploymentBranchPolicies(input, ctx)
+      const { status, body } = await implementation
+        .reposListDeploymentBranchPolicies(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListDeploymentBranchPoliciesResponseValidator(
         status,
@@ -33506,16 +35938,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateDeploymentBranchPolicyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateDeploymentBranchPolicyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposCreateDeploymentBranchPolicy(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateDeploymentBranchPolicy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateDeploymentBranchPolicyResponseValidator(
         status,
@@ -33544,13 +35981,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetDeploymentBranchPolicyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetDeploymentBranchPolicy(input, ctx)
+      const { status, body } = await implementation
+        .reposGetDeploymentBranchPolicy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetDeploymentBranchPolicyResponseValidator(status, body)
       ctx.status = status
@@ -33579,16 +36020,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateDeploymentBranchPolicyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateDeploymentBranchPolicyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposUpdateDeploymentBranchPolicy(input, ctx)
+      const { status, body } = await implementation
+        .reposUpdateDeploymentBranchPolicy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateDeploymentBranchPolicyResponseValidator(
         status,
@@ -33617,13 +36063,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteDeploymentBranchPolicyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDeleteDeploymentBranchPolicy(input, ctx)
+      const { status, body } = await implementation
+        .reposDeleteDeploymentBranchPolicy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteDeploymentBranchPolicyResponseValidator(
         status,
@@ -33664,13 +36114,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetAllDeploymentProtectionRulesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetAllDeploymentProtectionRules(input, ctx)
+      const { status, body } = await implementation
+        .reposGetAllDeploymentProtectionRules(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAllDeploymentProtectionRulesResponseValidator(
         status,
@@ -33705,16 +36159,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateDeploymentProtectionRuleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateDeploymentProtectionRuleBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposCreateDeploymentProtectionRule(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateDeploymentProtectionRule(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateDeploymentProtectionRuleResponseValidator(
         status,
@@ -33760,19 +36219,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListCustomDeploymentRuleIntegrationsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListCustomDeploymentRuleIntegrationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListCustomDeploymentRuleIntegrations(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposListCustomDeploymentRuleIntegrations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListCustomDeploymentRuleIntegrationsResponseValidator(
         status,
@@ -33804,13 +36265,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCustomDeploymentProtectionRuleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetCustomDeploymentProtectionRule(input, ctx)
+      const { status, body } = await implementation
+        .reposGetCustomDeploymentProtectionRule(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCustomDeploymentProtectionRuleResponseValidator(
         status,
@@ -33839,13 +36304,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDisableDeploymentProtectionRuleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDisableDeploymentProtectionRule(input, ctx)
+      const { status, body } = await implementation
+        .reposDisableDeploymentProtectionRule(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDisableDeploymentProtectionRuleResponseValidator(
         status,
@@ -33879,15 +36348,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListRepoEventsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(activityListRepoEventsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          activityListRepoEventsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.activityListRepoEvents(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activityListRepoEvents(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListRepoEventsResponseValidator(status, body)
       ctx.status = status
@@ -33919,12 +36394,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/forks",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListForksParamSchema, ctx.params),
-        query: parseRequestInput(reposListForksQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListForksParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListForksQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListForks(input, ctx)
+      const { status, body } = await implementation
+        .reposListForks(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListForksResponseValidator(status, body)
       ctx.status = status
@@ -33962,12 +36449,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/forks",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateForkParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateForkParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposCreateForkBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposCreateForkBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposCreateFork(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateFork(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateForkResponseValidator(status, body)
       ctx.status = status
@@ -34001,12 +36500,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/blobs",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitCreateBlobParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitCreateBlobParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gitCreateBlobBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gitCreateBlobBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gitCreateBlob(input, ctx)
+      const { status, body } = await implementation
+        .gitCreateBlob(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitCreateBlobResponseValidator(status, body)
       ctx.status = status
@@ -34035,12 +36546,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/blobs/:fileSha",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitGetBlobParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitGetBlobParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitGetBlob(input, ctx)
+      const { status, body } = await implementation
+        .gitGetBlob(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitGetBlobResponseValidator(status, body)
       ctx.status = status
@@ -34088,12 +36607,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/commits",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitCreateCommitParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitCreateCommitParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gitCreateCommitBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gitCreateCommitBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gitCreateCommit(input, ctx)
+      const { status, body } = await implementation
+        .gitCreateCommit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitCreateCommitResponseValidator(status, body)
       ctx.status = status
@@ -34120,12 +36651,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/commits/:commitSha",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitGetCommitParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitGetCommitParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitGetCommit(input, ctx)
+      const { status, body } = await implementation
+        .gitGetCommit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitGetCommitResponseValidator(status, body)
       ctx.status = status
@@ -34149,15 +36688,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/matching-refs/:ref",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitListMatchingRefsParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitListMatchingRefsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitListMatchingRefs(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .gitListMatchingRefs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitListMatchingRefsResponseValidator(status, body)
       ctx.status = status
@@ -34184,12 +36728,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/ref/:ref",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitGetRefParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitGetRefParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitGetRef(input, ctx)
+      const { status, body } = await implementation
+        .gitGetRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitGetRefResponseValidator(status, body)
       ctx.status = status
@@ -34217,12 +36769,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/refs",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitCreateRefParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitCreateRefParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gitCreateRefBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gitCreateRefBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gitCreateRef(input, ctx)
+      const { status, body } = await implementation
+        .gitCreateRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitCreateRefResponseValidator(status, body)
       ctx.status = status
@@ -34254,12 +36818,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/refs/:ref",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitUpdateRefParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitUpdateRefParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gitUpdateRefBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gitUpdateRefBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gitUpdateRef(input, ctx)
+      const { status, body } = await implementation
+        .gitUpdateRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitUpdateRefResponseValidator(status, body)
       ctx.status = status
@@ -34286,12 +36862,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/refs/:ref",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitDeleteRefParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitDeleteRefParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitDeleteRef(input, ctx)
+      const { status, body } = await implementation
+        .gitDeleteRef(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitDeleteRefResponseValidator(status, body)
       ctx.status = status
@@ -34331,12 +36915,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/tags",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitCreateTagParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitCreateTagParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gitCreateTagBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gitCreateTagBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gitCreateTag(input, ctx)
+      const { status, body } = await implementation
+        .gitCreateTag(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitCreateTagResponseValidator(status, body)
       ctx.status = status
@@ -34363,12 +36959,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/tags/:tagSha",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitGetTagParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitGetTagParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitGetTag(input, ctx)
+      const { status, body } = await implementation
+        .gitGetTag(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitGetTagResponseValidator(status, body)
       ctx.status = status
@@ -34411,12 +37015,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/trees",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitCreateTreeParamSchema, ctx.params),
+        params: parseRequestInput(
+          gitCreateTreeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(gitCreateTreeBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          gitCreateTreeBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.gitCreateTree(input, ctx)
+      const { status, body } = await implementation
+        .gitCreateTree(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitCreateTreeResponseValidator(status, body)
       ctx.status = status
@@ -34446,12 +37062,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/git/trees/:treeSha",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gitGetTreeParamSchema, ctx.params),
-        query: parseRequestInput(gitGetTreeQuerySchema, ctx.query),
+        params: parseRequestInput(
+          gitGetTreeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          gitGetTreeQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.gitGetTree(input, ctx)
+      const { status, body } = await implementation
+        .gitGetTree(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gitGetTreeResponseValidator(status, body)
       ctx.status = status
@@ -34482,15 +37110,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListWebhooksParamSchema, ctx.params),
-        query: parseRequestInput(reposListWebhooksQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListWebhooksParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListWebhooksQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListWebhooks(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListWebhooks(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListWebhooksResponseValidator(status, body)
       ctx.status = status
@@ -34537,15 +37174,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposCreateWebhookBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposCreateWebhookBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposCreateWebhook(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateWebhookResponseValidator(status, body)
       ctx.status = status
@@ -34572,12 +37218,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks/:hookId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetWebhook(input, ctx)
+      const { status, body } = await implementation
+        .reposGetWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetWebhookResponseValidator(status, body)
       ctx.status = status
@@ -34622,15 +37276,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks/:hookId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposUpdateWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposUpdateWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposUpdateWebhookBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposUpdateWebhookBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposUpdateWebhook(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateWebhookResponseValidator(status, body)
       ctx.status = status
@@ -34657,15 +37320,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks/:hookId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteWebhook(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteWebhookResponseValidator(status, body)
       ctx.status = status
@@ -34690,13 +37358,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetWebhookConfigForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposGetWebhookConfigForRepo(input, ctx)
+      const { status, body } = await implementation
+        .reposGetWebhookConfigForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetWebhookConfigForRepoResponseValidator(status, body)
       ctx.status = status
@@ -34730,16 +37402,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateWebhookConfigForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateWebhookConfigForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposUpdateWebhookConfigForRepo(input, ctx)
+      const { status, body } = await implementation
+        .reposUpdateWebhookConfigForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateWebhookConfigForRepoResponseValidator(status, body)
       ctx.status = status
@@ -34776,18 +37453,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListWebhookDeliveriesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposListWebhookDeliveriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListWebhookDeliveries(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListWebhookDeliveries(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListWebhookDeliveriesResponseValidator(status, body)
       ctx.status = status
@@ -34819,15 +37499,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetWebhookDeliveryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetWebhookDelivery(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetWebhookDelivery(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetWebhookDeliveryResponseValidator(status, body)
       ctx.status = status
@@ -34860,13 +37542,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRedeliverWebhookDeliveryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposRedeliverWebhookDelivery(input, ctx)
+      const { status, body } = await implementation
+        .reposRedeliverWebhookDelivery(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRedeliverWebhookDeliveryResponseValidator(status, body)
       ctx.status = status
@@ -34893,12 +37579,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks/:hookId/pings",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposPingWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposPingWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposPingWebhook(input, ctx)
+      const { status, body } = await implementation
+        .reposPingWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposPingWebhookResponseValidator(status, body)
       ctx.status = status
@@ -34925,15 +37619,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/hooks/:hookId/tests",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposTestPushWebhookParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposTestPushWebhookParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposTestPushWebhook(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposTestPushWebhook(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposTestPushWebhookResponseValidator(status, body)
       ctx.status = status
@@ -34963,15 +37662,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsGetImportStatusParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsGetImportStatus(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsGetImportStatus(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsGetImportStatusResponseValidator(status, body)
       ctx.status = status
@@ -35007,18 +37708,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/import",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(migrationsStartImportParamSchema, ctx.params),
+        params: parseRequestInput(
+          migrationsStartImportParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           migrationsStartImportBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.migrationsStartImport(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsStartImport(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsStartImportResponseValidator(status, body)
       ctx.status = status
@@ -35057,18 +37764,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsUpdateImportParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           migrationsUpdateImportBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.migrationsUpdateImport(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsUpdateImport(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsUpdateImportResponseValidator(status, body)
       ctx.status = status
@@ -35097,15 +37807,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsCancelImportParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsCancelImport(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsCancelImport(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsCancelImportResponseValidator(status, body)
       ctx.status = status
@@ -35139,18 +37851,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsGetCommitAuthorsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           migrationsGetCommitAuthorsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsGetCommitAuthors(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsGetCommitAuthors(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsGetCommitAuthorsResponseValidator(status, body)
       ctx.status = status
@@ -35186,18 +37901,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsMapCommitAuthorParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           migrationsMapCommitAuthorBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.migrationsMapCommitAuthor(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsMapCommitAuthor(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsMapCommitAuthorResponseValidator(status, body)
       ctx.status = status
@@ -35226,15 +37944,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsGetLargeFilesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.migrationsGetLargeFiles(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsGetLargeFiles(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsGetLargeFilesResponseValidator(status, body)
       ctx.status = status
@@ -35268,18 +37988,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsSetLfsPreferenceParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           migrationsSetLfsPreferenceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.migrationsSetLfsPreference(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .migrationsSetLfsPreference(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsSetLfsPreferenceResponseValidator(status, body)
       ctx.status = status
@@ -35309,15 +38032,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsGetRepoInstallationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsGetRepoInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsGetRepoInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetRepoInstallationResponseValidator(status, body)
       ctx.status = status
@@ -35344,13 +38069,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           interactionsGetRestrictionsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.interactionsGetRestrictionsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .interactionsGetRestrictionsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = interactionsGetRestrictionsForRepoResponseValidator(
         status,
@@ -35385,16 +38114,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           interactionsSetRestrictionsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           interactionsSetRestrictionsForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.interactionsSetRestrictionsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .interactionsSetRestrictionsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = interactionsSetRestrictionsForRepoResponseValidator(
         status,
@@ -35427,13 +38161,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           interactionsRemoveRestrictionsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.interactionsRemoveRestrictionsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .interactionsRemoveRestrictionsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = interactionsRemoveRestrictionsForRepoResponseValidator(
         status,
@@ -35464,15 +38202,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/invitations",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListInvitationsParamSchema, ctx.params),
-        query: parseRequestInput(reposListInvitationsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListInvitationsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListInvitationsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListInvitations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListInvitations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListInvitationsResponseValidator(status, body)
       ctx.status = status
@@ -35504,18 +38251,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/invitations/:invitationId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposUpdateInvitationParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposUpdateInvitationParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateInvitationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUpdateInvitation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateInvitation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateInvitationResponseValidator(status, body)
       ctx.status = status
@@ -35539,15 +38292,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/invitations/:invitationId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteInvitationParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteInvitationParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteInvitation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteInvitation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteInvitationResponseValidator(status, body)
       ctx.status = status
@@ -35589,15 +38347,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesListForRepoParamSchema, ctx.params),
-        query: parseRequestInput(issuesListForRepoQuerySchema, ctx.query),
+        params: parseRequestInput(
+          issuesListForRepoParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          issuesListForRepoQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListForRepoResponseValidator(status, body)
       ctx.status = status
@@ -35656,12 +38423,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesCreateParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesCreateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesCreateBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesCreateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesCreate(input, ctx)
+      const { status, body } = await implementation
+        .issuesCreate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesCreateResponseValidator(status, body)
       ctx.status = status
@@ -35699,18 +38478,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesListCommentsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           issuesListCommentsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListCommentsForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListCommentsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListCommentsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -35737,12 +38519,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesGetCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesGetCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesGetComment(input, ctx)
+      const { status, body } = await implementation
+        .issuesGetComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesGetCommentResponseValidator(status, body)
       ctx.status = status
@@ -35771,18 +38561,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesUpdateCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesUpdateCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           issuesUpdateCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.issuesUpdateComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesUpdateComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesUpdateCommentResponseValidator(status, body)
       ctx.status = status
@@ -35806,15 +38602,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesDeleteCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesDeleteCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesDeleteComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesDeleteComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesDeleteCommentResponseValidator(status, body)
       ctx.status = status
@@ -35862,16 +38663,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForIssueCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForIssueCommentQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForIssueComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsListForIssueComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForIssueCommentResponseValidator(status, body)
       ctx.status = status
@@ -35916,16 +38722,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForIssueCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForIssueCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForIssueComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsCreateForIssueComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForIssueCommentResponseValidator(status, body)
       ctx.status = status
@@ -35951,13 +38762,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForIssueCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsDeleteForIssueComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsDeleteForIssueComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForIssueCommentResponseValidator(status, body)
       ctx.status = status
@@ -35991,15 +38806,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesListEventsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(issuesListEventsForRepoQuerySchema, ctx.query),
+        query: parseRequestInput(
+          issuesListEventsForRepoQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListEventsForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListEventsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListEventsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -36028,12 +38849,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/events/:eventId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesGetEventParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesGetEventParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesGetEvent(input, ctx)
+      const { status, body } = await implementation
+        .issuesGetEvent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesGetEventResponseValidator(status, body)
       ctx.status = status
@@ -36063,12 +38892,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesGetParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesGetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesGet(input, ctx)
+      const { status, body } = await implementation
+        .issuesGet(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesGetResponseValidator(status, body)
       ctx.status = status
@@ -36135,12 +38972,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesUpdateParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesUpdateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesUpdateBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesUpdateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesUpdate(input, ctx)
+      const { status, body } = await implementation
+        .issuesUpdate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesUpdateResponseValidator(status, body)
       ctx.status = status
@@ -36168,15 +39017,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/assignees",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesAddAssigneesParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesAddAssigneesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesAddAssigneesBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesAddAssigneesBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesAddAssignees(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesAddAssignees(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesAddAssigneesResponseValidator(status, body)
       ctx.status = status
@@ -36204,18 +39062,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/assignees",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesRemoveAssigneesParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesRemoveAssigneesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           issuesRemoveAssigneesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.issuesRemoveAssignees(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesRemoveAssignees(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesRemoveAssigneesResponseValidator(status, body)
       ctx.status = status
@@ -36247,13 +39111,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesCheckUserCanBeAssignedToIssueParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.issuesCheckUserCanBeAssignedToIssue(input, ctx)
+      const { status, body } = await implementation
+        .issuesCheckUserCanBeAssignedToIssue(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesCheckUserCanBeAssignedToIssueResponseValidator(
         status,
@@ -36290,15 +39158,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/comments",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesListCommentsParamSchema, ctx.params),
-        query: parseRequestInput(issuesListCommentsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          issuesListCommentsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          issuesListCommentsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListComments(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListComments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListCommentsResponseValidator(status, body)
       ctx.status = status
@@ -36330,18 +39207,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/comments",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesCreateCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesCreateCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           issuesCreateCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.issuesCreateComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesCreateComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesCreateCommentResponseValidator(status, body)
       ctx.status = status
@@ -36373,12 +39256,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/events",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesListEventsParamSchema, ctx.params),
-        query: parseRequestInput(issuesListEventsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          issuesListEventsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          issuesListEventsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListEvents(input, ctx)
+      const { status, body } = await implementation
+        .issuesListEvents(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListEventsResponseValidator(status, body)
       ctx.status = status
@@ -36415,15 +39310,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesListLabelsOnIssueParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(issuesListLabelsOnIssueQuerySchema, ctx.query),
+        query: parseRequestInput(
+          issuesListLabelsOnIssueQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListLabelsOnIssue(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListLabelsOnIssue(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListLabelsOnIssueResponseValidator(status, body)
       ctx.status = status
@@ -36463,12 +39364,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/labels",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesAddLabelsParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesAddLabelsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesAddLabelsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesAddLabelsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesAddLabels(input, ctx)
+      const { status, body } = await implementation
+        .issuesAddLabels(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesAddLabelsResponseValidator(status, body)
       ctx.status = status
@@ -36508,12 +39421,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/labels",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesSetLabelsParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesSetLabelsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesSetLabelsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesSetLabelsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesSetLabels(input, ctx)
+      const { status, body } = await implementation
+        .issuesSetLabels(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesSetLabelsResponseValidator(status, body)
       ctx.status = status
@@ -36542,15 +39467,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/labels",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesRemoveAllLabelsParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesRemoveAllLabelsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesRemoveAllLabels(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesRemoveAllLabels(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesRemoveAllLabelsResponseValidator(status, body)
       ctx.status = status
@@ -36580,15 +39510,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/labels/:name",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesRemoveLabelParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesRemoveLabelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesRemoveLabel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesRemoveLabel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesRemoveLabelResponseValidator(status, body)
       ctx.status = status
@@ -36627,12 +39562,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/lock",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesLockParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesLockParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesLockBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesLockBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesLock(input, ctx)
+      const { status, body } = await implementation
+        .issuesLock(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesLockResponseValidator(status, body)
       ctx.status = status
@@ -36660,12 +39607,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/lock",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesUnlockParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesUnlockParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesUnlock(input, ctx)
+      const { status, body } = await implementation
+        .issuesUnlock(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesUnlockResponseValidator(status, body)
       ctx.status = status
@@ -36710,15 +39665,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/issues/:issueNumber/reactions",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reactionsListForIssueParamSchema, ctx.params),
-        query: parseRequestInput(reactionsListForIssueQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reactionsListForIssueParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reactionsListForIssueQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reactionsListForIssue(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reactionsListForIssue(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForIssueResponseValidator(status, body)
       ctx.status = status
@@ -36762,18 +39726,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForIssueParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForIssueBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reactionsCreateForIssue(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reactionsCreateForIssue(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForIssueResponseValidator(status, body)
       ctx.status = status
@@ -36801,15 +39768,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForIssueParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reactionsDeleteForIssue(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reactionsDeleteForIssue(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForIssueResponseValidator(status, body)
       ctx.status = status
@@ -36846,18 +39815,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesListEventsForTimelineParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           issuesListEventsForTimelineQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListEventsForTimeline(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListEventsForTimeline(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListEventsForTimelineResponseValidator(status, body)
       ctx.status = status
@@ -36885,15 +39857,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/keys",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListDeployKeysParamSchema, ctx.params),
-        query: parseRequestInput(reposListDeployKeysQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListDeployKeysParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListDeployKeysQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListDeployKeys(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListDeployKeys(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListDeployKeysResponseValidator(status, body)
       ctx.status = status
@@ -36925,18 +39906,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/keys",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateDeployKeyParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateDeployKeyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposCreateDeployKeyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateDeployKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateDeployKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateDeployKeyResponseValidator(status, body)
       ctx.status = status
@@ -36963,15 +39950,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/keys/:keyId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetDeployKeyParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetDeployKeyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetDeployKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetDeployKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetDeployKeyResponseValidator(status, body)
       ctx.status = status
@@ -36995,15 +39987,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/keys/:keyId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteDeployKeyParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteDeployKeyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteDeployKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteDeployKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteDeployKeyResponseValidator(status, body)
       ctx.status = status
@@ -37037,15 +40034,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesListLabelsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(issuesListLabelsForRepoQuerySchema, ctx.query),
+        query: parseRequestInput(
+          issuesListLabelsForRepoQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListLabelsForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListLabelsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListLabelsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -37078,15 +40081,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/labels",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesCreateLabelParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesCreateLabelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesCreateLabelBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesCreateLabelBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesCreateLabel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesCreateLabel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesCreateLabelResponseValidator(status, body)
       ctx.status = status
@@ -37113,12 +40125,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/labels/:name",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesGetLabelParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesGetLabelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesGetLabel(input, ctx)
+      const { status, body } = await implementation
+        .issuesGetLabel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesGetLabelResponseValidator(status, body)
       ctx.status = status
@@ -37150,15 +40170,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/labels/:name",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesUpdateLabelParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesUpdateLabelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(issuesUpdateLabelBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          issuesUpdateLabelBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.issuesUpdateLabel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesUpdateLabel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesUpdateLabelResponseValidator(status, body)
       ctx.status = status
@@ -37182,15 +40211,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/labels/:name",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesDeleteLabelParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesDeleteLabelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesDeleteLabel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesDeleteLabel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesDeleteLabelResponseValidator(status, body)
       ctx.status = status
@@ -37213,15 +40247,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/languages",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListLanguagesParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposListLanguagesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListLanguages(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListLanguages(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListLanguagesResponseValidator(status, body)
       ctx.status = status
@@ -37244,15 +40283,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/license",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(licensesGetForRepoParamSchema, ctx.params),
+        params: parseRequestInput(
+          licensesGetForRepoParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.licensesGetForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .licensesGetForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = licensesGetForRepoResponseValidator(status, body)
       ctx.status = status
@@ -37281,15 +40325,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/merge-upstream",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposMergeUpstreamParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposMergeUpstreamParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposMergeUpstreamBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposMergeUpstreamBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposMergeUpstream(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposMergeUpstream(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposMergeUpstreamResponseValidator(status, body)
       ctx.status = status
@@ -37322,12 +40375,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("reposMerge", "/repos/:owner/:repo/merges", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposMergeParamSchema, ctx.params),
+      params: parseRequestInput(
+        reposMergeParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(reposMergeBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        reposMergeBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.reposMerge(input, ctx)
+    const { status, body } = await implementation
+      .reposMerge(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposMergeResponseValidator(status, body)
     ctx.status = status
@@ -37360,15 +40425,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/milestones",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesListMilestonesParamSchema, ctx.params),
-        query: parseRequestInput(issuesListMilestonesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          issuesListMilestonesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          issuesListMilestonesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesListMilestones(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesListMilestones(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListMilestonesResponseValidator(status, body)
       ctx.status = status
@@ -37402,18 +40476,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/milestones",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesCreateMilestoneParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesCreateMilestoneParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           issuesCreateMilestoneBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.issuesCreateMilestone(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesCreateMilestone(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesCreateMilestoneResponseValidator(status, body)
       ctx.status = status
@@ -37440,15 +40520,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/milestones/:milestoneNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesGetMilestoneParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesGetMilestoneParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesGetMilestone(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesGetMilestone(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesGetMilestoneResponseValidator(status, body)
       ctx.status = status
@@ -37481,18 +40566,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/milestones/:milestoneNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesUpdateMilestoneParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesUpdateMilestoneParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           issuesUpdateMilestoneBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.issuesUpdateMilestone(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesUpdateMilestone(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesUpdateMilestoneResponseValidator(status, body)
       ctx.status = status
@@ -37519,15 +40610,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/milestones/:milestoneNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(issuesDeleteMilestoneParamSchema, ctx.params),
+        params: parseRequestInput(
+          issuesDeleteMilestoneParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.issuesDeleteMilestone(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .issuesDeleteMilestone(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesDeleteMilestoneResponseValidator(status, body)
       ctx.status = status
@@ -37557,16 +40653,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           issuesListLabelsForMilestoneParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           issuesListLabelsForMilestoneQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.issuesListLabelsForMilestone(input, ctx)
+      const { status, body } = await implementation
+        .issuesListLabelsForMilestone(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListLabelsForMilestoneResponseValidator(status, body)
       ctx.status = status
@@ -37600,19 +40701,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListRepoNotificationsForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListRepoNotificationsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListRepoNotificationsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityListRepoNotificationsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         activityListRepoNotificationsForAuthenticatedUserResponseValidator(
@@ -37656,16 +40759,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityMarkRepoNotificationsAsReadParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           activityMarkRepoNotificationsAsReadBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.activityMarkRepoNotificationsAsRead(input, ctx)
+      const { status, body } = await implementation
+        .activityMarkRepoNotificationsAsRead(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityMarkRepoNotificationsAsReadResponseValidator(
         status,
@@ -37694,12 +40802,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pages",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetPagesParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetPagesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetPages(input, ctx)
+      const { status, body } = await implementation
+        .reposGetPages(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetPagesResponseValidator(status, body)
       ctx.status = status
@@ -37735,18 +40851,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pages",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreatePagesSiteParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreatePagesSiteParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposCreatePagesSiteBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreatePagesSite(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreatePagesSite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreatePagesSiteResponseValidator(status, body)
       ctx.status = status
@@ -37790,16 +40912,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateInformationAboutPagesSiteParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateInformationAboutPagesSiteBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposUpdateInformationAboutPagesSite(input, ctx)
+      const { status, body } = await implementation
+        .reposUpdateInformationAboutPagesSite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateInformationAboutPagesSiteResponseValidator(
         status,
@@ -37830,15 +40957,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pages",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeletePagesSiteParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeletePagesSiteParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeletePagesSite(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeletePagesSite(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeletePagesSiteResponseValidator(status, body)
       ctx.status = status
@@ -37866,15 +40998,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pages/builds",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListPagesBuildsParamSchema, ctx.params),
-        query: parseRequestInput(reposListPagesBuildsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListPagesBuildsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListPagesBuildsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListPagesBuilds(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListPagesBuilds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListPagesBuildsResponseValidator(status, body)
       ctx.status = status
@@ -37900,15 +41041,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposRequestPagesBuildParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposRequestPagesBuild(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposRequestPagesBuild(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposRequestPagesBuildResponseValidator(status, body)
       ctx.status = status
@@ -37934,15 +41077,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetLatestPagesBuildParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetLatestPagesBuild(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetLatestPagesBuild(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetLatestPagesBuildResponseValidator(status, body)
       ctx.status = status
@@ -37966,15 +41111,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pages/builds/:buildId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetPagesBuildParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetPagesBuildParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetPagesBuild(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetPagesBuild(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetPagesBuildResponseValidator(status, body)
       ctx.status = status
@@ -38012,18 +41162,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreatePagesDeploymentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreatePagesDeploymentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreatePagesDeployment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreatePagesDeployment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreatePagesDeploymentResponseValidator(status, body)
       ctx.status = status
@@ -38055,15 +41208,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetPagesHealthCheckParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetPagesHealthCheck(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetPagesHealthCheck(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetPagesHealthCheckResponseValidator(status, body)
       ctx.status = status
@@ -38093,16 +41248,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposEnablePrivateVulnerabilityReportingParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposEnablePrivateVulnerabilityReporting(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposEnablePrivateVulnerabilityReporting(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposEnablePrivateVulnerabilityReportingResponseValidator(
         status,
@@ -38135,16 +41291,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDisablePrivateVulnerabilityReportingParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDisablePrivateVulnerabilityReporting(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposDisablePrivateVulnerabilityReporting(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDisablePrivateVulnerabilityReportingResponseValidator(
         status,
@@ -38183,15 +41340,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/projects",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsListForRepoParamSchema, ctx.params),
-        query: parseRequestInput(projectsListForRepoQuerySchema, ctx.query),
+        params: parseRequestInput(
+          projectsListForRepoParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          projectsListForRepoQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsListForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsListForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsListForRepoResponseValidator(status, body)
       ctx.status = status
@@ -38226,18 +41392,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/projects",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsCreateForRepoParamSchema, ctx.params),
+        params: parseRequestInput(
+          projectsCreateForRepoParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           projectsCreateForRepoBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.projectsCreateForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsCreateForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsCreateForRepoResponseValidator(status, body)
       ctx.status = status
@@ -38270,12 +41442,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("pullsList", "/repos/:owner/:repo/pulls", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(pullsListParamSchema, ctx.params),
-      query: parseRequestInput(pullsListQuerySchema, ctx.query),
+      params: parseRequestInput(
+        pullsListParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        pullsListQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.pullsList(input, ctx)
+    const { status, body } = await implementation
+      .pullsList(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = pullsListResponseValidator(status, body)
     ctx.status = status
@@ -38309,12 +41493,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("pullsCreate", "/repos/:owner/:repo/pulls", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(pullsCreateParamSchema, ctx.params),
+      params: parseRequestInput(
+        pullsCreateParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(pullsCreateBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        pullsCreateBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.pullsCreate(input, ctx)
+    const { status, body } = await implementation
+      .pullsCreate(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = pullsCreateResponseValidator(status, body)
     ctx.status = status
@@ -38348,16 +41544,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsListReviewCommentsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           pullsListReviewCommentsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.pullsListReviewCommentsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .pullsListReviewCommentsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListReviewCommentsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -38384,15 +41585,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/comments/:commentId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsGetReviewCommentParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsGetReviewCommentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsGetReviewComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsGetReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsGetReviewCommentResponseValidator(status, body)
       ctx.status = status
@@ -38421,18 +41627,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsUpdateReviewCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           pullsUpdateReviewCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.pullsUpdateReviewComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsUpdateReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsUpdateReviewCommentResponseValidator(status, body)
       ctx.status = status
@@ -38462,15 +41671,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsDeleteReviewCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsDeleteReviewComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsDeleteReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsDeleteReviewCommentResponseValidator(status, body)
       ctx.status = status
@@ -38518,19 +41729,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForPullRequestReviewCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForPullRequestReviewCommentQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForPullRequestReviewComment(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reactionsListForPullRequestReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForPullRequestReviewCommentResponseValidator(
         status,
@@ -38578,19 +41791,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForPullRequestReviewCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForPullRequestReviewCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForPullRequestReviewComment(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reactionsCreateForPullRequestReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForPullRequestReviewCommentResponseValidator(
         status,
@@ -38619,13 +41834,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForPullRequestCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsDeleteForPullRequestComment(input, ctx)
+      const { status, body } = await implementation
+        .reactionsDeleteForPullRequestComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForPullRequestCommentResponseValidator(
         status,
@@ -38665,12 +41884,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsGetParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsGetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsGet(input, ctx)
+      const { status, body } = await implementation
+        .pullsGet(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsGetResponseValidator(status, body)
       ctx.status = status
@@ -38708,12 +41935,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsUpdateParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsUpdateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsUpdateBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsUpdateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsUpdate(input, ctx)
+      const { status, body } = await implementation
+        .pullsUpdate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsUpdateResponseValidator(status, body)
       ctx.status = status
@@ -38772,19 +42011,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesCreateWithPrForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesCreateWithPrForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesCreateWithPrForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesCreateWithPrForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesCreateWithPrForAuthenticatedUserResponseValidator(
         status,
@@ -38822,15 +42063,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsListReviewCommentsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(pullsListReviewCommentsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          pullsListReviewCommentsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsListReviewComments(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsListReviewComments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListReviewCommentsResponseValidator(status, body)
       ctx.status = status
@@ -38874,18 +42121,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsCreateReviewCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           pullsCreateReviewCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.pullsCreateReviewComment(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsCreateReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsCreateReviewCommentResponseValidator(status, body)
       ctx.status = status
@@ -38921,16 +42171,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsCreateReplyForReviewCommentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           pullsCreateReplyForReviewCommentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.pullsCreateReplyForReviewComment(input, ctx)
+      const { status, body } = await implementation
+        .pullsCreateReplyForReviewComment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsCreateReplyForReviewCommentResponseValidator(status, body)
       ctx.status = status
@@ -38959,12 +42214,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/commits",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsListCommitsParamSchema, ctx.params),
-        query: parseRequestInput(pullsListCommitsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          pullsListCommitsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          pullsListCommitsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsListCommits(input, ctx)
+      const { status, body } = await implementation
+        .pullsListCommits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListCommitsResponseValidator(status, body)
       ctx.status = status
@@ -39005,12 +42272,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/files",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsListFilesParamSchema, ctx.params),
-        query: parseRequestInput(pullsListFilesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          pullsListFilesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          pullsListFilesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsListFiles(input, ctx)
+      const { status, body } = await implementation
+        .pullsListFiles(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListFilesResponseValidator(status, body)
       ctx.status = status
@@ -39037,15 +42316,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/merge",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsCheckIfMergedParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsCheckIfMergedParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsCheckIfMerged(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsCheckIfMerged(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsCheckIfMergedResponseValidator(status, body)
       ctx.status = status
@@ -39098,12 +42382,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/merge",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsMergeParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsMergeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsMergeBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsMergeBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsMerge(input, ctx)
+      const { status, body } = await implementation
+        .pullsMerge(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsMergeResponseValidator(status, body)
       ctx.status = status
@@ -39131,15 +42427,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsListRequestedReviewersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsListRequestedReviewers(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsListRequestedReviewers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListRequestedReviewersResponseValidator(status, body)
       ctx.status = status
@@ -39174,18 +42472,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/requested_reviewers",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsRequestReviewersParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsRequestReviewersParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           pullsRequestReviewersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.pullsRequestReviewers(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsRequestReviewers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsRequestReviewersResponseValidator(status, body)
       ctx.status = status
@@ -39221,16 +42525,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsRemoveRequestedReviewersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           pullsRemoveRequestedReviewersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.pullsRemoveRequestedReviewers(input, ctx)
+      const { status, body } = await implementation
+        .pullsRemoveRequestedReviewers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsRemoveRequestedReviewersResponseValidator(status, body)
       ctx.status = status
@@ -39259,12 +42568,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/reviews",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsListReviewsParamSchema, ctx.params),
-        query: parseRequestInput(pullsListReviewsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          pullsListReviewsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          pullsListReviewsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsListReviews(input, ctx)
+      const { status, body } = await implementation
+        .pullsListReviews(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListReviewsResponseValidator(status, body)
       ctx.status = status
@@ -39313,15 +42634,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/reviews",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsCreateReviewParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsCreateReviewParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsCreateReviewBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsCreateReviewBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsCreateReview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsCreateReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsCreateReviewResponseValidator(status, body)
       ctx.status = status
@@ -39349,12 +42679,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/reviews/:reviewId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsGetReviewParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsGetReviewParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsGetReview(input, ctx)
+      const { status, body } = await implementation
+        .pullsGetReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsGetReviewResponseValidator(status, body)
       ctx.status = status
@@ -39384,15 +42722,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/reviews/:reviewId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsUpdateReviewParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsUpdateReviewParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsUpdateReviewBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsUpdateReviewBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsUpdateReview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsUpdateReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsUpdateReviewResponseValidator(status, body)
       ctx.status = status
@@ -39424,15 +42771,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsDeletePendingReviewParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsDeletePendingReview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsDeletePendingReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsDeletePendingReviewResponseValidator(status, body)
       ctx.status = status
@@ -39468,18 +42817,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pullsListCommentsForReviewParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           pullsListCommentsForReviewQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.pullsListCommentsForReview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsListCommentsForReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsListCommentsForReviewResponseValidator(status, body)
       ctx.status = status
@@ -39513,15 +42865,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/reviews/:reviewId/dismissals",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsDismissReviewParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsDismissReviewParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsDismissReviewBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsDismissReviewBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsDismissReview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsDismissReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsDismissReviewResponseValidator(status, body)
       ctx.status = status
@@ -39556,15 +42917,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/reviews/:reviewId/events",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsSubmitReviewParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsSubmitReviewParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsSubmitReviewBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsSubmitReviewBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsSubmitReview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsSubmitReview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsSubmitReviewResponseValidator(status, body)
       ctx.status = status
@@ -39603,15 +42973,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/pulls/:pullNumber/update-branch",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(pullsUpdateBranchParamSchema, ctx.params),
+        params: parseRequestInput(
+          pullsUpdateBranchParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(pullsUpdateBranchBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          pullsUpdateBranchBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.pullsUpdateBranch(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .pullsUpdateBranch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pullsUpdateBranchResponseValidator(status, body)
       ctx.status = status
@@ -39640,12 +43019,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/readme",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetReadmeParamSchema, ctx.params),
-        query: parseRequestInput(reposGetReadmeQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetReadmeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetReadmeQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetReadme(input, ctx)
+      const { status, body } = await implementation
+        .reposGetReadme(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetReadmeResponseValidator(status, body)
       ctx.status = status
@@ -39680,18 +43071,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetReadmeInDirectoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reposGetReadmeInDirectoryQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetReadmeInDirectory(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetReadmeInDirectory(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetReadmeInDirectoryResponseValidator(status, body)
       ctx.status = status
@@ -39722,15 +43116,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListReleasesParamSchema, ctx.params),
-        query: parseRequestInput(reposListReleasesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListReleasesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListReleasesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListReleases(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListReleases(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListReleasesResponseValidator(status, body)
       ctx.status = status
@@ -39769,15 +43172,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposCreateReleaseParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposCreateReleaseParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposCreateReleaseBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposCreateReleaseBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposCreateRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateReleaseResponseValidator(status, body)
       ctx.status = status
@@ -39805,15 +43217,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases/assets/:assetId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetReleaseAssetParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetReleaseAssetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetReleaseAsset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetReleaseAsset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetReleaseAssetResponseValidator(status, body)
       ctx.status = status
@@ -39848,18 +43265,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateReleaseAssetParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateReleaseAssetBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUpdateReleaseAsset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateReleaseAsset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateReleaseAssetResponseValidator(status, body)
       ctx.status = status
@@ -39886,15 +43306,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteReleaseAssetParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteReleaseAsset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteReleaseAsset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteReleaseAssetResponseValidator(status, body)
       ctx.status = status
@@ -39930,18 +43352,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGenerateReleaseNotesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposGenerateReleaseNotesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposGenerateReleaseNotes(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGenerateReleaseNotes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGenerateReleaseNotesResponseValidator(status, body)
       ctx.status = status
@@ -39964,15 +43389,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases/latest",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetLatestReleaseParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetLatestReleaseParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetLatestRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetLatestRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetLatestReleaseResponseValidator(status, body)
       ctx.status = status
@@ -39999,15 +43429,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases/tags/:tag",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetReleaseByTagParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetReleaseByTagParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetReleaseByTag(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetReleaseByTag(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetReleaseByTagResponseValidator(status, body)
       ctx.status = status
@@ -40034,12 +43469,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases/:releaseId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetReleaseParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetReleaseParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetRelease(input, ctx)
+      const { status, body } = await implementation
+        .reposGetRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetReleaseResponseValidator(status, body)
       ctx.status = status
@@ -40079,15 +43522,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases/:releaseId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposUpdateReleaseParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposUpdateReleaseParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposUpdateReleaseBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposUpdateReleaseBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposUpdateRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateReleaseResponseValidator(status, body)
       ctx.status = status
@@ -40111,15 +43563,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/releases/:releaseId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposDeleteReleaseParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposDeleteReleaseParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteReleaseResponseValidator(status, body)
       ctx.status = status
@@ -40151,15 +43608,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListReleaseAssetsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(reposListReleaseAssetsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          reposListReleaseAssetsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListReleaseAssets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListReleaseAssets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListReleaseAssetsResponseValidator(status, body)
       ctx.status = status
@@ -40196,18 +43659,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUploadReleaseAssetParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(reposUploadReleaseAssetQuerySchema, ctx.query),
+        query: parseRequestInput(
+          reposUploadReleaseAssetQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           reposUploadReleaseAssetBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUploadReleaseAsset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUploadReleaseAsset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUploadReleaseAssetResponseValidator(status, body)
       ctx.status = status
@@ -40245,15 +43715,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForReleaseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(reactionsListForReleaseQuerySchema, ctx.query),
+        query: parseRequestInput(
+          reactionsListForReleaseQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reactionsListForRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reactionsListForRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForReleaseResponseValidator(status, body)
       ctx.status = status
@@ -40288,18 +43764,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForReleaseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForReleaseBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reactionsCreateForRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reactionsCreateForRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForReleaseResponseValidator(status, body)
       ctx.status = status
@@ -40327,15 +43806,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsDeleteForReleaseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reactionsDeleteForRelease(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reactionsDeleteForRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsDeleteForReleaseResponseValidator(status, body)
       ctx.status = status
@@ -40364,15 +43845,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/rules/branches/:branch",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetBranchRulesParamSchema, ctx.params),
-        query: parseRequestInput(reposGetBranchRulesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetBranchRulesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetBranchRulesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetBranchRules(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetBranchRules(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetBranchRulesResponseValidator(status, body)
       ctx.status = status
@@ -40405,15 +43895,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/rulesets",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetRepoRulesetsParamSchema, ctx.params),
-        query: parseRequestInput(reposGetRepoRulesetsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetRepoRulesetsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetRepoRulesetsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetRepoRulesets(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetRepoRulesets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetRepoRulesetsResponseValidator(status, body)
       ctx.status = status
@@ -40452,18 +43951,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateRepoRulesetParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateRepoRulesetBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateRepoRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateRepoRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateRepoRulesetResponseValidator(status, body)
       ctx.status = status
@@ -40495,15 +43997,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/rulesets/:rulesetId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetRepoRulesetParamSchema, ctx.params),
-        query: parseRequestInput(reposGetRepoRulesetQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetRepoRulesetParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetRepoRulesetQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetRepoRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetRepoRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetRepoRulesetResponseValidator(status, body)
       ctx.status = status
@@ -40545,18 +44056,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposUpdateRepoRulesetParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposUpdateRepoRulesetBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposUpdateRepoRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposUpdateRepoRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposUpdateRepoRulesetResponseValidator(status, body)
       ctx.status = status
@@ -40587,15 +44101,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteRepoRulesetParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteRepoRuleset(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteRepoRuleset(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteRepoRulesetResponseValidator(status, body)
       ctx.status = status
@@ -40645,16 +44161,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           secretScanningListAlertsForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           secretScanningListAlertsForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.secretScanningListAlertsForRepo(input, ctx)
+      const { status, body } = await implementation
+        .secretScanningListAlertsForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = secretScanningListAlertsForRepoResponseValidator(status, body)
       ctx.status = status
@@ -40693,15 +44214,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           secretScanningGetAlertParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.secretScanningGetAlert(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .secretScanningGetAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = secretScanningGetAlertResponseValidator(status, body)
       ctx.status = status
@@ -40747,18 +44270,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           secretScanningUpdateAlertParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           secretScanningUpdateAlertBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.secretScanningUpdateAlert(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .secretScanningUpdateAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = secretScanningUpdateAlertResponseValidator(status, body)
       ctx.status = status
@@ -40802,16 +44328,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           secretScanningListLocationsForAlertParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           secretScanningListLocationsForAlertQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.secretScanningListLocationsForAlert(input, ctx)
+      const { status, body } = await implementation
+        .secretScanningListLocationsForAlert(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = secretScanningListLocationsForAlertResponseValidator(
         status,
@@ -40854,19 +44385,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesListRepositoryAdvisoriesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           securityAdvisoriesListRepositoryAdvisoriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesListRepositoryAdvisories(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .securityAdvisoriesListRepositoryAdvisories(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesListRepositoryAdvisoriesResponseValidator(
         status,
@@ -40904,19 +44437,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesCreateRepositoryAdvisoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           securityAdvisoriesCreateRepositoryAdvisoryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesCreateRepositoryAdvisory(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .securityAdvisoriesCreateRepositoryAdvisory(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesCreateRepositoryAdvisoryResponseValidator(
         status,
@@ -40952,19 +44487,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesCreatePrivateVulnerabilityReportParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           securityAdvisoriesCreatePrivateVulnerabilityReportBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesCreatePrivateVulnerabilityReport(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .securityAdvisoriesCreatePrivateVulnerabilityReport(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         securityAdvisoriesCreatePrivateVulnerabilityReportResponseValidator(
@@ -41000,13 +44537,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesGetRepositoryAdvisoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesGetRepositoryAdvisory(input, ctx)
+      const { status, body } = await implementation
+        .securityAdvisoriesGetRepositoryAdvisory(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesGetRepositoryAdvisoryResponseValidator(
         status,
@@ -41045,19 +44586,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesUpdateRepositoryAdvisoryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           securityAdvisoriesUpdateRepositoryAdvisoryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesUpdateRepositoryAdvisory(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .securityAdvisoriesUpdateRepositoryAdvisory(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = securityAdvisoriesUpdateRepositoryAdvisoryResponseValidator(
         status,
@@ -41091,16 +44634,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           securityAdvisoriesCreateRepositoryAdvisoryCveRequestParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.securityAdvisoriesCreateRepositoryAdvisoryCveRequest(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .securityAdvisoriesCreateRepositoryAdvisoryCveRequest(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         securityAdvisoriesCreateRepositoryAdvisoryCveRequestResponseValidator(
@@ -41139,16 +44683,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListStargazersForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListStargazersForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListStargazersForRepo(input, ctx)
+      const { status, body } = await implementation
+        .activityListStargazersForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListStargazersForRepoResponseValidator(status, body)
       ctx.status = status
@@ -41178,15 +44727,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCodeFrequencyStatsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetCodeFrequencyStats(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetCodeFrequencyStats(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCodeFrequencyStatsResponseValidator(status, body)
       ctx.status = status
@@ -41217,15 +44768,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetCommitActivityStatsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetCommitActivityStats(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetCommitActivityStats(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetCommitActivityStatsResponseValidator(status, body)
       ctx.status = status
@@ -41255,15 +44808,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetContributorsStatsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetContributorsStats(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetContributorsStats(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetContributorsStatsResponseValidator(status, body)
       ctx.status = status
@@ -41292,15 +44847,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetParticipationStatsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetParticipationStats(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetParticipationStats(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetParticipationStatsResponseValidator(status, body)
       ctx.status = status
@@ -41329,15 +44886,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposGetPunchCardStatsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetPunchCardStats(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetPunchCardStats(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetPunchCardStatsResponseValidator(status, body)
       ctx.status = status
@@ -41371,18 +44930,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateCommitStatusParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateCommitStatusBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateCommitStatus(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateCommitStatus(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateCommitStatusResponseValidator(status, body)
       ctx.status = status
@@ -41411,18 +44973,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListWatchersForRepoParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListWatchersForRepoQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.activityListWatchersForRepo(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activityListWatchersForRepo(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListWatchersForRepoResponseValidator(status, body)
       ctx.status = status
@@ -41453,15 +45018,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityGetRepoSubscriptionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.activityGetRepoSubscription(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activityGetRepoSubscription(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityGetRepoSubscriptionResponseValidator(status, body)
       ctx.status = status
@@ -41492,18 +45059,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activitySetRepoSubscriptionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           activitySetRepoSubscriptionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.activitySetRepoSubscription(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .activitySetRepoSubscription(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activitySetRepoSubscriptionResponseValidator(status, body)
       ctx.status = status
@@ -41527,13 +45097,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityDeleteRepoSubscriptionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityDeleteRepoSubscription(input, ctx)
+      const { status, body } = await implementation
+        .activityDeleteRepoSubscription(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityDeleteRepoSubscriptionResponseValidator(status, body)
       ctx.status = status
@@ -41558,12 +45132,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("reposListTags", "/repos/:owner/:repo/tags", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(reposListTagsParamSchema, ctx.params),
-      query: parseRequestInput(reposListTagsQuerySchema, ctx.query),
+      params: parseRequestInput(
+        reposListTagsParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        reposListTagsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.reposListTags(input, ctx)
+    const { status, body } = await implementation
+      .reposListTags(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposListTagsResponseValidator(status, body)
     ctx.status = status
@@ -41592,15 +45178,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposListTagProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListTagProtection(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposListTagProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListTagProtectionResponseValidator(status, body)
       ctx.status = status
@@ -41632,18 +45220,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateTagProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateTagProtectionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateTagProtection(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateTagProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateTagProtectionResponseValidator(status, body)
       ctx.status = status
@@ -41674,15 +45265,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeleteTagProtectionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDeleteTagProtection(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDeleteTagProtection(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeleteTagProtectionResponseValidator(status, body)
       ctx.status = status
@@ -41707,15 +45300,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDownloadTarballArchiveParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDownloadTarballArchive(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDownloadTarballArchive(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDownloadTarballArchiveResponseValidator(status, body)
       ctx.status = status
@@ -41746,12 +45341,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/teams",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListTeamsParamSchema, ctx.params),
-        query: parseRequestInput(reposListTeamsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListTeamsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListTeamsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListTeams(input, ctx)
+      const { status, body } = await implementation
+        .reposListTeams(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListTeamsResponseValidator(status, body)
       ctx.status = status
@@ -41782,15 +45389,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/topics",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetAllTopicsParamSchema, ctx.params),
-        query: parseRequestInput(reposGetAllTopicsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetAllTopicsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetAllTopicsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetAllTopics(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetAllTopics(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetAllTopicsResponseValidator(status, body)
       ctx.status = status
@@ -41821,18 +45437,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/topics",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposReplaceAllTopicsParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposReplaceAllTopicsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           reposReplaceAllTopicsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposReplaceAllTopics(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposReplaceAllTopics(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposReplaceAllTopicsResponseValidator(status, body)
       ctx.status = status
@@ -41862,12 +45484,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/traffic/clones",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetClonesParamSchema, ctx.params),
-        query: parseRequestInput(reposGetClonesQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetClonesParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetClonesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetClones(input, ctx)
+      const { status, body } = await implementation
+        .reposGetClones(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetClonesResponseValidator(status, body)
       ctx.status = status
@@ -41893,12 +45527,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/traffic/popular/paths",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetTopPathsParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetTopPathsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetTopPaths(input, ctx)
+      const { status, body } = await implementation
+        .reposGetTopPaths(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetTopPathsResponseValidator(status, body)
       ctx.status = status
@@ -41924,15 +45566,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/traffic/popular/referrers",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetTopReferrersParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposGetTopReferrersParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetTopReferrers(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposGetTopReferrers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetTopReferrersResponseValidator(status, body)
       ctx.status = status
@@ -41962,12 +45609,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/traffic/views",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposGetViewsParamSchema, ctx.params),
-        query: parseRequestInput(reposGetViewsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposGetViewsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposGetViewsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposGetViews(input, ctx)
+      const { status, body } = await implementation
+        .reposGetViews(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposGetViewsResponseValidator(status, body)
       ctx.status = status
@@ -41996,12 +45655,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/repos/:owner/:repo/transfer",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposTransferParamSchema, ctx.params),
+        params: parseRequestInput(
+          reposTransferParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(reposTransferBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          reposTransferBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.reposTransfer(input, ctx)
+      const { status, body } = await implementation
+        .reposTransfer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposTransferResponseValidator(status, body)
       ctx.status = status
@@ -42031,13 +45702,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCheckVulnerabilityAlertsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposCheckVulnerabilityAlerts(input, ctx)
+      const { status, body } = await implementation
+        .reposCheckVulnerabilityAlerts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCheckVulnerabilityAlertsResponseValidator(status, body)
       ctx.status = status
@@ -42061,13 +45736,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposEnableVulnerabilityAlertsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposEnableVulnerabilityAlerts(input, ctx)
+      const { status, body } = await implementation
+        .reposEnableVulnerabilityAlerts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposEnableVulnerabilityAlertsResponseValidator(status, body)
       ctx.status = status
@@ -42091,13 +45770,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDisableVulnerabilityAlertsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDisableVulnerabilityAlerts(input, ctx)
+      const { status, body } = await implementation
+        .reposDisableVulnerabilityAlerts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDisableVulnerabilityAlertsResponseValidator(status, body)
       ctx.status = status
@@ -42122,15 +45805,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDownloadZipballArchiveParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposDownloadZipballArchive(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposDownloadZipballArchive(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDownloadZipballArchiveResponseValidator(status, body)
       ctx.status = status
@@ -42164,18 +45849,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposCreateUsingTemplateParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reposCreateUsingTemplateBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.reposCreateUsingTemplate(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .reposCreateUsingTemplate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateUsingTemplateResponseValidator(status, body)
       ctx.status = status
@@ -42199,11 +45887,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("reposListPublic", "/repositories", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(reposListPublicQuerySchema, ctx.query),
+      query: parseRequestInput(
+        reposListPublicQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.reposListPublic(input, ctx)
+    const { status, body } = await implementation
+      .reposListPublic(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = reposListPublicResponseValidator(status, body)
     ctx.status = status
@@ -42242,16 +45938,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListEnvironmentSecretsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListEnvironmentSecretsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListEnvironmentSecrets(input, ctx)
+      const { status, body } = await implementation
+        .actionsListEnvironmentSecrets(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListEnvironmentSecretsResponseValidator(status, body)
       ctx.status = status
@@ -42275,13 +45976,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetEnvironmentPublicKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetEnvironmentPublicKey(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetEnvironmentPublicKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetEnvironmentPublicKeyResponseValidator(status, body)
       ctx.status = status
@@ -42306,15 +46011,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetEnvironmentSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.actionsGetEnvironmentSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .actionsGetEnvironmentSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetEnvironmentSecretResponseValidator(status, body)
       ctx.status = status
@@ -42350,16 +46057,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateOrUpdateEnvironmentSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateOrUpdateEnvironmentSecretBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsCreateOrUpdateEnvironmentSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateOrUpdateEnvironmentSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateOrUpdateEnvironmentSecretResponseValidator(
         status,
@@ -42387,13 +46099,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteEnvironmentSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteEnvironmentSecret(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteEnvironmentSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteEnvironmentSecretResponseValidator(status, body)
       ctx.status = status
@@ -42433,16 +46149,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsListEnvironmentVariablesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           actionsListEnvironmentVariablesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsListEnvironmentVariables(input, ctx)
+      const { status, body } = await implementation
+        .actionsListEnvironmentVariables(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsListEnvironmentVariablesResponseValidator(status, body)
       ctx.status = status
@@ -42471,16 +46192,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsCreateEnvironmentVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsCreateEnvironmentVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsCreateEnvironmentVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsCreateEnvironmentVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsCreateEnvironmentVariableResponseValidator(status, body)
       ctx.status = status
@@ -42505,13 +46231,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsGetEnvironmentVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsGetEnvironmentVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsGetEnvironmentVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsGetEnvironmentVariableResponseValidator(status, body)
       ctx.status = status
@@ -42541,16 +46271,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsUpdateEnvironmentVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           actionsUpdateEnvironmentVariableBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.actionsUpdateEnvironmentVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsUpdateEnvironmentVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsUpdateEnvironmentVariableResponseValidator(status, body)
       ctx.status = status
@@ -42575,13 +46310,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           actionsDeleteEnvironmentVariableParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.actionsDeleteEnvironmentVariable(input, ctx)
+      const { status, body } = await implementation
+        .actionsDeleteEnvironmentVariable(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = actionsDeleteEnvironmentVariableResponseValidator(status, body)
       ctx.status = status
@@ -42625,11 +46364,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("searchCode", "/search/code", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(searchCodeQuerySchema, ctx.query),
+      query: parseRequestInput(
+        searchCodeQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.searchCode(input, ctx)
+    const { status, body } = await implementation
+      .searchCode(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = searchCodeResponseValidator(status, body)
     ctx.status = status
@@ -42662,11 +46409,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("searchCommits", "/search/commits", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(searchCommitsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        searchCommitsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.searchCommits(input, ctx)
+    const { status, body } = await implementation
+      .searchCommits(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = searchCommitsResponseValidator(status, body)
     ctx.status = status
@@ -42730,14 +46485,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           searchIssuesAndPullRequestsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.searchIssuesAndPullRequests(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .searchIssuesAndPullRequests(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = searchIssuesAndPullRequestsResponseValidator(status, body)
       ctx.status = status
@@ -42775,11 +46532,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("searchLabels", "/search/labels", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(searchLabelsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        searchLabelsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.searchLabels(input, ctx)
+    const { status, body } = await implementation
+      .searchLabels(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = searchLabelsResponseValidator(status, body)
     ctx.status = status
@@ -42823,11 +46588,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("searchRepos", "/search/repositories", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(searchReposQuerySchema, ctx.query),
+      query: parseRequestInput(
+        searchReposQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.searchRepos(input, ctx)
+    const { status, body } = await implementation
+      .searchRepos(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = searchReposResponseValidator(status, body)
     ctx.status = status
@@ -42858,11 +46631,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("searchTopics", "/search/topics", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(searchTopicsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        searchTopicsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.searchTopics(input, ctx)
+    const { status, body } = await implementation
+      .searchTopics(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = searchTopicsResponseValidator(status, body)
     ctx.status = status
@@ -42904,11 +46685,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("searchUsers", "/search/users", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(searchUsersQuerySchema, ctx.query),
+      query: parseRequestInput(
+        searchUsersQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.searchUsers(input, ctx)
+    const { status, body } = await implementation
+      .searchUsers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = searchUsersResponseValidator(status, body)
     ctx.status = status
@@ -42927,12 +46716,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("teamsGetLegacy", "/teams/:teamId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(teamsGetLegacyParamSchema, ctx.params),
+      params: parseRequestInput(
+        teamsGetLegacyParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.teamsGetLegacy(input, ctx)
+    const { status, body } = await implementation
+      .teamsGetLegacy(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = teamsGetLegacyResponseValidator(status, body)
     ctx.status = status
@@ -42965,12 +46762,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.patch("teamsUpdateLegacy", "/teams/:teamId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(teamsUpdateLegacyParamSchema, ctx.params),
+      params: parseRequestInput(
+        teamsUpdateLegacyParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(teamsUpdateLegacyBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        teamsUpdateLegacyBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.teamsUpdateLegacy(input, ctx)
+    const { status, body } = await implementation
+      .teamsUpdateLegacy(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = teamsUpdateLegacyResponseValidator(status, body)
     ctx.status = status
@@ -42990,12 +46799,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("teamsDeleteLegacy", "/teams/:teamId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(teamsDeleteLegacyParamSchema, ctx.params),
+      params: parseRequestInput(
+        teamsDeleteLegacyParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.teamsDeleteLegacy(input, ctx)
+    const { status, body } = await implementation
+      .teamsDeleteLegacy(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = teamsDeleteLegacyResponseValidator(status, body)
     ctx.status = status
@@ -43025,18 +46842,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListDiscussionsLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           teamsListDiscussionsLegacyQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListDiscussionsLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListDiscussionsLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListDiscussionsLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43065,18 +46885,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCreateDiscussionLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsCreateDiscussionLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.teamsCreateDiscussionLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsCreateDiscussionLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCreateDiscussionLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43102,15 +46925,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsGetDiscussionLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsGetDiscussionLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsGetDiscussionLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetDiscussionLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43138,18 +46963,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsUpdateDiscussionLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsUpdateDiscussionLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.teamsUpdateDiscussionLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsUpdateDiscussionLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsUpdateDiscussionLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43173,15 +47001,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsDeleteDiscussionLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsDeleteDiscussionLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsDeleteDiscussionLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsDeleteDiscussionLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43214,16 +47044,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListDiscussionCommentsLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           teamsListDiscussionCommentsLegacyQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsListDiscussionCommentsLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsListDiscussionCommentsLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListDiscussionCommentsLegacyResponseValidator(
         status,
@@ -43254,16 +47089,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCreateDiscussionCommentLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsCreateDiscussionCommentLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsCreateDiscussionCommentLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsCreateDiscussionCommentLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCreateDiscussionCommentLegacyResponseValidator(
         status,
@@ -43291,13 +47131,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsGetDiscussionCommentLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsGetDiscussionCommentLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsGetDiscussionCommentLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetDiscussionCommentLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43326,16 +47170,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsUpdateDiscussionCommentLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsUpdateDiscussionCommentLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsUpdateDiscussionCommentLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsUpdateDiscussionCommentLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsUpdateDiscussionCommentLegacyResponseValidator(
         status,
@@ -43363,13 +47212,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsDeleteDiscussionCommentLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsDeleteDiscussionCommentLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsDeleteDiscussionCommentLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsDeleteDiscussionCommentLegacyResponseValidator(
         status,
@@ -43414,19 +47267,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForTeamDiscussionCommentLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForTeamDiscussionCommentLegacyQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForTeamDiscussionCommentLegacy(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reactionsListForTeamDiscussionCommentLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForTeamDiscussionCommentLegacyResponseValidator(
         status,
@@ -43467,19 +47322,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForTeamDiscussionCommentLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForTeamDiscussionCommentLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForTeamDiscussionCommentLegacy(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reactionsCreateForTeamDiscussionCommentLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForTeamDiscussionCommentLegacyResponseValidator(
         status,
@@ -43523,16 +47380,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsListForTeamDiscussionLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           reactionsListForTeamDiscussionLegacyQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reactionsListForTeamDiscussionLegacy(input, ctx)
+      const { status, body } = await implementation
+        .reactionsListForTeamDiscussionLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsListForTeamDiscussionLegacyResponseValidator(
         status,
@@ -43572,16 +47434,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reactionsCreateForTeamDiscussionLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           reactionsCreateForTeamDiscussionLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reactionsCreateForTeamDiscussionLegacy(input, ctx)
+      const { status, body } = await implementation
+        .reactionsCreateForTeamDiscussionLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reactionsCreateForTeamDiscussionLegacyResponseValidator(
         status,
@@ -43615,16 +47482,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListPendingInvitationsLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           teamsListPendingInvitationsLegacyQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsListPendingInvitationsLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsListPendingInvitationsLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListPendingInvitationsLegacyResponseValidator(
         status,
@@ -43661,15 +47533,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListMembersLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(teamsListMembersLegacyQuerySchema, ctx.query),
+        query: parseRequestInput(
+          teamsListMembersLegacyQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListMembersLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListMembersLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListMembersLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43695,15 +47573,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/teams/:teamId/members/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsGetMemberLegacyParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsGetMemberLegacyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsGetMemberLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsGetMemberLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetMemberLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43731,15 +47614,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/teams/:teamId/members/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsAddMemberLegacyParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsAddMemberLegacyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsAddMemberLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsAddMemberLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddMemberLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43768,15 +47656,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsRemoveMemberLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsRemoveMemberLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsRemoveMemberLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveMemberLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43806,13 +47696,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsGetMembershipForUserLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsGetMembershipForUserLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsGetMembershipForUserLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsGetMembershipForUserLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43848,16 +47742,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsAddOrUpdateMembershipForUserLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsAddOrUpdateMembershipForUserLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsAddOrUpdateMembershipForUserLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsAddOrUpdateMembershipForUserLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddOrUpdateMembershipForUserLegacyResponseValidator(
         status,
@@ -43890,13 +47789,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsRemoveMembershipForUserLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsRemoveMembershipForUserLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsRemoveMembershipForUserLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveMembershipForUserLegacyResponseValidator(
         status,
@@ -43932,15 +47835,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsListProjectsLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(teamsListProjectsLegacyQuerySchema, ctx.query),
+        query: parseRequestInput(
+          teamsListProjectsLegacyQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListProjectsLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListProjectsLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListProjectsLegacyResponseValidator(status, body)
       ctx.status = status
@@ -43970,13 +47879,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCheckPermissionsForProjectLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsCheckPermissionsForProjectLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsCheckPermissionsForProjectLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCheckPermissionsForProjectLegacyResponseValidator(
         status,
@@ -44021,19 +47934,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsAddOrUpdateProjectPermissionsLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsAddOrUpdateProjectPermissionsLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsAddOrUpdateProjectPermissionsLegacy(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .teamsAddOrUpdateProjectPermissionsLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddOrUpdateProjectPermissionsLegacyResponseValidator(
         status,
@@ -44066,15 +47981,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsRemoveProjectLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsRemoveProjectLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsRemoveProjectLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveProjectLegacyResponseValidator(status, body)
       ctx.status = status
@@ -44104,15 +48021,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/teams/:teamId/repos",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsListReposLegacyParamSchema, ctx.params),
-        query: parseRequestInput(teamsListReposLegacyQuerySchema, ctx.query),
+        params: parseRequestInput(
+          teamsListReposLegacyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          teamsListReposLegacyQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListReposLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListReposLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListReposLegacyResponseValidator(status, body)
       ctx.status = status
@@ -44144,13 +48070,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsCheckPermissionsForRepoLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsCheckPermissionsForRepoLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsCheckPermissionsForRepoLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsCheckPermissionsForRepoLegacyResponseValidator(
         status,
@@ -44189,16 +48119,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           teamsAddOrUpdateRepoPermissionsLegacyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           teamsAddOrUpdateRepoPermissionsLegacyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.teamsAddOrUpdateRepoPermissionsLegacy(input, ctx)
+      const { status, body } = await implementation
+        .teamsAddOrUpdateRepoPermissionsLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsAddOrUpdateRepoPermissionsLegacyResponseValidator(
         status,
@@ -44225,15 +48160,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/teams/:teamId/repos/:owner/:repo",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsRemoveRepoLegacyParamSchema, ctx.params),
+        params: parseRequestInput(
+          teamsRemoveRepoLegacyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsRemoveRepoLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsRemoveRepoLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsRemoveRepoLegacyResponseValidator(status, body)
       ctx.status = status
@@ -44265,15 +48205,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/teams/:teamId/teams",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(teamsListChildLegacyParamSchema, ctx.params),
-        query: parseRequestInput(teamsListChildLegacyQuerySchema, ctx.query),
+        params: parseRequestInput(
+          teamsListChildLegacyParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          teamsListChildLegacyQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.teamsListChildLegacy(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .teamsListChildLegacy(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListChildLegacyResponseValidator(status, body)
       ctx.status = status
@@ -44298,10 +48247,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.usersGetAuthenticated(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .usersGetAuthenticated(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersGetAuthenticatedResponseValidator(status, body)
     ctx.status = status
@@ -44340,13 +48290,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: parseRequestInput(
         usersUpdateAuthenticatedBodySchema,
         ctx.request.body,
+        RequestInputType.RequestBody,
       ),
     }
 
-    const { status, body } = await implementation.usersUpdateAuthenticated(
-      input,
-      ctx,
-    )
+    const { status, body } = await implementation
+      .usersUpdateAuthenticated(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersUpdateAuthenticatedResponseValidator(status, body)
     ctx.status = status
@@ -44379,12 +48331,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListBlockedByAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListBlockedByAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListBlockedByAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListBlockedByAuthenticatedUserResponseValidator(
         status,
@@ -44413,15 +48369,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/user/blocks/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(usersCheckBlockedParamSchema, ctx.params),
+        params: parseRequestInput(
+          usersCheckBlockedParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersCheckBlocked(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersCheckBlocked(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersCheckBlockedResponseValidator(status, body)
       ctx.status = status
@@ -44445,12 +48406,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.put("usersBlock", "/user/blocks/:username", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(usersBlockParamSchema, ctx.params),
+      params: parseRequestInput(
+        usersBlockParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.usersBlock(input, ctx)
+    const { status, body } = await implementation
+      .usersBlock(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersBlockResponseValidator(status, body)
     ctx.status = status
@@ -44472,12 +48441,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("usersUnblock", "/user/blocks/:username", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(usersUnblockParamSchema, ctx.params),
+      params: parseRequestInput(
+        usersUnblockParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.usersUnblock(input, ctx)
+    const { status, body } = await implementation
+      .usersUnblock(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersUnblockResponseValidator(status, body)
     ctx.status = status
@@ -44518,12 +48495,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           codespacesListForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesListForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesListForAuthenticatedUserResponseValidator(
         status,
@@ -44597,11 +48578,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           codespacesCreateForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesCreateForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesCreateForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesCreateForAuthenticatedUserResponseValidator(
         status,
@@ -44640,15 +48625,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           codespacesListSecretsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListSecretsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesListSecretsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesListSecretsForAuthenticatedUserResponseValidator(
         status,
@@ -44675,11 +48661,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesGetPublicKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesGetPublicKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetPublicKeyForAuthenticatedUserResponseValidator(
         status,
@@ -44705,13 +48691,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesGetSecretForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesGetSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetSecretForAuthenticatedUserResponseValidator(
         status,
@@ -44754,19 +48744,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesCreateOrUpdateSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesCreateOrUpdateSecretForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesCreateOrUpdateSecretForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesCreateOrUpdateSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesCreateOrUpdateSecretForAuthenticatedUserResponseValidator(
@@ -44793,16 +48785,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesDeleteSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesDeleteSecretForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesDeleteSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesDeleteSecretForAuthenticatedUserResponseValidator(
         status,
@@ -44842,16 +48835,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesListRepositoriesForSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesListRepositoriesForSecretForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesListRepositoriesForSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesListRepositoriesForSecretForAuthenticatedUserResponseValidator(
@@ -44889,19 +48883,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesSetRepositoriesForSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesSetRepositoriesForSecretForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesSetRepositoriesForSecretForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesSetRepositoriesForSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesSetRepositoriesForSecretForAuthenticatedUserResponseValidator(
@@ -44936,16 +48932,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesAddRepositoryForSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesAddRepositoryForSecretForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesAddRepositoryForSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesAddRepositoryForSecretForAuthenticatedUserResponseValidator(
@@ -44980,16 +48977,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesRemoveRepositoryForSecretForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesRemoveRepositoryForSecretForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesRemoveRepositoryForSecretForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesRemoveRepositoryForSecretForAuthenticatedUserResponseValidator(
@@ -45026,13 +49024,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesGetForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesGetForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesGetForAuthenticatedUserResponseValidator(
         status,
@@ -45074,16 +49076,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesUpdateForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesUpdateForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesUpdateForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesUpdateForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesUpdateForAuthenticatedUserResponseValidator(
         status,
@@ -45119,13 +49126,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesDeleteForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesDeleteForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesDeleteForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesDeleteForAuthenticatedUserResponseValidator(
         status,
@@ -45161,13 +49172,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesExportForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesExportForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesExportForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesExportForAuthenticatedUserResponseValidator(
         status,
@@ -45200,16 +49215,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesGetExportDetailsForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesGetExportDetailsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesGetExportDetailsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesGetExportDetailsForAuthenticatedUserResponseValidator(
@@ -45252,16 +49268,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesCodespaceMachinesForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesCodespaceMachinesForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .codespacesCodespaceMachinesForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         codespacesCodespaceMachinesForAuthenticatedUserResponseValidator(
@@ -45302,16 +49319,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesPublishForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           codespacesPublishForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.codespacesPublishForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesPublishForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesPublishForAuthenticatedUserResponseValidator(
         status,
@@ -45350,13 +49372,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesStartForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesStartForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesStartForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesStartForAuthenticatedUserResponseValidator(
         status,
@@ -45391,13 +49417,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           codespacesStopForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.codespacesStopForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .codespacesStopForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = codespacesStopForAuthenticatedUserResponseValidator(
         status,
@@ -45421,11 +49451,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesListDockerMigrationConflictingPackagesForAuthenticatedUser(
+      const { status, body } = await implementation
+        .packagesListDockerMigrationConflictingPackagesForAuthenticatedUser(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesListDockerMigrationConflictingPackagesForAuthenticatedUserResponseValidator(
@@ -45464,14 +49497,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersSetPrimaryEmailVisibilityForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersSetPrimaryEmailVisibilityForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersSetPrimaryEmailVisibilityForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         usersSetPrimaryEmailVisibilityForAuthenticatedUserResponseValidator(
@@ -45509,12 +49543,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListEmailsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListEmailsForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListEmailsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListEmailsForAuthenticatedUserResponseValidator(
         status,
@@ -45556,11 +49594,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersAddEmailForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersAddEmailForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersAddEmailForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersAddEmailForAuthenticatedUserResponseValidator(
         status,
@@ -45600,11 +49642,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersDeleteEmailForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersDeleteEmailForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersDeleteEmailForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersDeleteEmailForAuthenticatedUserResponseValidator(
         status,
@@ -45640,12 +49686,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListFollowersForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListFollowersForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListFollowersForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListFollowersForAuthenticatedUserResponseValidator(
         status,
@@ -45681,12 +49731,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListFollowedByAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListFollowedByAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListFollowedByAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListFollowedByAuthenticatedUserResponseValidator(
         status,
@@ -45721,16 +49775,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersCheckPersonIsFollowedByAuthenticatedParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersCheckPersonIsFollowedByAuthenticated(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersCheckPersonIsFollowedByAuthenticated(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersCheckPersonIsFollowedByAuthenticatedResponseValidator(
         status,
@@ -45756,12 +49811,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.put("usersFollow", "/user/following/:username", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(usersFollowParamSchema, ctx.params),
+      params: parseRequestInput(
+        usersFollowParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.usersFollow(input, ctx)
+    const { status, body } = await implementation
+      .usersFollow(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersFollowResponseValidator(status, body)
     ctx.status = status
@@ -45786,12 +49849,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/user/following/:username",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(usersUnfollowParamSchema, ctx.params),
+        params: parseRequestInput(
+          usersUnfollowParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersUnfollow(input, ctx)
+      const { status, body } = await implementation
+        .usersUnfollow(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersUnfollowResponseValidator(status, body)
       ctx.status = status
@@ -45825,12 +49896,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListGpgKeysForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListGpgKeysForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListGpgKeysForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListGpgKeysForAuthenticatedUserResponseValidator(
         status,
@@ -45869,11 +49944,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersCreateGpgKeyForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersCreateGpgKeyForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersCreateGpgKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersCreateGpgKeyForAuthenticatedUserResponseValidator(
         status,
@@ -45908,13 +49987,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersGetGpgKeyForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersGetGpgKeyForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersGetGpgKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersGetGpgKeyForAuthenticatedUserResponseValidator(
         status,
@@ -45950,13 +50033,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersDeleteGpgKeyForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersDeleteGpgKeyForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .usersDeleteGpgKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersDeleteGpgKeyForAuthenticatedUserResponseValidator(
         status,
@@ -45998,15 +50085,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           appsListInstallationsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListInstallationsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsListInstallationsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListInstallationsForAuthenticatedUserResponseValidator(
         status,
@@ -46052,19 +50140,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsListInstallationReposForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           appsListInstallationReposForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListInstallationReposForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsListInstallationReposForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListInstallationReposForAuthenticatedUserResponseValidator(
         status,
@@ -46099,16 +50189,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsAddRepoToInstallationForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsAddRepoToInstallationForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsAddRepoToInstallationForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsAddRepoToInstallationForAuthenticatedUserResponseValidator(
         status,
@@ -46145,16 +50236,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsRemoveRepoFromInstallationForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsRemoveRepoFromInstallationForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsRemoveRepoFromInstallationForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         appsRemoveRepoFromInstallationForAuthenticatedUserResponseValidator(
@@ -46185,11 +50277,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.interactionsGetRestrictionsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .interactionsGetRestrictionsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         interactionsGetRestrictionsForAuthenticatedUserResponseValidator(
@@ -46223,14 +50315,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           interactionsSetRestrictionsForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.interactionsSetRestrictionsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .interactionsSetRestrictionsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         interactionsSetRestrictionsForAuthenticatedUserResponseValidator(
@@ -46255,11 +50348,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.interactionsRemoveRestrictionsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .interactionsRemoveRestrictionsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         interactionsRemoveRestrictionsForAuthenticatedUserResponseValidator(
@@ -46303,12 +50396,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           issuesListForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.issuesListForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .issuesListForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = issuesListForAuthenticatedUserResponseValidator(status, body)
       ctx.status = status
@@ -46342,15 +50439,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListPublicSshKeysForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListPublicSshKeysForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersListPublicSshKeysForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListPublicSshKeysForAuthenticatedUserResponseValidator(
         status,
@@ -46389,14 +50487,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersCreatePublicSshKeyForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersCreatePublicSshKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersCreatePublicSshKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersCreatePublicSshKeyForAuthenticatedUserResponseValidator(
         status,
@@ -46431,16 +50530,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersGetPublicSshKeyForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersGetPublicSshKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersGetPublicSshKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersGetPublicSshKeyForAuthenticatedUserResponseValidator(
         status,
@@ -46475,16 +50575,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersDeletePublicSshKeyForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersDeletePublicSshKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersDeletePublicSshKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersDeletePublicSshKeyForAuthenticatedUserResponseValidator(
         status,
@@ -46520,15 +50621,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           appsListSubscriptionsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListSubscriptionsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsListSubscriptionsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsListSubscriptionsForAuthenticatedUserResponseValidator(
         status,
@@ -46563,15 +50665,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           appsListSubscriptionsForAuthenticatedUserStubbedQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.appsListSubscriptionsForAuthenticatedUserStubbed(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .appsListSubscriptionsForAuthenticatedUserStubbed(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         appsListSubscriptionsForAuthenticatedUserStubbedResponseValidator(
@@ -46610,12 +50713,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           orgsListMembershipsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsListMembershipsForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .orgsListMembershipsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListMembershipsForAuthenticatedUserResponseValidator(
         status,
@@ -46648,13 +50755,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsGetMembershipForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsGetMembershipForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .orgsGetMembershipForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsGetMembershipForAuthenticatedUserResponseValidator(
         status,
@@ -46692,19 +50803,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           orgsUpdateMembershipForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           orgsUpdateMembershipForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.orgsUpdateMembershipForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .orgsUpdateMembershipForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsUpdateMembershipForAuthenticatedUserResponseValidator(
         status,
@@ -46740,12 +50853,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           migrationsListForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsListForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .migrationsListForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsListForAuthenticatedUserResponseValidator(
         status,
@@ -46790,11 +50907,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           migrationsStartForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.migrationsStartForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .migrationsStartForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsStartForAuthenticatedUserResponseValidator(
         status,
@@ -46833,16 +50954,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsGetStatusForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           migrationsGetStatusForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsGetStatusForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .migrationsGetStatusForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsGetStatusForAuthenticatedUserResponseValidator(
         status,
@@ -46876,16 +51002,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsGetArchiveForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsGetArchiveForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .migrationsGetArchiveForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsGetArchiveForAuthenticatedUserResponseValidator(
         status,
@@ -46920,16 +51047,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsDeleteArchiveForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsDeleteArchiveForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .migrationsDeleteArchiveForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsDeleteArchiveForAuthenticatedUserResponseValidator(
         status,
@@ -46965,16 +51093,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsUnlockRepoForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsUnlockRepoForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .migrationsUnlockRepoForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsUnlockRepoForAuthenticatedUserResponseValidator(
         status,
@@ -47011,16 +51140,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           migrationsListReposForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           migrationsListReposForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.migrationsListReposForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .migrationsListReposForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = migrationsListReposForAuthenticatedUserResponseValidator(
         status,
@@ -47056,12 +51190,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           orgsListForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.orgsListForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .orgsListForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = orgsListForAuthenticatedUserResponseValidator(status, body)
       ctx.status = status
@@ -47101,15 +51239,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           packagesListPackagesForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesListPackagesForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesListPackagesForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesListPackagesForAuthenticatedUserResponseValidator(
         status,
@@ -47143,13 +51282,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetPackageForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetPackageForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .packagesGetPackageForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesGetPackageForAuthenticatedUserResponseValidator(
         status,
@@ -47191,16 +51334,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesDeletePackageForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesDeletePackageForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesDeletePackageForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesDeletePackageForAuthenticatedUserResponseValidator(
         status,
@@ -47246,19 +51390,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesRestorePackageForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesRestorePackageForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesRestorePackageForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesRestorePackageForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesRestorePackageForAuthenticatedUserResponseValidator(
         status,
@@ -47308,19 +51454,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser(
+      const { status, body } = await implementation
+        .packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserResponseValidator(
@@ -47356,16 +51507,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetPackageVersionForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetPackageVersionForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesGetPackageVersionForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesGetPackageVersionForAuthenticatedUserResponseValidator(
         status,
@@ -47408,16 +51560,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesDeletePackageVersionForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesDeletePackageVersionForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesDeletePackageVersionForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesDeletePackageVersionForAuthenticatedUserResponseValidator(
@@ -47463,16 +51616,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesRestorePackageVersionForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesRestorePackageVersionForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesRestorePackageVersionForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesRestorePackageVersionForAuthenticatedUserResponseValidator(
@@ -47511,11 +51665,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           projectsCreateForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.projectsCreateForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .projectsCreateForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsCreateForAuthenticatedUserResponseValidator(
         status,
@@ -47552,15 +51710,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListPublicEmailsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListPublicEmailsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersListPublicEmailsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListPublicEmailsForAuthenticatedUserResponseValidator(
         status,
@@ -47604,12 +51763,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           reposListForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .reposListForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListForAuthenticatedUserResponseValidator(status, body)
       ctx.status = status
@@ -47671,11 +51834,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           reposCreateForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.reposCreateForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .reposCreateForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposCreateForAuthenticatedUserResponseValidator(status, body)
       ctx.status = status
@@ -47709,15 +51876,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           reposListInvitationsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposListInvitationsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposListInvitationsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListInvitationsForAuthenticatedUserResponseValidator(
         status,
@@ -47752,16 +51920,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposAcceptInvitationForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposAcceptInvitationForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposAcceptInvitationForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposAcceptInvitationForAuthenticatedUserResponseValidator(
         status,
@@ -47796,16 +51965,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           reposDeclineInvitationForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.reposDeclineInvitationForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .reposDeclineInvitationForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposDeclineInvitationForAuthenticatedUserResponseValidator(
         status,
@@ -47842,15 +52012,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListSocialAccountsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListSocialAccountsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersListSocialAccountsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListSocialAccountsForAuthenticatedUserResponseValidator(
         status,
@@ -47888,14 +52059,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersAddSocialAccountForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersAddSocialAccountForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersAddSocialAccountForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersAddSocialAccountForAuthenticatedUserResponseValidator(
         status,
@@ -47933,14 +52105,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersDeleteSocialAccountForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersDeleteSocialAccountForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersDeleteSocialAccountForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersDeleteSocialAccountForAuthenticatedUserResponseValidator(
         status,
@@ -47977,15 +52150,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           usersListSshSigningKeysForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListSshSigningKeysForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersListSshSigningKeysForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListSshSigningKeysForAuthenticatedUserResponseValidator(
         status,
@@ -48024,14 +52198,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           usersCreateSshSigningKeyForAuthenticatedUserBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.usersCreateSshSigningKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersCreateSshSigningKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersCreateSshSigningKeyForAuthenticatedUserResponseValidator(
         status,
@@ -48066,16 +52241,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersGetSshSigningKeyForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersGetSshSigningKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersGetSshSigningKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersGetSshSigningKeyForAuthenticatedUserResponseValidator(
         status,
@@ -48110,16 +52286,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersDeleteSshSigningKeyForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersDeleteSshSigningKeyForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .usersDeleteSshSigningKeyForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersDeleteSshSigningKeyForAuthenticatedUserResponseValidator(
         status,
@@ -48157,15 +52334,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           activityListReposStarredByAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListReposStarredByAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityListReposStarredByAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListReposStarredByAuthenticatedUserResponseValidator(
         status,
@@ -48201,16 +52379,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityCheckRepoIsStarredByAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityCheckRepoIsStarredByAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityCheckRepoIsStarredByAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityCheckRepoIsStarredByAuthenticatedUserResponseValidator(
         status,
@@ -48246,13 +52425,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityStarRepoForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityStarRepoForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .activityStarRepoForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityStarRepoForAuthenticatedUserResponseValidator(
         status,
@@ -48288,13 +52471,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityUnstarRepoForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityUnstarRepoForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .activityUnstarRepoForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityUnstarRepoForAuthenticatedUserResponseValidator(
         status,
@@ -48330,15 +52517,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           activityListWatchedReposForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListWatchedReposForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityListWatchedReposForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListWatchedReposForAuthenticatedUserResponseValidator(
         status,
@@ -48374,12 +52562,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           teamsListForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.teamsListForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .teamsListForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = teamsListForAuthenticatedUserResponseValidator(status, body)
       ctx.status = status
@@ -48403,11 +52595,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("usersList", "/users", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(usersListQuerySchema, ctx.query),
+      query: parseRequestInput(
+        usersListQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.usersList(input, ctx)
+    const { status, body } = await implementation
+      .usersList(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersListResponseValidator(status, body)
     ctx.status = status
@@ -48426,12 +52626,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("usersGetByUsername", "/users/:username", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(usersGetByUsernameParamSchema, ctx.params),
+      params: parseRequestInput(
+        usersGetByUsernameParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.usersGetByUsername(input, ctx)
+    const { status, body } = await implementation
+      .usersGetByUsername(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = usersGetByUsernameResponseValidator(status, body)
     ctx.status = status
@@ -48459,16 +52667,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesListDockerMigrationConflictingPackagesForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesListDockerMigrationConflictingPackagesForUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesListDockerMigrationConflictingPackagesForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesListDockerMigrationConflictingPackagesForUserResponseValidator(
@@ -48500,16 +52709,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListEventsForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListEventsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListEventsForAuthenticatedUser(input, ctx)
+      const { status, body } = await implementation
+        .activityListEventsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListEventsForAuthenticatedUserResponseValidator(
         status,
@@ -48541,19 +52755,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListOrgEventsForAuthenticatedUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListOrgEventsForAuthenticatedUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListOrgEventsForAuthenticatedUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .activityListOrgEventsForAuthenticatedUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListOrgEventsForAuthenticatedUserResponseValidator(
         status,
@@ -48584,16 +52800,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListPublicEventsForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListPublicEventsForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListPublicEventsForUser(input, ctx)
+      const { status, body } = await implementation
+        .activityListPublicEventsForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListPublicEventsForUserResponseValidator(status, body)
       ctx.status = status
@@ -48623,18 +52844,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersListFollowersForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           usersListFollowersForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersListFollowersForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersListFollowersForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListFollowersForUserResponseValidator(status, body)
       ctx.status = status
@@ -48664,18 +52888,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersListFollowingForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           usersListFollowingForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersListFollowingForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersListFollowingForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListFollowingForUserResponseValidator(status, body)
       ctx.status = status
@@ -48704,15 +52931,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersCheckFollowingForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersCheckFollowingForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersCheckFollowingForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersCheckFollowingForUserResponseValidator(status, body)
       ctx.status = status
@@ -48741,12 +52970,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/users/:username/gists",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(gistsListForUserParamSchema, ctx.params),
-        query: parseRequestInput(gistsListForUserQuerySchema, ctx.query),
+        params: parseRequestInput(
+          gistsListForUserParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          gistsListForUserQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.gistsListForUser(input, ctx)
+      const { status, body } = await implementation
+        .gistsListForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = gistsListForUserResponseValidator(status, body)
       ctx.status = status
@@ -48774,15 +53015,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersListGpgKeysForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(usersListGpgKeysForUserQuerySchema, ctx.query),
+        query: parseRequestInput(
+          usersListGpgKeysForUserQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersListGpgKeysForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersListGpgKeysForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListGpgKeysForUserResponseValidator(status, body)
       ctx.status = status
@@ -48816,15 +53063,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersGetContextForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(usersGetContextForUserQuerySchema, ctx.query),
+        query: parseRequestInput(
+          usersGetContextForUserQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersGetContextForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersGetContextForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersGetContextForUserResponseValidator(status, body)
       ctx.status = status
@@ -48847,15 +53100,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           appsGetUserInstallationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.appsGetUserInstallation(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .appsGetUserInstallation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = appsGetUserInstallationResponseValidator(status, body)
       ctx.status = status
@@ -48885,18 +53140,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersListPublicKeysForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           usersListPublicKeysForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.usersListPublicKeysForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .usersListPublicKeysForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListPublicKeysForUserResponseValidator(status, body)
       ctx.status = status
@@ -48918,12 +53176,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("orgsListForUser", "/users/:username/orgs", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(orgsListForUserParamSchema, ctx.params),
-      query: parseRequestInput(orgsListForUserQuerySchema, ctx.query),
+      params: parseRequestInput(
+        orgsListForUserParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        orgsListForUserQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.orgsListForUser(input, ctx)
+    const { status, body } = await implementation
+      .orgsListForUser(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = orgsListForUserResponseValidator(status, body)
     ctx.status = status
@@ -48967,18 +53237,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesListPackagesForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesListPackagesForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.packagesListPackagesForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .packagesListPackagesForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesListPackagesForUserResponseValidator(status, body)
       ctx.status = status
@@ -49012,15 +53285,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetPackageForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.packagesGetPackageForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .packagesGetPackageForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesGetPackageForUserResponseValidator(status, body)
       ctx.status = status
@@ -49060,13 +53335,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesDeletePackageForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesDeletePackageForUser(input, ctx)
+      const { status, body } = await implementation
+        .packagesDeletePackageForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesDeletePackageForUserResponseValidator(status, body)
       ctx.status = status
@@ -49110,16 +53389,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesRestorePackageForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           packagesRestorePackageForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesRestorePackageForUser(input, ctx)
+      const { status, body } = await implementation
+        .packagesRestorePackageForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesRestorePackageForUserResponseValidator(status, body)
       ctx.status = status
@@ -49160,16 +53444,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetAllPackageVersionsForPackageOwnedByUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetAllPackageVersionsForPackageOwnedByUser(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .packagesGetAllPackageVersionsForPackageOwnedByUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         packagesGetAllPackageVersionsForPackageOwnedByUserResponseValidator(
@@ -49206,13 +53491,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesGetPackageVersionForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesGetPackageVersionForUser(input, ctx)
+      const { status, body } = await implementation
+        .packagesGetPackageVersionForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesGetPackageVersionForUserResponseValidator(status, body)
       ctx.status = status
@@ -49253,13 +53542,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesDeletePackageVersionForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesDeletePackageVersionForUser(input, ctx)
+      const { status, body } = await implementation
+        .packagesDeletePackageVersionForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesDeletePackageVersionForUserResponseValidator(
         status,
@@ -49303,13 +53596,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           packagesRestorePackageVersionForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.packagesRestorePackageVersionForUser(input, ctx)
+      const { status, body } = await implementation
+        .packagesRestorePackageVersionForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = packagesRestorePackageVersionForUserResponseValidator(
         status,
@@ -49341,15 +53638,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/users/:username/projects",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(projectsListForUserParamSchema, ctx.params),
-        query: parseRequestInput(projectsListForUserQuerySchema, ctx.query),
+        params: parseRequestInput(
+          projectsListForUserParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          projectsListForUserQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.projectsListForUser(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .projectsListForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = projectsListForUserResponseValidator(status, body)
       ctx.status = status
@@ -49377,16 +53683,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListReceivedEventsForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListReceivedEventsForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListReceivedEventsForUser(input, ctx)
+      const { status, body } = await implementation
+        .activityListReceivedEventsForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListReceivedEventsForUserResponseValidator(
         status,
@@ -49417,16 +53728,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListReceivedPublicEventsForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListReceivedPublicEventsForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListReceivedPublicEventsForUser(input, ctx)
+      const { status, body } = await implementation
+        .activityListReceivedPublicEventsForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListReceivedPublicEventsForUserResponseValidator(
         status,
@@ -49457,12 +53773,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/users/:username/repos",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(reposListForUserParamSchema, ctx.params),
-        query: parseRequestInput(reposListForUserQuerySchema, ctx.query),
+        params: parseRequestInput(
+          reposListForUserParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          reposListForUserQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.reposListForUser(input, ctx)
+      const { status, body } = await implementation
+        .reposListForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = reposListForUserResponseValidator(status, body)
       ctx.status = status
@@ -49485,13 +53813,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           billingGetGithubActionsBillingUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.billingGetGithubActionsBillingUser(input, ctx)
+      const { status, body } = await implementation
+        .billingGetGithubActionsBillingUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = billingGetGithubActionsBillingUserResponseValidator(
         status,
@@ -49517,13 +53849,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           billingGetGithubPackagesBillingUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.billingGetGithubPackagesBillingUser(input, ctx)
+      const { status, body } = await implementation
+        .billingGetGithubPackagesBillingUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = billingGetGithubPackagesBillingUserResponseValidator(
         status,
@@ -49549,13 +53885,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           billingGetSharedStorageBillingUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.billingGetSharedStorageBillingUser(input, ctx)
+      const { status, body } = await implementation
+        .billingGetSharedStorageBillingUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = billingGetSharedStorageBillingUserResponseValidator(
         status,
@@ -49586,16 +53926,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersListSocialAccountsForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           usersListSocialAccountsForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListSocialAccountsForUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListSocialAccountsForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListSocialAccountsForUserResponseValidator(status, body)
       ctx.status = status
@@ -49623,16 +53968,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           usersListSshSigningKeysForUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           usersListSshSigningKeysForUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.usersListSshSigningKeysForUser(input, ctx)
+      const { status, body } = await implementation
+        .usersListSshSigningKeysForUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = usersListSshSigningKeysForUserResponseValidator(status, body)
       ctx.status = status
@@ -49670,16 +54020,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListReposStarredByUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListReposStarredByUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListReposStarredByUser(input, ctx)
+      const { status, body } = await implementation
+        .activityListReposStarredByUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListReposStarredByUserResponseValidator(status, body)
       ctx.status = status
@@ -49710,16 +54065,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           activityListReposWatchedByUserParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           activityListReposWatchedByUserQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.activityListReposWatchedByUser(input, ctx)
+      const { status, body } = await implementation
+        .activityListReposWatchedByUser(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = activityListReposWatchedByUserResponseValidator(status, body)
       ctx.status = status
@@ -49742,7 +54102,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.metaGetAllVersions(input, ctx)
+    const { status, body } = await implementation
+      .metaGetAllVersions(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = metaGetAllVersionsResponseValidator(status, body)
     ctx.status = status
@@ -49761,7 +54125,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.metaGetZen(input, ctx)
+    const { status, body } = await implementation
+      .metaGetZen(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = metaGetZenResponseValidator(status, body)
     ctx.status = status

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -58,6 +58,10 @@ import {
 } from "./schemas"
 import KoaRouter from "@koa/router"
 import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
+import {
   Response,
   ServerConfig,
   StatusCode,
@@ -395,11 +399,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           createAppAuthenticatorEnrollmentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.createAppAuthenticatorEnrollment(input, ctx)
+      const { status, body } = await implementation
+        .createAppAuthenticatorEnrollment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = createAppAuthenticatorEnrollmentResponseValidator(status, body)
       ctx.status = status
@@ -432,19 +440,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           verifyAppAuthenticatorPushNotificationChallengeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           verifyAppAuthenticatorPushNotificationChallengeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.verifyAppAuthenticatorPushNotificationChallenge(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .verifyAppAuthenticatorPushNotificationChallenge(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         verifyAppAuthenticatorPushNotificationChallengeResponseValidator(
@@ -482,16 +492,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           updateAppAuthenticatorEnrollmentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           updateAppAuthenticatorEnrollmentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.updateAppAuthenticatorEnrollment(input, ctx)
+      const { status, body } = await implementation
+        .updateAppAuthenticatorEnrollment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = updateAppAuthenticatorEnrollmentResponseValidator(status, body)
       ctx.status = status
@@ -522,13 +537,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteAppAuthenticatorEnrollmentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.deleteAppAuthenticatorEnrollment(input, ctx)
+      const { status, body } = await implementation
+        .deleteAppAuthenticatorEnrollment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteAppAuthenticatorEnrollmentResponseValidator(status, body)
       ctx.status = status
@@ -553,16 +572,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           listAppAuthenticatorPendingPushNotificationChallengesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.listAppAuthenticatorPendingPushNotificationChallenges(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .listAppAuthenticatorPendingPushNotificationChallenges(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         listAppAuthenticatorPendingPushNotificationChallengesResponseValidator(
@@ -589,7 +609,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.listEmails(input, ctx)
+    const { status, body } = await implementation
+      .listEmails(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = listEmailsResponseValidator(status, body)
     ctx.status = status
@@ -618,10 +642,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(createEmailBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        createEmailBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.createEmail(input, ctx)
+    const { status, body } = await implementation
+      .createEmail(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = createEmailResponseValidator(status, body)
     ctx.status = status
@@ -640,12 +672,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getEmail", "/idp/myaccount/emails/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getEmailParamSchema, ctx.params),
+      params: parseRequestInput(
+        getEmailParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.getEmail(input, ctx)
+    const { status, body } = await implementation
+      .getEmail(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getEmailResponseValidator(status, body)
     ctx.status = status
@@ -670,12 +710,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/idp/myaccount/emails/:id",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(deleteEmailParamSchema, ctx.params),
+        params: parseRequestInput(
+          deleteEmailParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.deleteEmail(input, ctx)
+      const { status, body } = await implementation
+        .deleteEmail(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteEmailResponseValidator(status, body)
       ctx.status = status
@@ -720,15 +768,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/idp/myaccount/emails/:id/challenge",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(sendEmailChallengeParamSchema, ctx.params),
+        params: parseRequestInput(
+          sendEmailChallengeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(sendEmailChallengeBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          sendEmailChallengeBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.sendEmailChallenge(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .sendEmailChallenge(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = sendEmailChallengeResponseValidator(status, body)
       ctx.status = status
@@ -777,13 +834,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           pollChallengeForEmailMagicLinkParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.pollChallengeForEmailMagicLink(input, ctx)
+      const { status, body } = await implementation
+        .pollChallengeForEmailMagicLink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = pollChallengeForEmailMagicLinkResponseValidator(status, body)
       ctx.status = status
@@ -813,12 +874,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/idp/myaccount/emails/:id/challenge/:challengeId/verify",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(verifyEmailOtpParamSchema, ctx.params),
+        params: parseRequestInput(
+          verifyEmailOtpParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(verifyEmailOtpBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          verifyEmailOtpBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.verifyEmailOtp(input, ctx)
+      const { status, body } = await implementation
+        .verifyEmailOtp(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = verifyEmailOtpResponseValidator(status, body)
       ctx.status = status
@@ -841,7 +914,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.listPhones(input, ctx)
+    const { status, body } = await implementation
+      .listPhones(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = listPhonesResponseValidator(status, body)
     ctx.status = status
@@ -870,10 +947,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(createPhoneBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        createPhoneBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.createPhone(input, ctx)
+    const { status, body } = await implementation
+      .createPhone(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = createPhoneResponseValidator(status, body)
     ctx.status = status
@@ -893,12 +978,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getPhone", "/idp/myaccount/phones/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getPhoneParamSchema, ctx.params),
+      params: parseRequestInput(
+        getPhoneParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.getPhone(input, ctx)
+    const { status, body } = await implementation
+      .getPhone(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPhoneResponseValidator(status, body)
     ctx.status = status
@@ -922,12 +1015,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/idp/myaccount/phones/:id",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(deletePhoneParamSchema, ctx.params),
+        params: parseRequestInput(
+          deletePhoneParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.deletePhone(input, ctx)
+      const { status, body } = await implementation
+        .deletePhone(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deletePhoneResponseValidator(status, body)
       ctx.status = status
@@ -973,15 +1074,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/idp/myaccount/phones/:id/challenge",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(sendPhoneChallengeParamSchema, ctx.params),
+        params: parseRequestInput(
+          sendPhoneChallengeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(sendPhoneChallengeBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          sendPhoneChallengeBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.sendPhoneChallenge(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .sendPhoneChallenge(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = sendPhoneChallengeResponseValidator(status, body)
       ctx.status = status
@@ -1012,18 +1122,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/idp/myaccount/phones/:id/verify",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(verifyPhoneChallengeParamSchema, ctx.params),
+        params: parseRequestInput(
+          verifyPhoneChallengeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           verifyPhoneChallengeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.verifyPhoneChallenge(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .verifyPhoneChallenge(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = verifyPhoneChallengeResponseValidator(status, body)
       ctx.status = status
@@ -1046,7 +1162,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.getProfile(input, ctx)
+    const { status, body } = await implementation
+      .getProfile(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getProfileResponseValidator(status, body)
     ctx.status = status
@@ -1071,10 +1191,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(replaceProfileBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        replaceProfileBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.replaceProfile(input, ctx)
+    const { status, body } = await implementation
+      .replaceProfile(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = replaceProfileResponseValidator(status, body)
     ctx.status = status
@@ -1099,7 +1227,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: undefined,
       }
 
-      const { status, body } = await implementation.getProfileSchema(input, ctx)
+      const { status, body } = await implementation
+        .getProfileSchema(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getProfileSchemaResponseValidator(status, body)
       ctx.status = status

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
@@ -123,6 +123,10 @@ import {
 } from "./schemas"
 import KoaRouter from "@koa/router"
 import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
+import {
   Response,
   ServerConfig,
   StatusCode,
@@ -482,12 +486,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getWellKnownOpenIdConfigurationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.getWellKnownOpenIdConfiguration(input, ctx)
+      const { status, body } = await implementation
+        .getWellKnownOpenIdConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getWellKnownOpenIdConfigurationResponseValidator(status, body)
       ctx.status = status
@@ -526,11 +534,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("authorize", "/oauth2/v1/authorize", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(authorizeQuerySchema, ctx.query),
+      query: parseRequestInput(
+        authorizeQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.authorize(input, ctx)
+    const { status, body } = await implementation
+      .authorize(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = authorizeResponseValidator(status, body)
     ctx.status = status
@@ -553,10 +569,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(bcAuthorizeBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        bcAuthorizeBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.bcAuthorize(input, ctx)
+    const { status, body } = await implementation
+      .bcAuthorize(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = bcAuthorizeResponseValidator(status, body)
     ctx.status = status
@@ -581,11 +605,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("listClients", "/oauth2/v1/clients", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(listClientsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        listClientsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.listClients(input, ctx)
+    const { status, body } = await implementation
+      .listClients(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = listClientsResponseValidator(status, body)
     ctx.status = status
@@ -608,10 +640,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(createClientBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        createClientBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.createClient(input, ctx)
+    const { status, body } = await implementation
+      .createClient(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = createClientResponseValidator(status, body)
     ctx.status = status
@@ -632,12 +672,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getClient", "/oauth2/v1/clients/:clientId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getClientParamSchema, ctx.params),
+      params: parseRequestInput(
+        getClientParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.getClient(input, ctx)
+    const { status, body } = await implementation
+      .getClient(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getClientResponseValidator(status, body)
     ctx.status = status
@@ -664,12 +712,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/v1/clients/:clientId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(replaceClientParamSchema, ctx.params),
+        params: parseRequestInput(
+          replaceClientParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(replaceClientBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          replaceClientBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.replaceClient(input, ctx)
+      const { status, body } = await implementation
+        .replaceClient(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = replaceClientResponseValidator(status, body)
       ctx.status = status
@@ -694,12 +754,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/v1/clients/:clientId",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(deleteClientParamSchema, ctx.params),
+        params: parseRequestInput(
+          deleteClientParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.deleteClient(input, ctx)
+      const { status, body } = await implementation
+        .deleteClient(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteClientResponseValidator(status, body)
       ctx.status = status
@@ -727,15 +795,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           generateNewClientSecretParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.generateNewClientSecret(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .generateNewClientSecret(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = generateNewClientSecretResponseValidator(status, body)
       ctx.status = status
@@ -762,10 +832,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(deviceAuthorizeBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          deviceAuthorizeBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.deviceAuthorize(input, ctx)
+      const { status, body } = await implementation
+        .deviceAuthorize(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deviceAuthorizeResponseValidator(status, body)
       ctx.status = status
@@ -789,10 +867,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(introspectBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        introspectBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.introspect(input, ctx)
+    const { status, body } = await implementation
+      .introspect(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = introspectResponseValidator(status, body)
     ctx.status = status
@@ -812,11 +898,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("oauthKeys", "/oauth2/v1/keys", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(oauthKeysQuerySchema, ctx.query),
+      query: parseRequestInput(
+        oauthKeysQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.oauthKeys(input, ctx)
+    const { status, body } = await implementation
+      .oauthKeys(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = oauthKeysResponseValidator(status, body)
     ctx.status = status
@@ -837,11 +931,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("logout", "/oauth2/v1/logout", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(logoutQuerySchema, ctx.query),
+      query: parseRequestInput(
+        logoutQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.logout(input, ctx)
+    const { status, body } = await implementation
+      .logout(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = logoutResponseValidator(status, body)
     ctx.status = status
@@ -865,10 +967,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(parBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        parBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.par(input, ctx)
+    const { status, body } = await implementation
+      .par(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = parResponseValidator(status, body)
     ctx.status = status
@@ -891,10 +1001,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(revokeBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        revokeBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.revoke(input, ctx)
+    const { status, body } = await implementation
+      .revoke(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = revokeResponseValidator(status, body)
     ctx.status = status
@@ -917,10 +1035,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(tokenBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        tokenBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.token(input, ctx)
+    const { status, body } = await implementation
+      .token(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = tokenResponseValidator(status, body)
     ctx.status = status
@@ -944,7 +1070,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: undefined,
     }
 
-    const { status, body } = await implementation.userinfo(input, ctx)
+    const { status, body } = await implementation
+      .userinfo(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = userinfoResponseValidator(status, body)
     ctx.status = status
@@ -977,16 +1107,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getWellKnownOAuthConfigurationCustomAsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getWellKnownOAuthConfigurationCustomAsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.getWellKnownOAuthConfigurationCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .getWellKnownOAuthConfigurationCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getWellKnownOAuthConfigurationCustomAsResponseValidator(
         status,
@@ -1023,16 +1158,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getWellKnownOpenIdConfigurationCustomAsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getWellKnownOpenIdConfigurationCustomAsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: undefined,
       }
 
-      const { status, body } =
-        await implementation.getWellKnownOpenIdConfigurationCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .getWellKnownOpenIdConfigurationCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getWellKnownOpenIdConfigurationCustomAsResponseValidator(
         status,
@@ -1080,15 +1220,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/authorize",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(authorizeCustomAsParamSchema, ctx.params),
-        query: parseRequestInput(authorizeCustomAsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          authorizeCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          authorizeCustomAsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.authorizeCustomAs(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .authorizeCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = authorizeCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1117,18 +1266,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/bc/authorize",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(bcAuthorizeCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          bcAuthorizeCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           bcAuthorizeCustomAsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.bcAuthorizeCustomAs(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .bcAuthorizeCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = bcAuthorizeCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1160,18 +1315,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deviceAuthorizeCustomAsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deviceAuthorizeCustomAsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deviceAuthorizeCustomAs(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deviceAuthorizeCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deviceAuthorizeCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1200,15 +1358,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/introspect",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(introspectCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          introspectCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(introspectCustomAsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          introspectCustomAsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.introspectCustomAs(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .introspectCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = introspectCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1233,15 +1400,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/keys",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(oauthKeysCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          oauthKeysCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.oauthKeysCustomAs(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .oauthKeysCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = oauthKeysCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1269,12 +1441,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/logout",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(logoutCustomAsParamSchema, ctx.params),
-        query: parseRequestInput(logoutCustomAsQuerySchema, ctx.query),
+        params: parseRequestInput(
+          logoutCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          logoutCustomAsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: undefined,
       }
 
-      const { status, body } = await implementation.logoutCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .logoutCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = logoutCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1302,12 +1486,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/par",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(parCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          parCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(parCustomAsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          parCustomAsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.parCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .parCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = parCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1336,12 +1532,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/revoke",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(revokeCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          revokeCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(revokeCustomAsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          revokeCustomAsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.revokeCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .revokeCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = revokeCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1370,12 +1578,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/token",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(tokenCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          tokenCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(tokenCustomAsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          tokenCustomAsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.tokenCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .tokenCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = tokenCustomAsResponseValidator(status, body)
       ctx.status = status
@@ -1402,12 +1622,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/oauth2/:authorizationServerId/v1/userinfo",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(userinfoCustomAsParamSchema, ctx.params),
+        params: parseRequestInput(
+          userinfoCustomAsParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: undefined,
       }
 
-      const { status, body } = await implementation.userinfoCustomAs(input, ctx)
+      const { status, body } = await implementation
+        .userinfoCustomAs(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = userinfoCustomAsResponseValidator(status, body)
       ctx.status = status

--- a/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
@@ -14,6 +14,10 @@ import {
 import { s_Error, s_NewPet, s_Pet } from "./schemas"
 import KoaRouter from "@koa/router"
 import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
+import {
   Response,
   ServerConfig,
   StatusCode,
@@ -78,11 +82,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("findPets", "/pets", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(findPetsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        findPetsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.findPets(input, ctx)
+    const { status, body } = await implementation
+      .findPets(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = findPetsResponseValidator(status, body)
     ctx.status = status
@@ -100,10 +112,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(addPetBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        addPetBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.addPet(input, ctx)
+    const { status, body } = await implementation
+      .addPet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = addPetResponseValidator(status, body)
     ctx.status = status
@@ -119,12 +139,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("findPetById", "/pets/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(findPetByIdParamSchema, ctx.params),
+      params: parseRequestInput(
+        findPetByIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.findPetById(input, ctx)
+    const { status, body } = await implementation
+      .findPetById(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = findPetByIdResponseValidator(status, body)
     ctx.status = status
@@ -140,12 +168,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("deletePet", "/pets/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(deletePetParamSchema, ctx.params),
+      params: parseRequestInput(
+        deletePetParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.deletePet(input, ctx)
+    const { status, body } = await implementation
+      .deletePet(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = deletePetResponseValidator(status, body)
     ctx.status = status

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -2658,6 +2658,10 @@ import {
 } from "./schemas"
 import KoaRouter from "@koa/router"
 import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
+import {
   Response,
   ServerConfig,
   StatusCode,
@@ -8682,11 +8686,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getAccount", "/v1/account", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getAccountQuerySchema, ctx.query),
-      body: parseRequestInput(getAccountBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getAccountQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getAccountBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getAccount(input, ctx)
+    const { status, body } = await implementation
+      .getAccount(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getAccountResponseValidator(status, body)
     ctx.status = status
@@ -8711,10 +8727,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postAccountLinksBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postAccountLinksBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postAccountLinks(input, ctx)
+    const { status, body } = await implementation
+      .postAccountLinks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postAccountLinksResponseValidator(status, body)
     ctx.status = status
@@ -8744,13 +8768,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postAccountSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postAccountSessions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postAccountSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountSessionsResponseValidator(status, body)
       ctx.status = status
@@ -8796,11 +8822,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getAccounts", "/v1/accounts", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getAccountsQuerySchema, ctx.query),
-      body: parseRequestInput(getAccountsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getAccountsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getAccountsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getAccounts(input, ctx)
+    const { status, body } = await implementation
+      .getAccounts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getAccountsResponseValidator(status, body)
     ctx.status = status
@@ -9294,10 +9332,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postAccountsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postAccountsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postAccounts(input, ctx)
+    const { status, body } = await implementation
+      .postAccounts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postAccountsResponseValidator(status, body)
     ctx.status = status
@@ -9318,18 +9364,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/accounts/:account",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(deleteAccountsAccountParamSchema, ctx.params),
+        params: parseRequestInput(
+          deleteAccountsAccountParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           deleteAccountsAccountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteAccountsAccount(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteAccountsAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteAccountsAccountResponseValidator(status, body)
       ctx.status = status
@@ -9355,15 +9407,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/accounts/:account",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getAccountsAccountParamSchema, ctx.params),
-        query: parseRequestInput(getAccountsAccountQuerySchema, ctx.query),
-        body: parseRequestInput(getAccountsAccountBodySchema, ctx.request.body),
+        params: parseRequestInput(
+          getAccountsAccountParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getAccountsAccountQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getAccountsAccountBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getAccountsAccount(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getAccountsAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountResponseValidator(status, body)
       ctx.status = status
@@ -9835,18 +9900,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/accounts/:account",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postAccountsAccountParamSchema, ctx.params),
+        params: parseRequestInput(
+          postAccountsAccountParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postAccountsAccount(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postAccountsAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountResponseValidator(status, body)
       ctx.status = status
@@ -9902,16 +9973,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountBankAccountsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountBankAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountBankAccounts(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountBankAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountBankAccountsResponseValidator(status, body)
       ctx.status = status
@@ -9937,16 +10013,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteAccountsAccountBankAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteAccountsAccountBankAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteAccountsAccountBankAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .deleteAccountsAccountBankAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteAccountsAccountBankAccountsIdResponseValidator(
         status,
@@ -9979,19 +10060,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountBankAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountBankAccountsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountBankAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountBankAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .getAccountsAccountBankAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountBankAccountsIdResponseValidator(status, body)
       ctx.status = status
@@ -10042,16 +10129,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountBankAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountBankAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountBankAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountBankAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountBankAccountsIdResponseValidator(
         status,
@@ -10096,19 +10188,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountCapabilitiesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountCapabilitiesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountCapabilitiesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountCapabilities(input, ctx)
+      const { status, body } = await implementation
+        .getAccountsAccountCapabilities(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountCapabilitiesResponseValidator(status, body)
       ctx.status = status
@@ -10140,22 +10238,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountCapabilitiesCapabilityParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountCapabilitiesCapabilityQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountCapabilitiesCapabilityBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountCapabilitiesCapability(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getAccountsAccountCapabilitiesCapability(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountCapabilitiesCapabilityResponseValidator(
         status,
@@ -10189,19 +10290,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountCapabilitiesCapabilityParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountCapabilitiesCapabilityBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountCapabilitiesCapability(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postAccountsAccountCapabilitiesCapability(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountCapabilitiesCapabilityResponseValidator(
         status,
@@ -10251,19 +10354,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountExternalAccountsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountExternalAccountsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountExternalAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountExternalAccounts(input, ctx)
+      const { status, body } = await implementation
+        .getAccountsAccountExternalAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountExternalAccountsResponseValidator(
         status,
@@ -10322,16 +10431,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountExternalAccountsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountExternalAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountExternalAccounts(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountExternalAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountExternalAccountsResponseValidator(
         status,
@@ -10362,16 +10476,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteAccountsAccountExternalAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteAccountsAccountExternalAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteAccountsAccountExternalAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .deleteAccountsAccountExternalAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteAccountsAccountExternalAccountsIdResponseValidator(
         status,
@@ -10404,19 +10523,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountExternalAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountExternalAccountsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountExternalAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountExternalAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .getAccountsAccountExternalAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountExternalAccountsIdResponseValidator(
         status,
@@ -10470,16 +10595,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountExternalAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountExternalAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountExternalAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountExternalAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountExternalAccountsIdResponseValidator(
         status,
@@ -10509,16 +10639,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountLoginLinksParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountLoginLinksBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountLoginLinks(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountLoginLinks(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountLoginLinksResponseValidator(status, body)
       ctx.status = status
@@ -10568,21 +10703,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountPeopleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountPeopleQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountPeopleBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getAccountsAccountPeople(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getAccountsAccountPeople(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountPeopleResponseValidator(status, body)
       ctx.status = status
@@ -10730,18 +10869,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountPeopleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountPeopleBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postAccountsAccountPeople(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postAccountsAccountPeople(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountPeopleResponseValidator(status, body)
       ctx.status = status
@@ -10767,16 +10909,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteAccountsAccountPeoplePersonParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteAccountsAccountPeoplePersonBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteAccountsAccountPeoplePerson(input, ctx)
+      const { status, body } = await implementation
+        .deleteAccountsAccountPeoplePerson(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteAccountsAccountPeoplePersonResponseValidator(
         status,
@@ -10809,19 +10956,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountPeoplePersonParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountPeoplePersonQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountPeoplePersonBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountPeoplePerson(input, ctx)
+      const { status, body } = await implementation
+        .getAccountsAccountPeoplePerson(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountPeoplePersonResponseValidator(status, body)
       ctx.status = status
@@ -10970,16 +11123,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountPeoplePersonParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountPeoplePersonBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountPeoplePerson(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountPeoplePerson(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountPeoplePersonResponseValidator(status, body)
       ctx.status = status
@@ -11029,21 +11187,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountPersonsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountPersonsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountPersonsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getAccountsAccountPersons(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getAccountsAccountPersons(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountPersonsResponseValidator(status, body)
       ctx.status = status
@@ -11193,18 +11355,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountPersonsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountPersonsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postAccountsAccountPersons(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postAccountsAccountPersons(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountPersonsResponseValidator(status, body)
       ctx.status = status
@@ -11230,16 +11395,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteAccountsAccountPersonsPersonParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteAccountsAccountPersonsPersonBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteAccountsAccountPersonsPerson(input, ctx)
+      const { status, body } = await implementation
+        .deleteAccountsAccountPersonsPerson(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteAccountsAccountPersonsPersonResponseValidator(
         status,
@@ -11272,19 +11442,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getAccountsAccountPersonsPersonParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getAccountsAccountPersonsPersonQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getAccountsAccountPersonsPersonBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getAccountsAccountPersonsPerson(input, ctx)
+      const { status, body } = await implementation
+        .getAccountsAccountPersonsPerson(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAccountsAccountPersonsPersonResponseValidator(status, body)
       ctx.status = status
@@ -11433,16 +11609,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountPersonsPersonParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountPersonsPersonBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postAccountsAccountPersonsPerson(input, ctx)
+      const { status, body } = await implementation
+        .postAccountsAccountPersonsPerson(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountPersonsPersonResponseValidator(status, body)
       ctx.status = status
@@ -11470,18 +11651,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postAccountsAccountRejectParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postAccountsAccountRejectBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postAccountsAccountReject(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postAccountsAccountReject(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAccountsAccountRejectResponseValidator(status, body)
       ctx.status = status
@@ -11520,14 +11704,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getApplePayDomainsQuerySchema, ctx.query),
-        body: parseRequestInput(getApplePayDomainsBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getApplePayDomainsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getApplePayDomainsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getApplePayDomains(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getApplePayDomains(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getApplePayDomainsResponseValidator(status, body)
       ctx.status = status
@@ -11555,13 +11748,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postApplePayDomainsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postApplePayDomains(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postApplePayDomains(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postApplePayDomainsResponseValidator(status, body)
       ctx.status = status
@@ -11586,18 +11781,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteApplePayDomainsDomainParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteApplePayDomainsDomainBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteApplePayDomainsDomain(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteApplePayDomainsDomain(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteApplePayDomainsDomainResponseValidator(status, body)
       ctx.status = status
@@ -11626,21 +11824,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getApplePayDomainsDomainParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getApplePayDomainsDomainQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getApplePayDomainsDomainBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getApplePayDomainsDomain(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getApplePayDomainsDomain(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getApplePayDomainsDomainResponseValidator(status, body)
       ctx.status = status
@@ -11690,14 +11892,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getApplicationFeesQuerySchema, ctx.query),
-        body: parseRequestInput(getApplicationFeesBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getApplicationFeesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getApplicationFeesBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getApplicationFees(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getApplicationFees(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getApplicationFeesResponseValidator(status, body)
       ctx.status = status
@@ -11727,19 +11938,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getApplicationFeesFeeRefundsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getApplicationFeesFeeRefundsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getApplicationFeesFeeRefundsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getApplicationFeesFeeRefundsId(input, ctx)
+      const { status, body } = await implementation
+        .getApplicationFeesFeeRefundsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getApplicationFeesFeeRefundsIdResponseValidator(status, body)
       ctx.status = status
@@ -11770,16 +11987,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postApplicationFeesFeeRefundsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postApplicationFeesFeeRefundsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postApplicationFeesFeeRefundsId(input, ctx)
+      const { status, body } = await implementation
+        .postApplicationFeesFeeRefundsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postApplicationFeesFeeRefundsIdResponseValidator(status, body)
       ctx.status = status
@@ -11805,18 +12027,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/application_fees/:id",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getApplicationFeesIdParamSchema, ctx.params),
-        query: parseRequestInput(getApplicationFeesIdQuerySchema, ctx.query),
+        params: parseRequestInput(
+          getApplicationFeesIdParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getApplicationFeesIdQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getApplicationFeesIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getApplicationFeesId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getApplicationFeesId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getApplicationFeesIdResponseValidator(status, body)
       ctx.status = status
@@ -11845,18 +12077,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postApplicationFeesIdRefundParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postApplicationFeesIdRefundBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postApplicationFeesIdRefund(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postApplicationFeesIdRefund(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postApplicationFeesIdRefundResponseValidator(status, body)
       ctx.status = status
@@ -11899,21 +12134,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getApplicationFeesIdRefundsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getApplicationFeesIdRefundsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getApplicationFeesIdRefundsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getApplicationFeesIdRefunds(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getApplicationFeesIdRefunds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getApplicationFeesIdRefundsResponseValidator(status, body)
       ctx.status = status
@@ -11942,16 +12181,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postApplicationFeesIdRefundsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postApplicationFeesIdRefundsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postApplicationFeesIdRefunds(input, ctx)
+      const { status, body } = await implementation
+        .postApplicationFeesIdRefunds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postApplicationFeesIdRefundsResponseValidator(status, body)
       ctx.status = status
@@ -11990,11 +12234,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getAppsSecrets", "/v1/apps/secrets", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getAppsSecretsQuerySchema, ctx.query),
-      body: parseRequestInput(getAppsSecretsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getAppsSecretsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getAppsSecretsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getAppsSecrets(input, ctx)
+    const { status, body } = await implementation
+      .getAppsSecrets(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getAppsSecretsResponseValidator(status, body)
     ctx.status = status
@@ -12021,10 +12277,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postAppsSecretsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postAppsSecretsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postAppsSecrets(input, ctx)
+    const { status, body } = await implementation
+      .postAppsSecrets(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postAppsSecretsResponseValidator(status, body)
     ctx.status = status
@@ -12055,13 +12319,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postAppsSecretsDeleteBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postAppsSecretsDelete(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postAppsSecretsDelete(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postAppsSecretsDeleteResponseValidator(status, body)
       ctx.status = status
@@ -12091,14 +12357,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getAppsSecretsFindQuerySchema, ctx.query),
-        body: parseRequestInput(getAppsSecretsFindBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getAppsSecretsFindQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getAppsSecretsFindBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getAppsSecretsFind(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getAppsSecretsFind(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getAppsSecretsFindResponseValidator(status, body)
       ctx.status = status
@@ -12120,11 +12395,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getBalance", "/v1/balance", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getBalanceQuerySchema, ctx.query),
-      body: parseRequestInput(getBalanceBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getBalanceQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getBalanceBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getBalance(input, ctx)
+    const { status, body } = await implementation
+      .getBalance(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getBalanceResponseValidator(status, body)
     ctx.status = status
@@ -12173,11 +12460,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getBalanceHistory", "/v1/balance/history", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getBalanceHistoryQuerySchema, ctx.query),
-      body: parseRequestInput(getBalanceHistoryBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getBalanceHistoryQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getBalanceHistoryBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getBalanceHistory(input, ctx)
+    const { status, body } = await implementation
+      .getBalanceHistory(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getBalanceHistoryResponseValidator(status, body)
     ctx.status = status
@@ -12202,18 +12501,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/balance/history/:id",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getBalanceHistoryIdParamSchema, ctx.params),
-        query: parseRequestInput(getBalanceHistoryIdQuerySchema, ctx.query),
+        params: parseRequestInput(
+          getBalanceHistoryIdParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getBalanceHistoryIdQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getBalanceHistoryIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getBalanceHistoryId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getBalanceHistoryId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getBalanceHistoryIdResponseValidator(status, body)
       ctx.status = status
@@ -12266,17 +12575,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getBalanceTransactionsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getBalanceTransactionsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getBalanceTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getBalanceTransactions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getBalanceTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getBalanceTransactionsResponseValidator(status, body)
       ctx.status = status
@@ -12305,21 +12620,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getBalanceTransactionsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getBalanceTransactionsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getBalanceTransactionsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getBalanceTransactionsId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getBalanceTransactionsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getBalanceTransactionsIdResponseValidator(status, body)
       ctx.status = status
@@ -12363,15 +12682,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getBillingPortalConfigurationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getBillingPortalConfigurationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getBillingPortalConfigurations(input, ctx)
+      const { status, body } = await implementation
+        .getBillingPortalConfigurations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getBillingPortalConfigurationsResponseValidator(status, body)
       ctx.status = status
@@ -12483,11 +12807,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postBillingPortalConfigurationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postBillingPortalConfigurations(input, ctx)
+      const { status, body } = await implementation
+        .postBillingPortalConfigurations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postBillingPortalConfigurationsResponseValidator(status, body)
       ctx.status = status
@@ -12521,22 +12849,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getBillingPortalConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getBillingPortalConfigurationsConfigurationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getBillingPortalConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getBillingPortalConfigurationsConfiguration(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getBillingPortalConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getBillingPortalConfigurationsConfigurationResponseValidator(
         status,
@@ -12669,19 +13000,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postBillingPortalConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postBillingPortalConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postBillingPortalConfigurationsConfiguration(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postBillingPortalConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postBillingPortalConfigurationsConfigurationResponseValidator(
         status,
@@ -12821,13 +13154,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postBillingPortalSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postBillingPortalSessions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postBillingPortalSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postBillingPortalSessionsResponseValidator(status, body)
       ctx.status = status
@@ -12876,11 +13211,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getCharges", "/v1/charges", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getChargesQuerySchema, ctx.query),
-      body: parseRequestInput(getChargesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getChargesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getChargesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCharges(input, ctx)
+    const { status, body } = await implementation
+      .getCharges(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getChargesResponseValidator(status, body)
     ctx.status = status
@@ -12968,10 +13315,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postChargesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postChargesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postCharges(input, ctx)
+    const { status, body } = await implementation
+      .postCharges(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postChargesResponseValidator(status, body)
     ctx.status = status
@@ -13007,11 +13362,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getChargesSearch", "/v1/charges/search", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getChargesSearchQuerySchema, ctx.query),
-      body: parseRequestInput(getChargesSearchBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getChargesSearchQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getChargesSearchBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getChargesSearch(input, ctx)
+    const { status, body } = await implementation
+      .getChargesSearch(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getChargesSearchResponseValidator(status, body)
     ctx.status = status
@@ -13033,12 +13400,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getChargesCharge", "/v1/charges/:charge", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getChargesChargeParamSchema, ctx.params),
-      query: parseRequestInput(getChargesChargeQuerySchema, ctx.query),
-      body: parseRequestInput(getChargesChargeBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getChargesChargeParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getChargesChargeQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getChargesChargeBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getChargesCharge(input, ctx)
+    const { status, body } = await implementation
+      .getChargesCharge(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getChargesChargeResponseValidator(status, body)
     ctx.status = status
@@ -13084,12 +13467,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postChargesCharge", "/v1/charges/:charge", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postChargesChargeParamSchema, ctx.params),
+      params: parseRequestInput(
+        postChargesChargeParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postChargesChargeBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postChargesChargeBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postChargesCharge(input, ctx)
+    const { status, body } = await implementation
+      .postChargesCharge(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postChargesChargeResponseValidator(status, body)
     ctx.status = status
@@ -13127,18 +13522,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postChargesChargeCaptureParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postChargesChargeCaptureBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postChargesChargeCapture(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postChargesChargeCapture(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postChargesChargeCaptureResponseValidator(status, body)
       ctx.status = status
@@ -13167,18 +13565,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getChargesChargeDisputeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getChargesChargeDisputeQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getChargesChargeDisputeQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getChargesChargeDisputeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getChargesChargeDispute(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getChargesChargeDispute(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getChargesChargeDisputeResponseValidator(status, body)
       ctx.status = status
@@ -13240,18 +13645,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postChargesChargeDisputeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postChargesChargeDisputeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postChargesChargeDispute(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postChargesChargeDispute(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postChargesChargeDisputeResponseValidator(status, body)
       ctx.status = status
@@ -13278,16 +13686,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postChargesChargeDisputeCloseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postChargesChargeDisputeCloseBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postChargesChargeDisputeClose(input, ctx)
+      const { status, body } = await implementation
+        .postChargesChargeDisputeClose(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postChargesChargeDisputeCloseResponseValidator(status, body)
       ctx.status = status
@@ -13325,18 +13738,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postChargesChargeRefundParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postChargesChargeRefundBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postChargesChargeRefund(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postChargesChargeRefund(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postChargesChargeRefundResponseValidator(status, body)
       ctx.status = status
@@ -13378,18 +13794,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getChargesChargeRefundsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getChargesChargeRefundsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getChargesChargeRefundsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getChargesChargeRefundsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getChargesChargeRefunds(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getChargesChargeRefunds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getChargesChargeRefundsResponseValidator(status, body)
       ctx.status = status
@@ -13430,18 +13853,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postChargesChargeRefundsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postChargesChargeRefundsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postChargesChargeRefunds(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postChargesChargeRefunds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postChargesChargeRefundsResponseValidator(status, body)
       ctx.status = status
@@ -13471,19 +13897,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getChargesChargeRefundsRefundParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getChargesChargeRefundsRefundQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getChargesChargeRefundsRefundBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getChargesChargeRefundsRefund(input, ctx)
+      const { status, body } = await implementation
+        .getChargesChargeRefundsRefund(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getChargesChargeRefundsRefundResponseValidator(status, body)
       ctx.status = status
@@ -13514,16 +13946,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postChargesChargeRefundsRefundParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postChargesChargeRefundsRefundBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postChargesChargeRefundsRefund(input, ctx)
+      const { status, body } = await implementation
+        .postChargesChargeRefundsRefund(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postChargesChargeRefundsRefundResponseValidator(status, body)
       ctx.status = status
@@ -13566,17 +14003,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getCheckoutSessionsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getCheckoutSessionsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getCheckoutSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCheckoutSessions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCheckoutSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCheckoutSessionsResponseValidator(status, body)
       ctx.status = status
@@ -14455,13 +14898,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postCheckoutSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postCheckoutSessions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postCheckoutSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCheckoutSessionsResponseValidator(status, body)
       ctx.status = status
@@ -14492,21 +14937,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCheckoutSessionsSessionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCheckoutSessionsSessionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCheckoutSessionsSessionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCheckoutSessionsSession(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCheckoutSessionsSession(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCheckoutSessionsSessionResponseValidator(status, body)
       ctx.status = status
@@ -14533,16 +14982,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCheckoutSessionsSessionExpireParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCheckoutSessionsSessionExpireBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCheckoutSessionsSessionExpire(input, ctx)
+      const { status, body } = await implementation
+        .postCheckoutSessionsSessionExpire(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCheckoutSessionsSessionExpireResponseValidator(
         status,
@@ -14590,19 +15044,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCheckoutSessionsSessionLineItemsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCheckoutSessionsSessionLineItemsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCheckoutSessionsSessionLineItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCheckoutSessionsSessionLineItems(input, ctx)
+      const { status, body } = await implementation
+        .getCheckoutSessionsSessionLineItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCheckoutSessionsSessionLineItemsResponseValidator(
         status,
@@ -14640,11 +15100,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getCountrySpecs", "/v1/country_specs", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getCountrySpecsQuerySchema, ctx.query),
-      body: parseRequestInput(getCountrySpecsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getCountrySpecsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getCountrySpecsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCountrySpecs(input, ctx)
+    const { status, body } = await implementation
+      .getCountrySpecs(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getCountrySpecsResponseValidator(status, body)
     ctx.status = status
@@ -14672,18 +15144,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCountrySpecsCountryParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getCountrySpecsCountryQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getCountrySpecsCountryQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getCountrySpecsCountryBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCountrySpecsCountry(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCountrySpecsCountry(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCountrySpecsCountryResponseValidator(status, body)
       ctx.status = status
@@ -14729,11 +15208,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getCoupons", "/v1/coupons", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getCouponsQuerySchema, ctx.query),
-      body: parseRequestInput(getCouponsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getCouponsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getCouponsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCoupons(input, ctx)
+    const { status, body } = await implementation
+      .getCoupons(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getCouponsResponseValidator(status, body)
     ctx.status = status
@@ -14769,10 +15260,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postCouponsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postCouponsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postCoupons(input, ctx)
+    const { status, body } = await implementation
+      .postCoupons(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postCouponsResponseValidator(status, body)
     ctx.status = status
@@ -14793,18 +15292,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/coupons/:coupon",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(deleteCouponsCouponParamSchema, ctx.params),
+        params: parseRequestInput(
+          deleteCouponsCouponParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           deleteCouponsCouponBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteCouponsCoupon(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteCouponsCoupon(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCouponsCouponResponseValidator(status, body)
       ctx.status = status
@@ -14827,12 +15332,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getCouponsCoupon", "/v1/coupons/:coupon", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getCouponsCouponParamSchema, ctx.params),
-      query: parseRequestInput(getCouponsCouponQuerySchema, ctx.query),
-      body: parseRequestInput(getCouponsCouponBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getCouponsCouponParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getCouponsCouponQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getCouponsCouponBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCouponsCoupon(input, ctx)
+    const { status, body } = await implementation
+      .getCouponsCoupon(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getCouponsCouponResponseValidator(status, body)
     ctx.status = status
@@ -14857,12 +15378,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postCouponsCoupon", "/v1/coupons/:coupon", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postCouponsCouponParamSchema, ctx.params),
+      params: parseRequestInput(
+        postCouponsCouponParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postCouponsCouponBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postCouponsCouponBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postCouponsCoupon(input, ctx)
+    const { status, body } = await implementation
+      .postCouponsCoupon(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postCouponsCouponResponseValidator(status, body)
     ctx.status = status
@@ -14898,11 +15431,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getCreditNotes", "/v1/credit_notes", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getCreditNotesQuerySchema, ctx.query),
-      body: parseRequestInput(getCreditNotesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getCreditNotesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getCreditNotesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCreditNotes(input, ctx)
+    const { status, body } = await implementation
+      .getCreditNotes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getCreditNotesResponseValidator(status, body)
     ctx.status = status
@@ -14956,10 +15501,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postCreditNotesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postCreditNotesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postCreditNotes(input, ctx)
+    const { status, body } = await implementation
+      .postCreditNotes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postCreditNotesResponseValidator(status, body)
     ctx.status = status
@@ -15017,17 +15570,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getCreditNotesPreviewQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getCreditNotesPreviewQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getCreditNotesPreviewBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCreditNotesPreview(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCreditNotesPreview(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCreditNotesPreviewResponseValidator(status, body)
       ctx.status = status
@@ -15102,17 +15661,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getCreditNotesPreviewLinesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCreditNotesPreviewLinesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCreditNotesPreviewLines(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCreditNotesPreviewLines(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCreditNotesPreviewLinesResponseValidator(status, body)
       ctx.status = status
@@ -15157,19 +15719,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCreditNotesCreditNoteLinesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCreditNotesCreditNoteLinesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCreditNotesCreditNoteLinesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCreditNotesCreditNoteLines(input, ctx)
+      const { status, body } = await implementation
+        .getCreditNotesCreditNoteLines(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCreditNotesCreditNoteLinesResponseValidator(status, body)
       ctx.status = status
@@ -15192,12 +15760,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getCreditNotesId", "/v1/credit_notes/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getCreditNotesIdParamSchema, ctx.params),
-      query: parseRequestInput(getCreditNotesIdQuerySchema, ctx.query),
-      body: parseRequestInput(getCreditNotesIdBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getCreditNotesIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getCreditNotesIdQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getCreditNotesIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCreditNotesId(input, ctx)
+    const { status, body } = await implementation
+      .getCreditNotesId(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getCreditNotesIdResponseValidator(status, body)
     ctx.status = status
@@ -15224,15 +15808,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/credit_notes/:id",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postCreditNotesIdParamSchema, ctx.params),
+        params: parseRequestInput(
+          postCreditNotesIdParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(postCreditNotesIdBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          postCreditNotesIdBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.postCreditNotesId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postCreditNotesId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCreditNotesIdResponseValidator(status, body)
       ctx.status = status
@@ -15256,18 +15849,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/credit_notes/:id/void",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postCreditNotesIdVoidParamSchema, ctx.params),
+        params: parseRequestInput(
+          postCreditNotesIdVoidParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postCreditNotesIdVoidBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postCreditNotesIdVoid(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postCreditNotesIdVoid(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCreditNotesIdVoidResponseValidator(status, body)
       ctx.status = status
@@ -15315,11 +15914,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getCustomers", "/v1/customers", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getCustomersQuerySchema, ctx.query),
-      body: parseRequestInput(getCustomersBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getCustomersQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getCustomersBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getCustomers(input, ctx)
+    const { status, body } = await implementation
+      .getCustomers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getCustomersResponseValidator(status, body)
     ctx.status = status
@@ -15497,10 +16108,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postCustomersBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postCustomersBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postCustomers(input, ctx)
+    const { status, body } = await implementation
+      .postCustomers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postCustomersResponseValidator(status, body)
     ctx.status = status
@@ -15539,14 +16158,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getCustomersSearchQuerySchema, ctx.query),
-        body: parseRequestInput(getCustomersSearchBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getCustomersSearchQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getCustomersSearchBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getCustomersSearch(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCustomersSearch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersSearchResponseValidator(status, body)
       ctx.status = status
@@ -15571,18 +16199,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteCustomersCustomer(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteCustomersCustomer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCustomersCustomerResponseValidator(status, body)
       ctx.status = status
@@ -15608,18 +16239,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/customers/:customer",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getCustomersCustomerParamSchema, ctx.params),
-        query: parseRequestInput(getCustomersCustomerQuerySchema, ctx.query),
+        params: parseRequestInput(
+          getCustomersCustomerParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getCustomersCustomerQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getCustomersCustomerBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCustomersCustomer(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCustomersCustomer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerResponseValidator(status, body)
       ctx.status = status
@@ -15762,18 +16403,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/customers/:customer",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postCustomersCustomerParamSchema, ctx.params),
+        params: parseRequestInput(
+          postCustomersCustomerParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postCustomersCustomer(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postCustomersCustomer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerResponseValidator(status, body)
       ctx.status = status
@@ -15820,19 +16467,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerBalanceTransactionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerBalanceTransactionsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerBalanceTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerBalanceTransactions(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerBalanceTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerBalanceTransactionsResponseValidator(
         status,
@@ -15869,19 +16522,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerBalanceTransactionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerBalanceTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerBalanceTransactions(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postCustomersCustomerBalanceTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerBalanceTransactionsResponseValidator(
         status,
@@ -15916,22 +16571,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerBalanceTransactionsTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerBalanceTransactionsTransactionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerBalanceTransactionsTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerBalanceTransactionsTransaction(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getCustomersCustomerBalanceTransactionsTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getCustomersCustomerBalanceTransactionsTransactionResponseValidator(
@@ -15968,19 +16626,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerBalanceTransactionsTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerBalanceTransactionsTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerBalanceTransactionsTransaction(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postCustomersCustomerBalanceTransactionsTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postCustomersCustomerBalanceTransactionsTransactionResponseValidator(
@@ -16029,19 +16689,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerBankAccountsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerBankAccountsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerBankAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerBankAccounts(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerBankAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerBankAccountsResponseValidator(status, body)
       ctx.status = status
@@ -16107,16 +16773,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerBankAccountsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerBankAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerBankAccounts(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerBankAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerBankAccountsResponseValidator(
         status,
@@ -16155,16 +16826,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerBankAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerBankAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerBankAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .deleteCustomersCustomerBankAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCustomersCustomerBankAccountsIdResponseValidator(
         status,
@@ -16197,19 +16873,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerBankAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerBankAccountsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerBankAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerBankAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerBankAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerBankAccountsIdResponseValidator(
         status,
@@ -16283,16 +16965,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerBankAccountsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerBankAccountsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerBankAccountsId(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerBankAccountsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerBankAccountsIdResponseValidator(
         status,
@@ -16326,19 +17013,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerBankAccountsIdVerifyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerBankAccountsIdVerifyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerBankAccountsIdVerify(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postCustomersCustomerBankAccountsIdVerify(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerBankAccountsIdVerifyResponseValidator(
         status,
@@ -16385,21 +17074,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerCardsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerCardsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerCardsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCustomersCustomerCards(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCustomersCustomerCards(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerCardsResponseValidator(status, body)
       ctx.status = status
@@ -16467,18 +17160,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerCardsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerCardsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postCustomersCustomerCards(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postCustomersCustomerCards(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerCardsResponseValidator(status, body)
       ctx.status = status
@@ -16514,16 +17210,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerCardsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerCardsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerCardsId(input, ctx)
+      const { status, body } = await implementation
+        .deleteCustomersCustomerCardsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCustomersCustomerCardsIdResponseValidator(status, body)
       ctx.status = status
@@ -16553,21 +17254,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerCardsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerCardsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerCardsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCustomersCustomerCardsId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCustomersCustomerCardsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerCardsIdResponseValidator(status, body)
       ctx.status = status
@@ -16638,16 +17343,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerCardsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerCardsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerCardsId(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerCardsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerCardsIdResponseValidator(status, body)
       ctx.status = status
@@ -16676,19 +17386,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerCashBalanceParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerCashBalanceQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerCashBalanceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerCashBalance(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerCashBalance(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerCashBalanceResponseValidator(status, body)
       ctx.status = status
@@ -16724,16 +17440,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerCashBalanceParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerCashBalanceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerCashBalance(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerCashBalance(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerCashBalanceResponseValidator(status, body)
       ctx.status = status
@@ -16780,22 +17501,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerCashBalanceTransactionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerCashBalanceTransactionsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerCashBalanceTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerCashBalanceTransactions(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getCustomersCustomerCashBalanceTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerCashBalanceTransactionsResponseValidator(
         status,
@@ -16830,22 +17554,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerCashBalanceTransactionsTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerCashBalanceTransactionsTransactionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerCashBalanceTransactionsTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerCashBalanceTransactionsTransaction(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getCustomersCustomerCashBalanceTransactionsTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getCustomersCustomerCashBalanceTransactionsTransactionResponseValidator(
@@ -16874,16 +17601,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerDiscountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerDiscountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerDiscount(input, ctx)
+      const { status, body } = await implementation
+        .deleteCustomersCustomerDiscount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCustomersCustomerDiscountResponseValidator(status, body)
       ctx.status = status
@@ -16912,19 +17644,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerDiscountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerDiscountQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerDiscountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerDiscount(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerDiscount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerDiscountResponseValidator(status, body)
       ctx.status = status
@@ -16966,19 +17704,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerFundingInstructionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerFundingInstructionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerFundingInstructions(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postCustomersCustomerFundingInstructions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerFundingInstructionsResponseValidator(
         status,
@@ -17061,19 +17801,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerPaymentMethodsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerPaymentMethodsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerPaymentMethodsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerPaymentMethods(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerPaymentMethods(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerPaymentMethodsResponseValidator(
         status,
@@ -17108,22 +17854,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerPaymentMethodsPaymentMethodParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerPaymentMethodsPaymentMethodQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerPaymentMethodsPaymentMethodBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerPaymentMethodsPaymentMethod(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getCustomersCustomerPaymentMethodsPaymentMethod(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getCustomersCustomerPaymentMethodsPaymentMethodResponseValidator(
@@ -17179,21 +17928,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerSourcesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerSourcesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerSourcesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCustomersCustomerSources(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCustomersCustomerSources(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerSourcesResponseValidator(status, body)
       ctx.status = status
@@ -17259,16 +18012,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerSourcesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerSourcesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerSources(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerSources(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerSourcesResponseValidator(status, body)
       ctx.status = status
@@ -17304,16 +18062,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerSourcesIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerSourcesIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerSourcesId(input, ctx)
+      const { status, body } = await implementation
+        .deleteCustomersCustomerSourcesId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCustomersCustomerSourcesIdResponseValidator(status, body)
       ctx.status = status
@@ -17343,19 +18106,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerSourcesIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerSourcesIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerSourcesIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerSourcesId(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerSourcesId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerSourcesIdResponseValidator(status, body)
       ctx.status = status
@@ -17426,16 +18195,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerSourcesIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerSourcesIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerSourcesId(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerSourcesId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerSourcesIdResponseValidator(status, body)
       ctx.status = status
@@ -17466,16 +18240,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerSourcesIdVerifyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerSourcesIdVerifyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerSourcesIdVerify(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerSourcesIdVerify(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerSourcesIdVerifyResponseValidator(
         status,
@@ -17523,19 +18302,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerSubscriptionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerSubscriptionsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerSubscriptionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerSubscriptions(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerSubscriptions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerSubscriptionsResponseValidator(
         status,
@@ -17828,16 +18613,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerSubscriptionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerSubscriptionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerSubscriptions(input, ctx)
+      const { status, body } = await implementation
+        .postCustomersCustomerSubscriptions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerSubscriptionsResponseValidator(
         status,
@@ -17870,19 +18660,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerSubscriptionsSubscriptionExposedId(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .deleteCustomersCustomerSubscriptionsSubscriptionExposedId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         deleteCustomersCustomerSubscriptionsSubscriptionExposedIdResponseValidator(
@@ -17915,22 +18707,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerSubscriptionsSubscriptionExposedId(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getCustomersCustomerSubscriptionsSubscriptionExposedId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getCustomersCustomerSubscriptionsSubscriptionExposedIdResponseValidator(
@@ -18254,19 +19049,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postCustomersCustomerSubscriptionsSubscriptionExposedId(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postCustomersCustomerSubscriptionsSubscriptionExposedId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postCustomersCustomerSubscriptionsSubscriptionExposedIdResponseValidator(
@@ -18295,19 +19092,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
+      const { status, body } = await implementation
+        .deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponseValidator(
@@ -18339,22 +19141,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
+      const { status, body } = await implementation
+        .getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponseValidator(
@@ -18402,21 +19210,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerTaxIdsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerTaxIdsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerTaxIdsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getCustomersCustomerTaxIds(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getCustomersCustomerTaxIds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerTaxIdsResponseValidator(status, body)
       ctx.status = status
@@ -18512,18 +19324,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postCustomersCustomerTaxIdsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postCustomersCustomerTaxIdsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postCustomersCustomerTaxIds(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postCustomersCustomerTaxIds(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postCustomersCustomerTaxIdsResponseValidator(status, body)
       ctx.status = status
@@ -18549,16 +19364,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteCustomersCustomerTaxIdsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteCustomersCustomerTaxIdsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteCustomersCustomerTaxIdsId(input, ctx)
+      const { status, body } = await implementation
+        .deleteCustomersCustomerTaxIdsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteCustomersCustomerTaxIdsIdResponseValidator(status, body)
       ctx.status = status
@@ -18588,19 +19408,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getCustomersCustomerTaxIdsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getCustomersCustomerTaxIdsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getCustomersCustomerTaxIdsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getCustomersCustomerTaxIdsId(input, ctx)
+      const { status, body } = await implementation
+        .getCustomersCustomerTaxIdsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getCustomersCustomerTaxIdsIdResponseValidator(status, body)
       ctx.status = status
@@ -18648,11 +19474,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getDisputes", "/v1/disputes", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getDisputesQuerySchema, ctx.query),
-      body: parseRequestInput(getDisputesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getDisputesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getDisputesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getDisputes(input, ctx)
+    const { status, body } = await implementation
+      .getDisputes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getDisputesResponseValidator(status, body)
     ctx.status = status
@@ -18677,15 +19515,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/disputes/:dispute",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getDisputesDisputeParamSchema, ctx.params),
-        query: parseRequestInput(getDisputesDisputeQuerySchema, ctx.query),
-        body: parseRequestInput(getDisputesDisputeBodySchema, ctx.request.body),
+        params: parseRequestInput(
+          getDisputesDisputeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getDisputesDisputeQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getDisputesDisputeBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getDisputesDispute(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getDisputesDispute(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getDisputesDisputeResponseValidator(status, body)
       ctx.status = status
@@ -18744,18 +19595,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/disputes/:dispute",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postDisputesDisputeParamSchema, ctx.params),
+        params: parseRequestInput(
+          postDisputesDisputeParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postDisputesDisputeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postDisputesDispute(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postDisputesDispute(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postDisputesDisputeResponseValidator(status, body)
       ctx.status = status
@@ -18782,18 +19639,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postDisputesDisputeCloseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postDisputesDisputeCloseBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postDisputesDisputeClose(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postDisputesDisputeClose(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postDisputesDisputeCloseResponseValidator(status, body)
       ctx.status = status
@@ -18820,10 +19680,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postEphemeralKeysBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postEphemeralKeysBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postEphemeralKeys(input, ctx)
+    const { status, body } = await implementation
+      .postEphemeralKeys(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postEphemeralKeysResponseValidator(status, body)
     ctx.status = status
@@ -18849,18 +19717,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteEphemeralKeysKeyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteEphemeralKeysKeyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteEphemeralKeysKey(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteEphemeralKeysKey(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteEphemeralKeysKeyResponseValidator(status, body)
       ctx.status = status
@@ -18909,11 +19780,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getEvents", "/v1/events", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getEventsQuerySchema, ctx.query),
-      body: parseRequestInput(getEventsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getEventsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getEventsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getEvents(input, ctx)
+    const { status, body } = await implementation
+      .getEvents(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getEventsResponseValidator(status, body)
     ctx.status = status
@@ -18935,12 +19818,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getEventsId", "/v1/events/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getEventsIdParamSchema, ctx.params),
-      query: parseRequestInput(getEventsIdQuerySchema, ctx.query),
-      body: parseRequestInput(getEventsIdBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getEventsIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getEventsIdQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getEventsIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getEventsId(input, ctx)
+    const { status, body } = await implementation
+      .getEventsId(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getEventsIdResponseValidator(status, body)
     ctx.status = status
@@ -18974,11 +19873,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getExchangeRates", "/v1/exchange_rates", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getExchangeRatesQuerySchema, ctx.query),
-      body: parseRequestInput(getExchangeRatesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getExchangeRatesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getExchangeRatesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getExchangeRates(input, ctx)
+    const { status, body } = await implementation
+      .getExchangeRates(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getExchangeRatesResponseValidator(status, body)
     ctx.status = status
@@ -19006,18 +19917,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getExchangeRatesRateIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getExchangeRatesRateIdQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getExchangeRatesRateIdQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getExchangeRatesRateIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getExchangeRatesRateId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getExchangeRatesRateId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getExchangeRatesRateIdResponseValidator(status, body)
       ctx.status = status
@@ -19065,11 +19983,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getFileLinks", "/v1/file_links", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getFileLinksQuerySchema, ctx.query),
-      body: parseRequestInput(getFileLinksBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getFileLinksQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getFileLinksBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getFileLinks(input, ctx)
+    const { status, body } = await implementation
+      .getFileLinks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getFileLinksResponseValidator(status, body)
     ctx.status = status
@@ -19092,10 +20022,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postFileLinksBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postFileLinksBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postFileLinks(input, ctx)
+    const { status, body } = await implementation
+      .postFileLinks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postFileLinksResponseValidator(status, body)
     ctx.status = status
@@ -19117,12 +20055,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getFileLinksLink", "/v1/file_links/:link", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getFileLinksLinkParamSchema, ctx.params),
-      query: parseRequestInput(getFileLinksLinkQuerySchema, ctx.query),
-      body: parseRequestInput(getFileLinksLinkBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getFileLinksLinkParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getFileLinksLinkQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getFileLinksLinkBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getFileLinksLink(input, ctx)
+    const { status, body } = await implementation
+      .getFileLinksLink(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getFileLinksLinkResponseValidator(status, body)
     ctx.status = status
@@ -19151,15 +20105,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/file_links/:link",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postFileLinksLinkParamSchema, ctx.params),
+        params: parseRequestInput(
+          postFileLinksLinkParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
-        body: parseRequestInput(postFileLinksLinkBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          postFileLinksLinkBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.postFileLinksLink(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postFileLinksLink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postFileLinksLinkResponseValidator(status, body)
       ctx.status = status
@@ -19224,11 +20187,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getFiles", "/v1/files", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getFilesQuerySchema, ctx.query),
-      body: parseRequestInput(getFilesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getFilesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getFilesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getFiles(input, ctx)
+    const { status, body } = await implementation
+      .getFiles(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getFilesResponseValidator(status, body)
     ctx.status = status
@@ -19268,10 +20243,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postFilesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postFilesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postFiles(input, ctx)
+    const { status, body } = await implementation
+      .postFiles(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postFilesResponseValidator(status, body)
     ctx.status = status
@@ -19293,12 +20276,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getFilesFile", "/v1/files/:file", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getFilesFileParamSchema, ctx.params),
-      query: parseRequestInput(getFilesFileQuerySchema, ctx.query),
-      body: parseRequestInput(getFilesFileBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getFilesFileParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getFilesFileQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getFilesFileBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getFilesFile(input, ctx)
+    const { status, body } = await implementation
+      .getFilesFile(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getFilesFileResponseValidator(status, body)
     ctx.status = status
@@ -19346,15 +20345,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getFinancialConnectionsAccountsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getFinancialConnectionsAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getFinancialConnectionsAccounts(input, ctx)
+      const { status, body } = await implementation
+        .getFinancialConnectionsAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getFinancialConnectionsAccountsResponseValidator(status, body)
       ctx.status = status
@@ -19388,19 +20392,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getFinancialConnectionsAccountsAccountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getFinancialConnectionsAccountsAccountQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getFinancialConnectionsAccountsAccountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getFinancialConnectionsAccountsAccount(input, ctx)
+      const { status, body } = await implementation
+        .getFinancialConnectionsAccountsAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getFinancialConnectionsAccountsAccountResponseValidator(
         status,
@@ -19433,19 +20443,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postFinancialConnectionsAccountsAccountDisconnectParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postFinancialConnectionsAccountsAccountDisconnectBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postFinancialConnectionsAccountsAccountDisconnect(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postFinancialConnectionsAccountsAccountDisconnect(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postFinancialConnectionsAccountsAccountDisconnectResponseValidator(
@@ -19497,22 +20509,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getFinancialConnectionsAccountsAccountOwnersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getFinancialConnectionsAccountsAccountOwnersQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getFinancialConnectionsAccountsAccountOwnersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getFinancialConnectionsAccountsAccountOwners(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getFinancialConnectionsAccountsAccountOwners(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getFinancialConnectionsAccountsAccountOwnersResponseValidator(
         status,
@@ -19546,19 +20561,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postFinancialConnectionsAccountsAccountRefreshParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postFinancialConnectionsAccountsAccountRefreshBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postFinancialConnectionsAccountsAccountRefresh(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postFinancialConnectionsAccountsAccountRefresh(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postFinancialConnectionsAccountsAccountRefreshResponseValidator(
@@ -19601,11 +20618,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postFinancialConnectionsSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postFinancialConnectionsSessions(input, ctx)
+      const { status, body } = await implementation
+        .postFinancialConnectionsSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postFinancialConnectionsSessionsResponseValidator(status, body)
       ctx.status = status
@@ -19639,19 +20660,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getFinancialConnectionsSessionsSessionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getFinancialConnectionsSessionsSessionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getFinancialConnectionsSessionsSessionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getFinancialConnectionsSessionsSession(input, ctx)
+      const { status, body } = await implementation
+        .getFinancialConnectionsSessionsSession(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getFinancialConnectionsSessionsSessionResponseValidator(
         status,
@@ -19709,15 +20736,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getIdentityVerificationReportsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIdentityVerificationReportsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIdentityVerificationReports(input, ctx)
+      const { status, body } = await implementation
+        .getIdentityVerificationReports(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIdentityVerificationReportsResponseValidator(status, body)
       ctx.status = status
@@ -19749,19 +20781,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIdentityVerificationReportsReportParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIdentityVerificationReportsReportQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIdentityVerificationReportsReportBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIdentityVerificationReportsReport(input, ctx)
+      const { status, body } = await implementation
+        .getIdentityVerificationReportsReport(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIdentityVerificationReportsReportResponseValidator(
         status,
@@ -19820,15 +20858,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getIdentityVerificationSessionsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIdentityVerificationSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIdentityVerificationSessions(input, ctx)
+      const { status, body } = await implementation
+        .getIdentityVerificationSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIdentityVerificationSessionsResponseValidator(status, body)
       ctx.status = status
@@ -19876,11 +20919,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postIdentityVerificationSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIdentityVerificationSessions(input, ctx)
+      const { status, body } = await implementation
+        .postIdentityVerificationSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIdentityVerificationSessionsResponseValidator(status, body)
       ctx.status = status
@@ -19914,19 +20961,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIdentityVerificationSessionsSessionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIdentityVerificationSessionsSessionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIdentityVerificationSessionsSessionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIdentityVerificationSessionsSession(input, ctx)
+      const { status, body } = await implementation
+        .getIdentityVerificationSessionsSession(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIdentityVerificationSessionsSessionResponseValidator(
         status,
@@ -19980,16 +21033,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIdentityVerificationSessionsSessionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIdentityVerificationSessionsSessionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIdentityVerificationSessionsSession(input, ctx)
+      const { status, body } = await implementation
+        .postIdentityVerificationSessionsSession(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIdentityVerificationSessionsSessionResponseValidator(
         status,
@@ -20022,19 +21080,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIdentityVerificationSessionsSessionCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIdentityVerificationSessionsSessionCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIdentityVerificationSessionsSessionCancel(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postIdentityVerificationSessionsSessionCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIdentityVerificationSessionsSessionCancelResponseValidator(
         status,
@@ -20067,19 +21127,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIdentityVerificationSessionsSessionRedactParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIdentityVerificationSessionsSessionRedactBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIdentityVerificationSessionsSessionRedact(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postIdentityVerificationSessionsSessionRedact(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIdentityVerificationSessionsSessionRedactResponseValidator(
         status,
@@ -20131,11 +21193,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getInvoiceitems", "/v1/invoiceitems", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getInvoiceitemsQuerySchema, ctx.query),
-      body: parseRequestInput(getInvoiceitemsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getInvoiceitemsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getInvoiceitemsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getInvoiceitems(input, ctx)
+    const { status, body } = await implementation
+      .getInvoiceitems(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getInvoiceitemsResponseValidator(status, body)
     ctx.status = status
@@ -20195,10 +21269,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postInvoiceitemsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postInvoiceitemsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postInvoiceitems(input, ctx)
+    const { status, body } = await implementation
+      .postInvoiceitems(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postInvoiceitemsResponseValidator(status, body)
     ctx.status = status
@@ -20222,16 +21304,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteInvoiceitemsInvoiceitemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteInvoiceitemsInvoiceitemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteInvoiceitemsInvoiceitem(input, ctx)
+      const { status, body } = await implementation
+        .deleteInvoiceitemsInvoiceitem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteInvoiceitemsInvoiceitemResponseValidator(status, body)
       ctx.status = status
@@ -20262,21 +21349,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getInvoiceitemsInvoiceitemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getInvoiceitemsInvoiceitemQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getInvoiceitemsInvoiceitemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getInvoiceitemsInvoiceitem(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getInvoiceitemsInvoiceitem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getInvoiceitemsInvoiceitemResponseValidator(status, body)
       ctx.status = status
@@ -20343,18 +21434,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postInvoiceitemsInvoiceitemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postInvoiceitemsInvoiceitemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postInvoiceitemsInvoiceitem(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postInvoiceitemsInvoiceitem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoiceitemsInvoiceitemResponseValidator(status, body)
       ctx.status = status
@@ -20419,11 +21513,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getInvoices", "/v1/invoices", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getInvoicesQuerySchema, ctx.query),
-      body: parseRequestInput(getInvoicesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getInvoicesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getInvoicesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getInvoices(input, ctx)
+    const { status, body } = await implementation
+      .getInvoices(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getInvoicesResponseValidator(status, body)
     ctx.status = status
@@ -20715,10 +21821,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postInvoicesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postInvoicesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postInvoices(input, ctx)
+    const { status, body } = await implementation
+      .postInvoices(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postInvoicesResponseValidator(status, body)
     ctx.status = status
@@ -20754,11 +21868,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getInvoicesSearch", "/v1/invoices/search", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getInvoicesSearchQuerySchema, ctx.query),
-      body: parseRequestInput(getInvoicesSearchBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getInvoicesSearchQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getInvoicesSearchBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getInvoicesSearch(input, ctx)
+    const { status, body } = await implementation
+      .getInvoicesSearch(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getInvoicesSearchResponseValidator(status, body)
     ctx.status = status
@@ -21012,17 +22138,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getInvoicesUpcomingQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getInvoicesUpcomingQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getInvoicesUpcomingBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getInvoicesUpcoming(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getInvoicesUpcoming(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getInvoicesUpcomingResponseValidator(status, body)
       ctx.status = status
@@ -21293,17 +22425,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getInvoicesUpcomingLinesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getInvoicesUpcomingLinesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getInvoicesUpcomingLines(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getInvoicesUpcomingLines(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getInvoicesUpcomingLinesResponseValidator(status, body)
       ctx.status = status
@@ -21325,18 +22460,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/invoices/:invoice",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(deleteInvoicesInvoiceParamSchema, ctx.params),
+        params: parseRequestInput(
+          deleteInvoicesInvoiceParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           deleteInvoicesInvoiceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteInvoicesInvoice(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteInvoicesInvoice(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteInvoicesInvoiceResponseValidator(status, body)
       ctx.status = status
@@ -21362,15 +22503,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/invoices/:invoice",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getInvoicesInvoiceParamSchema, ctx.params),
-        query: parseRequestInput(getInvoicesInvoiceQuerySchema, ctx.query),
-        body: parseRequestInput(getInvoicesInvoiceBodySchema, ctx.request.body),
+        params: parseRequestInput(
+          getInvoicesInvoiceParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getInvoicesInvoiceQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getInvoicesInvoiceBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getInvoicesInvoice(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getInvoicesInvoice(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getInvoicesInvoiceResponseValidator(status, body)
       ctx.status = status
@@ -21668,18 +22822,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/invoices/:invoice",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postInvoicesInvoiceParamSchema, ctx.params),
+        params: parseRequestInput(
+          postInvoicesInvoiceParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postInvoicesInvoiceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postInvoicesInvoice(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postInvoicesInvoice(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoicesInvoiceResponseValidator(status, body)
       ctx.status = status
@@ -21709,18 +22869,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postInvoicesInvoiceFinalizeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postInvoicesInvoiceFinalizeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postInvoicesInvoiceFinalize(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postInvoicesInvoiceFinalize(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoicesInvoiceFinalizeResponseValidator(status, body)
       ctx.status = status
@@ -21762,18 +22925,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getInvoicesInvoiceLinesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getInvoicesInvoiceLinesQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getInvoicesInvoiceLinesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getInvoicesInvoiceLinesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getInvoicesInvoiceLines(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getInvoicesInvoiceLines(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getInvoicesInvoiceLinesResponseValidator(status, body)
       ctx.status = status
@@ -21800,16 +22970,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postInvoicesInvoiceMarkUncollectibleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postInvoicesInvoiceMarkUncollectibleBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postInvoicesInvoiceMarkUncollectible(input, ctx)
+      const { status, body } = await implementation
+        .postInvoicesInvoiceMarkUncollectible(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoicesInvoiceMarkUncollectibleResponseValidator(
         status,
@@ -21847,18 +23022,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postInvoicesInvoicePayParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postInvoicesInvoicePayBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postInvoicesInvoicePay(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postInvoicesInvoicePay(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoicesInvoicePayResponseValidator(status, body)
       ctx.status = status
@@ -21885,18 +23063,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postInvoicesInvoiceSendParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postInvoicesInvoiceSendBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postInvoicesInvoiceSend(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postInvoicesInvoiceSend(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoicesInvoiceSendResponseValidator(status, body)
       ctx.status = status
@@ -21923,18 +23104,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postInvoicesInvoiceVoidParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postInvoicesInvoiceVoidBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postInvoicesInvoiceVoid(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postInvoicesInvoiceVoid(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postInvoicesInvoiceVoidResponseValidator(status, body)
       ctx.status = status
@@ -21989,17 +23173,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getIssuingAuthorizationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIssuingAuthorizationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getIssuingAuthorizations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingAuthorizations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingAuthorizationsResponseValidator(status, body)
       ctx.status = status
@@ -22030,19 +23217,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIssuingAuthorizationsAuthorizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIssuingAuthorizationsAuthorizationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIssuingAuthorizationsAuthorizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIssuingAuthorizationsAuthorization(input, ctx)
+      const { status, body } = await implementation
+        .getIssuingAuthorizationsAuthorization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingAuthorizationsAuthorizationResponseValidator(
         status,
@@ -22075,16 +23268,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingAuthorizationsAuthorizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingAuthorizationsAuthorizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingAuthorizationsAuthorization(input, ctx)
+      const { status, body } = await implementation
+        .postIssuingAuthorizationsAuthorization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingAuthorizationsAuthorizationResponseValidator(
         status,
@@ -22118,19 +23316,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingAuthorizationsAuthorizationApproveParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingAuthorizationsAuthorizationApproveBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingAuthorizationsAuthorizationApprove(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postIssuingAuthorizationsAuthorizationApprove(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingAuthorizationsAuthorizationApproveResponseValidator(
         status,
@@ -22163,19 +23363,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingAuthorizationsAuthorizationDeclineParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingAuthorizationsAuthorizationDeclineBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingAuthorizationsAuthorizationDecline(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postIssuingAuthorizationsAuthorizationDecline(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingAuthorizationsAuthorizationDeclineResponseValidator(
         status,
@@ -22231,17 +23433,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getIssuingCardholdersQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getIssuingCardholdersQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getIssuingCardholdersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getIssuingCardholders(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingCardholders(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingCardholdersResponseValidator(status, body)
       ctx.status = status
@@ -23245,13 +24453,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postIssuingCardholdersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postIssuingCardholders(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postIssuingCardholders(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingCardholdersResponseValidator(status, body)
       ctx.status = status
@@ -23280,19 +24490,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIssuingCardholdersCardholderParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIssuingCardholdersCardholderQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIssuingCardholdersCardholderBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIssuingCardholdersCardholder(input, ctx)
+      const { status, body } = await implementation
+        .getIssuingCardholdersCardholder(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingCardholdersCardholderResponseValidator(status, body)
       ctx.status = status
@@ -24298,16 +25514,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingCardholdersCardholderParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingCardholdersCardholderBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingCardholdersCardholder(input, ctx)
+      const { status, body } = await implementation
+        .postIssuingCardholdersCardholder(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingCardholdersCardholderResponseValidator(status, body)
       ctx.status = status
@@ -24359,11 +25580,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getIssuingCards", "/v1/issuing/cards", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getIssuingCardsQuerySchema, ctx.query),
-      body: parseRequestInput(getIssuingCardsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getIssuingCardsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getIssuingCardsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getIssuingCards(input, ctx)
+    const { status, body } = await implementation
+      .getIssuingCards(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getIssuingCardsResponseValidator(status, body)
     ctx.status = status
@@ -25333,10 +26566,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postIssuingCardsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postIssuingCardsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postIssuingCards(input, ctx)
+    const { status, body } = await implementation
+      .postIssuingCards(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postIssuingCardsResponseValidator(status, body)
     ctx.status = status
@@ -25361,18 +26602,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/issuing/cards/:card",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getIssuingCardsCardParamSchema, ctx.params),
-        query: parseRequestInput(getIssuingCardsCardQuerySchema, ctx.query),
+        params: parseRequestInput(
+          getIssuingCardsCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getIssuingCardsCardQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getIssuingCardsCardBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getIssuingCardsCard(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingCardsCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingCardsCardResponseValidator(status, body)
       ctx.status = status
@@ -26324,18 +27575,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/issuing/cards/:card",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postIssuingCardsCardParamSchema, ctx.params),
+        params: parseRequestInput(
+          postIssuingCardsCardParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postIssuingCardsCardBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postIssuingCardsCard(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postIssuingCardsCard(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingCardsCardResponseValidator(status, body)
       ctx.status = status
@@ -26388,14 +27645,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getIssuingDisputesQuerySchema, ctx.query),
-        body: parseRequestInput(getIssuingDisputesBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getIssuingDisputesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getIssuingDisputesBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getIssuingDisputes(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingDisputes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingDisputesResponseValidator(status, body)
       ctx.status = status
@@ -26578,13 +27844,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postIssuingDisputesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postIssuingDisputes(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postIssuingDisputes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingDisputesResponseValidator(status, body)
       ctx.status = status
@@ -26613,21 +27881,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIssuingDisputesDisputeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIssuingDisputesDisputeQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIssuingDisputesDisputeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getIssuingDisputesDispute(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingDisputesDispute(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingDisputesDisputeResponseValidator(status, body)
       ctx.status = status
@@ -26810,18 +28082,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingDisputesDisputeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingDisputesDisputeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postIssuingDisputesDispute(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postIssuingDisputesDispute(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingDisputesDisputeResponseValidator(status, body)
       ctx.status = status
@@ -26851,16 +28126,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingDisputesDisputeSubmitParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingDisputesDisputeSubmitBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingDisputesDisputeSubmit(input, ctx)
+      const { status, body } = await implementation
+        .postIssuingDisputesDisputeSubmit(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingDisputesDisputeSubmitResponseValidator(status, body)
       ctx.status = status
@@ -26909,17 +28189,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getIssuingSettlementsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getIssuingSettlementsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getIssuingSettlementsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getIssuingSettlements(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingSettlements(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingSettlementsResponseValidator(status, body)
       ctx.status = status
@@ -26948,19 +28234,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIssuingSettlementsSettlementParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIssuingSettlementsSettlementQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIssuingSettlementsSettlementBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIssuingSettlementsSettlement(input, ctx)
+      const { status, body } = await implementation
+        .getIssuingSettlementsSettlement(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingSettlementsSettlementResponseValidator(status, body)
       ctx.status = status
@@ -26990,16 +28282,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingSettlementsSettlementParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingSettlementsSettlementBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingSettlementsSettlement(input, ctx)
+      const { status, body } = await implementation
+        .postIssuingSettlementsSettlement(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingSettlementsSettlementResponseValidator(status, body)
       ctx.status = status
@@ -27051,17 +28348,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getIssuingTransactionsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getIssuingTransactionsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getIssuingTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getIssuingTransactions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getIssuingTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingTransactionsResponseValidator(status, body)
       ctx.status = status
@@ -27090,19 +28393,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getIssuingTransactionsTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getIssuingTransactionsTransactionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getIssuingTransactionsTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getIssuingTransactionsTransaction(input, ctx)
+      const { status, body } = await implementation
+        .getIssuingTransactionsTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getIssuingTransactionsTransactionResponseValidator(
         status,
@@ -27135,16 +28444,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postIssuingTransactionsTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postIssuingTransactionsTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postIssuingTransactionsTransaction(input, ctx)
+      const { status, body } = await implementation
+        .postIssuingTransactionsTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postIssuingTransactionsTransactionResponseValidator(
         status,
@@ -27185,13 +28499,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postLinkAccountSessionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postLinkAccountSessions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postLinkAccountSessions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postLinkAccountSessionsResponseValidator(status, body)
       ctx.status = status
@@ -27223,19 +28539,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getLinkAccountSessionsSessionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getLinkAccountSessionsSessionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getLinkAccountSessionsSessionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getLinkAccountSessionsSession(input, ctx)
+      const { status, body } = await implementation
+        .getLinkAccountSessionsSession(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getLinkAccountSessionsSessionResponseValidator(status, body)
       ctx.status = status
@@ -27277,11 +28599,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getLinkedAccounts", "/v1/linked_accounts", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getLinkedAccountsQuerySchema, ctx.query),
-      body: parseRequestInput(getLinkedAccountsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getLinkedAccountsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getLinkedAccountsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getLinkedAccounts(input, ctx)
+    const { status, body } = await implementation
+      .getLinkedAccounts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getLinkedAccountsResponseValidator(status, body)
     ctx.status = status
@@ -27309,21 +28643,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getLinkedAccountsAccountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getLinkedAccountsAccountQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getLinkedAccountsAccountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getLinkedAccountsAccount(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getLinkedAccountsAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getLinkedAccountsAccountResponseValidator(status, body)
       ctx.status = status
@@ -27353,16 +28691,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postLinkedAccountsAccountDisconnectParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postLinkedAccountsAccountDisconnectBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postLinkedAccountsAccountDisconnect(input, ctx)
+      const { status, body } = await implementation
+        .postLinkedAccountsAccountDisconnect(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postLinkedAccountsAccountDisconnectResponseValidator(
         status,
@@ -27411,19 +28754,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getLinkedAccountsAccountOwnersParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getLinkedAccountsAccountOwnersQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getLinkedAccountsAccountOwnersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getLinkedAccountsAccountOwners(input, ctx)
+      const { status, body } = await implementation
+        .getLinkedAccountsAccountOwners(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getLinkedAccountsAccountOwnersResponseValidator(status, body)
       ctx.status = status
@@ -27454,16 +28803,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postLinkedAccountsAccountRefreshParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postLinkedAccountsAccountRefreshBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postLinkedAccountsAccountRefresh(input, ctx)
+      const { status, body } = await implementation
+        .postLinkedAccountsAccountRefresh(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postLinkedAccountsAccountRefreshResponseValidator(status, body)
       ctx.status = status
@@ -27489,15 +28843,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/mandates/:mandate",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getMandatesMandateParamSchema, ctx.params),
-        query: parseRequestInput(getMandatesMandateQuerySchema, ctx.query),
-        body: parseRequestInput(getMandatesMandateBodySchema, ctx.request.body),
+        params: parseRequestInput(
+          getMandatesMandateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getMandatesMandateQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getMandatesMandateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getMandatesMandate(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getMandatesMandate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getMandatesMandateResponseValidator(status, body)
       ctx.status = status
@@ -27544,11 +28911,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPaymentIntents", "/v1/payment_intents", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPaymentIntentsQuerySchema, ctx.query),
-      body: parseRequestInput(getPaymentIntentsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPaymentIntentsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPaymentIntentsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPaymentIntents(input, ctx)
+    const { status, body } = await implementation
+      .getPaymentIntents(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPaymentIntentsResponseValidator(status, body)
     ctx.status = status
@@ -28385,13 +29764,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(postPaymentIntentsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          postPaymentIntentsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.postPaymentIntents(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPaymentIntents(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsResponseValidator(status, body)
       ctx.status = status
@@ -28431,17 +29815,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getPaymentIntentsSearchQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getPaymentIntentsSearchQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getPaymentIntentsSearchBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getPaymentIntentsSearch(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getPaymentIntentsSearch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentIntentsSearchResponseValidator(status, body)
       ctx.status = status
@@ -28471,18 +29861,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPaymentIntentsIntentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getPaymentIntentsIntentQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getPaymentIntentsIntentQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getPaymentIntentsIntentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getPaymentIntentsIntent(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getPaymentIntentsIntent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentIntentsIntentResponseValidator(status, body)
       ctx.status = status
@@ -29304,18 +30701,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postPaymentIntentsIntent(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPaymentIntentsIntent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsIntentResponseValidator(status, body)
       ctx.status = status
@@ -29346,19 +30746,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentApplyCustomerBalanceParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentApplyCustomerBalanceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentIntentsIntentApplyCustomerBalance(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postPaymentIntentsIntentApplyCustomerBalance(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsIntentApplyCustomerBalanceResponseValidator(
         status,
@@ -29393,16 +30795,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentIntentsIntentCancel(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentIntentsIntentCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsIntentCancelResponseValidator(status, body)
       ctx.status = status
@@ -29439,16 +30846,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentCaptureParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentCaptureBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentIntentsIntentCapture(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentIntentsIntentCapture(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsIntentCaptureResponseValidator(status, body)
       ctx.status = status
@@ -30288,16 +31700,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentConfirmParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentConfirmBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentIntentsIntentConfirm(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentIntentsIntentConfirm(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsIntentConfirmResponseValidator(status, body)
       ctx.status = status
@@ -30332,19 +31749,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentIncrementAuthorizationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentIncrementAuthorizationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentIntentsIntentIncrementAuthorization(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postPaymentIntentsIntentIncrementAuthorization(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postPaymentIntentsIntentIncrementAuthorizationResponseValidator(
@@ -30380,19 +31799,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentIntentsIntentVerifyMicrodepositsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentIntentsIntentVerifyMicrodepositsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentIntentsIntentVerifyMicrodeposits(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postPaymentIntentsIntentVerifyMicrodeposits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentIntentsIntentVerifyMicrodepositsResponseValidator(
         status,
@@ -30431,11 +31852,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPaymentLinks", "/v1/payment_links", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPaymentLinksQuerySchema, ctx.query),
-      body: parseRequestInput(getPaymentLinksBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPaymentLinksQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPaymentLinksBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPaymentLinks(input, ctx)
+    const { status, body } = await implementation
+      .getPaymentLinks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPaymentLinksResponseValidator(status, body)
     ctx.status = status
@@ -30870,10 +32303,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postPaymentLinksBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPaymentLinksBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPaymentLinks(input, ctx)
+    const { status, body } = await implementation
+      .postPaymentLinks(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPaymentLinksResponseValidator(status, body)
     ctx.status = status
@@ -30903,21 +32344,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPaymentLinksPaymentLinkParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getPaymentLinksPaymentLinkQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPaymentLinksPaymentLinkBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getPaymentLinksPaymentLink(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getPaymentLinksPaymentLink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentLinksPaymentLinkResponseValidator(status, body)
       ctx.status = status
@@ -31338,18 +32783,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentLinksPaymentLinkParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentLinksPaymentLinkBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postPaymentLinksPaymentLink(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPaymentLinksPaymentLink(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentLinksPaymentLinkResponseValidator(status, body)
       ctx.status = status
@@ -31394,19 +32842,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPaymentLinksPaymentLinkLineItemsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getPaymentLinksPaymentLinkLineItemsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPaymentLinksPaymentLinkLineItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getPaymentLinksPaymentLinkLineItems(input, ctx)
+      const { status, body } = await implementation
+        .getPaymentLinksPaymentLinkLineItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentLinksPaymentLinkLineItemsResponseValidator(
         status,
@@ -31449,15 +32903,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getPaymentMethodConfigurationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPaymentMethodConfigurationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getPaymentMethodConfigurations(input, ctx)
+      const { status, body } = await implementation
+        .getPaymentMethodConfigurations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentMethodConfigurationsResponseValidator(status, body)
       ctx.status = status
@@ -31720,11 +33179,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postPaymentMethodConfigurationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodConfigurations(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentMethodConfigurations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodConfigurationsResponseValidator(status, body)
       ctx.status = status
@@ -31758,22 +33221,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPaymentMethodConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getPaymentMethodConfigurationsConfigurationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPaymentMethodConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getPaymentMethodConfigurationsConfiguration(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getPaymentMethodConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentMethodConfigurationsConfigurationResponseValidator(
         status,
@@ -32041,19 +33507,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentMethodConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentMethodConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodConfigurationsConfiguration(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postPaymentMethodConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodConfigurationsConfigurationResponseValidator(
         status,
@@ -32096,17 +33564,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getPaymentMethodDomainsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getPaymentMethodDomainsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getPaymentMethodDomainsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getPaymentMethodDomains(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getPaymentMethodDomains(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentMethodDomainsResponseValidator(status, body)
       ctx.status = status
@@ -32135,13 +33609,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postPaymentMethodDomainsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postPaymentMethodDomains(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPaymentMethodDomains(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodDomainsResponseValidator(status, body)
       ctx.status = status
@@ -32172,22 +33648,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPaymentMethodDomainsPaymentMethodDomainParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getPaymentMethodDomainsPaymentMethodDomainQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPaymentMethodDomainsPaymentMethodDomainBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getPaymentMethodDomainsPaymentMethodDomain(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getPaymentMethodDomainsPaymentMethodDomain(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentMethodDomainsPaymentMethodDomainResponseValidator(
         status,
@@ -32220,19 +33699,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentMethodDomainsPaymentMethodDomainParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentMethodDomainsPaymentMethodDomainBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodDomainsPaymentMethodDomain(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postPaymentMethodDomainsPaymentMethodDomain(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodDomainsPaymentMethodDomainResponseValidator(
         status,
@@ -32261,19 +33742,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentMethodDomainsPaymentMethodDomainValidateParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentMethodDomainsPaymentMethodDomainValidateBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodDomainsPaymentMethodDomainValidate(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postPaymentMethodDomainsPaymentMethodDomainValidate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postPaymentMethodDomainsPaymentMethodDomainValidateResponseValidator(
@@ -32348,11 +33831,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPaymentMethods", "/v1/payment_methods", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPaymentMethodsQuerySchema, ctx.query),
-      body: parseRequestInput(getPaymentMethodsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPaymentMethodsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPaymentMethodsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPaymentMethods(input, ctx)
+    const { status, body } = await implementation
+      .getPaymentMethods(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPaymentMethodsResponseValidator(status, body)
     ctx.status = status
@@ -32627,13 +34122,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(postPaymentMethodsBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          postPaymentMethodsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.postPaymentMethods(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPaymentMethods(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodsResponseValidator(status, body)
       ctx.status = status
@@ -32662,19 +34162,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPaymentMethodsPaymentMethodParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getPaymentMethodsPaymentMethodQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPaymentMethodsPaymentMethodBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getPaymentMethodsPaymentMethod(input, ctx)
+      const { status, body } = await implementation
+        .getPaymentMethodsPaymentMethod(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPaymentMethodsPaymentMethodResponseValidator(status, body)
       ctx.status = status
@@ -32736,16 +34242,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentMethodsPaymentMethodParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentMethodsPaymentMethodBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodsPaymentMethod(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentMethodsPaymentMethod(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodsPaymentMethodResponseValidator(status, body)
       ctx.status = status
@@ -32773,16 +34284,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentMethodsPaymentMethodAttachParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentMethodsPaymentMethodAttachBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodsPaymentMethodAttach(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentMethodsPaymentMethodAttach(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodsPaymentMethodAttachResponseValidator(
         status,
@@ -32812,16 +34328,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPaymentMethodsPaymentMethodDetachParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPaymentMethodsPaymentMethodDetachBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPaymentMethodsPaymentMethodDetach(input, ctx)
+      const { status, body } = await implementation
+        .postPaymentMethodsPaymentMethodDetach(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPaymentMethodsPaymentMethodDetachResponseValidator(
         status,
@@ -32883,11 +34404,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPayouts", "/v1/payouts", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPayoutsQuerySchema, ctx.query),
-      body: parseRequestInput(getPayoutsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPayoutsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPayoutsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPayouts(input, ctx)
+    const { status, body } = await implementation
+      .getPayouts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPayoutsResponseValidator(status, body)
     ctx.status = status
@@ -32915,10 +34448,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postPayoutsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPayoutsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPayouts(input, ctx)
+    const { status, body } = await implementation
+      .postPayouts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPayoutsResponseValidator(status, body)
     ctx.status = status
@@ -32940,12 +34481,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getPayoutsPayout", "/v1/payouts/:payout", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getPayoutsPayoutParamSchema, ctx.params),
-      query: parseRequestInput(getPayoutsPayoutQuerySchema, ctx.query),
-      body: parseRequestInput(getPayoutsPayoutBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getPayoutsPayoutParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getPayoutsPayoutQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPayoutsPayoutBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPayoutsPayout(input, ctx)
+    const { status, body } = await implementation
+      .getPayoutsPayout(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPayoutsPayoutResponseValidator(status, body)
     ctx.status = status
@@ -32968,12 +34525,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postPayoutsPayout", "/v1/payouts/:payout", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postPayoutsPayoutParamSchema, ctx.params),
+      params: parseRequestInput(
+        postPayoutsPayoutParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postPayoutsPayoutBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPayoutsPayoutBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPayoutsPayout(input, ctx)
+    const { status, body } = await implementation
+      .postPayoutsPayout(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPayoutsPayoutResponseValidator(status, body)
     ctx.status = status
@@ -32999,18 +34568,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPayoutsPayoutCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPayoutsPayoutCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postPayoutsPayoutCancel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPayoutsPayoutCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPayoutsPayoutCancelResponseValidator(status, body)
       ctx.status = status
@@ -33040,18 +34612,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPayoutsPayoutReverseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPayoutsPayoutReverseBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postPayoutsPayoutReverse(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPayoutsPayoutReverse(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPayoutsPayoutReverseResponseValidator(status, body)
       ctx.status = status
@@ -33099,11 +34674,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPlans", "/v1/plans", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPlansQuerySchema, ctx.query),
-      body: parseRequestInput(getPlansBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPlansQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPlansBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPlans(input, ctx)
+    const { status, body } = await implementation
+      .getPlans(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPlansResponseValidator(status, body)
     ctx.status = status
@@ -33167,10 +34754,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postPlansBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPlansBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPlans(input, ctx)
+    const { status, body } = await implementation
+      .postPlans(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPlansResponseValidator(status, body)
     ctx.status = status
@@ -33188,12 +34783,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("deletePlansPlan", "/v1/plans/:plan", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(deletePlansPlanParamSchema, ctx.params),
+      params: parseRequestInput(
+        deletePlansPlanParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(deletePlansPlanBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        deletePlansPlanBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.deletePlansPlan(input, ctx)
+    const { status, body } = await implementation
+      .deletePlansPlan(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = deletePlansPlanResponseValidator(status, body)
     ctx.status = status
@@ -33215,12 +34822,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getPlansPlan", "/v1/plans/:plan", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getPlansPlanParamSchema, ctx.params),
-      query: parseRequestInput(getPlansPlanQuerySchema, ctx.query),
-      body: parseRequestInput(getPlansPlanBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getPlansPlanParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getPlansPlanQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPlansPlanBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPlansPlan(input, ctx)
+    const { status, body } = await implementation
+      .getPlansPlan(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPlansPlanResponseValidator(status, body)
     ctx.status = status
@@ -33247,12 +34870,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postPlansPlan", "/v1/plans/:plan", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postPlansPlanParamSchema, ctx.params),
+      params: parseRequestInput(
+        postPlansPlanParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postPlansPlanBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPlansPlanBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPlansPlan(input, ctx)
+    const { status, body } = await implementation
+      .postPlansPlan(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPlansPlanResponseValidator(status, body)
     ctx.status = status
@@ -33308,11 +34943,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPrices", "/v1/prices", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPricesQuerySchema, ctx.query),
-      body: parseRequestInput(getPricesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPricesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPricesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPrices(input, ctx)
+    const { status, body } = await implementation
+      .getPrices(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPricesResponseValidator(status, body)
     ctx.status = status
@@ -33388,10 +35035,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postPricesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPricesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPrices(input, ctx)
+    const { status, body } = await implementation
+      .postPrices(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPricesResponseValidator(status, body)
     ctx.status = status
@@ -33427,11 +35082,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPricesSearch", "/v1/prices/search", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPricesSearchQuerySchema, ctx.query),
-      body: parseRequestInput(getPricesSearchBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPricesSearchQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPricesSearchBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPricesSearch(input, ctx)
+    const { status, body } = await implementation
+      .getPricesSearch(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPricesSearchResponseValidator(status, body)
     ctx.status = status
@@ -33453,12 +35120,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getPricesPrice", "/v1/prices/:price", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getPricesPriceParamSchema, ctx.params),
-      query: parseRequestInput(getPricesPriceQuerySchema, ctx.query),
-      body: parseRequestInput(getPricesPriceBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getPricesPriceParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getPricesPriceQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPricesPriceBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPricesPrice(input, ctx)
+    const { status, body } = await implementation
+      .getPricesPrice(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPricesPriceResponseValidator(status, body)
     ctx.status = status
@@ -33489,12 +35172,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postPricesPrice", "/v1/prices/:price", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postPricesPriceParamSchema, ctx.params),
+      params: parseRequestInput(
+        postPricesPriceParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postPricesPriceBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postPricesPriceBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postPricesPrice(input, ctx)
+    const { status, body } = await implementation
+      .postPricesPrice(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postPricesPriceResponseValidator(status, body)
     ctx.status = status
@@ -33543,11 +35238,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getProducts", "/v1/products", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getProductsQuerySchema, ctx.query),
-      body: parseRequestInput(getProductsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getProductsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getProductsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getProducts(input, ctx)
+    const { status, body } = await implementation
+      .getProducts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getProductsResponseValidator(status, body)
     ctx.status = status
@@ -33604,10 +35311,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postProductsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postProductsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postProducts(input, ctx)
+    const { status, body } = await implementation
+      .postProducts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postProductsResponseValidator(status, body)
     ctx.status = status
@@ -33643,11 +35358,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getProductsSearch", "/v1/products/search", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getProductsSearchQuerySchema, ctx.query),
-      body: parseRequestInput(getProductsSearchBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getProductsSearchQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getProductsSearchBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getProductsSearch(input, ctx)
+    const { status, body } = await implementation
+      .getProductsSearch(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getProductsSearchResponseValidator(status, body)
     ctx.status = status
@@ -33665,12 +35392,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("deleteProductsId", "/v1/products/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(deleteProductsIdParamSchema, ctx.params),
+      params: parseRequestInput(
+        deleteProductsIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(deleteProductsIdBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        deleteProductsIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.deleteProductsId(input, ctx)
+    const { status, body } = await implementation
+      .deleteProductsId(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = deleteProductsIdResponseValidator(status, body)
     ctx.status = status
@@ -33692,12 +35431,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getProductsId", "/v1/products/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getProductsIdParamSchema, ctx.params),
-      query: parseRequestInput(getProductsIdQuerySchema, ctx.query),
-      body: parseRequestInput(getProductsIdBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getProductsIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getProductsIdQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getProductsIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getProductsId(input, ctx)
+    const { status, body } = await implementation
+      .getProductsId(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getProductsIdResponseValidator(status, body)
     ctx.status = status
@@ -33744,12 +35499,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postProductsId", "/v1/products/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postProductsIdParamSchema, ctx.params),
+      params: parseRequestInput(
+        postProductsIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postProductsIdBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postProductsIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postProductsId(input, ctx)
+    const { status, body } = await implementation
+      .postProductsId(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postProductsIdResponseValidator(status, body)
     ctx.status = status
@@ -33798,11 +35565,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getPromotionCodes", "/v1/promotion_codes", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getPromotionCodesQuerySchema, ctx.query),
-      body: parseRequestInput(getPromotionCodesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getPromotionCodesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getPromotionCodesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getPromotionCodes(input, ctx)
+    const { status, body } = await implementation
+      .getPromotionCodes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getPromotionCodesResponseValidator(status, body)
     ctx.status = status
@@ -33840,13 +35619,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
       const input = {
         params: undefined,
         query: undefined,
-        body: parseRequestInput(postPromotionCodesBodySchema, ctx.request.body),
+        body: parseRequestInput(
+          postPromotionCodesBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.postPromotionCodes(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postPromotionCodes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPromotionCodesResponseValidator(status, body)
       ctx.status = status
@@ -33875,19 +35659,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getPromotionCodesPromotionCodeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getPromotionCodesPromotionCodeQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getPromotionCodesPromotionCodeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getPromotionCodesPromotionCode(input, ctx)
+      const { status, body } = await implementation
+        .getPromotionCodesPromotionCode(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getPromotionCodesPromotionCodeResponseValidator(status, body)
       ctx.status = status
@@ -33921,16 +35711,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postPromotionCodesPromotionCodeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postPromotionCodesPromotionCodeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postPromotionCodesPromotionCode(input, ctx)
+      const { status, body } = await implementation
+        .postPromotionCodesPromotionCode(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postPromotionCodesPromotionCodeResponseValidator(status, body)
       ctx.status = status
@@ -33968,11 +35763,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getQuotes", "/v1/quotes", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getQuotesQuerySchema, ctx.query),
-      body: parseRequestInput(getQuotesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getQuotesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getQuotesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getQuotes(input, ctx)
+    const { status, body } = await implementation
+      .getQuotes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getQuotesResponseValidator(status, body)
     ctx.status = status
@@ -34086,10 +35893,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postQuotesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postQuotesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postQuotes(input, ctx)
+    const { status, body } = await implementation
+      .postQuotes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postQuotesResponseValidator(status, body)
     ctx.status = status
@@ -34111,12 +35926,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getQuotesQuote", "/v1/quotes/:quote", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getQuotesQuoteParamSchema, ctx.params),
-      query: parseRequestInput(getQuotesQuoteQuerySchema, ctx.query),
-      body: parseRequestInput(getQuotesQuoteBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getQuotesQuoteParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getQuotesQuoteQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getQuotesQuoteBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getQuotesQuote(input, ctx)
+    const { status, body } = await implementation
+      .getQuotesQuote(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getQuotesQuoteResponseValidator(status, body)
     ctx.status = status
@@ -34224,12 +36055,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postQuotesQuote", "/v1/quotes/:quote", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postQuotesQuoteParamSchema, ctx.params),
+      params: parseRequestInput(
+        postQuotesQuoteParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postQuotesQuoteBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postQuotesQuoteBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postQuotesQuote(input, ctx)
+    const { status, body } = await implementation
+      .postQuotesQuote(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postQuotesQuoteResponseValidator(status, body)
     ctx.status = status
@@ -34252,18 +36095,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/quotes/:quote/accept",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postQuotesQuoteAcceptParamSchema, ctx.params),
+        params: parseRequestInput(
+          postQuotesQuoteAcceptParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postQuotesQuoteAcceptBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postQuotesQuoteAccept(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postQuotesQuoteAccept(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postQuotesQuoteAcceptResponseValidator(status, body)
       ctx.status = status
@@ -34287,18 +36136,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/quotes/:quote/cancel",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postQuotesQuoteCancelParamSchema, ctx.params),
+        params: parseRequestInput(
+          postQuotesQuoteCancelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postQuotesQuoteCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postQuotesQuoteCancel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postQuotesQuoteCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postQuotesQuoteCancelResponseValidator(status, body)
       ctx.status = status
@@ -34345,19 +36200,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getQuotesQuoteComputedUpfrontLineItemsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getQuotesQuoteComputedUpfrontLineItemsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getQuotesQuoteComputedUpfrontLineItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getQuotesQuoteComputedUpfrontLineItems(input, ctx)
+      const { status, body } = await implementation
+        .getQuotesQuoteComputedUpfrontLineItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getQuotesQuoteComputedUpfrontLineItemsResponseValidator(
         status,
@@ -34390,18 +36251,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postQuotesQuoteFinalizeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postQuotesQuoteFinalizeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postQuotesQuoteFinalize(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postQuotesQuoteFinalize(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postQuotesQuoteFinalizeResponseValidator(status, body)
       ctx.status = status
@@ -34443,18 +36307,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getQuotesQuoteLineItemsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getQuotesQuoteLineItemsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getQuotesQuoteLineItemsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getQuotesQuoteLineItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getQuotesQuoteLineItems(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getQuotesQuoteLineItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getQuotesQuoteLineItemsResponseValidator(status, body)
       ctx.status = status
@@ -34480,15 +36351,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/quotes/:quote/pdf",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getQuotesQuotePdfParamSchema, ctx.params),
-        query: parseRequestInput(getQuotesQuotePdfQuerySchema, ctx.query),
-        body: parseRequestInput(getQuotesQuotePdfBodySchema, ctx.request.body),
+        params: parseRequestInput(
+          getQuotesQuotePdfParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getQuotesQuotePdfQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getQuotesQuotePdfBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getQuotesQuotePdf(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getQuotesQuotePdf(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getQuotesQuotePdfResponseValidator(status, body)
       ctx.status = status
@@ -34531,17 +36415,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getRadarEarlyFraudWarningsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getRadarEarlyFraudWarningsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getRadarEarlyFraudWarnings(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getRadarEarlyFraudWarnings(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getRadarEarlyFraudWarningsResponseValidator(status, body)
       ctx.status = status
@@ -34572,22 +36459,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getRadarEarlyFraudWarningsEarlyFraudWarningParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getRadarEarlyFraudWarningsEarlyFraudWarningBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getRadarEarlyFraudWarningsEarlyFraudWarning(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getRadarEarlyFraudWarningsEarlyFraudWarning(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getRadarEarlyFraudWarningsEarlyFraudWarningResponseValidator(
         status,
@@ -34641,17 +36531,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getRadarValueListItemsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getRadarValueListItemsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getRadarValueListItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getRadarValueListItems(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getRadarValueListItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getRadarValueListItemsResponseValidator(status, body)
       ctx.status = status
@@ -34680,13 +36576,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postRadarValueListItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postRadarValueListItems(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postRadarValueListItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postRadarValueListItemsResponseValidator(status, body)
       ctx.status = status
@@ -34714,16 +36612,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteRadarValueListItemsItemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteRadarValueListItemsItemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteRadarValueListItemsItem(input, ctx)
+      const { status, body } = await implementation
+        .deleteRadarValueListItemsItem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteRadarValueListItemsItemResponseValidator(status, body)
       ctx.status = status
@@ -34752,21 +36655,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getRadarValueListItemsItemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getRadarValueListItemsItemQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getRadarValueListItemsItemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getRadarValueListItemsItem(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getRadarValueListItemsItem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getRadarValueListItemsItemResponseValidator(status, body)
       ctx.status = status
@@ -34817,14 +36724,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getRadarValueListsQuerySchema, ctx.query),
-        body: parseRequestInput(getRadarValueListsBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getRadarValueListsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getRadarValueListsBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getRadarValueLists(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getRadarValueLists(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getRadarValueListsResponseValidator(status, body)
       ctx.status = status
@@ -34868,13 +36784,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postRadarValueListsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postRadarValueLists(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postRadarValueLists(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postRadarValueListsResponseValidator(status, body)
       ctx.status = status
@@ -34899,16 +36817,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteRadarValueListsValueListParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteRadarValueListsValueListBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteRadarValueListsValueList(input, ctx)
+      const { status, body } = await implementation
+        .deleteRadarValueListsValueList(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteRadarValueListsValueListResponseValidator(status, body)
       ctx.status = status
@@ -34937,21 +36860,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getRadarValueListsValueListParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getRadarValueListsValueListQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getRadarValueListsValueListBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getRadarValueListsValueList(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getRadarValueListsValueList(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getRadarValueListsValueListResponseValidator(status, body)
       ctx.status = status
@@ -34983,16 +36910,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postRadarValueListsValueListParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postRadarValueListsValueListBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postRadarValueListsValueList(input, ctx)
+      const { status, body } = await implementation
+        .postRadarValueListsValueList(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postRadarValueListsValueListResponseValidator(status, body)
       ctx.status = status
@@ -35040,11 +36972,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getRefunds", "/v1/refunds", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getRefundsQuerySchema, ctx.query),
-      body: parseRequestInput(getRefundsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getRefundsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getRefundsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getRefunds(input, ctx)
+    const { status, body } = await implementation
+      .getRefunds(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getRefundsResponseValidator(status, body)
     ctx.status = status
@@ -35079,10 +37023,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postRefundsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postRefundsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postRefunds(input, ctx)
+    const { status, body } = await implementation
+      .postRefunds(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postRefundsResponseValidator(status, body)
     ctx.status = status
@@ -35104,12 +37056,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getRefundsRefund", "/v1/refunds/:refund", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getRefundsRefundParamSchema, ctx.params),
-      query: parseRequestInput(getRefundsRefundQuerySchema, ctx.query),
-      body: parseRequestInput(getRefundsRefundBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getRefundsRefundParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getRefundsRefundQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getRefundsRefundBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getRefundsRefund(input, ctx)
+    const { status, body } = await implementation
+      .getRefundsRefund(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getRefundsRefundResponseValidator(status, body)
     ctx.status = status
@@ -35132,12 +37100,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postRefundsRefund", "/v1/refunds/:refund", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postRefundsRefundParamSchema, ctx.params),
+      params: parseRequestInput(
+        postRefundsRefundParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postRefundsRefundBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postRefundsRefundBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postRefundsRefund(input, ctx)
+    const { status, body } = await implementation
+      .postRefundsRefund(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postRefundsRefundResponseValidator(status, body)
     ctx.status = status
@@ -35163,18 +37143,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postRefundsRefundCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postRefundsRefundCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postRefundsRefundCancel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postRefundsRefundCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postRefundsRefundCancelResponseValidator(status, body)
       ctx.status = status
@@ -35223,17 +37206,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getReportingReportRunsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getReportingReportRunsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getReportingReportRunsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getReportingReportRuns(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getReportingReportRuns(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getReportingReportRunsResponseValidator(status, body)
       ctx.status = status
@@ -35912,13 +37901,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postReportingReportRunsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postReportingReportRuns(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postReportingReportRuns(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postReportingReportRunsResponseValidator(status, body)
       ctx.status = status
@@ -35947,19 +37938,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getReportingReportRunsReportRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getReportingReportRunsReportRunQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getReportingReportRunsReportRunBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getReportingReportRunsReportRun(input, ctx)
+      const { status, body } = await implementation
+        .getReportingReportRunsReportRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getReportingReportRunsReportRunResponseValidator(status, body)
       ctx.status = status
@@ -35994,17 +37991,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getReportingReportTypesQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getReportingReportTypesQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getReportingReportTypesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getReportingReportTypes(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getReportingReportTypes(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getReportingReportTypesResponseValidator(status, body)
       ctx.status = status
@@ -36033,19 +38036,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getReportingReportTypesReportTypeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getReportingReportTypesReportTypeQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getReportingReportTypesReportTypeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getReportingReportTypesReportType(input, ctx)
+      const { status, body } = await implementation
+        .getReportingReportTypesReportType(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getReportingReportTypesReportTypeResponseValidator(
         status,
@@ -36094,11 +38103,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getReviews", "/v1/reviews", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getReviewsQuerySchema, ctx.query),
-      body: parseRequestInput(getReviewsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getReviewsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getReviewsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getReviews(input, ctx)
+    const { status, body } = await implementation
+      .getReviews(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getReviewsResponseValidator(status, body)
     ctx.status = status
@@ -36120,12 +38141,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getReviewsReview", "/v1/reviews/:review", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getReviewsReviewParamSchema, ctx.params),
-      query: parseRequestInput(getReviewsReviewQuerySchema, ctx.query),
-      body: parseRequestInput(getReviewsReviewBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getReviewsReviewParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getReviewsReviewQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getReviewsReviewBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getReviewsReview(input, ctx)
+    const { status, body } = await implementation
+      .getReviewsReview(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getReviewsReviewResponseValidator(status, body)
     ctx.status = status
@@ -36151,18 +38188,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postReviewsReviewApproveParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postReviewsReviewApproveBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postReviewsReviewApprove(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postReviewsReviewApprove(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postReviewsReviewApproveResponseValidator(status, body)
       ctx.status = status
@@ -36209,11 +38249,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getSetupAttempts", "/v1/setup_attempts", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getSetupAttemptsQuerySchema, ctx.query),
-      body: parseRequestInput(getSetupAttemptsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getSetupAttemptsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getSetupAttemptsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getSetupAttempts(input, ctx)
+    const { status, body } = await implementation
+      .getSetupAttempts(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getSetupAttemptsResponseValidator(status, body)
     ctx.status = status
@@ -36261,11 +38313,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getSetupIntents", "/v1/setup_intents", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getSetupIntentsQuerySchema, ctx.query),
-      body: parseRequestInput(getSetupIntentsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getSetupIntentsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getSetupIntentsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getSetupIntents(input, ctx)
+    const { status, body } = await implementation
+      .getSetupIntents(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getSetupIntentsResponseValidator(status, body)
     ctx.status = status
@@ -36668,10 +38732,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postSetupIntentsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postSetupIntentsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postSetupIntents(input, ctx)
+    const { status, body } = await implementation
+      .postSetupIntents(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postSetupIntentsResponseValidator(status, body)
     ctx.status = status
@@ -36697,18 +38769,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/setup_intents/:intent",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getSetupIntentsIntentParamSchema, ctx.params),
-        query: parseRequestInput(getSetupIntentsIntentQuerySchema, ctx.query),
+        params: parseRequestInput(
+          getSetupIntentsIntentParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getSetupIntentsIntentQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getSetupIntentsIntentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getSetupIntentsIntent(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getSetupIntentsIntent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSetupIntentsIntentResponseValidator(status, body)
       ctx.status = status
@@ -37089,18 +39171,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSetupIntentsIntentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSetupIntentsIntentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postSetupIntentsIntent(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postSetupIntentsIntent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSetupIntentsIntentResponseValidator(status, body)
       ctx.status = status
@@ -37132,16 +39217,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSetupIntentsIntentCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSetupIntentsIntentCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSetupIntentsIntentCancel(input, ctx)
+      const { status, body } = await implementation
+        .postSetupIntentsIntentCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSetupIntentsIntentCancelResponseValidator(status, body)
       ctx.status = status
@@ -37542,16 +39632,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSetupIntentsIntentConfirmParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSetupIntentsIntentConfirmBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSetupIntentsIntentConfirm(input, ctx)
+      const { status, body } = await implementation
+        .postSetupIntentsIntentConfirm(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSetupIntentsIntentConfirmResponseValidator(status, body)
       ctx.status = status
@@ -37583,19 +39678,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSetupIntentsIntentVerifyMicrodepositsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSetupIntentsIntentVerifyMicrodepositsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSetupIntentsIntentVerifyMicrodeposits(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postSetupIntentsIntentVerifyMicrodeposits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSetupIntentsIntentVerifyMicrodepositsResponseValidator(
         status,
@@ -37646,11 +39743,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getShippingRates", "/v1/shipping_rates", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getShippingRatesQuerySchema, ctx.query),
-      body: parseRequestInput(getShippingRatesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getShippingRatesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getShippingRatesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getShippingRates(input, ctx)
+    const { status, body } = await implementation
+      .getShippingRates(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getShippingRatesResponseValidator(status, body)
     ctx.status = status
@@ -37698,10 +39807,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postShippingRatesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postShippingRatesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postShippingRates(input, ctx)
+    const { status, body } = await implementation
+      .postShippingRates(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postShippingRatesResponseValidator(status, body)
     ctx.status = status
@@ -37729,19 +39846,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getShippingRatesShippingRateTokenParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getShippingRatesShippingRateTokenQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getShippingRatesShippingRateTokenBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getShippingRatesShippingRateToken(input, ctx)
+      const { status, body } = await implementation
+        .getShippingRatesShippingRateToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getShippingRatesShippingRateTokenResponseValidator(
         status,
@@ -37781,16 +39904,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postShippingRatesShippingRateTokenParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postShippingRatesShippingRateTokenBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postShippingRatesShippingRateToken(input, ctx)
+      const { status, body } = await implementation
+        .postShippingRatesShippingRateToken(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postShippingRatesShippingRateTokenResponseValidator(
         status,
@@ -37834,17 +39962,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getSigmaScheduledQueryRunsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSigmaScheduledQueryRunsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getSigmaScheduledQueryRuns(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getSigmaScheduledQueryRuns(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSigmaScheduledQueryRunsResponseValidator(status, body)
       ctx.status = status
@@ -37875,22 +40006,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSigmaScheduledQueryRunsScheduledQueryRunParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSigmaScheduledQueryRunsScheduledQueryRunQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSigmaScheduledQueryRunsScheduledQueryRunBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSigmaScheduledQueryRunsScheduledQueryRun(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getSigmaScheduledQueryRunsScheduledQueryRun(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSigmaScheduledQueryRunsScheduledQueryRunResponseValidator(
         status,
@@ -38018,10 +40152,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postSourcesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postSourcesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postSources(input, ctx)
+    const { status, body } = await implementation
+      .postSources(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postSourcesResponseValidator(status, body)
     ctx.status = status
@@ -38044,12 +40186,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getSourcesSource", "/v1/sources/:source", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getSourcesSourceParamSchema, ctx.params),
-      query: parseRequestInput(getSourcesSourceQuerySchema, ctx.query),
-      body: parseRequestInput(getSourcesSourceBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getSourcesSourceParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getSourcesSourceQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getSourcesSourceBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getSourcesSource(input, ctx)
+    const { status, body } = await implementation
+      .getSourcesSource(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getSourcesSourceResponseValidator(status, body)
     ctx.status = status
@@ -38155,12 +40313,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postSourcesSource", "/v1/sources/:source", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postSourcesSourceParamSchema, ctx.params),
+      params: parseRequestInput(
+        postSourcesSourceParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postSourcesSourceBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postSourcesSourceBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postSourcesSource(input, ctx)
+    const { status, body } = await implementation
+      .postSourcesSource(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postSourcesSourceResponseValidator(status, body)
     ctx.status = status
@@ -38188,22 +40358,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSourcesSourceMandateNotificationsMandateNotificationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSourcesSourceMandateNotificationsMandateNotificationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSourcesSourceMandateNotificationsMandateNotificationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSourcesSourceMandateNotificationsMandateNotification(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getSourcesSourceMandateNotificationsMandateNotification(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getSourcesSourceMandateNotificationsMandateNotificationResponseValidator(
@@ -38252,19 +40425,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSourcesSourceSourceTransactionsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSourcesSourceSourceTransactionsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSourcesSourceSourceTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSourcesSourceSourceTransactions(input, ctx)
+      const { status, body } = await implementation
+        .getSourcesSourceSourceTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSourcesSourceSourceTransactionsResponseValidator(
         status,
@@ -38296,22 +40475,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSourcesSourceSourceTransactionsSourceTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSourcesSourceSourceTransactionsSourceTransactionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSourcesSourceSourceTransactionsSourceTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSourcesSourceSourceTransactionsSourceTransaction(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getSourcesSourceSourceTransactionsSourceTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getSourcesSourceSourceTransactionsSourceTransactionResponseValidator(
@@ -38343,18 +40525,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSourcesSourceVerifyParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSourcesSourceVerifyBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postSourcesSourceVerify(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postSourcesSourceVerify(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSourcesSourceVerifyResponseValidator(status, body)
       ctx.status = status
@@ -38393,17 +40578,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getSubscriptionItemsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getSubscriptionItemsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getSubscriptionItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getSubscriptionItems(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getSubscriptionItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSubscriptionItemsResponseValidator(status, body)
       ctx.status = status
@@ -38465,13 +40656,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postSubscriptionItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postSubscriptionItems(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postSubscriptionItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionItemsResponseValidator(status, body)
       ctx.status = status
@@ -38502,18 +40695,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteSubscriptionItemsItemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteSubscriptionItemsItemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteSubscriptionItemsItem(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteSubscriptionItemsItem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteSubscriptionItemsItemResponseValidator(status, body)
       ctx.status = status
@@ -38542,21 +40738,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSubscriptionItemsItemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSubscriptionItemsItemQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSubscriptionItemsItemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getSubscriptionItemsItem(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getSubscriptionItemsItem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSubscriptionItemsItemResponseValidator(status, body)
       ctx.status = status
@@ -38620,18 +40820,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionItemsItemParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionItemsItemBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postSubscriptionItemsItem(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postSubscriptionItemsItem(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionItemsItemResponseValidator(status, body)
       ctx.status = status
@@ -38678,22 +40881,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSubscriptionItemsSubscriptionItemUsageRecordSummariesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSubscriptionItemsSubscriptionItemUsageRecordSummariesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSubscriptionItemsSubscriptionItemUsageRecordSummariesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSubscriptionItemsSubscriptionItemUsageRecordSummaries(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getSubscriptionItemsSubscriptionItemUsageRecordSummaries(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getSubscriptionItemsSubscriptionItemUsageRecordSummariesResponseValidator(
@@ -38727,19 +40933,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionItemsSubscriptionItemUsageRecordsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionItemsSubscriptionItemUsageRecordsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSubscriptionItemsSubscriptionItemUsageRecords(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postSubscriptionItemsSubscriptionItemUsageRecords(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postSubscriptionItemsSubscriptionItemUsageRecordsResponseValidator(
@@ -38830,17 +41038,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getSubscriptionSchedulesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSubscriptionSchedulesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getSubscriptionSchedules(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getSubscriptionSchedules(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSubscriptionSchedulesResponseValidator(status, body)
       ctx.status = status
@@ -39009,13 +41220,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postSubscriptionSchedulesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postSubscriptionSchedules(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postSubscriptionSchedules(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionSchedulesResponseValidator(status, body)
       ctx.status = status
@@ -39044,19 +41257,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSubscriptionSchedulesScheduleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSubscriptionSchedulesScheduleQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSubscriptionSchedulesScheduleBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSubscriptionSchedulesSchedule(input, ctx)
+      const { status, body } = await implementation
+        .getSubscriptionSchedulesSchedule(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSubscriptionSchedulesScheduleResponseValidator(status, body)
       ctx.status = status
@@ -39227,16 +41446,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionSchedulesScheduleParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionSchedulesScheduleBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSubscriptionSchedulesSchedule(input, ctx)
+      const { status, body } = await implementation
+        .postSubscriptionSchedulesSchedule(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionSchedulesScheduleResponseValidator(
         status,
@@ -39270,16 +41494,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionSchedulesScheduleCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionSchedulesScheduleCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSubscriptionSchedulesScheduleCancel(input, ctx)
+      const { status, body } = await implementation
+        .postSubscriptionSchedulesScheduleCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionSchedulesScheduleCancelResponseValidator(
         status,
@@ -39312,19 +41541,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionSchedulesScheduleReleaseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionSchedulesScheduleReleaseBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSubscriptionSchedulesScheduleRelease(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postSubscriptionSchedulesScheduleRelease(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionSchedulesScheduleReleaseResponseValidator(
         status,
@@ -39416,11 +41647,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getSubscriptions", "/v1/subscriptions", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getSubscriptionsQuerySchema, ctx.query),
-      body: parseRequestInput(getSubscriptionsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getSubscriptionsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getSubscriptionsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getSubscriptions(input, ctx)
+    const { status, body } = await implementation
+      .getSubscriptions(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getSubscriptionsResponseValidator(status, body)
     ctx.status = status
@@ -39698,10 +41941,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postSubscriptionsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postSubscriptionsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postSubscriptions(input, ctx)
+    const { status, body } = await implementation
+      .postSubscriptions(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postSubscriptionsResponseValidator(status, body)
     ctx.status = status
@@ -39740,17 +41991,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getSubscriptionsSearchQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getSubscriptionsSearchQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getSubscriptionsSearchBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getSubscriptionsSearch(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getSubscriptionsSearch(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSubscriptionsSearchResponseValidator(status, body)
       ctx.status = status
@@ -39799,19 +42056,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteSubscriptionsSubscriptionExposedIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteSubscriptionsSubscriptionExposedIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteSubscriptionsSubscriptionExposedId(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .deleteSubscriptionsSubscriptionExposedId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteSubscriptionsSubscriptionExposedIdResponseValidator(
         status,
@@ -39845,19 +42104,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getSubscriptionsSubscriptionExposedIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getSubscriptionsSubscriptionExposedIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getSubscriptionsSubscriptionExposedIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getSubscriptionsSubscriptionExposedId(input, ctx)
+      const { status, body } = await implementation
+        .getSubscriptionsSubscriptionExposedId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getSubscriptionsSubscriptionExposedIdResponseValidator(
         status,
@@ -40183,16 +42448,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionsSubscriptionExposedIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionsSubscriptionExposedIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSubscriptionsSubscriptionExposedId(input, ctx)
+      const { status, body } = await implementation
+        .postSubscriptionsSubscriptionExposedId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionsSubscriptionExposedIdResponseValidator(
         status,
@@ -40222,19 +42492,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteSubscriptionsSubscriptionExposedIdDiscountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteSubscriptionsSubscriptionExposedIdDiscountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteSubscriptionsSubscriptionExposedIdDiscount(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .deleteSubscriptionsSubscriptionExposedIdDiscount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         deleteSubscriptionsSubscriptionExposedIdDiscountResponseValidator(
@@ -40272,16 +42544,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postSubscriptionsSubscriptionResumeParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postSubscriptionsSubscriptionResumeBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postSubscriptionsSubscriptionResume(input, ctx)
+      const { status, body } = await implementation
+        .postSubscriptionsSubscriptionResume(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postSubscriptionsSubscriptionResumeResponseValidator(
         status,
@@ -40426,13 +42703,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTaxCalculationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTaxCalculations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTaxCalculations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTaxCalculationsResponseValidator(status, body)
       ctx.status = status
@@ -40479,19 +42758,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTaxCalculationsCalculationLineItemsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTaxCalculationsCalculationLineItemsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTaxCalculationsCalculationLineItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTaxCalculationsCalculationLineItems(input, ctx)
+      const { status, body } = await implementation
+        .getTaxCalculationsCalculationLineItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTaxCalculationsCalculationLineItemsResponseValidator(
         status,
@@ -40516,11 +42801,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getTaxSettings", "/v1/tax/settings", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getTaxSettingsQuerySchema, ctx.query),
-      body: parseRequestInput(getTaxSettingsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getTaxSettingsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTaxSettingsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTaxSettings(input, ctx)
+    const { status, body } = await implementation
+      .getTaxSettings(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTaxSettingsResponseValidator(status, body)
     ctx.status = status
@@ -40562,10 +42859,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postTaxSettingsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postTaxSettingsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postTaxSettings(input, ctx)
+    const { status, body } = await implementation
+      .postTaxSettings(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postTaxSettingsResponseValidator(status, body)
     ctx.status = status
@@ -40592,14 +42897,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTaxTransactionsCreateFromCalculationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTaxTransactionsCreateFromCalculation(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTaxTransactionsCreateFromCalculation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTaxTransactionsCreateFromCalculationResponseValidator(
         status,
@@ -40647,11 +42953,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTaxTransactionsCreateReversalBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTaxTransactionsCreateReversal(input, ctx)
+      const { status, body } = await implementation
+        .postTaxTransactionsCreateReversal(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTaxTransactionsCreateReversalResponseValidator(
         status,
@@ -40683,19 +42993,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTaxTransactionsTransactionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTaxTransactionsTransactionQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTaxTransactionsTransactionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTaxTransactionsTransaction(input, ctx)
+      const { status, body } = await implementation
+        .getTaxTransactionsTransaction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTaxTransactionsTransactionResponseValidator(status, body)
       ctx.status = status
@@ -40742,19 +43058,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTaxTransactionsTransactionLineItemsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTaxTransactionsTransactionLineItemsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTaxTransactionsTransactionLineItemsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTaxTransactionsTransactionLineItems(input, ctx)
+      const { status, body } = await implementation
+        .getTaxTransactionsTransactionLineItems(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTaxTransactionsTransactionLineItemsResponseValidator(
         status,
@@ -40792,11 +43114,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getTaxCodes", "/v1/tax_codes", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getTaxCodesQuerySchema, ctx.query),
-      body: parseRequestInput(getTaxCodesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getTaxCodesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTaxCodesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTaxCodes(input, ctx)
+    const { status, body } = await implementation
+      .getTaxCodes(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTaxCodesResponseValidator(status, body)
     ctx.status = status
@@ -40818,12 +43152,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getTaxCodesId", "/v1/tax_codes/:id", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getTaxCodesIdParamSchema, ctx.params),
-      query: parseRequestInput(getTaxCodesIdQuerySchema, ctx.query),
-      body: parseRequestInput(getTaxCodesIdBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getTaxCodesIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getTaxCodesIdQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTaxCodesIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTaxCodesId(input, ctx)
+    const { status, body } = await implementation
+      .getTaxCodesId(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTaxCodesIdResponseValidator(status, body)
     ctx.status = status
@@ -40870,11 +43220,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getTaxRates", "/v1/tax_rates", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getTaxRatesQuerySchema, ctx.query),
-      body: parseRequestInput(getTaxRatesBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getTaxRatesQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTaxRatesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTaxRates(input, ctx)
+    const { status, body } = await implementation
+      .getTaxRates(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTaxRatesResponseValidator(status, body)
     ctx.status = status
@@ -40920,10 +43282,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postTaxRatesBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postTaxRatesBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postTaxRates(input, ctx)
+    const { status, body } = await implementation
+      .postTaxRates(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postTaxRatesResponseValidator(status, body)
     ctx.status = status
@@ -40948,15 +43318,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/tax_rates/:taxRate",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getTaxRatesTaxRateParamSchema, ctx.params),
-        query: parseRequestInput(getTaxRatesTaxRateQuerySchema, ctx.query),
-        body: parseRequestInput(getTaxRatesTaxRateBodySchema, ctx.request.body),
+        params: parseRequestInput(
+          getTaxRatesTaxRateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getTaxRatesTaxRateQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getTaxRatesTaxRateBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getTaxRatesTaxRate(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTaxRatesTaxRate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTaxRatesTaxRateResponseValidator(status, body)
       ctx.status = status
@@ -41006,18 +43389,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/tax_rates/:taxRate",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postTaxRatesTaxRateParamSchema, ctx.params),
+        params: parseRequestInput(
+          postTaxRatesTaxRateParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postTaxRatesTaxRateBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTaxRatesTaxRate(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTaxRatesTaxRate(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTaxRatesTaxRateResponseValidator(status, body)
       ctx.status = status
@@ -41059,17 +43448,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTerminalConfigurationsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTerminalConfigurationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTerminalConfigurations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTerminalConfigurations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTerminalConfigurationsResponseValidator(status, body)
       ctx.status = status
@@ -41213,13 +43605,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTerminalConfigurationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTerminalConfigurations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTerminalConfigurations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalConfigurationsResponseValidator(status, body)
       ctx.status = status
@@ -41249,19 +43643,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteTerminalConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteTerminalConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteTerminalConfigurationsConfiguration(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .deleteTerminalConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteTerminalConfigurationsConfigurationResponseValidator(
         status,
@@ -41306,19 +43702,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTerminalConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTerminalConfigurationsConfigurationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTerminalConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTerminalConfigurationsConfiguration(input, ctx)
+      const { status, body } = await implementation
+        .getTerminalConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTerminalConfigurationsConfigurationResponseValidator(
         status,
@@ -41482,16 +43884,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalConfigurationsConfigurationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalConfigurationsConfigurationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalConfigurationsConfiguration(input, ctx)
+      const { status, body } = await implementation
+        .postTerminalConfigurationsConfiguration(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalConfigurationsConfigurationResponseValidator(
         status,
@@ -41522,11 +43929,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTerminalConnectionTokensBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalConnectionTokens(input, ctx)
+      const { status, body } = await implementation
+        .postTerminalConnectionTokens(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalConnectionTokensResponseValidator(status, body)
       ctx.status = status
@@ -41564,17 +43975,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getTerminalLocationsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getTerminalLocationsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getTerminalLocationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTerminalLocations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTerminalLocations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTerminalLocationsResponseValidator(status, body)
       ctx.status = status
@@ -41612,13 +44029,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTerminalLocationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTerminalLocations(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTerminalLocations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalLocationsResponseValidator(status, body)
       ctx.status = status
@@ -41643,16 +44062,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteTerminalLocationsLocationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteTerminalLocationsLocationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteTerminalLocationsLocation(input, ctx)
+      const { status, body } = await implementation
+        .deleteTerminalLocationsLocation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteTerminalLocationsLocationResponseValidator(status, body)
       ctx.status = status
@@ -41684,19 +44108,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTerminalLocationsLocationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTerminalLocationsLocationQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTerminalLocationsLocationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTerminalLocationsLocation(input, ctx)
+      const { status, body } = await implementation
+        .getTerminalLocationsLocation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTerminalLocationsLocationResponseValidator(status, body)
       ctx.status = status
@@ -41741,16 +44171,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalLocationsLocationParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalLocationsLocationBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalLocationsLocation(input, ctx)
+      const { status, body } = await implementation
+        .postTerminalLocationsLocation(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalLocationsLocationResponseValidator(status, body)
       ctx.status = status
@@ -41801,14 +44236,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getTerminalReadersQuerySchema, ctx.query),
-        body: parseRequestInput(getTerminalReadersBodySchema, ctx.request.body),
+        query: parseRequestInput(
+          getTerminalReadersQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
+        body: parseRequestInput(
+          getTerminalReadersBodySchema,
+          ctx.request.body,
+          RequestInputType.RequestBody,
+        ),
       }
 
-      const { status, body } = await implementation.getTerminalReaders(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTerminalReaders(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTerminalReadersResponseValidator(status, body)
       ctx.status = status
@@ -41839,13 +44283,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTerminalReadersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTerminalReaders(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTerminalReaders(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersResponseValidator(status, body)
       ctx.status = status
@@ -41870,18 +44316,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteTerminalReadersReaderParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteTerminalReadersReaderBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.deleteTerminalReadersReader(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .deleteTerminalReadersReader(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteTerminalReadersReaderResponseValidator(status, body)
       ctx.status = status
@@ -41915,21 +44364,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTerminalReadersReaderParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTerminalReadersReaderQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTerminalReadersReaderBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTerminalReadersReader(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTerminalReadersReader(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTerminalReadersReaderResponseValidator(status, body)
       ctx.status = status
@@ -41965,18 +44418,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalReadersReaderParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalReadersReaderBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTerminalReadersReader(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTerminalReadersReader(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersReaderResponseValidator(status, body)
       ctx.status = status
@@ -42003,16 +44459,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalReadersReaderCancelActionParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalReadersReaderCancelActionBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalReadersReaderCancelAction(input, ctx)
+      const { status, body } = await implementation
+        .postTerminalReadersReaderCancelAction(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersReaderCancelActionResponseValidator(
         status,
@@ -42051,19 +44512,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalReadersReaderProcessPaymentIntentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalReadersReaderProcessPaymentIntentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalReadersReaderProcessPaymentIntent(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTerminalReadersReaderProcessPaymentIntent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersReaderProcessPaymentIntentResponseValidator(
         status,
@@ -42096,19 +44559,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalReadersReaderProcessSetupIntentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalReadersReaderProcessSetupIntentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalReadersReaderProcessSetupIntent(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTerminalReadersReaderProcessSetupIntent(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersReaderProcessSetupIntentResponseValidator(
         status,
@@ -42146,16 +44611,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalReadersReaderRefundPaymentParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalReadersReaderRefundPaymentBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalReadersReaderRefundPayment(input, ctx)
+      const { status, body } = await implementation
+        .postTerminalReadersReaderRefundPayment(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersReaderRefundPaymentResponseValidator(
         status,
@@ -42200,19 +44670,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTerminalReadersReaderSetReaderDisplayParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTerminalReadersReaderSetReaderDisplayBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTerminalReadersReaderSetReaderDisplay(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTerminalReadersReaderSetReaderDisplay(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTerminalReadersReaderSetReaderDisplayResponseValidator(
         status,
@@ -42248,19 +44720,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersCustomersCustomerFundCashBalanceParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersCustomersCustomerFundCashBalanceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersCustomersCustomerFundCashBalance(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersCustomersCustomerFundCashBalance(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersCustomersCustomerFundCashBalanceResponseValidator(
@@ -42627,11 +45101,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTestHelpersIssuingAuthorizationsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingAuthorizations(input, ctx)
+      const { status, body } = await implementation
+        .postTestHelpersIssuingAuthorizations(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersIssuingAuthorizationsResponseValidator(
         status,
@@ -42721,19 +45199,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationCaptureParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationCaptureBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingAuthorizationsAuthorizationCapture(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingAuthorizationsAuthorizationCapture(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingAuthorizationsAuthorizationCaptureResponseValidator(
@@ -42763,19 +45243,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationExpireParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationExpireBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingAuthorizationsAuthorizationExpire(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingAuthorizationsAuthorizationExpire(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingAuthorizationsAuthorizationExpireResponseValidator(
@@ -42808,19 +45290,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationIncrementParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationIncrementBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingAuthorizationsAuthorizationIncrement(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingAuthorizationsAuthorizationIncrement(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingAuthorizationsAuthorizationIncrementResponseValidator(
@@ -42853,19 +45337,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationReverseParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingAuthorizationsAuthorizationReverseBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingAuthorizationsAuthorizationReverse(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingAuthorizationsAuthorizationReverse(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingAuthorizationsAuthorizationReverseResponseValidator(
@@ -42896,19 +45382,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingDeliverParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingDeliverBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingCardsCardShippingDeliver(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingCardsCardShippingDeliver(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingCardsCardShippingDeliverResponseValidator(
@@ -42939,19 +45427,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingFailParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingFailBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingCardsCardShippingFail(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingCardsCardShippingFail(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersIssuingCardsCardShippingFailResponseValidator(
         status,
@@ -42981,19 +45471,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingReturnParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingReturnBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingCardsCardShippingReturn(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingCardsCardShippingReturn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersIssuingCardsCardShippingReturnResponseValidator(
         status,
@@ -43023,19 +45515,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingShipParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingCardsCardShippingShipBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingCardsCardShippingShip(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingCardsCardShippingShip(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersIssuingCardsCardShippingShipResponseValidator(
         status,
@@ -43433,14 +45927,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTestHelpersIssuingTransactionsCreateForceCaptureBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingTransactionsCreateForceCapture(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingTransactionsCreateForceCapture(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingTransactionsCreateForceCaptureResponseValidator(
@@ -43839,14 +46334,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTestHelpersIssuingTransactionsCreateUnlinkedRefundBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingTransactionsCreateUnlinkedRefund(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingTransactionsCreateUnlinkedRefund(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingTransactionsCreateUnlinkedRefundResponseValidator(
@@ -43879,19 +46375,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersIssuingTransactionsTransactionRefundParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersIssuingTransactionsTransactionRefundBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersIssuingTransactionsTransactionRefund(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersIssuingTransactionsTransactionRefund(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersIssuingTransactionsTransactionRefundResponseValidator(
@@ -43922,16 +46420,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersRefundsRefundExpireParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersRefundsRefundExpireBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersRefundsRefundExpire(input, ctx)
+      const { status, body } = await implementation
+        .postTestHelpersRefundsRefundExpire(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersRefundsRefundExpireResponseValidator(
         status,
@@ -43966,19 +46469,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTerminalReadersReaderPresentPaymentMethodParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTerminalReadersReaderPresentPaymentMethodBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTerminalReadersReaderPresentPaymentMethod(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTerminalReadersReaderPresentPaymentMethod(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTerminalReadersReaderPresentPaymentMethodResponseValidator(
@@ -44023,17 +46528,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTestHelpersTestClocksQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTestHelpersTestClocksBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTestHelpersTestClocks(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTestHelpersTestClocks(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTestHelpersTestClocksResponseValidator(status, body)
       ctx.status = status
@@ -44062,13 +46570,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTestHelpersTestClocksBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTestHelpersTestClocks(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTestHelpersTestClocks(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTestClocksResponseValidator(status, body)
       ctx.status = status
@@ -44096,16 +46606,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteTestHelpersTestClocksTestClockParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteTestHelpersTestClocksTestClockBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteTestHelpersTestClocksTestClock(input, ctx)
+      const { status, body } = await implementation
+        .deleteTestHelpersTestClocksTestClock(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteTestHelpersTestClocksTestClockResponseValidator(
         status,
@@ -44137,19 +46652,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTestHelpersTestClocksTestClockParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTestHelpersTestClocksTestClockQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTestHelpersTestClocksTestClockBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTestHelpersTestClocksTestClock(input, ctx)
+      const { status, body } = await implementation
+        .getTestHelpersTestClocksTestClock(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTestHelpersTestClocksTestClockResponseValidator(
         status,
@@ -44180,19 +46701,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTestClocksTestClockAdvanceParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTestClocksTestClockAdvanceBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTestClocksTestClockAdvance(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTestClocksTestClockAdvance(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTestClocksTestClockAdvanceResponseValidator(
         status,
@@ -44245,19 +46768,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryInboundTransfersIdFailParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryInboundTransfersIdFailBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryInboundTransfersIdFail(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryInboundTransfersIdFail(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTreasuryInboundTransfersIdFailResponseValidator(
         status,
@@ -44287,19 +46812,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryInboundTransfersIdReturnParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryInboundTransfersIdReturnBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryInboundTransfersIdReturn(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryInboundTransfersIdReturn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTreasuryInboundTransfersIdReturnResponseValidator(
@@ -44330,19 +46857,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryInboundTransfersIdSucceedParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryInboundTransfersIdSucceedBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryInboundTransfersIdSucceed(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryInboundTransfersIdSucceed(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTreasuryInboundTransfersIdSucceedResponseValidator(
@@ -44373,19 +46902,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryOutboundPaymentsIdFailParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryOutboundPaymentsIdFailBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryOutboundPaymentsIdFail(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryOutboundPaymentsIdFail(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTreasuryOutboundPaymentsIdFailResponseValidator(
         status,
@@ -44415,19 +46946,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryOutboundPaymentsIdPostParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryOutboundPaymentsIdPostBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryOutboundPaymentsIdPost(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryOutboundPaymentsIdPost(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTreasuryOutboundPaymentsIdPostResponseValidator(
         status,
@@ -44477,19 +47010,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryOutboundPaymentsIdReturnParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryOutboundPaymentsIdReturnBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryOutboundPaymentsIdReturn(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryOutboundPaymentsIdReturn(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTreasuryOutboundPaymentsIdReturnResponseValidator(
@@ -44518,19 +47053,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryOutboundTransfersOutboundTransferFailParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryOutboundTransfersOutboundTransferFailBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryOutboundTransfersOutboundTransferFail(
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryOutboundTransfersOutboundTransferFail(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTreasuryOutboundTransfersOutboundTransferFailResponseValidator(
@@ -44559,19 +47099,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryOutboundTransfersOutboundTransferPostParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryOutboundTransfersOutboundTransferPostBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryOutboundTransfersOutboundTransferPost(
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryOutboundTransfersOutboundTransferPost(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTreasuryOutboundTransfersOutboundTransferPostResponseValidator(
@@ -44622,19 +47167,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryOutboundTransfersOutboundTransferReturn(
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryOutboundTransfersOutboundTransferReturn(
           input,
           ctx,
         )
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnResponseValidator(
@@ -44680,11 +47230,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTestHelpersTreasuryReceivedCreditsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryReceivedCredits(input, ctx)
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryReceivedCredits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTreasuryReceivedCreditsResponseValidator(
         status,
@@ -44729,11 +47283,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTestHelpersTreasuryReceivedDebitsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTestHelpersTreasuryReceivedDebits(input, ctx)
+      const { status, body } = await implementation
+        .postTestHelpersTreasuryReceivedDebits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTestHelpersTreasuryReceivedDebitsResponseValidator(
         status,
@@ -45116,10 +47674,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postTokensBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postTokensBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postTokens(input, ctx)
+    const { status, body } = await implementation
+      .postTokens(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postTokensResponseValidator(status, body)
     ctx.status = status
@@ -45141,12 +47707,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getTokensToken", "/v1/tokens/:token", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getTokensTokenParamSchema, ctx.params),
-      query: parseRequestInput(getTokensTokenQuerySchema, ctx.query),
-      body: parseRequestInput(getTokensTokenBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getTokensTokenParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getTokensTokenQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTokensTokenBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTokensToken(input, ctx)
+    const { status, body } = await implementation
+      .getTokensToken(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTokensTokenResponseValidator(status, body)
     ctx.status = status
@@ -45203,11 +47785,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getTopups", "/v1/topups", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getTopupsQuerySchema, ctx.query),
-      body: parseRequestInput(getTopupsBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getTopupsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTopupsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTopups(input, ctx)
+    const { status, body } = await implementation
+      .getTopups(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTopupsResponseValidator(status, body)
     ctx.status = status
@@ -45234,10 +47828,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postTopupsBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postTopupsBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postTopups(input, ctx)
+    const { status, body } = await implementation
+      .postTopups(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postTopupsResponseValidator(status, body)
     ctx.status = status
@@ -45259,12 +47861,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getTopupsTopup", "/v1/topups/:topup", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getTopupsTopupParamSchema, ctx.params),
-      query: parseRequestInput(getTopupsTopupQuerySchema, ctx.query),
-      body: parseRequestInput(getTopupsTopupBodySchema, ctx.request.body),
+      params: parseRequestInput(
+        getTopupsTopupParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
+      query: parseRequestInput(
+        getTopupsTopupQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTopupsTopupBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTopupsTopup(input, ctx)
+    const { status, body } = await implementation
+      .getTopupsTopup(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTopupsTopupResponseValidator(status, body)
     ctx.status = status
@@ -45288,12 +47906,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.post("postTopupsTopup", "/v1/topups/:topup", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(postTopupsTopupParamSchema, ctx.params),
+      params: parseRequestInput(
+        postTopupsTopupParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(postTopupsTopupBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postTopupsTopupBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postTopupsTopup(input, ctx)
+    const { status, body } = await implementation
+      .postTopupsTopup(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postTopupsTopupResponseValidator(status, body)
     ctx.status = status
@@ -45316,18 +47946,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/topups/:topup/cancel",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postTopupsTopupCancelParamSchema, ctx.params),
+        params: parseRequestInput(
+          postTopupsTopupCancelParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postTopupsTopupCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTopupsTopupCancel(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTopupsTopupCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTopupsTopupCancelResponseValidator(status, body)
       ctx.status = status
@@ -45375,11 +48011,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getTransfers", "/v1/transfers", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getTransfersQuerySchema, ctx.query),
-      body: parseRequestInput(getTransfersBodySchema, ctx.request.body),
+      query: parseRequestInput(
+        getTransfersQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
+      body: parseRequestInput(
+        getTransfersBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.getTransfers(input, ctx)
+    const { status, body } = await implementation
+      .getTransfers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTransfersResponseValidator(status, body)
     ctx.status = status
@@ -45407,10 +48055,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     const input = {
       params: undefined,
       query: undefined,
-      body: parseRequestInput(postTransfersBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        postTransfersBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.postTransfers(input, ctx)
+    const { status, body } = await implementation
+      .postTransfers(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = postTransfersResponseValidator(status, body)
     ctx.status = status
@@ -45451,18 +48107,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTransfersIdReversalsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
-        query: parseRequestInput(getTransfersIdReversalsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getTransfersIdReversalsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getTransfersIdReversalsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTransfersIdReversals(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTransfersIdReversals(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTransfersIdReversalsResponseValidator(status, body)
       ctx.status = status
@@ -45495,18 +48158,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTransfersIdReversalsParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTransfersIdReversalsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTransfersIdReversals(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTransfersIdReversals(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTransfersIdReversalsResponseValidator(status, body)
       ctx.status = status
@@ -45532,18 +48198,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/transfers/:transfer",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(getTransfersTransferParamSchema, ctx.params),
-        query: parseRequestInput(getTransfersTransferQuerySchema, ctx.query),
+        params: parseRequestInput(
+          getTransfersTransferParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
+        query: parseRequestInput(
+          getTransfersTransferQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getTransfersTransferBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTransfersTransfer(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTransfersTransfer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTransfersTransferResponseValidator(status, body)
       ctx.status = status
@@ -45571,18 +48247,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "/v1/transfers/:transfer",
     async (ctx, next) => {
       const input = {
-        params: parseRequestInput(postTransfersTransferParamSchema, ctx.params),
+        params: parseRequestInput(
+          postTransfersTransferParamSchema,
+          ctx.params,
+          RequestInputType.RouteParam,
+        ),
         query: undefined,
         body: parseRequestInput(
           postTransfersTransferBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTransfersTransfer(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTransfersTransfer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTransfersTransferResponseValidator(status, body)
       ctx.status = status
@@ -45612,19 +48294,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTransfersTransferReversalsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTransfersTransferReversalsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTransfersTransferReversalsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTransfersTransferReversalsId(input, ctx)
+      const { status, body } = await implementation
+        .getTransfersTransferReversalsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTransfersTransferReversalsIdResponseValidator(status, body)
       ctx.status = status
@@ -45655,16 +48343,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTransfersTransferReversalsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTransfersTransferReversalsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTransfersTransferReversalsId(input, ctx)
+      const { status, body } = await implementation
+        .postTransfersTransferReversalsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTransfersTransferReversalsIdResponseValidator(status, body)
       ctx.status = status
@@ -45708,17 +48401,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryCreditReversalsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryCreditReversalsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryCreditReversals(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryCreditReversals(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryCreditReversalsResponseValidator(status, body)
       ctx.status = status
@@ -45745,13 +48441,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTreasuryCreditReversalsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTreasuryCreditReversals(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTreasuryCreditReversals(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryCreditReversalsResponseValidator(status, body)
       ctx.status = status
@@ -45782,22 +48480,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryCreditReversalsCreditReversalParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryCreditReversalsCreditReversalQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryCreditReversalsCreditReversalBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryCreditReversalsCreditReversal(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getTreasuryCreditReversalsCreditReversal(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryCreditReversalsCreditReversalResponseValidator(
         status,
@@ -45845,17 +48546,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryDebitReversalsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryDebitReversalsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryDebitReversals(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryDebitReversals(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryDebitReversalsResponseValidator(status, body)
       ctx.status = status
@@ -45884,13 +48588,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTreasuryDebitReversalsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postTreasuryDebitReversals(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postTreasuryDebitReversals(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryDebitReversalsResponseValidator(status, body)
       ctx.status = status
@@ -45921,19 +48627,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryDebitReversalsDebitReversalParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryDebitReversalsDebitReversalQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryDebitReversalsDebitReversalBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryDebitReversalsDebitReversal(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryDebitReversalsDebitReversal(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryDebitReversalsDebitReversalResponseValidator(
         status,
@@ -45989,15 +48701,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryFinancialAccountsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryFinancialAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryFinancialAccounts(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryFinancialAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryFinancialAccountsResponseValidator(status, body)
       ctx.status = status
@@ -46067,11 +48784,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTreasuryFinancialAccountsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryFinancialAccounts(input, ctx)
+      const { status, body } = await implementation
+        .postTreasuryFinancialAccounts(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryFinancialAccountsResponseValidator(status, body)
       ctx.status = status
@@ -46102,22 +48823,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryFinancialAccountsFinancialAccountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryFinancialAccountsFinancialAccountQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryFinancialAccountsFinancialAccountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryFinancialAccountsFinancialAccount(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getTreasuryFinancialAccountsFinancialAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryFinancialAccountsFinancialAccountResponseValidator(
         status,
@@ -46193,19 +48917,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTreasuryFinancialAccountsFinancialAccountParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTreasuryFinancialAccountsFinancialAccountBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryFinancialAccountsFinancialAccount(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTreasuryFinancialAccountsFinancialAccount(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryFinancialAccountsFinancialAccountResponseValidator(
         status,
@@ -46240,22 +48966,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryFinancialAccountsFinancialAccountFeatures(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getTreasuryFinancialAccountsFinancialAccountFeatures(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         getTreasuryFinancialAccountsFinancialAccountFeaturesResponseValidator(
@@ -46317,19 +49046,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryFinancialAccountsFinancialAccountFeatures(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTreasuryFinancialAccountsFinancialAccountFeatures(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTreasuryFinancialAccountsFinancialAccountFeaturesResponseValidator(
@@ -46379,17 +49110,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryInboundTransfersQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryInboundTransfersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryInboundTransfers(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryInboundTransfers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryInboundTransfersResponseValidator(status, body)
       ctx.status = status
@@ -46421,11 +49155,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTreasuryInboundTransfersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryInboundTransfers(input, ctx)
+      const { status, body } = await implementation
+        .postTreasuryInboundTransfers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryInboundTransfersResponseValidator(status, body)
       ctx.status = status
@@ -46452,19 +49190,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryInboundTransfersIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryInboundTransfersIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryInboundTransfersIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryInboundTransfersId(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryInboundTransfersId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryInboundTransfersIdResponseValidator(status, body)
       ctx.status = status
@@ -46491,19 +49235,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTreasuryInboundTransfersInboundTransferCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTreasuryInboundTransfersInboundTransferCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryInboundTransfersInboundTransferCancel(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTreasuryInboundTransfersInboundTransferCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTreasuryInboundTransfersInboundTransferCancelResponseValidator(
@@ -46554,17 +49300,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryOutboundPaymentsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryOutboundPaymentsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryOutboundPayments(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryOutboundPayments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryOutboundPaymentsResponseValidator(status, body)
       ctx.status = status
@@ -46651,11 +49400,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTreasuryOutboundPaymentsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryOutboundPayments(input, ctx)
+      const { status, body } = await implementation
+        .postTreasuryOutboundPayments(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryOutboundPaymentsResponseValidator(status, body)
       ctx.status = status
@@ -46682,19 +49435,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryOutboundPaymentsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryOutboundPaymentsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryOutboundPaymentsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryOutboundPaymentsId(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryOutboundPaymentsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryOutboundPaymentsIdResponseValidator(status, body)
       ctx.status = status
@@ -46721,16 +49480,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTreasuryOutboundPaymentsIdCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTreasuryOutboundPaymentsIdCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryOutboundPaymentsIdCancel(input, ctx)
+      const { status, body } = await implementation
+        .postTreasuryOutboundPaymentsIdCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryOutboundPaymentsIdCancelResponseValidator(
         status,
@@ -46779,15 +49543,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryOutboundTransfersQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryOutboundTransfersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryOutboundTransfers(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryOutboundTransfers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryOutboundTransfersResponseValidator(status, body)
       ctx.status = status
@@ -46831,11 +49600,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postTreasuryOutboundTransfersBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryOutboundTransfers(input, ctx)
+      const { status, body } = await implementation
+        .postTreasuryOutboundTransfers(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postTreasuryOutboundTransfersResponseValidator(status, body)
       ctx.status = status
@@ -46866,22 +49639,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryOutboundTransfersOutboundTransferParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryOutboundTransfersOutboundTransferQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryOutboundTransfersOutboundTransferBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryOutboundTransfersOutboundTransfer(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .getTreasuryOutboundTransfersOutboundTransfer(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryOutboundTransfersOutboundTransferResponseValidator(
         status,
@@ -46910,19 +49686,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postTreasuryOutboundTransfersOutboundTransferCancelParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postTreasuryOutboundTransfersOutboundTransferCancelBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postTreasuryOutboundTransfersOutboundTransferCancel(
-          input,
-          ctx,
-        )
+      const { status, body } = await implementation
+        .postTreasuryOutboundTransfersOutboundTransferCancel(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body =
         postTreasuryOutboundTransfersOutboundTransferCancelResponseValidator(
@@ -46979,17 +49757,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryReceivedCreditsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryReceivedCreditsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryReceivedCredits(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryReceivedCredits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryReceivedCreditsResponseValidator(status, body)
       ctx.status = status
@@ -47016,19 +49797,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryReceivedCreditsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryReceivedCreditsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryReceivedCreditsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryReceivedCreditsId(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryReceivedCreditsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryReceivedCreditsIdResponseValidator(status, body)
       ctx.status = status
@@ -47071,17 +49858,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryReceivedDebitsQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryReceivedDebitsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryReceivedDebits(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryReceivedDebits(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryReceivedDebitsResponseValidator(status, body)
       ctx.status = status
@@ -47108,21 +49898,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryReceivedDebitsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryReceivedDebitsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryReceivedDebitsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryReceivedDebitsId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryReceivedDebitsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryReceivedDebitsIdResponseValidator(status, body)
       ctx.status = status
@@ -47189,15 +49983,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         query: parseRequestInput(
           getTreasuryTransactionEntriesQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryTransactionEntriesBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryTransactionEntries(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryTransactionEntries(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryTransactionEntriesResponseValidator(status, body)
       ctx.status = status
@@ -47226,19 +50025,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryTransactionEntriesIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryTransactionEntriesIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryTransactionEntriesIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getTreasuryTransactionEntriesId(input, ctx)
+      const { status, body } = await implementation
+        .getTreasuryTransactionEntriesId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryTransactionEntriesIdResponseValidator(status, body)
       ctx.status = status
@@ -47305,17 +50110,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getTreasuryTransactionsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getTreasuryTransactionsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getTreasuryTransactionsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryTransactions(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryTransactions(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryTransactionsResponseValidator(status, body)
       ctx.status = status
@@ -47344,21 +50155,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getTreasuryTransactionsIdParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getTreasuryTransactionsIdQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getTreasuryTransactionsIdBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getTreasuryTransactionsId(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getTreasuryTransactionsId(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getTreasuryTransactionsIdResponseValidator(status, body)
       ctx.status = status
@@ -47396,17 +50211,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     async (ctx, next) => {
       const input = {
         params: undefined,
-        query: parseRequestInput(getWebhookEndpointsQuerySchema, ctx.query),
+        query: parseRequestInput(
+          getWebhookEndpointsQuerySchema,
+          ctx.query,
+          RequestInputType.QueryString,
+        ),
         body: parseRequestInput(
           getWebhookEndpointsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.getWebhookEndpoints(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .getWebhookEndpoints(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getWebhookEndpointsResponseValidator(status, body)
       ctx.status = status
@@ -47760,13 +50581,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: parseRequestInput(
           postWebhookEndpointsBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } = await implementation.postWebhookEndpoints(
-        input,
-        ctx,
-      )
+      const { status, body } = await implementation
+        .postWebhookEndpoints(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postWebhookEndpointsResponseValidator(status, body)
       ctx.status = status
@@ -47793,16 +50616,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           deleteWebhookEndpointsWebhookEndpointParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           deleteWebhookEndpointsWebhookEndpointBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.deleteWebhookEndpointsWebhookEndpoint(input, ctx)
+      const { status, body } = await implementation
+        .deleteWebhookEndpointsWebhookEndpoint(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = deleteWebhookEndpointsWebhookEndpointResponseValidator(
         status,
@@ -47834,19 +50662,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           getWebhookEndpointsWebhookEndpointParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: parseRequestInput(
           getWebhookEndpointsWebhookEndpointQuerySchema,
           ctx.query,
+          RequestInputType.QueryString,
         ),
         body: parseRequestInput(
           getWebhookEndpointsWebhookEndpointBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.getWebhookEndpointsWebhookEndpoint(input, ctx)
+      const { status, body } = await implementation
+        .getWebhookEndpointsWebhookEndpoint(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = getWebhookEndpointsWebhookEndpointResponseValidator(
         status,
@@ -48104,16 +50938,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: parseRequestInput(
           postWebhookEndpointsWebhookEndpointParamSchema,
           ctx.params,
+          RequestInputType.RouteParam,
         ),
         query: undefined,
         body: parseRequestInput(
           postWebhookEndpointsWebhookEndpointBodySchema,
           ctx.request.body,
+          RequestInputType.RequestBody,
         ),
       }
 
-      const { status, body } =
-        await implementation.postWebhookEndpointsWebhookEndpoint(input, ctx)
+      const { status, body } = await implementation
+        .postWebhookEndpointsWebhookEndpoint(input, ctx)
+        .catch((err) => {
+          throw KoaRuntimeError.HandlerError(err)
+        })
 
       ctx.body = postWebhookEndpointsWebhookEndpointResponseValidator(
         status,

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -14,6 +14,10 @@ import {
 import { s_CreateUpdateTodoList, s_Error, s_TodoList } from "./schemas"
 import KoaRouter from "@koa/router"
 import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
+import {
   Response,
   ServerConfig,
   StatusCode,
@@ -94,11 +98,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
   router.get("getTodoLists", "/list", async (ctx, next) => {
     const input = {
       params: undefined,
-      query: parseRequestInput(getTodoListsQuerySchema, ctx.query),
+      query: parseRequestInput(
+        getTodoListsQuerySchema,
+        ctx.query,
+        RequestInputType.QueryString,
+      ),
       body: undefined,
     }
 
-    const { status, body } = await implementation.getTodoLists(input, ctx)
+    const { status, body } = await implementation
+      .getTodoLists(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTodoListsResponseValidator(status, body)
     ctx.status = status
@@ -117,12 +129,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.get("getTodoListById", "/list/:listId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(getTodoListByIdParamSchema, ctx.params),
+      params: parseRequestInput(
+        getTodoListByIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.getTodoListById(input, ctx)
+    const { status, body } = await implementation
+      .getTodoListById(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = getTodoListByIdResponseValidator(status, body)
     ctx.status = status
@@ -143,12 +163,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.put("updateTodoListById", "/list/:listId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(updateTodoListByIdParamSchema, ctx.params),
+      params: parseRequestInput(
+        updateTodoListByIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
-      body: parseRequestInput(updateTodoListByIdBodySchema, ctx.request.body),
+      body: parseRequestInput(
+        updateTodoListByIdBodySchema,
+        ctx.request.body,
+        RequestInputType.RequestBody,
+      ),
     }
 
-    const { status, body } = await implementation.updateTodoListById(input, ctx)
+    const { status, body } = await implementation
+      .updateTodoListById(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = updateTodoListByIdResponseValidator(status, body)
     ctx.status = status
@@ -167,12 +199,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   router.delete("deleteTodoListById", "/list/:listId", async (ctx, next) => {
     const input = {
-      params: parseRequestInput(deleteTodoListByIdParamSchema, ctx.params),
+      params: parseRequestInput(
+        deleteTodoListByIdParamSchema,
+        ctx.params,
+        RequestInputType.RouteParam,
+      ),
       query: undefined,
       body: undefined,
     }
 
-    const { status, body } = await implementation.deleteTodoListById(input, ctx)
+    const { status, body } = await implementation
+      .deleteTodoListById(input, ctx)
+      .catch((err) => {
+        throw KoaRuntimeError.HandlerError(err)
+      })
 
     ctx.body = deleteTodoListByIdResponseValidator(status, body)
     ctx.status = status

--- a/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
+++ b/integration-tests/typescript-koa/src/petstore-expanded.yaml.ts
@@ -7,6 +7,11 @@ import {
   FindPetById,
 } from "./generated/petstore-expanded.yaml/generated"
 
+import {Context, Next} from "koa"
+import {KoaRuntimeError} from "@nahkies/typescript-koa-runtime/errors"
+import {ZodError} from "zod"
+import {t_Error} from "./generated/petstore-expanded.yaml/models"
+
 const notImplemented = async () => {
   return {
     status: 501 as const,
@@ -47,6 +52,33 @@ const findPetById: FindPetById = async ({params}, ctx) => {
   }
 }
 
+export async function genericErrorMiddleware(ctx: Context, next: Next) {
+  try {
+    await next()
+  } catch (err) {
+    // if the request validation failed, return a 400 and include helpful
+    // information about the problem
+    if (KoaRuntimeError.isKoaError(err) && err.phase === "request_validation") {
+      ctx.status = 400
+      ctx.body = {
+        message: "request validation failed",
+        code: 400,
+        // @ts-ignore - petstore example doesn't include metadata on it's errors
+        meta: err.cause instanceof ZodError ? {issues: err.cause.issues} : {},
+      } satisfies t_Error
+      return
+    }
+
+    // return a 500 and omit information from the response otherwise
+    console.error("internal server error", err)
+    ctx.status = 500
+    ctx.body = {
+      message: "internal server error",
+      code: 500,
+    } satisfies t_Error
+  }
+}
+
 async function main() {
   const {server, address} = await bootstrap({
     router: createRouter({
@@ -55,6 +87,7 @@ async function main() {
       addPet: notImplemented,
       deletePet: notImplemented,
     }),
+    middleware: [genericErrorMiddleware],
     port: {port: 3000, host: "127.0.0.1"},
   })
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -60,6 +60,12 @@ export class ServerBuilder {
         "StatusCode",
       )
 
+    this.imports.from("@nahkies/typescript-koa-runtime/errors")
+      .add(
+        "KoaRuntimeError",
+        "RequestInputType",
+      )
+
     this.imports.from("koa")
       .add("Context")
 
@@ -166,12 +172,13 @@ export class ServerBuilder {
       `async (ctx, next) => {
 
        const input = {
-        params: ${paramSchema ? `parseRequestInput(${operation.operationId}ParamSchema, ctx.params)` : "undefined"},
-        query: ${querySchema ? `parseRequestInput(${operation.operationId}QuerySchema, ctx.query)` : "undefined"},
-        body: ${bodyParamSchema ? `parseRequestInput(${operation.operationId}BodySchema, ctx.request.body)` : "undefined"},
+        params: ${paramSchema ? `parseRequestInput(${operation.operationId}ParamSchema, ctx.params, RequestInputType.RouteParam)` : "undefined"},
+        query: ${querySchema ? `parseRequestInput(${operation.operationId}QuerySchema, ctx.query, RequestInputType.QueryString)` : "undefined"},
+        body: ${bodyParamSchema ? `parseRequestInput(${operation.operationId}BodySchema, ctx.request.body, RequestInputType.RequestBody)` : "undefined"},
        }
 
-        const {status, body} = await implementation.${operation.operationId}(input, ctx)
+          const {status, body} = await implementation.${operation.operationId}(input, ctx)
+            .catch(err => { throw KoaRuntimeError.HandlerError(err) })
 
         ctx.body = ${operation.operationId}ResponseValidator(status, body)
         ctx.status = status

--- a/packages/typescript-koa-runtime/package.json
+++ b/packages/typescript-koa-runtime/package.json
@@ -16,6 +16,11 @@
     "url": "https://github.com/mnahkies/openapi-code-generator/issues"
   },
   "exports": {
+    "./errors": {
+      "require": "./dist/errors.js",
+      "import": "./dist/errors.js",
+      "types": "./dist/errors.d.ts"
+    },
     "./server": {
       "require": "./dist/server.js",
       "import": "./dist/server.js",

--- a/packages/typescript-koa-runtime/src/errors.ts
+++ b/packages/typescript-koa-runtime/src/errors.ts
@@ -1,0 +1,53 @@
+/**
+ * @prettier
+ */
+
+export enum RequestInputType {
+  RouteParam = "route params",
+  QueryString = "querystring",
+  RequestBody = "request body",
+}
+
+export class KoaRuntimeError extends Error {
+  private constructor(
+    message: string,
+    cause: unknown,
+    public readonly phase:
+      | "request_validation"
+      | "request_handler"
+      | "response_validation",
+  ) {
+    super(message, {cause})
+  }
+
+  static RequestError(
+    cause: unknown,
+    inputType: RequestInputType,
+  ): KoaRuntimeError {
+    return new KoaRuntimeError(
+      `Request validation failed parsing ${inputType}`,
+      cause,
+      "request_validation",
+    )
+  }
+
+  static HandlerError(cause: unknown) {
+    return new KoaRuntimeError(
+      "Request handler threw unhandled exception",
+      cause,
+      "request_handler",
+    )
+  }
+
+  static ResponseError(cause: unknown) {
+    return new KoaRuntimeError(
+      "Response body failed validation",
+      cause,
+      "response_validation",
+    )
+  }
+
+  static isKoaError(err: unknown): err is KoaRuntimeError {
+    return err instanceof KoaRuntimeError
+  }
+}

--- a/packages/typescript-koa-runtime/src/joi.ts
+++ b/packages/typescript-koa-runtime/src/joi.ts
@@ -1,47 +1,62 @@
-import type {Schema as JoiSchema} from "@hapi/joi"
+/**
+ * @prettier
+ */
 
-export type Params<Params, Query, Body> = { params: Params, query: Query, body: Body }
+import type {Schema as JoiSchema} from "@hapi/joi"
+import {KoaRuntimeError, RequestInputType} from "./errors"
+
+export type Params<Params, Query, Body> = {
+  params: Params
+  query: Query
+  body: Body
+}
 
 // Note: joi types don't appear to have an equivalent of z.infer,
 //       hence any seems about as good as we can do here.
 export function parseRequestInput<Schema extends JoiSchema>(
   schema: Schema,
-  input: unknown
-): any;
+  input: unknown,
+  type: RequestInputType,
+): any
 export function parseRequestInput(
   schema: undefined,
-  input: unknown
-): undefined;
+  input: unknown,
+  type: RequestInputType,
+): undefined
 export function parseRequestInput<Schema extends JoiSchema>(
   schema: Schema | undefined,
   input: unknown,
+  type: RequestInputType,
 ): any {
+  try {
+    if (!schema) {
+      return undefined
+    }
 
-  if (!schema) {
-    return undefined
+    const result = schema.validate(input, {stripUnknown: true})
+
+    if (result.error) {
+      throw result.error
+    }
+
+    return result.value
+  } catch (err) {
+    throw KoaRuntimeError.RequestError(err, type)
   }
-
-  const result = schema.validate(input, {stripUnknown: true})
-
-  if (result.error) {
-    throw result.error
-  }
-
-  return result.value
 }
 
-export function responseValidationFactory(possibleResponses: [string, JoiSchema][], defaultResponse?: JoiSchema) {
-
+export function responseValidationFactory(
+  possibleResponses: [string, JoiSchema][],
+  defaultResponse?: JoiSchema,
+) {
   // Exploit the natural ordering matching the desired specificity of eg: 404 vs 4xx
-  possibleResponses.sort((x, y) => x[0] < y[0] ? -1 : 1)
+  possibleResponses.sort((x, y) => (x[0] < y[0] ? -1 : 1))
 
   return (status: number, value: unknown) => {
-
     for (const [match, schema] of possibleResponses) {
-
       const isMatch =
-        /^\d+$/.test(match) && String(status) === match ||
-        /^\d[xX]{2}$/.test(match) && String(status)[0] === match[0]
+        (/^\d+$/.test(match) && String(status) === match) ||
+        (/^\d[xX]{2}$/.test(match) && String(status)[0] === match[0])
 
       if (isMatch) {
         const result = schema.validate(value)

--- a/packages/typescript-koa-runtime/src/zod.ts
+++ b/packages/typescript-koa-runtime/src/zod.ts
@@ -1,44 +1,66 @@
-import {z} from "zod"
+/**
+ * @prettier
+ */
 
-export type Params<Params, Query, Body> = { params: Params, query: Query, body: Body }
+import {z} from "zod"
+import {KoaRuntimeError, RequestInputType} from "./errors"
+
+export type Params<Params, Query, Body> = {
+  params: Params
+  query: Query
+  body: Body
+}
 
 export function parseRequestInput<Schema extends z.ZodTypeAny>(
   schema: Schema,
-  input: unknown
-): z.infer<Schema>;
+  input: unknown,
+  type: RequestInputType,
+): z.infer<Schema>
 export function parseRequestInput(
   schema: undefined,
-  input: unknown
-): undefined;
+  input: unknown,
+  type: RequestInputType,
+): undefined
 export function parseRequestInput<Schema extends z.ZodTypeAny>(
   schema: Schema | undefined,
   input: unknown,
+  type: RequestInputType,
 ): z.infer<Schema> | undefined {
-  return schema?.parse(input)
+  try {
+    return schema?.parse(input)
+  } catch (err) {
+    throw KoaRuntimeError.RequestError(err, type)
+  }
 }
 
-export function responseValidationFactory(possibleResponses: [string, z.ZodTypeAny][], defaultResponse?: z.ZodTypeAny) {
-
+// TODO: optional response validation
+export function responseValidationFactory(
+  possibleResponses: [string, z.ZodTypeAny][],
+  defaultResponse?: z.ZodTypeAny,
+) {
   // Exploit the natural ordering matching the desired specificity of eg: 404 vs 4xx
-  possibleResponses.sort((x, y) => x[0] < y[0] ? -1 : 1)
+  possibleResponses.sort((x, y) => (x[0] < y[0] ? -1 : 1))
 
   return (status: number, value: unknown) => {
+    try {
+      for (const [match, schema] of possibleResponses) {
+        const isMatch =
+          (/^\d+$/.test(match) && String(status) === match) ||
+          (/^\d[xX]{2}$/.test(match) && String(status)[0] === match[0])
 
-    for (const [match, schema] of possibleResponses) {
-
-      const isMatch =
-        /^\d+$/.test(match) && String(status) === match ||
-        /^\d[xX]{2}$/.test(match) && String(status)[0] === match[0]
-
-      if (isMatch) {
-        return schema.parse(value)
+        if (isMatch) {
+          return schema.parse(value)
+        }
       }
-    }
 
-    if (defaultResponse) {
-      return defaultResponse.parse(value)
-    }
+      if (defaultResponse) {
+        return defaultResponse.parse(value)
+      }
 
-    return value
+      // TODO: throw on unmatched response
+      return value
+    } catch (err) {
+      throw KoaRuntimeError.ResponseError(err)
+    }
   }
 }

--- a/packages/typescript-koa-runtime/tsconfig.json
+++ b/packages/typescript-koa-runtime/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Previously if request validation or response validation failed you'd just get something like a `ZodError` without much context as to where in the request processing failed.

This change introduced a `KoaRuntimeError` that wraps all exceptions thrown during request processing and annotates them with additional context via a `phase` property.

The intention is that you can then mount a generic error handling middleware that can distinguish between request validation errors, etc.

See [integration-tests/typescript-koa/src/petstore-expanded.yaml.ts](https://github.com/mnahkies/openapi-code-generator/pull/95/files#diff-b82e27c39ae18163c6d5547d0bf1c5dd9a92302ae047f160a76ea0c7af5ad7b0) for an example.

**Breaking change:** errors thrown are now wrapped in `KoaRuntimeError` objects.