### PR TITLE
feat: joi number min/max validation

### DIFF
--- a/packages/openapi-code-generator/src/test/input.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/input.test-utils.ts
@@ -6,9 +6,9 @@ import {logger} from "../core/logger"
 import {OpenapiLoader} from "../core/openapi-loader"
 import {OpenapiValidator} from "../core/openapi-validator"
 
-type Version = "3.0.x" | "3.1.x"
+export type OpenApiVersion = "3.0.x" | "3.1.x"
 
-function getTestVersions(): Version[] {
+function getTestVersions(): OpenApiVersion[] {
   if (process.argv.find((arg) => ["--updateSnapshot", "-u"].includes(arg))) {
     logger.warn("Running with --updateSnapshot - only testing one version")
     return ["3.0.x"]
@@ -19,7 +19,7 @@ function getTestVersions(): Version[] {
 
 export const testVersions = getTestVersions()
 
-function fileForVersion(version: Version) {
+function fileForVersion(version: OpenApiVersion) {
   switch (version) {
     case "3.0.x":
       return path.join(__dirname, "unit-test-inputs-3.0.3.yaml")
@@ -30,7 +30,10 @@ function fileForVersion(version: Version) {
   }
 }
 
-export async function unitTestInput(version: Version, skipValidation = false) {
+export async function unitTestInput(
+  version: OpenApiVersion,
+  skipValidation = false,
+) {
   const validator = await OpenapiValidator.create()
 
   if (skipValidation) {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -1,38 +1,36 @@
 import {describe, expect, it} from "@jest/globals"
-import {testVersions, unitTestInput} from "../../../test/input.test-utils"
-import {ImportBuilder} from "../import-builder"
-import {formatOutput} from "../output-utils"
-import {JoiBuilder} from "./joi-schema-builder"
+import {testVersions} from "../../../test/input.test-utils"
+import {schemaBuilderTestHarness} from "./schema-builder.test-utils"
 
 describe.each(testVersions)(
   "%s - typescript/common/schema-builders/joi-schema-builder",
   (version) => {
+    const {getActual} = schemaBuilderTestHarness("joi", version)
+
     it("supports the SimpleObject", async () => {
       const {code, schemas} = await getActual("components/schemas/SimpleObject")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_SimpleObject } from "./unit-test.schemas"
+        "import { s_SimpleObject } from "./unit-test.schemas"
 
-      const x = s_SimpleObject.required()
-      "
+        const x = s_SimpleObject.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_SimpleObject = joi
-        .object()
-        .keys({
-          str: joi.string().required(),
-          num: joi.number().required(),
-          date: joi.string().required(),
-          datetime: joi.string().required(),
-          optional_str: joi.string(),
-          required_nullable: joi.string().allow(null).required(),
-        })
-        .required()
-        .id("s_SimpleObject")
-      "
+        export const s_SimpleObject = joi
+          .object()
+          .keys({
+            str: joi.string().required(),
+            num: joi.number().required(),
+            date: joi.string().required(),
+            datetime: joi.string().required(),
+            optional_str: joi.string(),
+            required_nullable: joi.string().allow(null).required(),
+          })
+          .required()
+          .id("s_SimpleObject")"
       `)
     })
 
@@ -42,48 +40,46 @@ describe.each(testVersions)(
       )
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_ObjectWithComplexProperties } from "./unit-test.schemas"
+        "import { s_ObjectWithComplexProperties } from "./unit-test.schemas"
 
-      const x = s_ObjectWithComplexProperties.required()
-      "
+        const x = s_ObjectWithComplexProperties.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_AString = joi.string().required().id("s_AString")
+        export const s_AString = joi.string().required().id("s_AString")
 
-      export const s_OneOf = joi
-        .alternatives()
-        .try(
-          joi
-            .object()
-            .keys({ strs: joi.array().items(joi.string().required()).required() })
-            .required(),
-          joi.array().items(joi.string().required()).required(),
-          joi.string().required(),
-        )
-        .required()
-        .id("s_OneOf")
+        export const s_OneOf = joi
+          .alternatives()
+          .try(
+            joi
+              .object()
+              .keys({ strs: joi.array().items(joi.string().required()).required() })
+              .required(),
+            joi.array().items(joi.string().required()).required(),
+            joi.string().required(),
+          )
+          .required()
+          .id("s_OneOf")
 
-      export const s_ObjectWithComplexProperties = joi
-        .object()
-        .keys({
-          requiredOneOf: joi
-            .alternatives()
-            .try(joi.string().required(), joi.number().required())
-            .required(),
-          requiredOneOfRef: s_OneOf.required(),
-          optionalOneOf: joi
-            .alternatives()
-            .try(joi.string().required(), joi.number().required()),
-          optionalOneOfRef: s_OneOf,
-          nullableSingularOneOf: joi.boolean().allow(null),
-          nullableSingularOneOfRef: s_AString.allow(null),
-        })
-        .required()
-        .id("s_ObjectWithComplexProperties")
-      "
+        export const s_ObjectWithComplexProperties = joi
+          .object()
+          .keys({
+            requiredOneOf: joi
+              .alternatives()
+              .try(joi.string().required(), joi.number().required())
+              .required(),
+            requiredOneOfRef: s_OneOf.required(),
+            optionalOneOf: joi
+              .alternatives()
+              .try(joi.string().required(), joi.number().required()),
+            optionalOneOfRef: s_OneOf,
+            nullableSingularOneOf: joi.boolean().allow(null),
+            nullableSingularOneOfRef: s_AString.allow(null),
+          })
+          .required()
+          .id("s_ObjectWithComplexProperties")"
       `)
     })
 
@@ -91,28 +87,26 @@ describe.each(testVersions)(
       const {code, schemas} = await getActual("components/schemas/OneOf")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_OneOf } from "./unit-test.schemas"
+        "import { s_OneOf } from "./unit-test.schemas"
 
-      const x = s_OneOf.required()
-      "
+        const x = s_OneOf.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_OneOf = joi
-        .alternatives()
-        .try(
-          joi
-            .object()
-            .keys({ strs: joi.array().items(joi.string().required()).required() })
-            .required(),
-          joi.array().items(joi.string().required()).required(),
-          joi.string().required(),
-        )
-        .required()
-        .id("s_OneOf")
-      "
+        export const s_OneOf = joi
+          .alternatives()
+          .try(
+            joi
+              .object()
+              .keys({ strs: joi.array().items(joi.string().required()).required() })
+              .required(),
+            joi.array().items(joi.string().required()).required(),
+            joi.string().required(),
+          )
+          .required()
+          .id("s_OneOf")"
       `)
     })
 
@@ -120,21 +114,19 @@ describe.each(testVersions)(
       const {code, schemas} = await getActual("components/schemas/AnyOf")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_AnyOf } from "./unit-test.schemas"
+        "import { s_AnyOf } from "./unit-test.schemas"
 
-      const x = s_AnyOf.required()
-      "
+        const x = s_AnyOf.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_AnyOf = joi
-        .alternatives()
-        .try(joi.number().required(), joi.string().required())
-        .required()
-        .id("s_AnyOf")
-      "
+        export const s_AnyOf = joi
+          .alternatives()
+          .try(joi.number().required(), joi.string().required())
+          .required()
+          .id("s_AnyOf")"
       `)
     })
 
@@ -142,27 +134,25 @@ describe.each(testVersions)(
       const {code, schemas} = await getActual("components/schemas/AllOf")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_AllOf } from "./unit-test.schemas"
+        "import { s_AllOf } from "./unit-test.schemas"
 
-      const x = s_AllOf.required()
-      "
+        const x = s_AllOf.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_Base = joi
-        .object()
-        .keys({ name: joi.string().required(), breed: joi.string() })
-        .required()
-        .id("s_Base")
+        export const s_Base = joi
+          .object()
+          .keys({ name: joi.string().required(), breed: joi.string() })
+          .required()
+          .id("s_Base")
 
-      export const s_AllOf = s_Base
-        .required()
-        .concat(joi.object().keys({ id: joi.number().required() }).required())
-        .required()
-        .id("s_AllOf")
-      "
+        export const s_AllOf = s_Base
+          .required()
+          .concat(joi.object().keys({ id: joi.number().required() }).required())
+          .required()
+          .id("s_AllOf")"
       `)
     })
 
@@ -170,21 +160,19 @@ describe.each(testVersions)(
       const {code, schemas} = await getActual("components/schemas/Recursive")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_Recursive } from "./unit-test.schemas"
+        "import { s_Recursive } from "./unit-test.schemas"
 
-      const x = joi.link("#s_Recursive.required()")
-      "
+        const x = joi.link("#s_Recursive.required()")"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_Recursive = joi
-        .object()
-        .keys({ child: joi.link("#s_Recursive") })
-        .required()
-        .id("s_Recursive")
-      "
+        export const s_Recursive = joi
+          .object()
+          .keys({ child: joi.link("#s_Recursive") })
+          .required()
+          .id("s_Recursive")"
       `)
     })
 
@@ -192,36 +180,34 @@ describe.each(testVersions)(
       const {code, schemas} = await getActual("components/schemas/Ordering")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_Ordering } from "./unit-test.schemas"
+        "import { s_Ordering } from "./unit-test.schemas"
 
-      const x = s_Ordering.required()
-      "
+        const x = s_Ordering.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_AOrdering = joi
-        .object()
-        .keys({ name: joi.string() })
-        .required()
-        .id("s_AOrdering")
+        export const s_AOrdering = joi
+          .object()
+          .keys({ name: joi.string() })
+          .required()
+          .id("s_AOrdering")
 
-      export const s_ZOrdering = joi
-        .object()
-        .keys({ name: joi.string(), dependency1: s_AOrdering.required() })
-        .required()
-        .id("s_ZOrdering")
+        export const s_ZOrdering = joi
+          .object()
+          .keys({ name: joi.string(), dependency1: s_AOrdering.required() })
+          .required()
+          .id("s_ZOrdering")
 
-      export const s_Ordering = joi
-        .object()
-        .keys({
-          dependency1: s_ZOrdering.required(),
-          dependency2: s_AOrdering.required(),
-        })
-        .required()
-        .id("s_Ordering")
-      "
+        export const s_Ordering = joi
+          .object()
+          .keys({
+            dependency1: s_ZOrdering.required(),
+            dependency2: s_AOrdering.required(),
+          })
+          .required()
+          .id("s_Ordering")"
       `)
     })
 
@@ -229,24 +215,22 @@ describe.each(testVersions)(
       const {code, schemas} = await getActual("components/schemas/Enums")
 
       expect(code).toMatchInlineSnapshot(`
-      "import { s_Enums } from "./unit-test.schemas"
+        "import { s_Enums } from "./unit-test.schemas"
 
-      const x = s_Enums.required()
-      "
+        const x = s_Enums.required()"
       `)
 
       expect(schemas).toMatchInlineSnapshot(`
-      "import joi from "@hapi/joi"
+        "import joi from "@hapi/joi"
 
-      export const s_Enums = joi
-        .object()
-        .keys({
-          str: joi.string().valid("foo", "bar").allow(null),
-          num: joi.number().valid(10, 20).allow(null),
-        })
-        .required()
-        .id("s_Enums")
-      "
+        export const s_Enums = joi
+          .object()
+          .keys({
+            str: joi.string().valid("foo", "bar").allow(null),
+            num: joi.number().valid(10, 20).allow(null),
+          })
+          .required()
+          .id("s_Enums")"
       `)
     })
 
@@ -257,21 +241,19 @@ describe.each(testVersions)(
         )
 
         expect(code).toMatchInlineSnapshot(`
-        "import { s_AdditionalPropertiesBool } from "./unit-test.schemas"
+          "import { s_AdditionalPropertiesBool } from "./unit-test.schemas"
 
-        const x = s_AdditionalPropertiesBool.required()
-        "
+          const x = s_AdditionalPropertiesBool.required()"
         `)
 
         expect(schemas).toMatchInlineSnapshot(`
-        "import joi from "@hapi/joi"
+          "import joi from "@hapi/joi"
 
-        export const s_AdditionalPropertiesBool = joi
-          .object()
-          .pattern(joi.any(), joi.any())
-          .required()
-          .id("s_AdditionalPropertiesBool")
-        "
+          export const s_AdditionalPropertiesBool = joi
+            .object()
+            .pattern(joi.any(), joi.any())
+            .required()
+            .id("s_AdditionalPropertiesBool")"
         `)
       })
 
@@ -281,21 +263,19 @@ describe.each(testVersions)(
         )
 
         expect(code).toMatchInlineSnapshot(`
-        "import { s_AdditionalPropertiesUnknownEmptySchema } from "./unit-test.schemas"
+          "import { s_AdditionalPropertiesUnknownEmptySchema } from "./unit-test.schemas"
 
-        const x = s_AdditionalPropertiesUnknownEmptySchema.required()
-        "
+          const x = s_AdditionalPropertiesUnknownEmptySchema.required()"
         `)
 
         expect(schemas).toMatchInlineSnapshot(`
-        "import joi from "@hapi/joi"
+          "import joi from "@hapi/joi"
 
-        export const s_AdditionalPropertiesUnknownEmptySchema = joi
-          .object()
-          .pattern(joi.any(), joi.any())
-          .required()
-          .id("s_AdditionalPropertiesUnknownEmptySchema")
-        "
+          export const s_AdditionalPropertiesUnknownEmptySchema = joi
+            .object()
+            .pattern(joi.any(), joi.any())
+            .required()
+            .id("s_AdditionalPropertiesUnknownEmptySchema")"
         `)
       })
 
@@ -305,21 +285,19 @@ describe.each(testVersions)(
         )
 
         expect(code).toMatchInlineSnapshot(`
-        "import { s_AdditionalPropertiesUnknownEmptyObjectSchema } from "./unit-test.schemas"
+          "import { s_AdditionalPropertiesUnknownEmptyObjectSchema } from "./unit-test.schemas"
 
-        const x = s_AdditionalPropertiesUnknownEmptyObjectSchema.required()
-        "
+          const x = s_AdditionalPropertiesUnknownEmptyObjectSchema.required()"
         `)
 
         expect(schemas).toMatchInlineSnapshot(`
-        "import joi from "@hapi/joi"
+          "import joi from "@hapi/joi"
 
-        export const s_AdditionalPropertiesUnknownEmptyObjectSchema = joi
-          .object()
-          .pattern(joi.any(), joi.object().pattern(joi.any(), joi.any()).required())
-          .required()
-          .id("s_AdditionalPropertiesUnknownEmptyObjectSchema")
-        "
+          export const s_AdditionalPropertiesUnknownEmptyObjectSchema = joi
+            .object()
+            .pattern(joi.any(), joi.object().pattern(joi.any(), joi.any()).required())
+            .required()
+            .id("s_AdditionalPropertiesUnknownEmptyObjectSchema")"
         `)
       })
 
@@ -329,29 +307,27 @@ describe.each(testVersions)(
         )
 
         expect(code).toMatchInlineSnapshot(`
-        "import { s_AdditionalPropertiesSchema } from "./unit-test.schemas"
+          "import { s_AdditionalPropertiesSchema } from "./unit-test.schemas"
 
-        const x = s_AdditionalPropertiesSchema.required()
-        "
+          const x = s_AdditionalPropertiesSchema.required()"
         `)
 
         expect(schemas).toMatchInlineSnapshot(`
-        "import joi from "@hapi/joi"
+          "import joi from "@hapi/joi"
 
-        export const s_NamedNullableStringEnum = joi
-          .string()
-          .valid("", "one", "two", "three")
-          .allow(null)
-          .required()
-          .id("s_NamedNullableStringEnum")
+          export const s_NamedNullableStringEnum = joi
+            .string()
+            .valid("", "one", "two", "three")
+            .allow(null)
+            .required()
+            .id("s_NamedNullableStringEnum")
 
-        export const s_AdditionalPropertiesSchema = joi
-          .object()
-          .keys({ name: joi.string() })
-          .concat(joi.object().pattern(joi.any(), s_NamedNullableStringEnum.required()))
-          .required()
-          .id("s_AdditionalPropertiesSchema")
-        "
+          export const s_AdditionalPropertiesSchema = joi
+            .object()
+            .keys({ name: joi.string() })
+            .concat(joi.object().pattern(joi.any(), s_NamedNullableStringEnum.required()))
+            .required()
+            .id("s_AdditionalPropertiesSchema")"
         `)
       })
 
@@ -361,57 +337,22 @@ describe.each(testVersions)(
         )
 
         expect(code).toMatchInlineSnapshot(`
-        "import { s_AdditionalPropertiesMixed } from "./unit-test.schemas"
+          "import { s_AdditionalPropertiesMixed } from "./unit-test.schemas"
 
-        const x = s_AdditionalPropertiesMixed.required()
-        "
+          const x = s_AdditionalPropertiesMixed.required()"
         `)
 
         expect(schemas).toMatchInlineSnapshot(`
-        "import joi from "@hapi/joi"
+          "import joi from "@hapi/joi"
 
-        export const s_AdditionalPropertiesMixed = joi
-          .object()
-          .keys({ id: joi.string(), name: joi.string() })
-          .concat(joi.object().pattern(joi.any(), joi.any()))
-          .required()
-          .id("s_AdditionalPropertiesMixed")
-        "
+          export const s_AdditionalPropertiesMixed = joi
+            .object()
+            .keys({ id: joi.string(), name: joi.string() })
+            .concat(joi.object().pattern(joi.any(), joi.any()))
+            .required()
+            .id("s_AdditionalPropertiesMixed")"
         `)
       })
     })
-
-    async function getActual(path: string) {
-      const {input, file} = await unitTestInput(version)
-
-      const imports = new ImportBuilder()
-
-      const builder = await JoiBuilder.fromInput(
-        "./unit-test.schemas.ts",
-        input,
-      )
-
-      const schema = builder
-        .withImports(imports)
-        .fromModel({$ref: `${file}#${path}`}, true)
-
-      return {
-        code: await formatOutput(
-          `
-          ${imports.toString()}
-
-          const x = ${schema}
-        `,
-          "unit-test.code.ts",
-        ),
-        schemas: await formatOutput(
-          builder.toCompilationUnit().getRawFileContent({
-            allowUnusedImports: false,
-            includeHeader: false,
-          }),
-          "unit-test.schemas.ts",
-        ),
-      }
-    }
   },
 )

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -135,7 +135,13 @@ export class JoiBuilder extends AbstractSchemaBuilder<JoiBuilder> {
         .join(".")
     }
 
-    return result
+    return [
+      result,
+      model.minimum ? `min(${model.minimum})` : undefined,
+      model.maximum ? `max(${model.maximum})` : undefined,
+    ]
+      .filter(isDefined)
+      .join(".")
   }
 
   protected string(model: IRModelString) {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
@@ -1,0 +1,64 @@
+import {Input} from "../../../core/input"
+import {IRModel, MaybeIRModel} from "../../../core/openapi-types-normalized"
+import {OpenApiVersion, unitTestInput} from "../../../test/input.test-utils"
+import {ImportBuilder} from "../import-builder"
+import {formatOutput} from "../output-utils"
+import {SchemaBuilderType, schemaBuilderFactory} from "./schema-builder"
+
+export function schemaBuilderTestHarness(
+  schemaBuilderType: SchemaBuilderType,
+  version: OpenApiVersion,
+) {
+  async function getActualFromModel(model: IRModel) {
+    const {input} = await unitTestInput(version)
+    return getResult(input, model, true)
+  }
+
+  async function getActual(path: string) {
+    const {input, file} = await unitTestInput(version)
+    return getResult(input, {$ref: `${file}#${path}`}, true)
+  }
+
+  async function getResult(
+    input: Input,
+    maybeModel: MaybeIRModel,
+    required: boolean,
+  ) {
+    const imports = new ImportBuilder()
+
+    const builder = await schemaBuilderFactory(
+      "./unit-test.schemas.ts",
+      input,
+      schemaBuilderType,
+    )
+
+    const schema = builder.withImports(imports).fromModel(maybeModel, required)
+
+    return {
+      code: (
+        await formatOutput(
+          `
+          ${imports.toString()}
+
+          const x = ${schema}
+        `,
+          "unit-test.code.ts",
+        )
+      ).trim(),
+      schemas: (
+        await formatOutput(
+          builder.toCompilationUnit().getRawFileContent({
+            allowUnusedImports: false,
+            includeHeader: false,
+          }),
+          "unit-test.schemas.ts",
+        )
+      ).trim(),
+    }
+  }
+
+  return {
+    getActualFromModel,
+    getActual,
+  }
+}


### PR DESCRIPTION
#140 but for `joi` schema builders.

also unifies the test harness between `zod` and `joi` schema builder tests, hopefully helping me be less lazy about improving the `joi` schema builder in lockstep with `zod`.