### PR TITLE
feat: basic support for openapi 3.1

### DIFF
--- a/packages/openapi-code-generator/src/core/dependency-graph.spec.ts
+++ b/packages/openapi-code-generator/src/core/dependency-graph.spec.ts
@@ -3,13 +3,13 @@
  */
 
 import {describe, it, expect} from "@jest/globals"
-import {unitTestInput} from "../test/input.test-utils"
+import {testVersions, unitTestInput} from "../test/input.test-utils"
 import {buildDependencyGraph} from "./dependency-graph"
 import {getSchemaNameFromRef} from "./openapi-utils"
 
-describe("core/dependency-graph", () => {
+describe.each(testVersions)("%s - core/dependency-graph", (version) => {
   it("works", async () => {
-    const {input} = await unitTestInput()
+    const {input} = await unitTestInput(version)
 
     const graph = buildDependencyGraph(input, getSchemaNameFromRef)
 

--- a/packages/openapi-code-generator/src/core/openapi-types.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types.ts
@@ -209,7 +209,7 @@ export interface Schema {
   minProperties?: number
   required?: string[] /* [] */
   enum?: string[] | number[]
-  type?: "integer" | "number" | "string" | "boolean" | "object" | "array" /* object */
+  type?: "null" | "integer" | "number" | "string" | "boolean" | "object" | "array" /* object */
   not?: Schema | Reference
   allOf?: (Schema | Reference)[]
   oneOf?: (Schema | Reference)[]

--- a/packages/openapi-code-generator/src/test/input.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/input.test-utils.ts
@@ -5,14 +5,28 @@ import {Input} from "../core/input"
 import path from "path"
 import yaml from "js-yaml"
 
-export async function unitTestInput(skipValidation = false) {
+type Version = "3.0.x" | "3.1.x"
+
+export const testVersions = ["3.0.x", "3.1.x"] satisfies Version[]
+
+function fileForVersion(version: Version) {
+  switch (version) {
+    case "3.0.x":
+      return path.join(__dirname, "unit-test-inputs-3.0.3.yaml")
+    case "3.1.x":
+      return path.join(__dirname, "unit-test-inputs-3.1.0.yaml")
+    default: throw new Error(`unsupported test version '${version}'`)
+  }
+}
+
+export async function unitTestInput(version: Version, skipValidation = false) {
   const validator = await OpenapiValidator.create()
 
   if (skipValidation) {
     jest.spyOn(validator, "validate").mockResolvedValue()
   }
 
-  const file = path.join(__dirname, "unit-test-inputs.yaml")
+  const file = fileForVersion(version)
   const loader = await OpenapiLoader.create(file, validator)
 
   return {input: new Input(loader), file}

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: "3.0.3"
 info:
   title: unit-test-inputs
   version: '0.0.1'

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
@@ -1,0 +1,179 @@
+openapi: "3.1.0"
+info:
+  title: unit-test-inputs
+  version: '0.0.1'
+components:
+  schemas:
+    SimpleObject:
+      required:
+        - str
+        - num
+        - date
+        - datetime
+        - required_nullable
+      properties:
+        str:
+          type: string
+        num:
+          type: number
+        date:
+          type: string
+          format: date
+        datetime:
+          type: string
+          format: date-time
+        optional_str:
+          type: string
+        required_nullable:
+          type:
+            - string
+            - "null"
+    NamedNullableStringEnum:
+      type:
+        - string
+        - "null"
+      enum:
+        - ''
+        - one
+        - two
+        - three
+        - null
+    ObjectWithRefs:
+      required:
+        - requiredObject
+      properties:
+        optionalObject:
+          $ref: '#/components/schemas/SimpleObject'
+        requiredObject:
+          $ref: '#/components/schemas/SimpleObject'
+
+    ObjectWithComplexProperties:
+      required:
+        - requiredOneOf
+        - requiredOneOfRef
+      properties:
+        requiredOneOf:
+          oneOf:
+            - type: string
+            - type: number
+        requiredOneOfRef:
+          $ref: '#/components/schemas/OneOf'
+        optionalOneOf:
+          oneOf:
+            - type: string
+            - type: number
+        optionalOneOfRef:
+          $ref: '#/components/schemas/OneOf'
+
+    OneOf:
+      oneOf:
+        - type: object
+          properties:
+            strs:
+              type: array
+              items:
+                type: string
+                minItems: 1
+          required:
+            - strs
+        - type: array
+          items:
+            type: string
+            minItems: 1
+        - type: string
+
+    AnyOf:
+      type:
+        - number
+        - string
+
+    AllOf:
+      allOf:
+        - $ref: '#/components/schemas/Base'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: integer
+              format: int64
+    Base:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        breed:
+          type: string
+
+    Ordering:
+      type: object
+      required:
+        - dependency1
+        - dependency2
+      properties:
+        dependency1:
+          $ref: "#/components/schemas/ZOrdering"
+        dependency2:
+          $ref: "#/components/schemas/AOrdering"
+
+    ZOrdering:
+      type: object
+      required:
+        - dependency1
+      properties:
+        name:
+          type: string
+        dependency1:
+          $ref: "#/components/schemas/AOrdering"
+    AOrdering:
+      type: object
+      properties:
+        name:
+          type: string
+
+    AdditionalPropertiesBool:
+      type: object
+      additionalProperties: true
+
+    AdditionalPropertiesSchema:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties:
+        $ref: "#/components/schemas/NamedNullableStringEnum"
+
+    Recursive:
+      type: object
+      properties:
+        child:
+          $ref: "#/components/schemas/Recursive"
+
+    OneOfAllOf:
+      type: object
+      oneOf:
+        - allOf:
+            - $ref: '#/components/schemas/AOrdering'
+            - $ref: '#/components/schemas/ZOrdering'
+
+    Enums:
+      properties:
+        str:
+          type:
+            - string
+            - "null"
+          enum:
+            - null
+            - "foo"
+            - "bar"
+        num:
+          type:
+            - number
+            - "null"
+          enum:
+            - null
+            - "ignored"
+            - 10
+            - 20

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -4,19 +4,23 @@
 
 import {describe, it, expect} from "@jest/globals"
 import {ZodBuilder} from "./zod-schema-builder"
-import {unitTestInput} from "../../../test/input.test-utils"
+import {testVersions, unitTestInput} from "../../../test/input.test-utils"
 import {ImportBuilder} from "../import-builder"
 import {formatOutput} from "../output-utils"
 
-describe("typescript/common/schema-builders/zod-schema-builder", () => {
-  it("supports the SimpleObject", async () => {
-    const {model, schemas} = await getActual("components/schemas/SimpleObject")
+describe.each(testVersions)(
+  "%s - typescript/common/schema-builders/zod-schema-builder",
+  (version) => {
+    it("supports the SimpleObject", async () => {
+      const {model, schemas} = await getActual(
+        "components/schemas/SimpleObject",
+      )
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_SimpleObject
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_SimpleObject = z.object({
@@ -29,18 +33,18 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       })
       "
     `)
-  })
+    })
 
-  it("supports the ObjectWithComplexProperties", async () => {
-    const {model, schemas} = await getActual(
-      "components/schemas/ObjectWithComplexProperties",
-    )
+    it("supports the ObjectWithComplexProperties", async () => {
+      const {model, schemas} = await getActual(
+        "components/schemas/ObjectWithComplexProperties",
+      )
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_ObjectWithComplexProperties
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_OneOf = z.union([
@@ -57,16 +61,16 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       })
       "
     `)
-  })
+    })
 
-  it("supports unions / oneOf", async () => {
-    const {model, schemas} = await getActual("components/schemas/OneOf")
+    it("supports unions / oneOf", async () => {
+      const {model, schemas} = await getActual("components/schemas/OneOf")
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_OneOf
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_OneOf = z.union([
@@ -76,31 +80,31 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       ])
       "
     `)
-  })
+    })
 
-  it("supports unions / anyOf", async () => {
-    const {model, schemas} = await getActual("components/schemas/AnyOf")
+    it("supports unions / anyOf", async () => {
+      const {model, schemas} = await getActual("components/schemas/AnyOf")
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_AnyOf
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_AnyOf = z.union([z.coerce.number(), z.string()])
       "
     `)
-  })
+    })
 
-  it("supports allOf", async () => {
-    const {model, schemas} = await getActual("components/schemas/AllOf")
+    it("supports allOf", async () => {
+      const {model, schemas} = await getActual("components/schemas/AllOf")
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_AllOf
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_Base = z.object({
@@ -111,16 +115,16 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       export const s_AllOf = s_Base.merge(z.object({ id: z.coerce.number() }))
       "
     `)
-  })
+    })
 
-  it("supports recursion", async () => {
-    const {model, schemas} = await getActual("components/schemas/Recursive")
+    it("supports recursion", async () => {
+      const {model, schemas} = await getActual("components/schemas/Recursive")
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "z.lazy(() => s_Recursive)
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { t_Recursive } from "./models"
       import { z } from "zod"
 
@@ -129,16 +133,16 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       })
       "
     `)
-  })
+    })
 
-  it("orders schemas such that dependencies are defined first", async () => {
-    const {model, schemas} = await getActual("components/schemas/Ordering")
+    it("orders schemas such that dependencies are defined first", async () => {
+      const {model, schemas} = await getActual("components/schemas/Ordering")
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_Ordering
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_AOrdering = z.object({ name: z.string().optional() })
@@ -154,16 +158,16 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       })
       "
     `)
-  })
+    })
 
-  it("supports string and numeric enums", async () => {
-    const {model, schemas} = await getActual("components/schemas/Enums")
+    it("supports string and numeric enums", async () => {
+      const {model, schemas} = await getActual("components/schemas/Enums")
 
-    expect(model).toMatchInlineSnapshot(`
+      expect(model).toMatchInlineSnapshot(`
       "s_Enums
       "
     `)
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "import { z } from "zod"
 
       export const s_Enums = z.object({
@@ -175,23 +179,24 @@ describe("typescript/common/schema-builders/zod-schema-builder", () => {
       })
       "
     `)
-  })
+    })
 
-  async function getActual(path: string) {
-    const {input, file} = await unitTestInput()
+    async function getActual(path: string) {
+      const {input, file} = await unitTestInput(version)
 
-    const builder = new ZodBuilder(
-      "z",
-      "schemas.ts",
-      input,
-      new ImportBuilder(),
-    )
+      const builder = new ZodBuilder(
+        "z",
+        "schemas.ts",
+        input,
+        new ImportBuilder(),
+      )
 
-    const model = builder.fromModel({$ref: `${file}#${path}`}, true)
+      const model = builder.fromModel({$ref: `${file}#${path}`}, true)
 
-    return {
-      model: await formatOutput(model),
-      schemas: await formatOutput(builder.toString()),
+      return {
+        model: await formatOutput(model),
+        schemas: await formatOutput(builder.toString()),
+      }
     }
-  }
-})
+  },
+)

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -3,23 +3,25 @@
  */
 
 import {describe, it, expect} from "@jest/globals"
-import {unitTestInput} from "../../test/input.test-utils"
+import {testVersions, unitTestInput} from "../../test/input.test-utils"
 import {TypeBuilder} from "./type-builder"
 import {ImportBuilder} from "./import-builder"
 import {formatOutput} from "./output-utils"
 
-describe("typescript/common/type-builder", () => {
-  it("can build a type for a simple object correctly", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/SimpleObject",
-    )
+describe.each(testVersions)(
+  "%s - typescript/common/type-builder",
+  (version) => {
+    it("can build a type for a simple object correctly", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/SimpleObject",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_SimpleObject
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_SimpleObject = {
         date: string
         datetime: string
@@ -31,23 +33,23 @@ describe("typescript/common/type-builder", () => {
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_SimpleObject } from "models"
       "
     `)
-  })
+    })
 
-  it("can build a type for an object that references other objects correctly", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/ObjectWithRefs",
-    )
+    it("can build a type for an object that references other objects correctly", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/ObjectWithRefs",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_ObjectWithRefs
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_ObjectWithRefs = {
         optionalObject?: t_SimpleObject
         requiredObject: t_SimpleObject
@@ -64,42 +66,44 @@ describe("typescript/common/type-builder", () => {
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_ObjectWithRefs, t_SimpleObject } from "models"
       "
     `)
-  })
+    })
 
-  it("can build a type for a named nullable string enum", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/NamedNullableStringEnum",
-    )
+    it("can build a type for a named nullable string enum", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/NamedNullableStringEnum",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_NamedNullableStringEnum
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_NamedNullableStringEnum = "" | "one" | "two" | "three" | null
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_NamedNullableStringEnum } from "models"
       "
     `)
-  })
+    })
 
-  it("can build a type for a oneOf correctly", async () => {
-    const {type, schemas, imports} = await getActual("components/schemas/OneOf")
+    it("can build a type for a oneOf correctly", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/OneOf",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_OneOf
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_OneOf =
         | {
             strs: string[]
@@ -109,40 +113,44 @@ describe("typescript/common/type-builder", () => {
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_OneOf } from "models"
       "
     `)
-  })
+    })
 
-  it("can build a type for a anyOf correctly", async () => {
-    const {type, schemas, imports} = await getActual("components/schemas/AnyOf")
+    it("can build a type for a anyOf correctly", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/AnyOf",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_AnyOf
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_AnyOf = number | string
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_AnyOf } from "models"
       "
     `)
-  })
+    })
 
-  it("can build a type for a allOf correctly", async () => {
-    const {type, schemas, imports} = await getActual("components/schemas/AllOf")
+    it("can build a type for a allOf correctly", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/AllOf",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_AllOf
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_AllOf = t_Base & {
         id: number
       }
@@ -154,69 +162,69 @@ describe("typescript/common/type-builder", () => {
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_AllOf, t_Base } from "models"
       "
     `)
-  })
+    })
 
-  it("handles additionalProperties set to true", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/AdditionalPropertiesBool",
-    )
+    it("handles additionalProperties set to true", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/AdditionalPropertiesBool",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_AdditionalPropertiesBool
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_AdditionalPropertiesBool = {
         [key: string]: unknown
       }
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_AdditionalPropertiesBool } from "models"
       "
     `)
-  })
+    })
 
-  it("can build a recursive type correctly", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/Recursive",
-    )
+    it("can build a recursive type correctly", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/Recursive",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_Recursive
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_Recursive = {
         child?: t_Recursive
       }
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_Recursive } from "models"
       "
     `)
-  })
+    })
 
-  it("handles additionalProperties specifying a schema", async () => {
-    const {type, schemas, imports} = await getActual(
-      "components/schemas/AdditionalPropertiesSchema",
-    )
+    it("handles additionalProperties specifying a schema", async () => {
+      const {type, schemas, imports} = await getActual(
+        "components/schemas/AdditionalPropertiesSchema",
+      )
 
-    expect(type).toMatchInlineSnapshot(`
+      expect(type).toMatchInlineSnapshot(`
       "const x: t_AdditionalPropertiesSchema
       "
     `)
 
-    expect(schemas).toMatchInlineSnapshot(`
+      expect(schemas).toMatchInlineSnapshot(`
       "export type t_AdditionalPropertiesSchema =
         | {
             name?: string
@@ -229,28 +237,29 @@ describe("typescript/common/type-builder", () => {
       "
     `)
 
-    expect(imports).toMatchInlineSnapshot(`
+      expect(imports).toMatchInlineSnapshot(`
       "import { t_AdditionalPropertiesSchema, t_NamedNullableStringEnum } from "models"
       "
     `)
-  })
+    })
 
-  async function getActual(path: string) {
-    const {input, file} = await unitTestInput()
-    const schema = {$ref: `${file}#/${path}`}
+    async function getActual(path: string) {
+      const {input, file} = await unitTestInput(version)
+      const schema = {$ref: `${file}#/${path}`}
 
-    const imports = new ImportBuilder()
+      const imports = new ImportBuilder()
 
-    const builder = TypeBuilder.fromInput("models.ts", input).withImports(
-      imports,
-    )
+      const builder = TypeBuilder.fromInput("models.ts", input).withImports(
+        imports,
+      )
 
-    const type = builder.schemaObjectToType(schema)
+      const type = builder.schemaObjectToType(schema)
 
-    return {
-      type: await formatOutput(`const x: ${type}`),
-      schemas: await formatOutput(builder.toString()),
-      imports: await formatOutput(imports.toString()),
+      return {
+        type: await formatOutput(`const x: ${type}`),
+        schemas: await formatOutput(builder.toString()),
+        imports: await formatOutput(imports.toString()),
+      }
     }
-  }
-})
+  },
+)


### PR DESCRIPTION
this adds basic support for openapi 3.1 definitions, based on the migration blog post from openapis.org.

the primary change is allowing `null` as a `type`, and that `type` can be an array.

the other changes listed relating to file uploads, and `exclusiveMinimum` aren't applicable as these aren't really supported at all yet (https://github.com/mnahkies/openapi-code-generator/issues/51, https://github.com/mnahkies/openapi-code-generator/issues/53)

there's probably a bunch of other gaps in general JSON schema support, such as the `if` / `else` things mentioned, but there's relatively few examples of complex `3.1.0` definitions to test against.

I stumbled across https://github.com/APIs-guru/openapi-directory looking for samples and I've tested these changes against these definitions:
- https://github.com/APIs-guru/openapi-directory/blob/dec74da7a6785d5d5b83bc6a4cebc07336d67ec9/APIs/vercel.com/0.0.1/openapi.yaml
- https://github.com/APIs-guru/openapi-directory/blob/dec74da7a6785d5d5b83bc6a4cebc07336d67ec9/APIs/discourse.local/latest/openapi.yaml
- https://github.com/APIs-guru/openapi-directory/blob/dec74da7a6785d5d5b83bc6a4cebc07336d67ec9/APIs/adyen.com/CheckoutService/70/openapi.yaml

It appears to be giving reasonable output - no compile errors at least, and nothing obviously wrong doing a quick scan of output.

ref: https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0