### PR TITLE
fix: skip broken openapi 3.1 validation for now

### DIFF
--- a/packages/openapi-code-generator/src/core/schemas/openapi-3.1-specification-base.json
+++ b/packages/openapi-code-generator/src/core/schemas/openapi-3.1-specification-base.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema-base/2022-10-07",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "description": "The description of OpenAPI v3.1.x documents using the OpenAPI JSON Schema dialect, as defined by https://spec.openapis.org/oas/v3.1.0",
+
+  "$ref": "https://spec.openapis.org/oas/3.1/schema/2022-10-07",
+  "properties": {
+    "jsonSchemaDialect": { "$ref": "#/$defs/dialect" }
+  },
+
+  "$defs": {
+    "dialect": { "const": "https://spec.openapis.org/oas/3.1/dialect/base" },
+
+    "schema": {
+      "$dynamicAnchor": "meta",
+      "$ref": "https://spec.openapis.org/oas/3.1/dialect/base",
+      "properties": {
+        "$schema": { "$ref": "#/$defs/dialect" }
+      }
+    }
+  }
+}

--- a/packages/openapi-code-generator/src/core/schemas/openapi-3.1-specification.json
+++ b/packages/openapi-code-generator/src/core/schemas/openapi-3.1-specification.json
@@ -535,7 +535,7 @@
               "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
             },
             {
-              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-form"
+              "$ref": "#/$defs/styles-for-form"
             }
           ],
           "$defs": {
@@ -637,32 +637,6 @@
                   "style": {
                     "default": "form",
                     "const": "form"
-                  }
-                }
-              }
-            },
-            "styles-for-form": {
-              "if": {
-                "properties": {
-                  "style": {
-                    "const": "form"
-                  }
-                },
-                "required": [
-                  "style"
-                ]
-              },
-              "then": {
-                "properties": {
-                  "explode": {
-                    "default": true
-                  }
-                }
-              },
-              "else": {
-                "properties": {
-                  "explode": {
-                    "default": false
                   }
                 }
               }
@@ -792,38 +766,10 @@
           "$ref": "#/$defs/specification-extensions"
         },
         {
-          "$ref": "#/$defs/encoding/$defs/explode-default"
+          "$ref": "#/$defs/styles-for-form"
         }
       ],
-      "unevaluatedProperties": false,
-      "$defs": {
-        "explode-default": {
-          "if": {
-            "properties": {
-              "style": {
-                "const": "form"
-              }
-            },
-            "required": [
-              "style"
-            ]
-          },
-          "then": {
-            "properties": {
-              "explode": {
-                "default": true
-              }
-            }
-          },
-          "else": {
-            "properties": {
-              "explode": {
-                "default": false
-              }
-            }
-          }
-        }
-      }
+      "unevaluatedProperties": false
     },
     "responses": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#responses-object",
@@ -1443,6 +1389,32 @@
       "type": "object",
       "additionalProperties": {
         "type": "string"
+      }
+    },
+    "styles-for-form": {
+      "if": {
+        "properties": {
+          "style": {
+            "const": "form"
+          }
+        },
+        "required": [
+          "style"
+        ]
+      },
+      "then": {
+        "properties": {
+          "explode": {
+            "default": true
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "explode": {
+            "default": false
+          }
+        }
       }
     }
   }

--- a/scripts/refresh-data.sh
+++ b/scripts/refresh-data.sh
@@ -4,6 +4,7 @@ set -e
 
 # Openapi v3.1 schema definitions
 curl https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json -o ./packages/openapi-code-generator/src/core/schemas/openapi-3.1-specification.json
+curl https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema-base.json -o ./packages/openapi-code-generator/src/core/schemas/openapi-3.1-specification-base.json
 curl https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json -o ./packages/openapi-code-generator/src/core/schemas/openapi-3.0-specification.json
 
 # Example API Definitions


### PR DESCRIPTION
skips validation of openapi 3.1.0 documents for now due to #103