### PR TITLE
feat: experimental support for extracting inline schemas

### DIFF
--- a/integration-tests-definitions/todo-lists.yaml
+++ b/integration-tests-definitions/todo-lists.yaml
@@ -72,6 +72,76 @@ paths:
           $ref: '../integration-tests-definitions-shared/error-handling.yaml#/components/responses/ClientError'
         default:
           $ref: '../integration-tests-definitions-shared/error-handling.yaml#/components/responses/ServerError'
+  /list/{listId}/items:
+    parameters:
+      - name: listId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      operationId: getTodoListItems
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - content
+                  - createdAt
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  content:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+                  completedAt:
+                    type: string
+                    format: date-time
+        5XX:
+          description: server error
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                  - code
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+    post:
+      operationId: createTodoListItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - id
+                - content
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                content:
+                  type: string
+                completedAt:
+                  type: string
+                  format: date-time
+      responses:
+        204:
+          description: success
 components:
   schemas:
     CreateUpdateTodoList:

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
@@ -171,4 +171,52 @@ export class ApiClient {
       },
     )
   }
+
+  getTodoListItems(p: { listId: string }): Observable<
+    | (HttpResponse<{
+        completedAt?: string
+        content: string
+        createdAt: string
+        id: string
+      }> & { status: 200 })
+    | (HttpResponse<{
+        code: string
+        message: string
+      }> & { status: StatusCode5xx })
+    | HttpResponse<unknown>
+  > {
+    return this.httpClient.request<any>(
+      "GET",
+      this.config.basePath + `/list/${p["listId"]}/items`,
+      {
+        observe: "response",
+        reportProgress: false,
+      },
+    )
+  }
+
+  createTodoListItem(p: {
+    listId: string
+    requestBody: {
+      completedAt?: string
+      content: string
+      id: string
+    }
+  }): Observable<
+    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
+  > {
+    const headers = this._headers({ "Content-Type": "application/json" })
+    const body = p["requestBody"]
+
+    return this.httpClient.request<any>(
+      "POST",
+      this.config.basePath + `/list/${p["listId"]}/items`,
+      {
+        headers,
+        body,
+        observe: "response",
+        reportProgress: false,
+      },
+    )
+  }
 }

--- a/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
@@ -93,4 +93,56 @@ export class ApiClient extends AbstractAxiosClient {
       ...(opts ?? {}),
     })
   }
+
+  async getTodoListItems(
+    p: {
+      listId: string
+    },
+    timeout?: number,
+    opts?: AxiosRequestConfig,
+  ): Promise<
+    AxiosResponse<{
+      completedAt?: string
+      content: string
+      createdAt: string
+      id: string
+    }>
+  > {
+    const url = `/list/${p["listId"]}/items`
+
+    return this.axios.request({
+      url: url,
+      baseURL: this.basePath,
+      method: "GET",
+      timeout,
+      ...(opts ?? {}),
+    })
+  }
+
+  async createTodoListItem(
+    p: {
+      listId: string
+      requestBody: {
+        completedAt?: string
+        content: string
+        id: string
+      }
+    },
+    timeout?: number,
+    opts?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<void>> {
+    const url = `/list/${p["listId"]}/items`
+    const headers = this._headers({ "Content-Type": "application/json" })
+    const body = JSON.stringify(p.requestBody)
+
+    return this.axios.request({
+      url: url,
+      baseURL: this.basePath,
+      method: "POST",
+      headers,
+      data: body,
+      timeout,
+      ...(opts ?? {}),
+    })
+  }
 }

--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
@@ -91,4 +91,58 @@ export class ApiClient extends AbstractFetchClient {
 
     return this._fetch(url, { method: "DELETE", ...(opts ?? {}) }, timeout)
   }
+
+  async getTodoListItems(
+    p: {
+      listId: string
+    },
+    timeout?: number,
+    opts?: RequestInit,
+  ): Promise<
+    TypedFetchResponse<
+      | Res<
+          200,
+          {
+            completedAt?: string
+            content: string
+            createdAt: string
+            id: string
+          }
+        >
+      | Res<
+          StatusCode5xx,
+          {
+            code: string
+            message: string
+          }
+        >
+    >
+  > {
+    const url = this.basePath + `/list/${p["listId"]}/items`
+
+    return this._fetch(url, { method: "GET", ...(opts ?? {}) }, timeout)
+  }
+
+  async createTodoListItem(
+    p: {
+      listId: string
+      requestBody: {
+        completedAt?: string
+        content: string
+        id: string
+      }
+    },
+    timeout?: number,
+    opts?: RequestInit,
+  ): Promise<TypedFetchResponse<Res<204, void>>> {
+    const url = this.basePath + `/list/${p["listId"]}/items`
+    const headers = this._headers({ "Content-Type": "application/json" })
+    const body = JSON.stringify(p.requestBody)
+
+    return this._fetch(
+      url,
+      { method: "POST", headers, body, ...(opts ?? {}) },
+      timeout,
+    )
+  }
 }

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
@@ -16,11 +16,25 @@ export type t_TodoList = {
   updated: string
 }
 
+export type t_CreateTodoListItemBodySchema = {
+  completedAt?: string
+  content: string
+  id: string
+}
+
+export type t_CreateTodoListItemParamSchema = {
+  listId: string
+}
+
 export type t_DeleteTodoListByIdParamSchema = {
   listId: string
 }
 
 export type t_GetTodoListByIdParamSchema = {
+  listId: string
+}
+
+export type t_GetTodoListItemsParamSchema = {
   listId: string
 }
 

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -62,14 +62,16 @@ export class Input {
 
         definition = this.loader.operation(definition)
 
+        const operationId = this.normalizeOperationId(definition.operationId, method, route)
+
         result.push({
           ...additionalAttributes,
           route,
           method: method.toUpperCase() as IROperation["method"],
           parameters: params.concat(this.normalizeParameters(definition.parameters)),
-          operationId: this.normalizeOperationId(definition.operationId, method, route),
+          operationId,
           tags: definition.tags ?? [],
-          requestBody: this.normalizeRequestBodyObject(definition.requestBody),
+          requestBody: this.normalizeRequestBodyObject(operationId, definition.requestBody),
           responses: this.normalizeResponsesObject(definition.responses),
           summary: definition.summary,
           description: definition.description,
@@ -113,12 +115,12 @@ export class Input {
     return normalizeSchemaObject(schema) as IRModel
   }
 
-  private normalizeRequestBodyObject(requestBody?: RequestBody | Reference) {
+  private normalizeRequestBodyObject(operationId: string, requestBody?: RequestBody | Reference) {
     if (!requestBody) {
       return undefined
     }
 
-    return normalizeRequestBodyObject(this.loader.requestBody(requestBody))
+    return normalizeRequestBodyObject(this.loader.requestBody(operationId, requestBody))
   }
 
   private normalizeResponsesObject(responses?: Responses): {[statusCode: string]: IRResponse} | undefined {

--- a/packages/openapi-code-generator/src/core/openapi-loader.ts
+++ b/packages/openapi-code-generator/src/core/openapi-loader.ts
@@ -16,7 +16,6 @@ import {
   Schema,
 } from "./openapi-types"
 import {isRef} from "./openapi-utils"
-import {contentTypeToIdentifier} from "./utils"
 
 export class OpenapiLoader {
 
@@ -54,19 +53,8 @@ export class OpenapiLoader {
     return isRef(maybeRef) ? this.$ref(maybeRef) : maybeRef
   }
 
-  requestBody(operationId: string, maybeRef: Reference | RequestBody): RequestBody {
-    const requestBody = isRef(maybeRef) ? this.$ref<RequestBody>(maybeRef) : maybeRef
-
-    requestBody.content = Object.fromEntries(Object.entries(requestBody.content).map(([contentType, value]) => {
-      if(!isRef(value.schema)){
-        value.schema = this.addVirtualType(operationId, `${operationId}${contentTypeToIdentifier(contentType)}RequestBody`, value.schema)
-
-        console.info(requestBody)
-      }
-      return [contentType, value]
-    }))
-
-    return requestBody
+  requestBody(maybeRef: Reference | RequestBody): RequestBody {
+    return isRef(maybeRef) ? this.$ref<RequestBody>(maybeRef) : maybeRef
   }
 
   response(maybeRef: Reference | Response): Response {

--- a/packages/openapi-code-generator/src/core/utils.spec.ts
+++ b/packages/openapi-code-generator/src/core/utils.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import {describe, expect, it} from "@jest/globals"
-import {contentTypeToIdentifier, titleCase} from "./utils"
+import {mediaTypeToIdentifier, titleCase} from "./utils"
 
 describe("core/utils", () => {
   describe("#titleCase", () => {
@@ -16,7 +16,7 @@ describe("core/utils", () => {
     })
   })
 
-  describe("#contentTypeToIdentifier", () => {
+  describe("#mediaTypeToIdentifier", () => {
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types ¯\_(ツ)_/¯
     it.each([
       ["audio/aac", "AudioAac"],
@@ -114,7 +114,7 @@ describe("core/utils", () => {
       ["video/3gpp2", "Video3Gpp2"],
       ["application/x-7z-compressed", "ApplicationX7ZCompressed"],
     ])("%s -> %s", async (contentType, expected) => {
-      expect(contentTypeToIdentifier(contentType)).toBe(expected)
+      expect(mediaTypeToIdentifier(contentType)).toBe(expected)
     })
   })
 })

--- a/packages/openapi-code-generator/src/core/utils.spec.ts
+++ b/packages/openapi-code-generator/src/core/utils.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @prettier
+ */
+
+import {describe, expect, it} from "@jest/globals"
+import {contentTypeToIdentifier, titleCase} from "./utils"
+
+describe("core/utils", () => {
+  describe("#titleCase", () => {
+    it.each([
+      ["single", "Single"],
+      ["two words", "TwoWords"],
+      ["camelCase", "CamelCase"],
+    ])("%s -> %s", (input, expected) => {
+      expect(titleCase(input)).toBe(expected)
+    })
+  })
+
+  describe("#contentTypeToIdentifier", () => {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types ¯\_(ツ)_/¯
+    it.each([
+      ["audio/aac", "AudioAac"],
+      ["application/x-abiword", "ApplicationXAbiword"],
+      ["image/apng", "ImageApng"],
+      ["application/x-freearc", "ApplicationXFreearc"],
+      ["image/avif", "ImageAvif"],
+      ["video/x-msvideo", "VideoXMsvideo"],
+      ["application/vnd.amazon.ebook", "ApplicationVndAmazonEbook"],
+      ["application/octet-stream", "ApplicationOctetStream"],
+      ["image/bmp", "ImageBmp"],
+      ["application/x-bzip", "ApplicationXBzip"],
+      ["application/x-bzip2", "ApplicationXBzip2"],
+      ["application/x-cdf", "ApplicationXCdf"],
+      ["application/x-csh", "ApplicationXCsh"],
+      ["text/css", "TextCss"],
+      ["text/csv", "TextCsv"],
+      ["application/msword", "ApplicationMsword"],
+      [
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "ApplicationVndOpenxmlformatsOfficedocumentWordprocessingmlDocument",
+      ],
+      ["application/vnd.ms-fontobject", "ApplicationVndMsFontobject"],
+      ["application/epub+zip", "ApplicationEpubZip"],
+      ["application/gzip", "ApplicationGzip"],
+      ["image/gif", "ImageGif"],
+      ["text/html", "TextHtml"],
+      ["image/vnd.microsoft.icon", "ImageVndMicrosoftIcon"],
+      ["text/calendar", "TextCalendar"],
+      ["application/java-archive", "ApplicationJavaArchive"],
+      ["image/jpeg", "ImageJpeg"],
+      ["text/javascript", "TextJavascript"],
+      ["application/json", "Json"],
+      ["application/ld+json", "ApplicationLdJson"],
+      ["audio/midi", "AudioMidi"],
+      ["text/javascript", "TextJavascript"],
+      ["audio/mpeg", "AudioMpeg"],
+      ["video/mp4", "VideoMp4"],
+      ["video/mpeg", "VideoMpeg"],
+      [
+        "application/vnd.apple.installer+xml",
+        "ApplicationVndAppleInstallerXml",
+      ],
+      [
+        "application/vnd.oasis.opendocument.presentation",
+        "ApplicationVndOasisOpendocumentPresentation",
+      ],
+      [
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "ApplicationVndOasisOpendocumentSpreadsheet",
+      ],
+      [
+        "application/vnd.oasis.opendocument.text",
+        "ApplicationVndOasisOpendocumentText",
+      ],
+      ["audio/ogg", "AudioOgg"],
+      ["video/ogg", "VideoOgg"],
+      ["application/ogg", "ApplicationOgg"],
+      ["audio/opus", "AudioOpus"],
+      ["font/otf", "FontOtf"],
+      ["image/png", "ImagePng"],
+      ["application/pdf", "ApplicationPdf"],
+      ["application/x-httpd-php", "ApplicationXHttpdPhp"],
+      ["application/vnd.ms-powerpoint", "ApplicationVndMsPowerpoint"],
+      [
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "ApplicationVndOpenxmlformatsOfficedocumentPresentationmlPresentation",
+      ],
+      ["application/vnd.rar", "ApplicationVndRar"],
+      ["application/rtf", "ApplicationRtf"],
+      ["application/x-sh", "ApplicationXSh"],
+      ["image/svg+xml", "ImageSvgXml"],
+      ["application/x-tar", "ApplicationXTar"],
+      ["image/tiff", "ImageTiff"],
+      ["video/mp2t", "VideoMp2T"],
+      ["font/ttf", "FontTtf"],
+      ["text/plain", "Text"],
+      ["application/vnd.visio", "ApplicationVndVisio"],
+      ["audio/wav", "AudioWav"],
+      ["audio/webm", "AudioWebm"],
+      ["video/webm", "VideoWebm"],
+      ["image/webp", "ImageWebp"],
+      ["font/woff", "FontWoff"],
+      ["font/woff2", "FontWoff2"],
+      ["application/xhtml+xml", "ApplicationXhtmlXml"],
+      ["application/vnd.ms-excel", "ApplicationVndMsExcel"],
+      [
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ApplicationVndOpenxmlformatsOfficedocumentSpreadsheetmlSheet",
+      ],
+      ["application/xml", "Xml"],
+      ["application/vnd.mozilla.xul+xml", "ApplicationVndMozillaXulXml"],
+      ["application/zip", "ApplicationZip"],
+      ["video/3gpp", "Video3Gpp"],
+      ["video/3gpp2", "Video3Gpp2"],
+      ["application/x-7z-compressed", "ApplicationX7ZCompressed"],
+    ])("%s -> %s", async (contentType, expected) => {
+      expect(contentTypeToIdentifier(contentType)).toBe(expected)
+    })
+  })
+})

--- a/packages/openapi-code-generator/src/core/utils.ts
+++ b/packages/openapi-code-generator/src/core/utils.ts
@@ -19,8 +19,8 @@ export function titleCase(str: string): string {
   return _.capitalize(camel[0]) + camel.slice(1)
 }
 
-export function contentTypeToIdentifier(contentType: string): string {
-  const [type, subType] = contentType.split("/").map((it) => {
+export function mediaTypeToIdentifier(mediaType: string): string {
+  const [type, subType] = mediaType.split("/").map((it) => {
     return _.camelCase(it.replaceAll(/[-.+]/g, " "))
   })
 

--- a/packages/openapi-code-generator/src/core/utils.ts
+++ b/packages/openapi-code-generator/src/core/utils.ts
@@ -1,16 +1,14 @@
+/**
+ * @prettier
+ */
+
 import _ from "lodash"
 
 export function isDefined<T>(it: T | undefined): it is T {
   return it !== undefined
 }
 
-const httpMethods = new Set([
-  "get",
-  "put",
-  "patch",
-  "delete",
-  "post",
-])
+const httpMethods = new Set(["get", "put", "patch", "delete", "post"])
 
 export function isHttpMethod(method: string): boolean {
   return httpMethods.has(method.toLowerCase())
@@ -19,4 +17,24 @@ export function isHttpMethod(method: string): boolean {
 export function titleCase(str: string): string {
   const camel = _.camelCase(str)
   return _.capitalize(camel[0]) + camel.slice(1)
+}
+
+export function contentTypeToIdentifier(contentType: string): string {
+  const [type, subType] = contentType.split("/").map((it) => {
+    return _.camelCase(it.replaceAll(/[-.+]/g, " "))
+  })
+
+  if (subType === "json") {
+    return "Json"
+  }
+
+  if (subType === "xml") {
+    return "Xml"
+  }
+
+  if (type === "text" && subType === "plain") {
+    return "Text"
+  }
+
+  return [type, subType].map(titleCase).join("")
 }

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -47,7 +47,7 @@ const program = new Command()
   .addOption(
     new Option(
       "--extract-inline-schemas",
-      "Generate names and extract types/schemas for inline schemas",
+      "(experimental) Generate names and extract types/schemas for inline schemas",
     )
       .env("OPENAPI_EXTRACT_INLINE_SCHEMAS")
       .default(false),

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -44,6 +44,14 @@ const program = new Command()
       .default("zod" as const)
       .makeOptionMandatory(),
   )
+  .addOption(
+    new Option(
+      "--extract-inline-schemas",
+      "Generate names and extract types/schemas for inline schemas",
+    )
+      .env("OPENAPI_EXTRACT_INLINE_SCHEMAS")
+      .default(false),
+  )
   .showHelpAfterError()
   .parse()
 
@@ -59,7 +67,9 @@ async function main() {
 
   const loader = await OpenapiLoader.create(config.input, validator)
 
-  const input = new Input(loader)
+  const input = new Input(loader, {
+    extractInlineSchemas: config.extractInlineSchemas,
+  })
 
   const generator = templates[config.template]
 

--- a/packages/openapi-code-generator/src/test/input.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/input.test-utils.ts
@@ -29,7 +29,7 @@ export async function unitTestInput(version: Version, skipValidation = false) {
   const file = fileForVersion(version)
   const loader = await OpenapiLoader.create(file, validator)
 
-  return {input: new Input(loader), file}
+  return {input: new Input(loader, {extractInlineSchemas: true}), file}
 }
 
 export async function createTestInputFromYamlString(
@@ -50,5 +50,5 @@ export async function createTestInputFromYamlString(
 
   const loader = await OpenapiLoader.createFromLiteral(spec, validator)
 
-  return new Input(loader)
+  return new Input(loader, {extractInlineSchemas: true})
 }

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -109,23 +109,19 @@ export class ServerBuilder {
 
     if (paramSchema) {
       const name = `${operation.operationId}ParamSchema`
-      pathParamsType = types.schemaObjectToType({$ref: this.input.loader.addVirtualType(operation.operationId, _.upperFirst(name), reduceParamsToOpenApiSchema(pathParams))})
+      pathParamsType = types.schemaObjectToType(this.input.loader.addVirtualType(operation.operationId, _.upperFirst(name), reduceParamsToOpenApiSchema(pathParams)))
       this.statements.push(`const ${name} = ${paramSchema.toString()}`)
     }
 
     if (querySchema) {
       const name = `${operation.operationId}QuerySchema`
-      queryParamsType = types.schemaObjectToType({
-        $ref: this.input.loader.addVirtualType(operation.operationId, _.upperFirst(name), reduceParamsToOpenApiSchema(queryParams)),
-      })
+      queryParamsType = types.schemaObjectToType(this.input.loader.addVirtualType(operation.operationId, _.upperFirst(name), reduceParamsToOpenApiSchema(queryParams)))
       this.statements.push(`const ${name} = ${querySchema.toString()}`)
     }
 
     if (bodyParamSchema && requestBodyParameter) {
       const name = `${operation.operationId}BodySchema`
-      bodyParamsType = types.schemaObjectToType({
-        $ref: this.input.loader.addVirtualType(operation.operationId, _.upperFirst(name), this.input.schema(requestBodyParameter.schema)),
-      })
+      bodyParamsType = types.schemaObjectToType(this.input.loader.addVirtualType(operation.operationId, _.upperFirst(name), this.input.schema(requestBodyParameter.schema)))
       this.statements.push(`const ${name} = ${bodyParamSchema}`)
     }
 


### PR DESCRIPTION
**Problem Statement**
Some `openapi` definitions don't make use of `$ref`'s to name their schemas, which until now has resulted in the generated types/schemas being in-lined at the site of usage.

I've found this is especially common when some packages that generate `openapi` schemas from your server implementation are used, as the additional metadata to create `$ref`'s is often omitted (YMMV).

This can make the code harder to read, and more awkward to consume, as you cannot easily use the generated types (without extracting them from another type), and the schemas simply can't be referenced.

**Solution**
Introduce a new experimental cli flag `--extract-inline-schemas` that will cause synthetic `$ref`'s to be created from inline schemas on request and response bodies where the following is true:
- It's not already a `$ref`
- It's not a primitive type, eg: not a `string` / `number`
- It's not an `array` with `$ref` for items

It seems to work fairly well, and is primarily experimental as I may still adjust the name generation, and it could be interesting to attempt de-duplication of repeated schemas - though I suspect that'll be difficult to do whilst keeping semantically meaningful names.

I've not enabled it on any integration tests yet, but the change for the new example operations added in this PR looks like this:

<details><summary>typescript-koa</summary>
<p>

```diff
diff --git a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
index f14385a..16f39be 100644
--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -13,8 +13,17 @@ import {
   t_TodoList,
   t_UpdateTodoListByIdBodySchema,
   t_UpdateTodoListByIdParamSchema,
+  t_getTodoListItemsJson200Response,
+  t_getTodoListItemsJson5XXResponse,
 } from "./models"
-import { s_CreateUpdateTodoList, s_Error, s_TodoList } from "./schemas"
+import {
+  s_CreateUpdateTodoList,
+  s_Error,
+  s_TodoList,
+  s_createTodoListItemJsonRequestBody,
+  s_getTodoListItemsJson200Response,
+  s_getTodoListItemsJson5XXResponse,
+} from "./schemas"
 import KoaRouter from "@koa/router"
 import {
   KoaRuntimeError,
@@ -110,16 +119,10 @@ export type DeleteTodoListById = (
 >
 
 export type GetTodoListItemsResponder = {
-  with200(): KoaRuntimeResponse<{
-    completedAt?: string
-    content: string
-    createdAt: string
-    id: string
-  }>
-  withStatusCode5xx(status: StatusCode5xx): KoaRuntimeResponse<{
-    code: string
-    message: string
-  }>
+  with200(): KoaRuntimeResponse<t_getTodoListItemsJson200Response>
+  withStatusCode5xx(
+    status: StatusCode5xx,
+  ): KoaRuntimeResponse<t_getTodoListItemsJson5XXResponse>
 } & KoaRuntimeResponder
 
 export type GetTodoListItems = (
@@ -128,22 +131,8 @@ export type GetTodoListItems = (
   ctx: Context,
 ) => Promise<
   | KoaRuntimeResponse<unknown>
-  | Response<
-      200,
-      {
-        completedAt?: string
-        content: string
-        createdAt: string
-        id: string
-      }
-    >
-  | Response<
-      StatusCode5xx,
-      {
-        code: string
-        message: string
-      }
-    >
+  | Response<200, t_getTodoListItemsJson200Response>
+  | Response<StatusCode5xx, t_getTodoListItemsJson5XXResponse>
 >
 
 export type CreateTodoListItemResponder = {
@@ -376,16 +365,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getTodoListItemsResponseValidator = responseValidationFactory(
     [
-      [
-        "200",
-        z.object({
-          id: z.string(),
-          content: z.string(),
-          createdAt: z.string().datetime({ offset: true }),
-          completedAt: z.string().datetime({ offset: true }).optional(),
-        }),
-      ],
-      ["5XX", z.object({ message: z.string(), code: z.string() })],
+      ["200", s_getTodoListItemsJson200Response],
+      ["5XX", s_getTodoListItemsJson5XXResponse],
     ],
     undefined,
   )
@@ -403,18 +384,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
     const responder = {
       with200() {
-        return new KoaRuntimeResponse<{
-          completedAt?: string
-          content: string
-          createdAt: string
-          id: string
-        }>(200)
+        return new KoaRuntimeResponse<t_getTodoListItemsJson200Response>(200)
       },
       withStatusCode5xx(status: StatusCode5xx) {
-        return new KoaRuntimeResponse<{
-          code: string
-          message: string
-        }>(status)
+        return new KoaRuntimeResponse<t_getTodoListItemsJson5XXResponse>(status)
       },
       withStatus(status: StatusCode) {
         return new KoaRuntimeResponse(status)
@@ -437,11 +410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const createTodoListItemParamSchema = z.object({ listId: z.string() })
 
-  const createTodoListItemBodySchema = z.object({
-    id: z.string(),
-    content: z.string(),
-    completedAt: z.string().datetime({ offset: true }).optional(),
-  })
+  const createTodoListItemBodySchema = s_createTodoListItemJsonRequestBody
 
   const createTodoListItemResponseValidator = responseValidationFactory(
     [["204", z.void()]],
diff --git a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
index da6dcb2..1f92dda 100644
--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/models.ts
@@ -38,6 +38,18 @@ export type t_GetTodoListItemsParamSchema = {
   listId: string
 }
 
+export type t_getTodoListItemsJson200Response = {
+  completedAt?: string
+  content: string
+  createdAt: string
+  id: string
+}
+
+export type t_getTodoListItemsJson5XXResponse = {
+  code: string
+  message: string
+}
+
 export type t_GetTodoListsQuerySchema = {
   created?: string
   status?: "incomplete" | "complete"
diff --git a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
index 3c99ec6..f132969 100644
--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
@@ -19,3 +19,21 @@ export const s_Error = z.object({
   message: z.string().optional(),
   code: z.coerce.number().optional(),
 })
+
+export const s_getTodoListItemsJson200Response = z.object({
+  id: z.string(),
+  content: z.string(),
+  createdAt: z.string().datetime({ offset: true }),
+  completedAt: z.string().datetime({ offset: true }).optional(),
+})
+
+export const s_getTodoListItemsJson5XXResponse = z.object({
+  message: z.string(),
+  code: z.string(),
+})
+
+export const s_createTodoListItemJsonRequestBody = z.object({
+  id: z.string(),
+  content: z.string(),
+  completedAt: z.string().datetime({ offset: true }).optional(),
+})

```

</p>
</details> 

<details><summary>typescript-fetch</summary>
<p>


```diff
diff --git a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
index e441863..78bfdea 100644
--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
@@ -2,7 +2,14 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { t_CreateUpdateTodoList, t_Error, t_TodoList } from "./models"
+import {
+  t_CreateUpdateTodoList,
+  t_Error,
+  t_TodoList,
+  t_createTodoListItemJsonRequestBody,
+  t_getTodoListItemsJson200Response,
+  t_getTodoListItemsJson5XXResponse,
+} from "./models"
 import {
   AbstractFetchClient,
   AbstractFetchClientConfig,
@@ -100,22 +107,8 @@ export class ApiClient extends AbstractFetchClient {
     opts?: RequestInit,
   ): Promise<
     TypedFetchResponse<
-      | Res<
-          200,
-          {
-            completedAt?: string
-            content: string
-            createdAt: string
-            id: string
-          }
-        >
-      | Res<
-          StatusCode5xx,
-          {
-            code: string
-            message: string
-          }
-        >
+      | Res<200, t_getTodoListItemsJson200Response>
+      | Res<StatusCode5xx, t_getTodoListItemsJson5XXResponse>
     >
   > {
     const url = this.basePath + `/list/${p["listId"]}/items`
@@ -126,11 +119,7 @@ export class ApiClient extends AbstractFetchClient {
   async createTodoListItem(
     p: {
       listId: string
-      requestBody: {
-        completedAt?: string
-        content: string
-        id: string
-      }
+      requestBody: t_createTodoListItemJsonRequestBody
     },
     timeout?: number,
     opts?: RequestInit,
diff --git a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/models.ts b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/models.ts
index 2874055..9978df9 100644
--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/models.ts
@@ -19,3 +19,21 @@ export type t_TodoList = {
   totalItemCount: number
   updated: string
 }
+
+export type t_createTodoListItemJsonRequestBody = {
+  completedAt?: string
+  content: string
+  id: string
+}
+
+export type t_getTodoListItemsJson200Response = {
+  completedAt?: string
+  content: string
+  createdAt: string
+  id: string
+}
+
+export type t_getTodoListItemsJson5XXResponse = {
+  code: string
+  message: string
+}
````

</p>
</details> 
