### PR TITLE
chore: use branch as preid / dist-tag on alpha versions

### DIFF
--- a/scripts/publish.alpha.sh
+++ b/scripts/publish.alpha.sh
@@ -10,8 +10,11 @@ yarn ci-pipeline
 
 ./scripts/assert-clean-working-directory.sh
 
+BRANCH="$(git branch --show-current | sed -e 's|/|-|g')"
+
 yarn lerna publish \
   --no-private \
   --force-publish \
   --canary \
-  --pre-dist-tag "$(git branch --show-current)"
+  --preid "${BRANCH}" \
+  --pre-dist-tag "${BRANCH}"

--- a/scripts/publish.alpha.sh
+++ b/scripts/publish.alpha.sh
@@ -13,4 +13,5 @@ yarn ci-pipeline
 yarn lerna publish \
   --no-private \
   --force-publish \
-  --canary
+  --canary \
+  --pre-dist-tag "$(git branch --show-current)"


### PR DESCRIPTION
this should make it a lot easier to keep track of and test alpha releases, as now you can:
```
yarn add @nahkies/openapi-code-generator@0.1.2-mn-chore-use-branch-dist-tag.2
```

![image](https://github.com/mnahkies/openapi-code-generator/assets/2555533/7a976090-af3a-42af-a411-4ff51e9c92bd)
