### PR TITLE
fix: handle `"` in string enum values

### DIFF
--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -13,6 +13,7 @@ import {
   getTypeNameFromRef,
 } from "../../../core/openapi-utils"
 import {ExportDefinition} from "../typescript-common"
+import {quotedStringLiteral} from "../type-utils"
 
 // todo: coerce is cool for input where everything starts as strings,
 //       but for output we probably don't want that as its more likely
@@ -142,7 +143,7 @@ export class ZodBuilder extends AbstractSchemaBuilder {
 
     return [
       this.zod,
-      `enum([${model.enum.map((it) => `"${it}"`).join(",")}])`,
+      `enum([${model.enum.map(quotedStringLiteral).join(",")}])`,
       required ? undefined : "optional()",
     ]
       .filter(isDefined)

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.ts
@@ -12,7 +12,7 @@ import {
   intersect,
   object,
   objectProperty,
-  quotedValue,
+  quotedStringLiteral,
   toString,
   union,
 } from "./type-utils"
@@ -144,7 +144,9 @@ export class TypeBuilder {
         }
 
         case "string": {
-          result.push(...(schemaObject.enum?.map(quotedValue) ?? ["string"]))
+          result.push(
+            ...(schemaObject.enum?.map(quotedStringLiteral) ?? ["string"]),
+          )
           break
         }
 

--- a/packages/openapi-code-generator/src/typescript/common/type-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-utils.ts
@@ -87,4 +87,6 @@ export const array = (type: string): string => `(${type})[]`
 
 export const toString = (it: string | number): string => it.toString()
 
-export const quotedValue = (it: string): string => `"${it}"`
+// TODO: more comprehensive escaping? Eg: `\n`
+export const quotedStringLiteral = (it: string): string =>
+  `"${it.replaceAll('"', '\\"')}"`


### PR DESCRIPTION
should probably expand this to handle other things like `\n` but I've not seen newlines appear in string enum values very often...

allows supporting stuff like this https://github.com/APIs-guru/openapi-directory/blob/dec74da7a6785d5d5b83bc6a4cebc07336d67ec9/APIs/vercel.com/0.0.1/openapi.yaml#L4810

though I'd bet money that this is a mistake, and was supposed to be `import(..)` and resolve to more sensible values like `production` / `preview` / `development` in the yaml
```
target:
  description: The target environment of the environment variable
  examples:
    - - production
      - preview
  items:
    enum:
      - mport("/vercel/path0/utils/env-variable-util/types").EnvTarget.Productio
      - mport("/vercel/path0/utils/env-variable-util/types").EnvTarget.Previe
      - mport("/vercel/path0/utils/env-variable-util/types").EnvTarget.Developmen
  type: array
```