### PR TITLE
feat: support exclusive min/max and multipleOf

### DIFF
--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -2245,7 +2245,7 @@ export const s_repository_rule_pull_request = z.object({
       dismiss_stale_reviews_on_push: z.coerce.boolean(),
       require_code_owner_review: z.coerce.boolean(),
       require_last_push_approval: z.coerce.boolean(),
-      required_approving_review_count: z.coerce.number().max(10),
+      required_approving_review_count: z.coerce.number().min(0).max(10),
       required_review_thread_resolution: z.coerce.boolean(),
     })
     .optional(),
@@ -3369,7 +3369,7 @@ export const s_global_advisory = z.object({
   cvss: z
     .object({
       vector_string: z.string().nullable(),
-      score: z.coerce.number().max(10).nullable(),
+      score: z.coerce.number().min(0).max(10).nullable(),
     })
     .nullable(),
   cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })).nullable(),
@@ -5473,7 +5473,7 @@ export const s_dependabot_alert_security_advisory = z.object({
   vulnerabilities: z.array(s_dependabot_alert_security_vulnerability),
   severity: z.enum(["low", "medium", "high", "critical"]),
   cvss: z.object({
-    score: z.coerce.number().max(10),
+    score: z.coerce.number().min(0).max(10),
     vector_string: z.string().nullable(),
   }),
   cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })),
@@ -6252,7 +6252,7 @@ export const s_protected_branch_pull_request_review = z.object({
     .optional(),
   dismiss_stale_reviews: z.coerce.boolean(),
   require_code_owner_reviews: z.coerce.boolean(),
-  required_approving_review_count: z.coerce.number().max(6).optional(),
+  required_approving_review_count: z.coerce.number().min(0).max(6).optional(),
   require_last_push_approval: z.coerce.boolean().optional(),
 })
 
@@ -6772,7 +6772,7 @@ export const s_repository_advisory = z.object({
   cvss: z
     .object({
       vector_string: z.string().nullable(),
-      score: z.coerce.number().max(10).nullable(),
+      score: z.coerce.number().min(0).max(10).nullable(),
     })
     .nullable(),
   cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })).nullable(),

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
@@ -309,7 +309,7 @@ export const s_Client = z.object({
   client_id_issued_at: z.coerce.number().optional(),
   client_name: z.string().optional(),
   client_secret: z.string().nullable().optional(),
-  client_secret_expires_at: z.coerce.number().nullable().optional(),
+  client_secret_expires_at: z.coerce.number().min(0).nullable().optional(),
   grant_types: z.array(s_GrantType).optional(),
   initiate_login_uri: z.string().optional(),
   jwks: z.array(s_JsonWebKey).optional(),

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -436,8 +436,11 @@ function normalizeSchemaObject(
         // todo: https://github.com/mnahkies/openapi-code-generator/issues/51
         format: schemaObject.format,
         enum: enumValues.length ? enumValues : undefined,
-        minimum: schemaObject.minimum,
+        exclusiveMaximum: schemaObject.exclusiveMaximum,
+        exclusiveMinimum: schemaObject.exclusiveMinimum,
         maximum: schemaObject.maximum,
+        minimum: schemaObject.minimum,
+        multipleOf: schemaObject.multipleOf,
       } satisfies IRModelNumeric
     }
     case "string": {

--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -14,8 +14,11 @@ export interface IRModelNumeric extends IRModelBase {
   type: "number"
   format?: IRModelNumericFormat | string | undefined
   enum?: number[] | undefined
-  minimum?: number | undefined
+  exclusiveMaximum?: number | undefined
+  exclusiveMinimum?: number | undefined
   maximum?: number | undefined
+  minimum?: number | undefined
+  multipleOf?: number | undefined
 }
 
 export type IRModelStringFormat =

--- a/packages/openapi-code-generator/src/core/openapi-types.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types.ts
@@ -196,9 +196,9 @@ export interface Schema {
   title?: string | undefined
   multipleOf?: number | undefined
   maximum?: number | undefined
-  exclusiveMaximum?: boolean | undefined
+  exclusiveMaximum?: number | undefined
   minimum?: number | undefined
-  exclusiveMinimum?: boolean | undefined
+  exclusiveMinimum?: number | undefined
   maxLength?: number | undefined
   minLength?: number | undefined
   pattern?: string | undefined

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -448,6 +448,90 @@ describe.each(testVersions)(
         )
         await expect(executeParseSchema(code, 20)).resolves.toBe(20)
       })
+
+      it("supports exclusiveMinimum", async () => {
+        const {code} = await getActualFromModel({
+          ...base,
+          exclusiveMinimum: 4,
+        })
+
+        expect(code).toMatchInlineSnapshot(
+          '"const x = joi.number().greater(4).required()"',
+        )
+
+        await expect(executeParseSchema(code, 4)).rejects.toThrow(
+          '"value" must be greater than 4',
+        )
+        await expect(executeParseSchema(code, 20)).resolves.toBe(20)
+      })
+
+      it("supports exclusiveMaximum", async () => {
+        const {code} = await getActualFromModel({
+          ...base,
+          exclusiveMaximum: 4,
+        })
+
+        expect(code).toMatchInlineSnapshot(
+          '"const x = joi.number().less(4).required()"',
+        )
+
+        await expect(executeParseSchema(code, 4)).rejects.toThrow(
+          '"value" must be less than 4',
+        )
+        await expect(executeParseSchema(code, 3)).resolves.toBe(3)
+      })
+
+      it("supports multipleOf", async () => {
+        const {code} = await getActualFromModel({
+          ...base,
+          multipleOf: 4,
+        })
+
+        expect(code).toMatchInlineSnapshot(
+          '"const x = joi.number().multiple(4).required()"',
+        )
+
+        await expect(executeParseSchema(code, 11)).rejects.toThrow(
+          '"value" must be a multiple of 4',
+        )
+        await expect(executeParseSchema(code, 16)).resolves.toBe(16)
+      })
+
+      it("supports combining multipleOf and min/max", async () => {
+        const {code} = await getActualFromModel({
+          ...base,
+          multipleOf: 4,
+          minimum: 10,
+          maximum: 20,
+        })
+
+        expect(code).toMatchInlineSnapshot(
+          '"const x = joi.number().multiple(4).min(10).max(20).required()"',
+        )
+
+        await expect(executeParseSchema(code, 11)).rejects.toThrow(
+          '"value" must be a multiple of 4',
+        )
+        await expect(executeParseSchema(code, 8)).rejects.toThrow(
+          '"value" must be larger than or equal to 10',
+        )
+        await expect(executeParseSchema(code, 24)).rejects.toThrow(
+          '"value" must be less than or equal to 20',
+        )
+        await expect(executeParseSchema(code, 16)).resolves.toBe(16)
+      })
+
+      it("supports 0", async () => {
+        const {code} = await getActualFromModel({...base, minimum: 0})
+
+        expect(code).toMatchInlineSnapshot(
+          '"const x = joi.number().min(0).required()"',
+        )
+
+        await expect(executeParseSchema(code, -1)).rejects.toThrow(
+          '"value" must be larger than or equal to 0',
+        )
+      })
     })
 
     async function executeParseSchema(code: string, input: unknown) {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -137,8 +137,19 @@ export class JoiBuilder extends AbstractSchemaBuilder<JoiBuilder> {
 
     return [
       result,
-      model.minimum ? `min(${model.minimum})` : undefined,
-      model.maximum ? `max(${model.maximum})` : undefined,
+      Number.isFinite(model.multipleOf)
+        ? `multiple(${model.multipleOf})`
+        : undefined,
+      Number.isFinite(model.exclusiveMinimum)
+        ? `greater(${model.exclusiveMinimum})`
+        : Number.isFinite(model.minimum)
+          ? `min(${model.minimum})`
+          : undefined,
+      Number.isFinite(model.exclusiveMaximum)
+        ? `less(${model.exclusiveMaximum})`
+        : Number.isFinite(model.maximum)
+          ? `max(${model.maximum})`
+          : undefined,
     ]
       .filter(isDefined)
       .join(".")

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -148,8 +148,19 @@ export class ZodBuilder extends AbstractSchemaBuilder<ZodBuilder> {
     return [
       zod,
       "coerce.number()",
-      model.minimum ? `min(${model.minimum})` : undefined,
-      model.maximum ? `max(${model.maximum})` : undefined,
+      Number.isFinite(model.multipleOf)
+        ? `multipleOf(${model.multipleOf})`
+        : undefined,
+      Number.isFinite(model.exclusiveMinimum)
+        ? `gt(${model.exclusiveMinimum})`
+        : Number.isFinite(model.minimum)
+          ? `min(${model.minimum})`
+          : undefined,
+      Number.isFinite(model.exclusiveMaximum)
+        ? `lt(${model.exclusiveMaximum})`
+        : Number.isFinite(model.maximum)
+          ? `max(${model.maximum})`
+          : undefined,
     ]
       .filter(isDefined)
       .join(".")


### PR DESCRIPTION
adds support for the rest of the number validation keywords defined by JSON schema validation.

also fixes a bug in #140 / #143 where `0` would be treated as `undefined`

relates #51 

ref: https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.2