### PR TITLE
fix: handle null in enums

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,19 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-explicit-any": "off",
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "isFinite",
+        message:
+          "Use Number.isFinite",
+      },
+      {
+        name: "isNaN",
+        message:
+          "Use Number.isNaN",
+      },
+    ],
   },
   overrides: [
     {

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/models.ts
@@ -586,7 +586,6 @@ export type t_check_suite = {
     | "action_required"
     | "startup_failure"
     | "stale"
-    | "null"
     | null
   created_at: string | null
   head_branch: string | null
@@ -720,7 +719,6 @@ export type t_code_scanning_alert_classification =
 export type t_code_scanning_alert_dismissed_comment = string | null
 
 export type t_code_scanning_alert_dismissed_reason =
-  | "null"
   | "false positive"
   | "won't fix"
   | "used in tests"

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/models.ts
@@ -586,7 +586,6 @@ export type t_check_suite = {
     | "action_required"
     | "startup_failure"
     | "stale"
-    | "null"
     | null
   created_at: string | null
   head_branch: string | null
@@ -720,7 +719,6 @@ export type t_code_scanning_alert_classification =
 export type t_code_scanning_alert_dismissed_comment = string | null
 
 export type t_code_scanning_alert_dismissed_reason =
-  | "null"
   | "false positive"
   | "won't fix"
   | "used in tests"

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/models.ts
@@ -581,7 +581,6 @@ export type t_check_suite = {
     | "action_required"
     | "startup_failure"
     | "stale"
-    | "null"
     | null
   created_at: string | null
   head_branch: string | null
@@ -715,7 +714,6 @@ export type t_code_scanning_alert_classification =
 export type t_code_scanning_alert_dismissed_comment = string | null
 
 export type t_code_scanning_alert_dismissed_reason =
-  | "null"
   | "false positive"
   | "won't fix"
   | "used in tests"

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -405,7 +405,7 @@ export const s_code_scanning_alert_classification = z
 export const s_code_scanning_alert_dismissed_comment = z.string().nullable()
 
 export const s_code_scanning_alert_dismissed_reason = z
-  .enum(["null", "false positive", "won't fix", "used in tests"])
+  .enum(["false positive", "won't fix", "used in tests"])
   .nullable()
 
 export const s_code_scanning_alert_environment = z.string()
@@ -4998,7 +4998,6 @@ export const s_check_suite = z.object({
       "action_required",
       "startup_failure",
       "stale",
-      "null",
     ])
     .nullable(),
   url: z.string().nullable(),

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -247,10 +247,14 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
     }
     case "number":
     case "integer": {
-      const enumValues = ((schemaObject.enum ?? []) as any[])
-        .filter((it): it is number => isFinite(it))
+      const schemaObjectEnum = ((schemaObject.enum ?? []) as any[])
+      const nullable = schemaObjectEnum.includes(null)
+      const enumValues = schemaObjectEnum
+        .filter((it): it is number => Number.isFinite(it))
+
       return {
         ...base,
+        nullable: nullable || base.nullable,
         type: "number",
         // todo: https://github.com/mnahkies/openapi-code-generator/issues/51
         format: schemaObject.format as any,
@@ -258,10 +262,15 @@ function normalizeSchemaObject(schemaObject: Schema | Reference): MaybeIRModel {
       } satisfies IRModelNumeric
     }
     case "string": {
-      const enumValues = ((schemaObject.enum ?? []) as any[])
+      const schemaObjectEnum = ((schemaObject.enum ?? []) as any[])
+      const nullable = schemaObjectEnum.includes(null)
+      const enumValues = schemaObjectEnum
+        .filter((it) => it !== undefined && it !== null)
         .map((it) => String(it))
+
       return {
         ...base,
+        nullable: nullable || base.nullable,
         type: schemaObject.type,
         format: schemaObject.format as any,
         enum: enumValues.length ? enumValues : undefined,


### PR DESCRIPTION
- use `Number.isFinite` instead of global `isFinite` which accepts `null` (see also https://www.destroyallsoftware.com/talks/wat)
- add `eslint` rules to forbid this mistake in future
- treat a `null` in the enum as an alias for setting nullable on the schema, meaning if _any_ of the schema `nullable` / `type` or the `enum` indicate `nullable`, it will be interpreted as `nullable`.

removes a couple of errant `"null"` types from some of the Github string enums, and is also required to support numeric `enums` that include it, as seen here:
https://github.com/APIs-guru/openapi-directory/blob/dec74da7a6785d5d5b83bc6a4cebc07336d67ec9/APIs/vercel.com/0.0.1/openapi.yaml#L4648-L4655
```
redirectStatusCode:
  description: Status code for domain redirect
  enum:
    - null
    - 301
    - 302
    - 307
    - 308
```
