### PR TITLE
fix: incorrect .d.ts path for zod

### DIFF
--- a/packages/typescript-koa-runtime/package.json
+++ b/packages/typescript-koa-runtime/package.json
@@ -34,7 +34,7 @@
     "./zod": {
       "require": "./dist/zod.js",
       "import": "./dist/zod.js",
-      "types": "./dist/joi.d.ts"
+      "types": "./dist/zod.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
(note: the public API between `joi` and `zod` parts of the runtime should be identical, so this should effectively be a noop)

relates #117