### PR TITLE
feat: support string validation

### DIFF
--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -23367,7 +23367,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const gistsCreateCommentParamSchema = z.object({ gist_id: z.string() })
 
-  const gistsCreateCommentBodySchema = z.object({ body: z.string() })
+  const gistsCreateCommentBodySchema = z.object({ body: z.string().max(65535) })
 
   const gistsCreateCommentResponseValidator = responseValidationFactory(
     [
@@ -23518,7 +23518,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     comment_id: z.coerce.number(),
   })
 
-  const gistsUpdateCommentBodySchema = z.object({ body: z.string() })
+  const gistsUpdateCommentBodySchema = z.object({ body: z.string().max(65535) })
 
   const gistsUpdateCommentResponseValidator = responseValidationFactory(
     [
@@ -27577,7 +27577,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsCreateOrUpdateOrgSecretBodySchema = z.object({
-    encrypted_value: z.string().optional(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      )
+      .optional(),
     key_id: z.string().optional(),
     visibility: z.enum(["all", "private", "selected"]),
     selected_repository_ids: z.array(z.coerce.number()).optional(),
@@ -29254,7 +29261,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const codespacesCreateOrUpdateOrgSecretBodySchema = z.object({
-    encrypted_value: z.string().optional(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      )
+      .optional(),
     key_id: z.string().optional(),
     visibility: z.enum(["all", "private", "selected"]),
     selected_repository_ids: z.array(z.coerce.number()).optional(),
@@ -30391,7 +30405,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const dependabotCreateOrUpdateOrgSecretBodySchema = z.object({
-    encrypted_value: z.string().optional(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      )
+      .optional(),
     key_id: z.string().optional(),
     visibility: z.enum(["all", "private", "selected"]),
     selected_repository_ids: z.array(z.string()).optional(),
@@ -34959,7 +34980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const orgsReviewPatGrantRequestsInBulkBodySchema = z.object({
     pat_request_ids: z.array(z.coerce.number()).optional(),
     action: z.enum(["approve", "deny"]),
-    reason: z.string().nullable().optional(),
+    reason: z.string().max(1024).nullable().optional(),
   })
 
   const orgsReviewPatGrantRequestsInBulkResponseValidator =
@@ -35037,7 +35058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const orgsReviewPatGrantRequestBodySchema = z.object({
     action: z.enum(["approve", "deny"]),
-    reason: z.string().nullable().optional(),
+    reason: z.string().max(1024).nullable().optional(),
   })
 
   const orgsReviewPatGrantRequestResponseValidator = responseValidationFactory(
@@ -35807,7 +35828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .nullable()
       .optional(),
     description: z.string().nullable().optional(),
-    allowed_values: z.array(z.string()).nullable().optional(),
+    allowed_values: z.array(z.string().max(75)).nullable().optional(),
   })
 
   const orgsCreateOrUpdateCustomPropertyResponseValidator =
@@ -39707,7 +39728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const projectsMoveCardParamSchema = z.object({ card_id: z.coerce.number() })
 
   const projectsMoveCardBodySchema = z.object({
-    position: z.string(),
+    position: z.string().regex(new RegExp("^(?:top|bottom|after:\\d+)$")),
     column_id: z.coerce.number().optional(),
   })
 
@@ -40199,7 +40220,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     column_id: z.coerce.number(),
   })
 
-  const projectsMoveColumnBodySchema = z.object({ position: z.string() })
+  const projectsMoveColumnBodySchema = z.object({
+    position: z.string().regex(new RegExp("^(?:first|last|after:\\d+)$")),
+  })
 
   const projectsMoveColumnResponseValidator = responseValidationFactory(
     [
@@ -44676,7 +44699,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsCreateOrUpdateRepoSecretBodySchema = z.object({
-    encrypted_value: z.string().optional(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      )
+      .optional(),
     key_id: z.string().optional(),
   })
 
@@ -48467,8 +48497,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     output: z
       .object({
         title: z.string().optional(),
-        summary: z.string(),
-        text: z.string().optional(),
+        summary: z.string().max(65535),
+        text: z.string().max(65535).optional(),
         annotations: z
           .array(
             z.object({
@@ -48498,9 +48528,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     actions: z
       .array(
         z.object({
-          label: z.string(),
-          description: z.string(),
-          identifier: z.string(),
+          label: z.string().max(20),
+          description: z.string().max(40),
+          identifier: z.string().max(20),
         }),
       )
       .optional(),
@@ -50865,7 +50895,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const codespacesCreateOrUpdateRepoSecretBodySchema = z.object({
-    encrypted_value: z.string().optional(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      )
+      .optional(),
     key_id: z.string().optional(),
   })
 
@@ -53060,7 +53097,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "tolerable_risk",
       ])
       .optional(),
-    dismissed_comment: z.string().optional(),
+    dismissed_comment: z.string().max(280).optional(),
   })
 
   const dependabotUpdateAlertResponseValidator = responseValidationFactory(
@@ -53304,7 +53341,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const dependabotCreateOrUpdateRepoSecretBodySchema = z.object({
-    encrypted_value: z.string().optional(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      )
+      .optional(),
     key_id: z.string().optional(),
   })
 
@@ -54072,7 +54116,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposCreateDispatchEventBodySchema = z.object({
-    event_type: z.string(),
+    event_type: z.string().min(1).max(100),
     client_payload: z.record(z.any()).optional(),
   })
 
@@ -55157,7 +55201,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsCreateOrUpdateEnvironmentSecretBodySchema = z.object({
-    encrypted_value: z.string(),
+    encrypted_value: z
+      .string()
+      .regex(
+        new RegExp(
+          "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+        ),
+      ),
     key_id: z.string(),
   })
 
@@ -72453,7 +72503,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const codespacesCreateOrUpdateSecretForAuthenticatedUserBodySchema = z.object(
     {
-      encrypted_value: z.string().optional(),
+      encrypted_value: z
+        .string()
+        .regex(
+          new RegExp(
+            "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$",
+          ),
+        )
+        .optional(),
       key_id: z.string(),
       selected_repository_ids: z
         .array(z.union([z.coerce.number(), z.string()]))
@@ -75108,7 +75165,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const usersCreatePublicSshKeyForAuthenticatedUserBodySchema = z.object({
     title: z.string().optional(),
-    key: z.string(),
+    key: z
+      .string()
+      .regex(
+        new RegExp("^ssh-(rsa|dss|ed25519) |^ecdsa-sha2-nistp(256|384|521) "),
+      ),
   })
 
   const usersCreatePublicSshKeyForAuthenticatedUserResponseValidator =
@@ -77595,7 +77656,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const usersCreateSshSigningKeyForAuthenticatedUserBodySchema = z.object({
     title: z.string().optional(),
-    key: z.string(),
+    key: z
+      .string()
+      .regex(
+        new RegExp(
+          "^ssh-(rsa|dss|ed25519) |^ecdsa-sha2-nistp(256|384|521) |^(sk-ssh-ed25519|sk-ecdsa-sha2-nistp256)@openssh.com ",
+        ),
+      ),
   })
 
   const usersCreateSshSigningKeyForAuthenticatedUserResponseValidator =

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -417,7 +417,10 @@ export const s_code_scanning_alert_classification = z
   .enum(["source", "generated", "test", "library"])
   .nullable()
 
-export const s_code_scanning_alert_dismissed_comment = z.string().nullable()
+export const s_code_scanning_alert_dismissed_comment = z
+  .string()
+  .max(280)
+  .nullable()
 
 export const s_code_scanning_alert_dismissed_reason = z
   .enum(["false positive", "won't fix", "used in tests"])
@@ -489,7 +492,11 @@ export const s_code_scanning_analysis_analysis_key = z.string()
 
 export const s_code_scanning_analysis_category = z.string()
 
-export const s_code_scanning_analysis_commit_sha = z.string()
+export const s_code_scanning_analysis_commit_sha = z
+  .string()
+  .min(40)
+  .max(40)
+  .regex(new RegExp("^[0-9a-fA-F]+$"))
 
 export const s_code_scanning_analysis_created_at = z
   .string()
@@ -563,7 +570,9 @@ export const s_code_scanning_default_setup_update_response = z.object({
 
 export const s_code_scanning_ref = z.string()
 
-export const s_code_scanning_ref_full = z.string()
+export const s_code_scanning_ref_full = z
+  .string()
+  .regex(new RegExp("^refs/(heads|tags|pull)/.*$"))
 
 export const s_code_scanning_sarifs_status = z.object({
   processing_status: z.enum(["pending", "complete", "failed"]).optional(),
@@ -1066,7 +1075,11 @@ export const s_git_ref = z.object({
   ref: z.string(),
   node_id: z.string(),
   url: z.string(),
-  object: z.object({ type: z.string(), sha: z.string(), url: z.string() }),
+  object: z.object({
+    type: z.string(),
+    sha: z.string().min(40).max(40),
+    url: z.string(),
+  }),
 })
 
 export const s_git_tree = z.object({
@@ -1585,7 +1598,7 @@ export const s_org_custom_property = z.object({
     .nullable()
     .optional(),
   description: z.string().nullable().optional(),
-  allowed_values: z.array(z.string()).nullable().optional(),
+  allowed_values: z.array(z.string().max(75)).nullable().optional(),
   values_editable_by: z
     .enum(["org_actors", "org_and_repo_actors"])
     .nullable()
@@ -3227,7 +3240,7 @@ export const s_dependabot_alert_security_vulnerability = z.object({
 })
 
 export const s_dependency = z.object({
-  package_url: z.string().optional(),
+  package_url: z.string().regex(new RegExp("^pkg")).optional(),
   metadata: s_metadata.optional(),
   relationship: z.enum(["direct", "indirect"]).optional(),
   scope: z.enum(["runtime", "development"]).optional(),
@@ -3287,7 +3300,7 @@ export const s_gist_comment = z.object({
   id: z.coerce.number(),
   node_id: z.string(),
   url: z.string(),
-  body: z.string(),
+  body: z.string().max(65535),
   user: s_nullable_simple_user,
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
@@ -3337,8 +3350,8 @@ export const s_global_advisory = z.object({
   url: z.string(),
   html_url: z.string(),
   repository_advisory_url: z.string().nullable(),
-  summary: z.string(),
-  description: z.string().nullable(),
+  summary: z.string().max(1024),
+  description: z.string().max(65535).nullable(),
   type: z.enum(["reviewed", "unreviewed", "malware"]),
   severity: z.enum(["critical", "high", "medium", "low", "unknown"]),
   source_code_location: z.string().nullable(),
@@ -4034,8 +4047,8 @@ export const s_page_build = z.object({
 })
 
 export const s_private_vulnerability_report_create = z.object({
-  summary: z.string(),
-  description: z.string(),
+  summary: z.string().max(1024),
+  description: z.string().max(65535),
   vulnerabilities: z
     .array(
       z.object({
@@ -4412,8 +4425,8 @@ export const s_repository = z.object({
 })
 
 export const s_repository_advisory_create = z.object({
-  summary: z.string(),
-  description: z.string(),
+  summary: z.string().max(1024),
+  description: z.string().max(65535),
   cve_id: z.string().nullable().optional(),
   vulnerabilities: z.array(
     z.object({
@@ -4445,8 +4458,8 @@ export const s_repository_advisory_credit = z.object({
 })
 
 export const s_repository_advisory_update = z.object({
-  summary: z.string().optional(),
-  description: z.string().optional(),
+  summary: z.string().max(1024).optional(),
+  description: z.string().max(65535).optional(),
   cve_id: z.string().nullable().optional(),
   vulnerabilities: z
     .array(
@@ -5468,7 +5481,7 @@ export const s_demilestoned_issue_event = z.object({
 export const s_dependabot_alert_security_advisory = z.object({
   ghsa_id: z.string(),
   cve_id: z.string().nullable(),
-  summary: z.string(),
+  summary: z.string().max(1024),
   description: z.string(),
   vulnerabilities: z.array(s_dependabot_alert_security_vulnerability),
   severity: z.enum(["low", "medium", "high", "critical"]),
@@ -5538,7 +5551,7 @@ export const s_deployment_status = z.object({
     "in_progress",
   ]),
   creator: s_nullable_simple_user,
-  description: z.string(),
+  description: z.string().max(140),
   environment: z.string().optional(),
   target_url: z.string(),
   created_at: z.string().datetime({ offset: true }),
@@ -6753,8 +6766,8 @@ export const s_repository_advisory = z.object({
   cve_id: z.string().nullable(),
   url: z.string(),
   html_url: z.string(),
-  summary: z.string(),
-  description: z.string().nullable(),
+  summary: z.string().max(1024),
+  description: z.string().max(65535).nullable(),
   severity: z.enum(["critical", "high", "medium", "low"]).nullable(),
   author: s_simple_user.nullable(),
   publisher: s_simple_user.nullable(),
@@ -7225,7 +7238,7 @@ export const s_dependabot_alert = z.object({
       "tolerable_risk",
     ])
     .nullable(),
-  dismissed_comment: z.string().nullable(),
+  dismissed_comment: z.string().max(280).nullable(),
   fixed_at: s_alert_fixed_at,
   auto_dismissed_at: s_alert_auto_dismissed_at.optional(),
 })
@@ -7255,7 +7268,7 @@ export const s_dependabot_alert_with_repository = z.object({
       "tolerable_risk",
     ])
     .nullable(),
-  dismissed_comment: z.string().nullable(),
+  dismissed_comment: z.string().max(280).nullable(),
   fixed_at: s_alert_fixed_at,
   auto_dismissed_at: s_alert_auto_dismissed_at.optional(),
   repository: s_simple_repository,
@@ -7365,8 +7378,8 @@ export const s_snapshot = z.object({
     correlator: z.string(),
     html_url: z.string().optional(),
   }),
-  sha: z.string(),
-  ref: z.string(),
+  sha: z.string().min(40).max(40),
+  ref: z.string().regex(new RegExp("^refs/")),
   detector: z.object({
     name: z.string(),
     version: z.string(),

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -1158,17 +1158,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
       [
         "201",
         z.object({
-          id: z.string(),
-          status: z.string(),
-          expiresAt: z.string(),
-          profile: z.object({ email: z.string() }),
+          id: z.string().min(1),
+          status: z.string().min(1),
+          expiresAt: z.string().min(1),
+          profile: z.object({ email: z.string().min(1) }),
           _links: z.object({
             verify: z.object({
-              href: z.string(),
+              href: z.string().min(1),
               hints: z.object({ allow: z.array(z.string()) }),
             }),
             poll: z.object({
-              href: z.string(),
+              href: z.string().min(1),
               hints: z.object({ allow: z.array(z.string()) }),
             }),
           }),
@@ -1264,17 +1264,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         [
           "200",
           z.object({
-            id: z.string(),
-            status: z.string(),
-            expiresAt: z.string(),
-            profile: z.object({ email: z.string() }),
+            id: z.string().min(1),
+            status: z.string().min(1),
+            expiresAt: z.string().min(1),
+            profile: z.object({ email: z.string().min(1) }),
             _links: z.object({
               verify: z.object({
-                href: z.string(),
+                href: z.string().min(1),
                 hints: z.object({ allow: z.array(z.string()) }),
               }),
               poll: z.object({
-                href: z.string(),
+                href: z.string().min(1),
                 hints: z.object({ allow: z.array(z.string()) }),
               }),
             }),
@@ -1653,7 +1653,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               verify: z
                 .object({
-                  href: z.string(),
+                  href: z.string().min(1),
                   hints: z.object({ allow: z.array(z.string()) }),
                 })
                 .optional(),

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
@@ -22,7 +22,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
     .object({
       self: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z
             .object({ allow: z.array(z.enum(["PATCH", "DELETE"])).optional() })
             .optional(),
@@ -41,33 +41,33 @@ export const s_AppAuthenticatorMethodCapabilities = z.object({
 })
 
 export const s_Email = z.object({
-  id: z.string(),
-  profile: z.object({ email: z.string() }),
+  id: z.string().min(1),
+  profile: z.object({ email: z.string().min(1) }),
   roles: z.array(z.string()),
-  status: z.string(),
+  status: z.string().min(1),
   _links: z
     .object({
       self: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),
       challenge: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),
       verify: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),
       poll: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),
@@ -103,26 +103,26 @@ export const s_KeyRSA = z.object({
 })
 
 export const s_Phone = z.object({
-  id: z.string(),
-  profile: z.object({ phoneNumber: z.string() }),
-  status: z.string(),
+  id: z.string().min(1),
+  profile: z.object({ phoneNumber: z.string().min(1) }),
+  status: z.string().min(1),
   _links: z
     .object({
       self: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),
       challenge: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),
       verify: z
         .object({
-          href: z.string().optional(),
+          href: z.string().min(1).optional(),
           hints: z.object({ allow: z.array(z.string()).optional() }).optional(),
         })
         .optional(),

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -13224,7 +13224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const getAccountQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountBodySchema = z.object({}).optional()
@@ -13276,7 +13276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postAccountLinksBodySchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     collect: z.enum(["currently_due", "eventually_due"]).optional(),
     collection_options: z
       .object({
@@ -13284,7 +13284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         future_requirements: z.enum(["include", "omit"]).optional(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     refresh_url: z.string().optional(),
     return_url: z.string().optional(),
     type: z.enum(["account_onboarding", "account_update"]),
@@ -13390,7 +13390,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
     }),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const postAccountSessionsResponseValidator = responseValidationFactory(
@@ -13452,7 +13452,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
   })
@@ -13467,7 +13467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_account)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/accounts")),
         }),
       ],
     ],
@@ -13522,29 +13522,29 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postAccountsBodySchema = z
     .object({
-      account_token: z.string().optional(),
+      account_token: z.string().max(5000).optional(),
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
+            account_number: z.string().max(5000),
             account_type: z
               .enum(["checking", "futsu", "savings", "toza"])
               .optional(),
-            country: z.string(),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string()).optional() })
+                  .object({ files: z.array(z.string().max(500)).optional() })
                   .optional(),
               })
               .optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       business_profile: z
@@ -13553,28 +13553,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               amount: z.coerce.number(),
               currency: z.string(),
-              fiscal_year_end: z.string(),
+              fiscal_year_end: z.string().max(5000),
             })
             .optional(),
           estimated_worker_count: z.coerce.number().optional(),
-          mcc: z.string().optional(),
+          mcc: z.string().max(4).optional(),
           monthly_estimated_revenue: z
             .object({ amount: z.coerce.number(), currency: z.string() })
             .optional(),
-          name: z.string().optional(),
-          product_description: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          product_description: z.string().max(40000).optional(),
           support_address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           support_email: z.string().optional(),
-          support_phone: z.string().optional(),
+          support_phone: z.string().max(5000).optional(),
           support_url: z.union([z.string(), z.enum([""])]).optional(),
           url: z.string().optional(),
         })
@@ -13710,53 +13710,53 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           address_kana: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           address_kanji: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           directors_provided: z.coerce.boolean().optional(),
           executives_provided: z.coerce.boolean().optional(),
-          export_license_id: z.string().optional(),
-          export_purpose_code: z.string().optional(),
-          name: z.string().optional(),
-          name_kana: z.string().optional(),
-          name_kanji: z.string().optional(),
+          export_license_id: z.string().max(5000).optional(),
+          export_purpose_code: z.string().max(5000).optional(),
+          name: z.string().max(100).optional(),
+          name_kana: z.string().max(100).optional(),
+          name_kanji: z.string().max(100).optional(),
           owners_provided: z.coerce.boolean().optional(),
           ownership_declaration: z
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              user_agent: z.string().optional(),
+              user_agent: z.string().max(5000).optional(),
             })
             .optional(),
-          phone: z.string().optional(),
-          registration_number: z.string().optional(),
+          phone: z.string().max(5000).optional(),
+          registration_number: z.string().max(5000).optional(),
           structure: z
             .enum([
               "",
@@ -13785,83 +13785,83 @@ export function createRouter(implementation: Implementation): KoaRouter {
               "unincorporated_partnership",
             ])
             .optional(),
-          tax_id: z.string().optional(),
-          tax_id_registrar: z.string().optional(),
-          vat_id: z.string().optional(),
+          tax_id: z.string().max(5000).optional(),
+          tax_id_registrar: z.string().max(5000).optional(),
+          vat_id: z.string().max(5000).optional(),
           verification: z
             .object({
               document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
             })
             .optional(),
         })
         .optional(),
-      country: z.string().optional(),
+      country: z.string().max(5000).optional(),
       default_currency: z.string().optional(),
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_license: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_memorandum_of_association: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_ministerial_decree: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_registration_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_tax_id_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           proof_of_registration: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
         })
         .optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      external_account: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      external_account: z.string().max(5000).optional(),
       individual: z
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           address_kana: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           address_kanji: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           dob: z
@@ -13875,30 +13875,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ])
             .optional(),
           email: z.string().optional(),
-          first_name: z.string().optional(),
-          first_name_kana: z.string().optional(),
-          first_name_kanji: z.string().optional(),
+          first_name: z.string().max(100).optional(),
+          first_name_kana: z.string().max(5000).optional(),
+          first_name_kanji: z.string().max(5000).optional(),
           full_name_aliases: z
-            .union([z.array(z.string()), z.enum([""])])
+            .union([z.array(z.string().max(300)), z.enum([""])])
             .optional(),
           gender: z.string().optional(),
-          id_number: z.string().optional(),
-          id_number_secondary: z.string().optional(),
-          last_name: z.string().optional(),
-          last_name_kana: z.string().optional(),
-          last_name_kanji: z.string().optional(),
-          maiden_name: z.string().optional(),
+          id_number: z.string().max(5000).optional(),
+          id_number_secondary: z.string().max(5000).optional(),
+          last_name: z.string().max(100).optional(),
+          last_name_kana: z.string().max(5000).optional(),
+          last_name_kanji: z.string().max(5000).optional(),
+          maiden_name: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
           phone: z.string().optional(),
           political_exposure: z.enum(["existing", "none"]).optional(),
           registered_address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           relationship: z
@@ -13909,22 +13909,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
               percent_ownership: z
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
-              title: z.string().optional(),
+              title: z.string().max(5000).optional(),
             })
             .optional(),
-          ssn_last_4: z.string().optional(),
+          ssn_last_4: z.string().max(5000).optional(),
           verification: z
             .object({
               additional_document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
               document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
             })
@@ -13939,10 +13939,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           branding: z
             .object({
-              icon: z.string().optional(),
-              logo: z.string().optional(),
-              primary_color: z.string().optional(),
-              secondary_color: z.string().optional(),
+              icon: z.string().max(5000).optional(),
+              logo: z.string().max(5000).optional(),
+              primary_color: z.string().max(5000).optional(),
+              secondary_color: z.string().max(5000).optional(),
             })
             .optional(),
           card_issuing: z
@@ -13951,7 +13951,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                  user_agent: z
+                    .union([z.string().max(5000), z.enum([""])])
+                    .optional(),
                 })
                 .optional(),
             })
@@ -13964,20 +13966,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   cvc_failure: z.coerce.boolean().optional(),
                 })
                 .optional(),
-              statement_descriptor_prefix: z.string().optional(),
+              statement_descriptor_prefix: z.string().max(10).optional(),
               statement_descriptor_prefix_kana: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(10), z.enum([""])])
                 .optional(),
               statement_descriptor_prefix_kanji: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(10), z.enum([""])])
                 .optional(),
             })
             .optional(),
           payments: z
             .object({
-              statement_descriptor: z.string().optional(),
-              statement_descriptor_kana: z.string().optional(),
-              statement_descriptor_kanji: z.string().optional(),
+              statement_descriptor: z.string().max(22).optional(),
+              statement_descriptor_kana: z.string().max(22).optional(),
+              statement_descriptor_kanji: z.string().max(22).optional(),
             })
             .optional(),
           payouts: z
@@ -14005,7 +14007,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .optional(),
                 })
                 .optional(),
-              statement_descriptor: z.string().optional(),
+              statement_descriptor: z.string().max(22).optional(),
             })
             .optional(),
           treasury: z
@@ -14014,7 +14016,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                  user_agent: z
+                    .union([z.string().max(5000), z.enum([""])])
+                    .optional(),
                 })
                 .optional(),
             })
@@ -14025,8 +14029,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          service_agreement: z.string().optional(),
-          user_agent: z.string().optional(),
+          service_agreement: z.string().max(5000).optional(),
+          user_agent: z.string().max(5000).optional(),
         })
         .optional(),
       type: z.enum(["custom", "express", "standard"]).optional(),
@@ -14075,7 +14079,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteAccountsAccountParamSchema = z.object({ account: z.string() })
+  const deleteAccountsAccountParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const deleteAccountsAccountBodySchema = z.object({}).optional()
 
@@ -14129,10 +14135,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getAccountsAccountParamSchema = z.object({ account: z.string() })
+  const getAccountsAccountParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const getAccountsAccountQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountBodySchema = z.object({}).optional()
@@ -14191,39 +14199,41 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postAccountsAccountParamSchema = z.object({ account: z.string() })
+  const postAccountsAccountParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const postAccountsAccountBodySchema = z
     .object({
-      account_token: z.string().optional(),
+      account_token: z.string().max(5000).optional(),
       business_profile: z
         .object({
           annual_revenue: z
             .object({
               amount: z.coerce.number(),
               currency: z.string(),
-              fiscal_year_end: z.string(),
+              fiscal_year_end: z.string().max(5000),
             })
             .optional(),
           estimated_worker_count: z.coerce.number().optional(),
-          mcc: z.string().optional(),
+          mcc: z.string().max(4).optional(),
           monthly_estimated_revenue: z
             .object({ amount: z.coerce.number(), currency: z.string() })
             .optional(),
-          name: z.string().optional(),
-          product_description: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          product_description: z.string().max(40000).optional(),
           support_address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           support_email: z.string().optional(),
-          support_phone: z.string().optional(),
+          support_phone: z.string().max(5000).optional(),
           support_url: z.union([z.string(), z.enum([""])]).optional(),
           url: z.string().optional(),
         })
@@ -14359,53 +14369,53 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           address_kana: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           address_kanji: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           directors_provided: z.coerce.boolean().optional(),
           executives_provided: z.coerce.boolean().optional(),
-          export_license_id: z.string().optional(),
-          export_purpose_code: z.string().optional(),
-          name: z.string().optional(),
-          name_kana: z.string().optional(),
-          name_kanji: z.string().optional(),
+          export_license_id: z.string().max(5000).optional(),
+          export_purpose_code: z.string().max(5000).optional(),
+          name: z.string().max(100).optional(),
+          name_kana: z.string().max(100).optional(),
+          name_kanji: z.string().max(100).optional(),
           owners_provided: z.coerce.boolean().optional(),
           ownership_declaration: z
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              user_agent: z.string().optional(),
+              user_agent: z.string().max(5000).optional(),
             })
             .optional(),
-          phone: z.string().optional(),
-          registration_number: z.string().optional(),
+          phone: z.string().max(5000).optional(),
+          registration_number: z.string().max(5000).optional(),
           structure: z
             .enum([
               "",
@@ -14434,15 +14444,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
               "unincorporated_partnership",
             ])
             .optional(),
-          tax_id: z.string().optional(),
-          tax_id_registrar: z.string().optional(),
-          vat_id: z.string().optional(),
+          tax_id: z.string().max(5000).optional(),
+          tax_id_registrar: z.string().max(5000).optional(),
+          vat_id: z.string().max(5000).optional(),
           verification: z
             .object({
               document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
             })
@@ -14453,63 +14463,63 @@ export function createRouter(implementation: Implementation): KoaRouter {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_license: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_memorandum_of_association: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_ministerial_decree: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_registration_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           company_tax_id_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
           proof_of_registration: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
         })
         .optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      external_account: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      external_account: z.string().max(5000).optional(),
       individual: z
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           address_kana: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           address_kanji: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           dob: z
@@ -14523,30 +14533,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ])
             .optional(),
           email: z.string().optional(),
-          first_name: z.string().optional(),
-          first_name_kana: z.string().optional(),
-          first_name_kanji: z.string().optional(),
+          first_name: z.string().max(100).optional(),
+          first_name_kana: z.string().max(5000).optional(),
+          first_name_kanji: z.string().max(5000).optional(),
           full_name_aliases: z
-            .union([z.array(z.string()), z.enum([""])])
+            .union([z.array(z.string().max(300)), z.enum([""])])
             .optional(),
           gender: z.string().optional(),
-          id_number: z.string().optional(),
-          id_number_secondary: z.string().optional(),
-          last_name: z.string().optional(),
-          last_name_kana: z.string().optional(),
-          last_name_kanji: z.string().optional(),
-          maiden_name: z.string().optional(),
+          id_number: z.string().max(5000).optional(),
+          id_number_secondary: z.string().max(5000).optional(),
+          last_name: z.string().max(100).optional(),
+          last_name_kana: z.string().max(5000).optional(),
+          last_name_kanji: z.string().max(5000).optional(),
+          maiden_name: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
           phone: z.string().optional(),
           political_exposure: z.enum(["existing", "none"]).optional(),
           registered_address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           relationship: z
@@ -14557,22 +14567,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
               percent_ownership: z
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
-              title: z.string().optional(),
+              title: z.string().max(5000).optional(),
             })
             .optional(),
-          ssn_last_4: z.string().optional(),
+          ssn_last_4: z.string().max(5000).optional(),
           verification: z
             .object({
               additional_document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
               document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
             })
@@ -14587,10 +14597,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           branding: z
             .object({
-              icon: z.string().optional(),
-              logo: z.string().optional(),
-              primary_color: z.string().optional(),
-              secondary_color: z.string().optional(),
+              icon: z.string().max(5000).optional(),
+              logo: z.string().max(5000).optional(),
+              primary_color: z.string().max(5000).optional(),
+              secondary_color: z.string().max(5000).optional(),
             })
             .optional(),
           card_issuing: z
@@ -14599,7 +14609,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                  user_agent: z
+                    .union([z.string().max(5000), z.enum([""])])
+                    .optional(),
                 })
                 .optional(),
             })
@@ -14612,27 +14624,27 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   cvc_failure: z.coerce.boolean().optional(),
                 })
                 .optional(),
-              statement_descriptor_prefix: z.string().optional(),
+              statement_descriptor_prefix: z.string().max(10).optional(),
               statement_descriptor_prefix_kana: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(10), z.enum([""])])
                 .optional(),
               statement_descriptor_prefix_kanji: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(10), z.enum([""])])
                 .optional(),
             })
             .optional(),
           invoices: z
             .object({
               default_account_tax_ids: z
-                .union([z.array(z.string()), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.enum([""])])
                 .optional(),
             })
             .optional(),
           payments: z
             .object({
-              statement_descriptor: z.string().optional(),
-              statement_descriptor_kana: z.string().optional(),
-              statement_descriptor_kanji: z.string().optional(),
+              statement_descriptor: z.string().max(22).optional(),
+              statement_descriptor_kana: z.string().max(22).optional(),
+              statement_descriptor_kanji: z.string().max(22).optional(),
             })
             .optional(),
           payouts: z
@@ -14660,7 +14672,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .optional(),
                 })
                 .optional(),
-              statement_descriptor: z.string().optional(),
+              statement_descriptor: z.string().max(22).optional(),
             })
             .optional(),
           treasury: z
@@ -14669,7 +14681,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                  user_agent: z
+                    .union([z.string().max(5000), z.enum([""])])
+                    .optional(),
                 })
                 .optional(),
             })
@@ -14680,8 +14694,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           date: z.coerce.number().optional(),
           ip: z.string().optional(),
-          service_agreement: z.string().optional(),
-          user_agent: z.string().optional(),
+          service_agreement: z.string().max(5000).optional(),
+          user_agent: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -14738,7 +14752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountBankAccountsParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postAccountsAccountBankAccountsBodySchema = z
@@ -14746,30 +14760,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
+            account_number: z.string().max(5000),
             account_type: z
               .enum(["checking", "futsu", "savings", "toza"])
               .optional(),
-            country: z.string(),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string()).optional() })
+                  .object({ files: z.array(z.string().max(500)).optional() })
                   .optional(),
               })
               .optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       default_for_currency: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
-      external_account: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      external_account: z.string().max(5000).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -14823,7 +14837,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteAccountsAccountBankAccountsIdParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     id: z.string(),
   })
 
@@ -14881,12 +14895,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountBankAccountsIdParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     id: z.string(),
   })
 
   const getAccountsAccountBankAccountsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountBankAccountsIdBodySchema = z.object({}).optional()
@@ -14944,34 +14958,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountBankAccountsIdParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     id: z.string(),
   })
 
   const postAccountsAccountBankAccountsIdBodySchema = z
     .object({
-      account_holder_name: z.string().optional(),
+      account_holder_name: z.string().max(5000).optional(),
       account_holder_type: z.enum(["", "company", "individual"]).optional(),
       account_type: z.enum(["checking", "futsu", "savings", "toza"]).optional(),
-      address_city: z.string().optional(),
-      address_country: z.string().optional(),
-      address_line1: z.string().optional(),
-      address_line2: z.string().optional(),
-      address_state: z.string().optional(),
-      address_zip: z.string().optional(),
+      address_city: z.string().max(5000).optional(),
+      address_country: z.string().max(5000).optional(),
+      address_line1: z.string().max(5000).optional(),
+      address_line2: z.string().max(5000).optional(),
+      address_state: z.string().max(5000).optional(),
+      address_zip: z.string().max(5000).optional(),
       default_for_currency: z.coerce.boolean().optional(),
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
         })
         .optional(),
-      exp_month: z.string().optional(),
-      exp_year: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      exp_month: z.string().max(5000).optional(),
+      exp_year: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -15027,11 +15041,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountCapabilitiesParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const getAccountsAccountCapabilitiesQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountCapabilitiesBodySchema = z.object({}).optional()
@@ -15045,7 +15059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_capability)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -15107,12 +15121,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountCapabilitiesCapabilityParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     capability: z.string(),
   })
 
   const getAccountsAccountCapabilitiesCapabilityQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountCapabilitiesCapabilityBodySchema = z
@@ -15175,13 +15189,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountCapabilitiesCapabilityParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     capability: z.string(),
   })
 
   const postAccountsAccountCapabilitiesCapabilityBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       requested: z.coerce.boolean().optional(),
     })
     .optional()
@@ -15238,12 +15252,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountExternalAccountsParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const getAccountsAccountExternalAccountsQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     object: z.enum(["bank_account", "card"]).optional(),
     starting_after: z.string().optional(),
@@ -15262,7 +15276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -15327,7 +15341,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountExternalAccountsParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postAccountsAccountExternalAccountsBodySchema = z
@@ -15335,30 +15349,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
+            account_number: z.string().max(5000),
             account_type: z
               .enum(["checking", "futsu", "savings", "toza"])
               .optional(),
-            country: z.string(),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string()).optional() })
+                  .object({ files: z.array(z.string().max(500)).optional() })
                   .optional(),
               })
               .optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       default_for_currency: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
-      external_account: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      external_account: z.string().max(5000).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -15415,7 +15429,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteAccountsAccountExternalAccountsIdParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     id: z.string(),
   })
 
@@ -15475,12 +15489,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountExternalAccountsIdParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     id: z.string(),
   })
 
   const getAccountsAccountExternalAccountsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountExternalAccountsIdBodySchema = z.object({}).optional()
@@ -15541,34 +15555,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountExternalAccountsIdParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
     id: z.string(),
   })
 
   const postAccountsAccountExternalAccountsIdBodySchema = z
     .object({
-      account_holder_name: z.string().optional(),
+      account_holder_name: z.string().max(5000).optional(),
       account_holder_type: z.enum(["", "company", "individual"]).optional(),
       account_type: z.enum(["checking", "futsu", "savings", "toza"]).optional(),
-      address_city: z.string().optional(),
-      address_country: z.string().optional(),
-      address_line1: z.string().optional(),
-      address_line2: z.string().optional(),
-      address_state: z.string().optional(),
-      address_zip: z.string().optional(),
+      address_city: z.string().max(5000).optional(),
+      address_country: z.string().max(5000).optional(),
+      address_line1: z.string().max(5000).optional(),
+      address_line2: z.string().max(5000).optional(),
+      address_state: z.string().max(5000).optional(),
+      address_zip: z.string().max(5000).optional(),
       default_for_currency: z.coerce.boolean().optional(),
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string()).optional() })
+            .object({ files: z.array(z.string().max(500)).optional() })
             .optional(),
         })
         .optional(),
-      exp_month: z.string().optional(),
-      exp_year: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      exp_month: z.string().max(5000).optional(),
+      exp_year: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -15624,11 +15638,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountLoginLinksParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postAccountsAccountLoginLinksBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postAccountsAccountLoginLinksResponseValidator =
@@ -15679,11 +15693,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getAccountsAccountPeopleParamSchema = z.object({ account: z.string() })
+  const getAccountsAccountPeopleParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const getAccountsAccountPeopleQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     relationship: z
       .object({
@@ -15694,7 +15710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         representative: z.coerce.boolean().optional(),
       })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getAccountsAccountPeopleBodySchema = z.object({}).optional()
@@ -15707,7 +15723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_person)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -15768,7 +15784,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postAccountsAccountPeopleParamSchema = z.object({ account: z.string() })
+  const postAccountsAccountPeopleParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const postAccountsAccountPeopleBodySchema = z
     .object({
@@ -15778,41 +15796,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              user_agent: z.union([z.string(), z.enum([""])]).optional(),
+              user_agent: z
+                .union([z.string().max(5000), z.enum([""])])
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       address_kana: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       address_kanji: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       dob: z
@@ -15829,49 +15849,55 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           company_authorization: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           passport: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           visa: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      first_name: z.string().optional(),
-      first_name_kana: z.string().optional(),
-      first_name_kanji: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      first_name: z.string().max(5000).optional(),
+      first_name_kana: z.string().max(5000).optional(),
+      first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       gender: z.string().optional(),
-      id_number: z.string().optional(),
-      id_number_secondary: z.string().optional(),
-      last_name: z.string().optional(),
-      last_name_kana: z.string().optional(),
-      last_name_kanji: z.string().optional(),
-      maiden_name: z.string().optional(),
+      id_number: z.string().max(5000).optional(),
+      id_number_secondary: z.string().max(5000).optional(),
+      last_name: z.string().max(5000).optional(),
+      last_name_kana: z.string().max(5000).optional(),
+      last_name_kanji: z.string().max(5000).optional(),
+      maiden_name: z.string().max(5000).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      nationality: z.string().optional(),
-      person_token: z.string().optional(),
+      nationality: z.string().max(5000).optional(),
+      person_token: z.string().max(5000).optional(),
       phone: z.string().optional(),
-      political_exposure: z.string().optional(),
+      political_exposure: z.string().max(5000).optional(),
       registered_address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       relationship: z
@@ -15884,7 +15910,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
           representative: z.coerce.boolean().optional(),
-          title: z.string().optional(),
+          title: z.string().max(5000).optional(),
         })
         .optional(),
       ssn_last_4: z.string().optional(),
@@ -15892,14 +15918,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           additional_document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
           document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
         })
@@ -15958,8 +15984,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteAccountsAccountPeoplePersonParamSchema = z.object({
-    account: z.string(),
-    person: z.string(),
+    account: z.string().max(5000),
+    person: z.string().max(5000),
   })
 
   const deleteAccountsAccountPeoplePersonBodySchema = z.object({}).optional()
@@ -16016,12 +16042,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountPeoplePersonParamSchema = z.object({
-    account: z.string(),
-    person: z.string(),
+    account: z.string().max(5000),
+    person: z.string().max(5000),
   })
 
   const getAccountsAccountPeoplePersonQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountPeoplePersonBodySchema = z.object({}).optional()
@@ -16079,8 +16105,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountPeoplePersonParamSchema = z.object({
-    account: z.string(),
-    person: z.string(),
+    account: z.string().max(5000),
+    person: z.string().max(5000),
   })
 
   const postAccountsAccountPeoplePersonBodySchema = z
@@ -16091,41 +16117,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              user_agent: z.union([z.string(), z.enum([""])]).optional(),
+              user_agent: z
+                .union([z.string().max(5000), z.enum([""])])
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       address_kana: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       address_kanji: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       dob: z
@@ -16142,49 +16170,55 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           company_authorization: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           passport: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           visa: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      first_name: z.string().optional(),
-      first_name_kana: z.string().optional(),
-      first_name_kanji: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      first_name: z.string().max(5000).optional(),
+      first_name_kana: z.string().max(5000).optional(),
+      first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       gender: z.string().optional(),
-      id_number: z.string().optional(),
-      id_number_secondary: z.string().optional(),
-      last_name: z.string().optional(),
-      last_name_kana: z.string().optional(),
-      last_name_kanji: z.string().optional(),
-      maiden_name: z.string().optional(),
+      id_number: z.string().max(5000).optional(),
+      id_number_secondary: z.string().max(5000).optional(),
+      last_name: z.string().max(5000).optional(),
+      last_name_kana: z.string().max(5000).optional(),
+      last_name_kanji: z.string().max(5000).optional(),
+      maiden_name: z.string().max(5000).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      nationality: z.string().optional(),
-      person_token: z.string().optional(),
+      nationality: z.string().max(5000).optional(),
+      person_token: z.string().max(5000).optional(),
       phone: z.string().optional(),
-      political_exposure: z.string().optional(),
+      political_exposure: z.string().max(5000).optional(),
       registered_address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       relationship: z
@@ -16197,7 +16231,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
           representative: z.coerce.boolean().optional(),
-          title: z.string().optional(),
+          title: z.string().max(5000).optional(),
         })
         .optional(),
       ssn_last_4: z.string().optional(),
@@ -16205,14 +16239,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           additional_document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
           document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
         })
@@ -16268,11 +16302,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getAccountsAccountPersonsParamSchema = z.object({ account: z.string() })
+  const getAccountsAccountPersonsParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const getAccountsAccountPersonsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     relationship: z
       .object({
@@ -16283,7 +16319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         representative: z.coerce.boolean().optional(),
       })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getAccountsAccountPersonsBodySchema = z.object({}).optional()
@@ -16296,7 +16332,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_person)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -16358,7 +16394,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountPersonsParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postAccountsAccountPersonsBodySchema = z
@@ -16369,41 +16405,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              user_agent: z.union([z.string(), z.enum([""])]).optional(),
+              user_agent: z
+                .union([z.string().max(5000), z.enum([""])])
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       address_kana: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       address_kanji: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       dob: z
@@ -16420,49 +16458,55 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           company_authorization: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           passport: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           visa: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      first_name: z.string().optional(),
-      first_name_kana: z.string().optional(),
-      first_name_kanji: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      first_name: z.string().max(5000).optional(),
+      first_name_kana: z.string().max(5000).optional(),
+      first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       gender: z.string().optional(),
-      id_number: z.string().optional(),
-      id_number_secondary: z.string().optional(),
-      last_name: z.string().optional(),
-      last_name_kana: z.string().optional(),
-      last_name_kanji: z.string().optional(),
-      maiden_name: z.string().optional(),
+      id_number: z.string().max(5000).optional(),
+      id_number_secondary: z.string().max(5000).optional(),
+      last_name: z.string().max(5000).optional(),
+      last_name_kana: z.string().max(5000).optional(),
+      last_name_kanji: z.string().max(5000).optional(),
+      maiden_name: z.string().max(5000).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      nationality: z.string().optional(),
-      person_token: z.string().optional(),
+      nationality: z.string().max(5000).optional(),
+      person_token: z.string().max(5000).optional(),
       phone: z.string().optional(),
-      political_exposure: z.string().optional(),
+      political_exposure: z.string().max(5000).optional(),
       registered_address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       relationship: z
@@ -16475,7 +16519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
           representative: z.coerce.boolean().optional(),
-          title: z.string().optional(),
+          title: z.string().max(5000).optional(),
         })
         .optional(),
       ssn_last_4: z.string().optional(),
@@ -16483,14 +16527,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           additional_document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
           document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
         })
@@ -16549,8 +16593,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteAccountsAccountPersonsPersonParamSchema = z.object({
-    account: z.string(),
-    person: z.string(),
+    account: z.string().max(5000),
+    person: z.string().max(5000),
   })
 
   const deleteAccountsAccountPersonsPersonBodySchema = z.object({}).optional()
@@ -16607,12 +16651,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAccountsAccountPersonsPersonParamSchema = z.object({
-    account: z.string(),
-    person: z.string(),
+    account: z.string().max(5000),
+    person: z.string().max(5000),
   })
 
   const getAccountsAccountPersonsPersonQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getAccountsAccountPersonsPersonBodySchema = z.object({}).optional()
@@ -16670,8 +16714,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postAccountsAccountPersonsPersonParamSchema = z.object({
-    account: z.string(),
-    person: z.string(),
+    account: z.string().max(5000),
+    person: z.string().max(5000),
   })
 
   const postAccountsAccountPersonsPersonBodySchema = z
@@ -16682,41 +16726,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              user_agent: z.union([z.string(), z.enum([""])]).optional(),
+              user_agent: z
+                .union([z.string().max(5000), z.enum([""])])
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       address_kana: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       address_kanji: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          town: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          town: z.string().max(5000).optional(),
         })
         .optional(),
       dob: z
@@ -16733,49 +16779,55 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           company_authorization: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           passport: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
           visa: z
             .object({
-              files: z.array(z.union([z.string(), z.enum([""])])).optional(),
+              files: z
+                .array(z.union([z.string().max(500), z.enum([""])]))
+                .optional(),
             })
             .optional(),
         })
         .optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      first_name: z.string().optional(),
-      first_name_kana: z.string().optional(),
-      first_name_kanji: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      first_name: z.string().max(5000).optional(),
+      first_name_kana: z.string().max(5000).optional(),
+      first_name_kanji: z.string().max(5000).optional(),
       full_name_aliases: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       gender: z.string().optional(),
-      id_number: z.string().optional(),
-      id_number_secondary: z.string().optional(),
-      last_name: z.string().optional(),
-      last_name_kana: z.string().optional(),
-      last_name_kanji: z.string().optional(),
-      maiden_name: z.string().optional(),
+      id_number: z.string().max(5000).optional(),
+      id_number_secondary: z.string().max(5000).optional(),
+      last_name: z.string().max(5000).optional(),
+      last_name_kana: z.string().max(5000).optional(),
+      last_name_kanji: z.string().max(5000).optional(),
+      maiden_name: z.string().max(5000).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      nationality: z.string().optional(),
-      person_token: z.string().optional(),
+      nationality: z.string().max(5000).optional(),
+      person_token: z.string().max(5000).optional(),
       phone: z.string().optional(),
-      political_exposure: z.string().optional(),
+      political_exposure: z.string().max(5000).optional(),
       registered_address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(100).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(200).optional(),
+          line2: z.string().max(200).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
       relationship: z
@@ -16788,7 +16840,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
           representative: z.coerce.boolean().optional(),
-          title: z.string().optional(),
+          title: z.string().max(5000).optional(),
         })
         .optional(),
       ssn_last_4: z.string().optional(),
@@ -16796,14 +16848,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           additional_document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
           document: z
             .object({
-              back: z.string().optional(),
-              front: z.string().optional(),
+              back: z.string().max(500).optional(),
+              front: z.string().max(500).optional(),
             })
             .optional(),
         })
@@ -16859,11 +16911,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postAccountsAccountRejectParamSchema = z.object({ account: z.string() })
+  const postAccountsAccountRejectParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const postAccountsAccountRejectBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    reason: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    reason: z.string().max(5000),
   })
 
   const postAccountsAccountRejectResponseValidator = responseValidationFactory(
@@ -16917,11 +16971,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getApplePayDomainsQuerySchema = z.object({
-    domain_name: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    domain_name: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getApplePayDomainsBodySchema = z.object({}).optional()
@@ -16934,7 +16988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_apple_pay_domain),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/apple_pay/domains")),
         }),
       ],
     ],
@@ -16993,7 +17047,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postApplePayDomainsBodySchema = z.object({
     domain_name: z.string(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const postApplePayDomainsResponseValidator = responseValidationFactory(
@@ -17043,7 +17097,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteApplePayDomainsDomainParamSchema = z.object({
-    domain: z.string(),
+    domain: z.string().max(5000),
   })
 
   const deleteApplePayDomainsDomainBodySchema = z.object({}).optional()
@@ -17096,10 +17150,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getApplePayDomainsDomainParamSchema = z.object({ domain: z.string() })
+  const getApplePayDomainsDomainParamSchema = z.object({
+    domain: z.string().max(5000),
+  })
 
   const getApplePayDomainsDomainQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getApplePayDomainsDomainBodySchema = z.object({}).optional()
@@ -17159,7 +17215,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getApplicationFeesQuerySchema = z.object({
-    charge: z.string().optional(),
+    charge: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -17171,10 +17227,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getApplicationFeesBodySchema = z.object({}).optional()
@@ -17187,7 +17243,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_application_fee)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/application_fees")),
         }),
       ],
     ],
@@ -17245,12 +17301,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getApplicationFeesFeeRefundsIdParamSchema = z.object({
-    fee: z.string(),
-    id: z.string(),
+    fee: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const getApplicationFeesFeeRefundsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getApplicationFeesFeeRefundsIdBodySchema = z.object({}).optional()
@@ -17308,13 +17364,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postApplicationFeesFeeRefundsIdParamSchema = z.object({
-    fee: z.string(),
-    id: z.string(),
+    fee: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const postApplicationFeesFeeRefundsIdBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -17367,10 +17423,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getApplicationFeesIdParamSchema = z.object({ id: z.string() })
+  const getApplicationFeesIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getApplicationFeesIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getApplicationFeesIdBodySchema = z.object({}).optional()
@@ -17429,13 +17485,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postApplicationFeesIdRefundParamSchema = z.object({ id: z.string() })
+  const postApplicationFeesIdRefundParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postApplicationFeesIdRefundBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      directive: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      directive: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -17487,13 +17545,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getApplicationFeesIdRefundsParamSchema = z.object({ id: z.string() })
+  const getApplicationFeesIdRefundsParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getApplicationFeesIdRefundsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getApplicationFeesIdRefundsBodySchema = z.object({}).optional()
@@ -17507,7 +17567,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_fee_refund)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -17568,12 +17628,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postApplicationFeesIdRefundsParamSchema = z.object({ id: z.string() })
+  const postApplicationFeesIdRefundsParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postApplicationFeesIdRefundsBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -17627,14 +17689,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAppsSecretsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     scope: z.object({
       type: z.enum(["account", "user"]),
-      user: z.string().optional(),
+      user: z.string().max(5000).optional(),
     }),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getAppsSecretsBodySchema = z.object({}).optional()
@@ -17647,7 +17709,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_apps_secret),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/apps/secrets")),
         }),
       ],
     ],
@@ -17701,13 +17763,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postAppsSecretsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     expires_at: z.coerce.number().optional(),
-    name: z.string(),
-    payload: z.string(),
+    name: z.string().max(5000),
+    payload: z.string().max(5000),
     scope: z.object({
       type: z.enum(["account", "user"]),
-      user: z.string().optional(),
+      user: z.string().max(5000).optional(),
     }),
   })
 
@@ -17754,11 +17816,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postAppsSecretsDeleteBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    name: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    name: z.string().max(5000),
     scope: z.object({
       type: z.enum(["account", "user"]),
-      user: z.string().optional(),
+      user: z.string().max(5000).optional(),
     }),
   })
 
@@ -17809,11 +17871,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getAppsSecretsFindQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    name: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    name: z.string().max(5000),
     scope: z.object({
       type: z.enum(["account", "user"]),
-      user: z.string().optional(),
+      user: z.string().max(5000).optional(),
     }),
   })
 
@@ -17870,7 +17932,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getBalanceQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getBalanceBodySchema = z.object({}).optional()
@@ -17934,13 +17996,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     currency: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payout: z.string().optional(),
-    source: z.string().optional(),
-    starting_after: z.string().optional(),
-    type: z.string().optional(),
+    payout: z.string().max(5000).optional(),
+    source: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
+    type: z.string().max(5000).optional(),
   })
 
   const getBalanceHistoryBodySchema = z.object({}).optional()
@@ -17953,7 +18015,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_balance_transaction)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/balance_transactions")),
         }),
       ],
     ],
@@ -18006,10 +18071,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getBalanceHistoryIdParamSchema = z.object({ id: z.string() })
+  const getBalanceHistoryIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getBalanceHistoryIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getBalanceHistoryIdBodySchema = z.object({}).optional()
@@ -18081,13 +18146,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     currency: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payout: z.string().optional(),
-    source: z.string().optional(),
-    starting_after: z.string().optional(),
-    type: z.string().optional(),
+    payout: z.string().max(5000).optional(),
+    source: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
+    type: z.string().max(5000).optional(),
   })
 
   const getBalanceTransactionsBodySchema = z.object({}).optional()
@@ -18100,7 +18165,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_balance_transaction)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/balance_transactions")),
         }),
       ],
     ],
@@ -18157,10 +18225,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getBalanceTransactionsIdParamSchema = z.object({ id: z.string() })
+  const getBalanceTransactionsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getBalanceTransactionsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getBalanceTransactionsIdBodySchema = z.object({}).optional()
@@ -18220,9 +18290,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postBillingMeterEventAdjustmentsBodySchema = z.object({
-    cancel: z.object({ identifier: z.string() }),
-    event_name: z.string(),
-    expand: z.array(z.string()).optional(),
+    cancel: z.object({ identifier: z.string().max(100) }),
+    event_name: z.string().max(100),
+    expand: z.array(z.string().max(5000)).optional(),
     type: z.enum(["cancel"]).optional(),
   })
 
@@ -18274,9 +18344,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postBillingMeterEventsBodySchema = z.object({
-    event_name: z.string(),
-    expand: z.array(z.string()).optional(),
-    identifier: z.string().optional(),
+    event_name: z.string().max(100),
+    expand: z.array(z.string().max(5000)).optional(),
+    identifier: z.string().max(100).optional(),
     payload: z.record(z.string()),
     timestamp: z.coerce.number(),
   })
@@ -18328,10 +18398,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getBillingMetersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "inactive"]).optional(),
   })
 
@@ -18345,7 +18415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_billing_meter),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/billing/meters")),
         }),
       ],
     ],
@@ -18400,14 +18470,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postBillingMetersBodySchema = z.object({
     customer_mapping: z
-      .object({ event_payload_key: z.string(), type: z.enum(["by_id"]) })
+      .object({
+        event_payload_key: z.string().max(100),
+        type: z.enum(["by_id"]),
+      })
       .optional(),
     default_aggregation: z.object({ formula: z.enum(["count", "sum"]) }),
-    display_name: z.string(),
-    event_name: z.string(),
+    display_name: z.string().max(250),
+    event_name: z.string().max(100),
     event_time_window: z.enum(["day", "hour"]).optional(),
-    expand: z.array(z.string()).optional(),
-    value_settings: z.object({ event_payload_key: z.string() }).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    value_settings: z
+      .object({ event_payload_key: z.string().max(100) })
+      .optional(),
   })
 
   const postBillingMetersResponseValidator = responseValidationFactory(
@@ -18452,10 +18527,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getBillingMetersIdParamSchema = z.object({ id: z.string() })
+  const getBillingMetersIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getBillingMetersIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getBillingMetersIdBodySchema = z.object({}).optional()
@@ -18514,12 +18589,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postBillingMetersIdParamSchema = z.object({ id: z.string() })
+  const postBillingMetersIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const postBillingMetersIdBodySchema = z
     .object({
-      display_name: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      display_name: z.string().max(250).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -18573,10 +18648,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postBillingMetersIdDeactivateParamSchema = z.object({ id: z.string() })
+  const postBillingMetersIdDeactivateParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postBillingMetersIdDeactivateBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postBillingMetersIdDeactivateResponseValidator =
@@ -18628,17 +18705,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getBillingMetersIdEventSummariesParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const getBillingMetersIdEventSummariesQuerySchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
     end_time: z.coerce.number(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     start_time: z.coerce.number(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     value_grouping_window: z.enum(["hour"]).optional(),
   })
 
@@ -18653,7 +18730,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_billing_meter_event_summary),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/billing/meters/[^/]+/event_summaries")),
           }),
         ],
       ],
@@ -18714,10 +18794,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postBillingMetersIdReactivateParamSchema = z.object({ id: z.string() })
+  const postBillingMetersIdReactivateParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postBillingMetersIdReactivateBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postBillingMetersIdReactivateResponseValidator =
@@ -18770,11 +18852,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getBillingPortalConfigurationsQuerySchema = z.object({
     active: z.coerce.boolean().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     is_default: z.coerce.boolean().optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getBillingPortalConfigurationsBodySchema = z.object({}).optional()
@@ -18788,7 +18870,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_billing_portal_configuration),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/billing_portal/configurations")),
           }),
         ],
       ],
@@ -18847,12 +18932,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postBillingPortalConfigurationsBodySchema = z.object({
     business_profile: z.object({
-      headline: z.union([z.string(), z.enum([""])]).optional(),
+      headline: z.union([z.string().max(60), z.enum([""])]).optional(),
       privacy_policy_url: z.string().optional(),
       terms_of_service_url: z.string().optional(),
     }),
     default_return_url: z.union([z.string(), z.enum([""])]).optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     features: z.object({
       customer_update: z
         .object({
@@ -18916,7 +19001,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           enabled: z.coerce.boolean(),
           products: z.union([
             z.array(
-              z.object({ prices: z.array(z.string()), product: z.string() }),
+              z.object({
+                prices: z.array(z.string().max(5000)),
+                product: z.string().max(5000),
+              }),
             ),
             z.enum([""]),
           ]),
@@ -18978,11 +19066,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getBillingPortalConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const getBillingPortalConfigurationsConfigurationQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getBillingPortalConfigurationsConfigurationBodySchema = z
@@ -19048,7 +19136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postBillingPortalConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const postBillingPortalConfigurationsConfigurationBodySchema = z
@@ -19056,13 +19144,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
       active: z.coerce.boolean().optional(),
       business_profile: z
         .object({
-          headline: z.union([z.string(), z.enum([""])]).optional(),
+          headline: z.union([z.string().max(60), z.enum([""])]).optional(),
           privacy_policy_url: z.union([z.string(), z.enum([""])]).optional(),
           terms_of_service_url: z.union([z.string(), z.enum([""])]).optional(),
         })
         .optional(),
       default_return_url: z.union([z.string(), z.enum([""])]).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       features: z
         .object({
           customer_update: z
@@ -19133,8 +19221,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .union([
                   z.array(
                     z.object({
-                      prices: z.array(z.string()),
-                      product: z.string(),
+                      prices: z.array(z.string().max(5000)),
+                      product: z.string().max(5000),
                     }),
                   ),
                   z.enum([""]),
@@ -19207,15 +19295,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postBillingPortalSessionsBodySchema = z.object({
-    configuration: z.string().optional(),
-    customer: z.string(),
-    expand: z.array(z.string()).optional(),
+    configuration: z.string().max(5000).optional(),
+    customer: z.string().max(5000),
+    expand: z.array(z.string().max(5000)).optional(),
     flow_data: z
       .object({
         after_completion: z
           .object({
             hosted_confirmation: z
-              .object({ custom_message: z.string().optional() })
+              .object({ custom_message: z.string().max(500).optional() })
               .optional(),
             redirect: z.object({ return_url: z.string() }).optional(),
             type: z.enum([
@@ -19229,32 +19317,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .object({
             retention: z
               .object({
-                coupon_offer: z.object({ coupon: z.string() }),
+                coupon_offer: z.object({ coupon: z.string().max(5000) }),
                 type: z.enum(["coupon_offer"]),
               })
               .optional(),
-            subscription: z.string(),
+            subscription: z.string().max(5000),
           })
           .optional(),
-        subscription_update: z.object({ subscription: z.string() }).optional(),
+        subscription_update: z
+          .object({ subscription: z.string().max(5000) })
+          .optional(),
         subscription_update_confirm: z
           .object({
             discounts: z
               .array(
                 z.object({
-                  coupon: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               )
               .optional(),
             items: z.array(
               z.object({
-                id: z.string(),
-                price: z.string().optional(),
+                id: z.string().max(5000),
+                price: z.string().max(5000).optional(),
                 quantity: z.coerce.number().optional(),
               }),
             ),
-            subscription: z.string(),
+            subscription: z.string().max(5000),
           })
           .optional(),
         type: z.enum([
@@ -19378,13 +19468,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payment_intent: z.string().optional(),
+    payment_intent: z.string().max(5000).optional(),
     starting_after: z.string().optional(),
-    transfer_group: z.string().optional(),
+    transfer_group: z.string().max(5000).optional(),
   })
 
   const getChargesBodySchema = z.object({}).optional()
@@ -19397,7 +19487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_charge)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/charges")),
         }),
       ],
     ],
@@ -19459,63 +19549,65 @@ export function createRouter(implementation: Implementation): KoaRouter {
       card: z
         .union([
           z.object({
-            address_city: z.string().optional(),
-            address_country: z.string().optional(),
-            address_line1: z.string().optional(),
-            address_line2: z.string().optional(),
-            address_state: z.string().optional(),
-            address_zip: z.string().optional(),
-            cvc: z.string().optional(),
+            address_city: z.string().max(5000).optional(),
+            address_country: z.string().max(5000).optional(),
+            address_line1: z.string().max(5000).optional(),
+            address_line2: z.string().max(5000).optional(),
+            address_state: z.string().max(5000).optional(),
+            address_zip: z.string().max(5000).optional(),
+            cvc: z.string().max(5000).optional(),
             exp_month: z.coerce.number(),
             exp_year: z.coerce.number(),
             metadata: z.record(z.string()).optional(),
-            name: z.string().optional(),
-            number: z.string(),
+            name: z.string().max(5000).optional(),
+            number: z.string().max(5000),
             object: z.enum(["card"]).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       currency: z.string().optional(),
-      customer: z.string().optional(),
-      description: z.string().optional(),
+      customer: z.string().max(500).optional(),
+      description: z.string().max(40000).optional(),
       destination: z
         .union([
           z.object({
-            account: z.string(),
+            account: z.string().max(5000),
             amount: z.coerce.number().optional(),
           }),
           z.string(),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      on_behalf_of: z.string().optional(),
-      radar_options: z.object({ session: z.string().optional() }).optional(),
+      on_behalf_of: z.string().max(5000).optional(),
+      radar_options: z
+        .object({ session: z.string().max(5000).optional() })
+        .optional(),
       receipt_email: z.string().optional(),
       shipping: z
         .object({
           address: z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
-          carrier: z.string().optional(),
-          name: z.string(),
-          phone: z.string().optional(),
-          tracking_number: z.string().optional(),
+          carrier: z.string().max(5000).optional(),
+          name: z.string().max(5000),
+          phone: z.string().max(5000).optional(),
+          tracking_number: z.string().max(5000).optional(),
         })
         .optional(),
-      source: z.string().optional(),
-      statement_descriptor: z.string().optional(),
-      statement_descriptor_suffix: z.string().optional(),
+      source: z.string().max(5000).optional(),
+      statement_descriptor: z.string().max(22).optional(),
+      statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
         .object({
           amount: z.coerce.number().optional(),
-          destination: z.string(),
+          destination: z.string().max(5000),
         })
         .optional(),
       transfer_group: z.string().optional(),
@@ -19565,10 +19657,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getChargesSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getChargesSearchBodySchema = z.object({}).optional()
@@ -19580,10 +19672,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_charge)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -19638,10 +19730,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getChargesChargeParamSchema = z.object({ charge: z.string() })
+  const getChargesChargeParamSchema = z.object({ charge: z.string().max(5000) })
 
   const getChargesChargeQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getChargesChargeBodySchema = z.object({}).optional()
@@ -19696,32 +19788,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postChargesChargeParamSchema = z.object({ charge: z.string() })
+  const postChargesChargeParamSchema = z.object({
+    charge: z.string().max(5000),
+  })
 
   const postChargesChargeBodySchema = z
     .object({
-      customer: z.string().optional(),
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(5000).optional(),
+      description: z.string().max(40000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       fraud_details: z
         .object({ user_report: z.enum(["", "fraudulent", "safe"]) })
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      receipt_email: z.string().optional(),
+      receipt_email: z.string().max(5000).optional(),
       shipping: z
         .object({
           address: z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
-          carrier: z.string().optional(),
-          name: z.string(),
-          phone: z.string().optional(),
-          tracking_number: z.string().optional(),
+          carrier: z.string().max(5000).optional(),
+          name: z.string().max(5000),
+          phone: z.string().max(5000).optional(),
+          tracking_number: z.string().max(5000).optional(),
         })
         .optional(),
       transfer_group: z.string().optional(),
@@ -19774,17 +19868,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postChargesChargeCaptureParamSchema = z.object({ charge: z.string() })
+  const postChargesChargeCaptureParamSchema = z.object({
+    charge: z.string().max(5000),
+  })
 
   const postChargesChargeCaptureBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
       application_fee: z.coerce.number().optional(),
       application_fee_amount: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       receipt_email: z.string().optional(),
-      statement_descriptor: z.string().optional(),
-      statement_descriptor_suffix: z.string().optional(),
+      statement_descriptor: z.string().max(22).optional(),
+      statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
         .object({ amount: z.coerce.number().optional() })
         .optional(),
@@ -19842,10 +19938,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getChargesChargeDisputeParamSchema = z.object({ charge: z.string() })
+  const getChargesChargeDisputeParamSchema = z.object({
+    charge: z.string().max(5000),
+  })
 
   const getChargesChargeDisputeQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getChargesChargeDisputeBodySchema = z.object({}).optional()
@@ -19904,42 +20002,44 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postChargesChargeDisputeParamSchema = z.object({ charge: z.string() })
+  const postChargesChargeDisputeParamSchema = z.object({
+    charge: z.string().max(5000),
+  })
 
   const postChargesChargeDisputeBodySchema = z
     .object({
       evidence: z
         .object({
-          access_activity_log: z.string().optional(),
-          billing_address: z.string().optional(),
+          access_activity_log: z.string().max(20000).optional(),
+          billing_address: z.string().max(5000).optional(),
           cancellation_policy: z.string().optional(),
-          cancellation_policy_disclosure: z.string().optional(),
-          cancellation_rebuttal: z.string().optional(),
+          cancellation_policy_disclosure: z.string().max(20000).optional(),
+          cancellation_rebuttal: z.string().max(20000).optional(),
           customer_communication: z.string().optional(),
-          customer_email_address: z.string().optional(),
-          customer_name: z.string().optional(),
-          customer_purchase_ip: z.string().optional(),
+          customer_email_address: z.string().max(5000).optional(),
+          customer_name: z.string().max(5000).optional(),
+          customer_purchase_ip: z.string().max(5000).optional(),
           customer_signature: z.string().optional(),
           duplicate_charge_documentation: z.string().optional(),
-          duplicate_charge_explanation: z.string().optional(),
-          duplicate_charge_id: z.string().optional(),
-          product_description: z.string().optional(),
+          duplicate_charge_explanation: z.string().max(20000).optional(),
+          duplicate_charge_id: z.string().max(5000).optional(),
+          product_description: z.string().max(20000).optional(),
           receipt: z.string().optional(),
           refund_policy: z.string().optional(),
-          refund_policy_disclosure: z.string().optional(),
-          refund_refusal_explanation: z.string().optional(),
-          service_date: z.string().optional(),
+          refund_policy_disclosure: z.string().max(20000).optional(),
+          refund_refusal_explanation: z.string().max(20000).optional(),
+          service_date: z.string().max(5000).optional(),
           service_documentation: z.string().optional(),
-          shipping_address: z.string().optional(),
-          shipping_carrier: z.string().optional(),
-          shipping_date: z.string().optional(),
+          shipping_address: z.string().max(5000).optional(),
+          shipping_carrier: z.string().max(5000).optional(),
+          shipping_date: z.string().max(5000).optional(),
           shipping_documentation: z.string().optional(),
-          shipping_tracking_number: z.string().optional(),
+          shipping_tracking_number: z.string().max(5000).optional(),
           uncategorized_file: z.string().optional(),
-          uncategorized_text: z.string().optional(),
+          uncategorized_text: z.string().max(20000).optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       submit: z.coerce.boolean().optional(),
     })
@@ -19996,11 +20096,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postChargesChargeDisputeCloseParamSchema = z.object({
-    charge: z.string(),
+    charge: z.string().max(5000),
   })
 
   const postChargesChargeDisputeCloseBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postChargesChargeDisputeCloseResponseValidator =
@@ -20051,15 +20151,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postChargesChargeRefundParamSchema = z.object({ charge: z.string() })
+  const postChargesChargeRefundParamSchema = z.object({
+    charge: z.string().max(5000),
+  })
 
   const postChargesChargeRefundBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       instructions_email: z.string().optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      payment_intent: z.string().optional(),
+      payment_intent: z.string().max(5000).optional(),
       reason: z
         .enum(["duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
@@ -20122,7 +20224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getChargesChargeRefundsQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
   })
@@ -20137,7 +20239,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_refund)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -20198,18 +20300,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postChargesChargeRefundsParamSchema = z.object({ charge: z.string() })
+  const postChargesChargeRefundsParamSchema = z.object({
+    charge: z.string().max(5000),
+  })
 
   const postChargesChargeRefundsBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
       currency: z.string().optional(),
-      customer: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       instructions_email: z.string().optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       origin: z.enum(["customer_balance"]).optional(),
-      payment_intent: z.string().optional(),
+      payment_intent: z.string().max(5000).optional(),
       reason: z
         .enum(["duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
@@ -20274,7 +20378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getChargesChargeRefundsRefundQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getChargesChargeRefundsRefundBodySchema = z.object({}).optional()
@@ -20338,7 +20442,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postChargesChargeRefundsRefundBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -20403,16 +20507,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     customer_details: z.object({ email: z.string() }).optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payment_intent: z.string().optional(),
-    payment_link: z.string().optional(),
-    starting_after: z.string().optional(),
+    payment_intent: z.string().max(5000).optional(),
+    payment_link: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["complete", "expired", "open"]).optional(),
-    subscription: z.string().optional(),
+    subscription: z.string().max(5000).optional(),
   })
 
   const getCheckoutSessionsBodySchema = z.object({}).optional()
@@ -20425,7 +20529,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_checkout_session)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -20507,8 +20611,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       billing_address_collection: z.enum(["auto", "required"]).optional(),
-      cancel_url: z.string().optional(),
-      client_reference_id: z.string().optional(),
+      cancel_url: z.string().max(5000).optional(),
+      client_reference_id: z.string().max(200).optional(),
       consent_collection: z
         .object({
           payment_method_reuse_agreement: z
@@ -20525,12 +20629,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
             dropdown: z
               .object({
                 options: z.array(
-                  z.object({ label: z.string(), value: z.string() }),
+                  z.object({
+                    label: z.string().max(100),
+                    value: z.string().max(100),
+                  }),
                 ),
               })
               .optional(),
-            key: z.string(),
-            label: z.object({ custom: z.string(), type: z.enum(["custom"]) }),
+            key: z.string().max(200),
+            label: z.object({
+              custom: z.string().max(50),
+              type: z.enum(["custom"]),
+            }),
             numeric: z
               .object({
                 maximum_length: z.coerce.number().optional(),
@@ -20551,20 +20661,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
       custom_text: z
         .object({
           after_submit: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
           shipping_address: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
           submit: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
           terms_of_service_acceptance: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
         })
         .optional(),
-      customer: z.string().optional(),
+      customer: z.string().max(5000).optional(),
       customer_creation: z.enum(["always", "if_required"]).optional(),
       customer_email: z.string().optional(),
       customer_update: z
@@ -20577,12 +20687,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
       discounts: z
         .array(
           z.object({
-            coupon: z.string().optional(),
-            promotion_code: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            promotion_code: z.string().max(5000).optional(),
           }),
         )
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       expires_at: z.coerce.number().optional(),
       invoice_creation: z
         .object({
@@ -20590,16 +20700,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
           invoice_data: z
             .object({
               account_tax_ids: z
-                .union([z.array(z.string()), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.enum([""])])
                 .optional(),
               custom_fields: z
                 .union([
-                  z.array(z.object({ name: z.string(), value: z.string() })),
+                  z.array(
+                    z.object({
+                      name: z.string().max(40),
+                      value: z.string().max(140),
+                    }),
+                  ),
                   z.enum([""]),
                 ])
                 .optional(),
-              description: z.string().optional(),
-              footer: z.string().optional(),
+              description: z.string().max(1500).optional(),
+              footer: z.string().max(5000).optional(),
               issuer: z
                 .object({
                   account: z.string().optional(),
@@ -20631,19 +20746,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 minimum: z.coerce.number().optional(),
               })
               .optional(),
-            dynamic_tax_rates: z.array(z.string()).optional(),
-            price: z.string().optional(),
+            dynamic_tax_rates: z.array(z.string().max(5000)).optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string().optional(),
+                product: z.string().max(5000).optional(),
                 product_data: z
                   .object({
-                    description: z.string().optional(),
+                    description: z.string().max(40000).optional(),
                     images: z.array(z.string()).optional(),
                     metadata: z.record(z.string()).optional(),
-                    name: z.string(),
-                    tax_code: z.string().optional(),
+                    name: z.string().max(5000),
+                    tax_code: z.string().max(5000).optional(),
                   })
                   .optional(),
                 recurring: z
@@ -20660,7 +20775,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.array(z.string()).optional(),
+            tax_rates: z.array(z.string().max(5000)).optional(),
           }),
         )
         .optional(),
@@ -20717,7 +20832,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           capture_method: z
             .enum(["automatic", "automatic_async", "manual"])
             .optional(),
-          description: z.string().optional(),
+          description: z.string().max(1000).optional(),
           metadata: z.record(z.string()).optional(),
           on_behalf_of: z.string().optional(),
           receipt_email: z.string().optional(),
@@ -20725,21 +20840,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
           shipping: z
             .object({
               address: z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
-              carrier: z.string().optional(),
-              name: z.string(),
-              phone: z.string().optional(),
-              tracking_number: z.string().optional(),
+              carrier: z.string().max(5000).optional(),
+              name: z.string().max(5000),
+              phone: z.string().max(5000).optional(),
+              tracking_number: z.string().max(5000).optional(),
             })
             .optional(),
-          statement_descriptor: z.string().optional(),
-          statement_descriptor_suffix: z.string().optional(),
+          statement_descriptor: z.string().max(22).optional(),
+          statement_descriptor_suffix: z.string().max(22).optional(),
           transfer_data: z
             .object({
               amount: z.coerce.number().optional(),
@@ -20750,7 +20865,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       payment_method_collection: z.enum(["always", "if_required"]).optional(),
-      payment_method_configuration: z.string().optional(),
+      payment_method_configuration: z.string().max(100).optional(),
       payment_method_options: z
         .object({
           acss_debit: z
@@ -20764,7 +20879,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   default_for: z
                     .array(z.enum(["invoice", "subscription"]))
                     .optional(),
-                  interval_description: z.string().optional(),
+                  interval_description: z.string().max(500).optional(),
                   payment_schedule: z
                     .enum(["combined", "interval", "sporadic"])
                     .optional(),
@@ -20820,8 +20935,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
               setup_future_usage: z
                 .enum(["off_session", "on_session"])
                 .optional(),
-              statement_descriptor_suffix_kana: z.string().optional(),
-              statement_descriptor_suffix_kanji: z.string().optional(),
+              statement_descriptor_suffix_kana: z.string().max(22).optional(),
+              statement_descriptor_suffix_kanji: z.string().max(17).optional(),
             })
             .optional(),
           cashapp: z
@@ -20836,7 +20951,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               bank_transfer: z
                 .object({
                   eu_bank_transfer: z
-                    .object({ country: z.string() })
+                    .object({ country: z.string().max(5000) })
                     .optional(),
                   requested_address_types: z
                     .array(
@@ -20936,8 +21051,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   "sv-SE",
                 ])
                 .optional(),
-              reference: z.string().optional(),
-              risk_correlation_id: z.string().optional(),
+              reference: z.string().max(127).optional(),
+              risk_correlation_id: z.string().max(32).optional(),
               setup_future_usage: z
                 .enum(["", "none", "off_session"])
                 .optional(),
@@ -20961,7 +21076,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           sofort: z
             .object({ setup_future_usage: z.enum(["none"]).optional() })
             .optional(),
-          swish: z.object({ reference: z.string().optional() }).optional(),
+          swish: z
+            .object({ reference: z.string().max(5000).optional() })
+            .optional(),
           us_bank_account: z
             .object({
               financial_connections: z
@@ -20989,7 +21106,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           wechat_pay: z
             .object({
-              app_id: z.string().optional(),
+              app_id: z.string().max(5000).optional(),
               client: z.enum(["android", "ios", "web"]),
               setup_future_usage: z.enum(["none"]).optional(),
             })
@@ -21041,10 +21158,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       redirect_on_completion: z
         .enum(["always", "if_required", "never"])
         .optional(),
-      return_url: z.string().optional(),
+      return_url: z.string().max(5000).optional(),
       setup_intent_data: z
         .object({
-          description: z.string().optional(),
+          description: z.string().max(1000).optional(),
           metadata: z.record(z.string()).optional(),
           on_behalf_of: z.string().optional(),
         })
@@ -21297,7 +21414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       shipping_options: z
         .array(
           z.object({
-            shipping_rate: z.string().optional(),
+            shipping_rate: z.string().max(5000).optional(),
             shipping_rate_data: z
               .object({
                 delivery_estimate: z
@@ -21328,7 +21445,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       .optional(),
                   })
                   .optional(),
-                display_name: z.string(),
+                display_name: z.string().max(100),
                 fixed_amount: z
                   .object({
                     amount: z.coerce.number(),
@@ -21361,8 +21478,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           application_fee_percent: z.coerce.number().optional(),
           billing_cycle_anchor: z.coerce.number().optional(),
-          default_tax_rates: z.array(z.string()).optional(),
-          description: z.string().optional(),
+          default_tax_rates: z.array(z.string().max(5000)).optional(),
+          description: z.string().max(500).optional(),
           invoice_settings: z
             .object({
               issuer: z
@@ -21397,7 +21514,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      success_url: z.string().optional(),
+      success_url: z.string().max(5000).optional(),
       tax_id_collection: z.object({ enabled: z.coerce.boolean() }).optional(),
       ui_mode: z.enum(["embedded", "hosted"]).optional(),
     })
@@ -21450,11 +21567,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCheckoutSessionsSessionParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(66),
   })
 
   const getCheckoutSessionsSessionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCheckoutSessionsSessionBodySchema = z.object({}).optional()
@@ -21514,11 +21631,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCheckoutSessionsSessionExpireParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const postCheckoutSessionsSessionExpireBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postCheckoutSessionsSessionExpireResponseValidator =
@@ -21573,14 +21690,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCheckoutSessionsSessionLineItemsParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const getCheckoutSessionsSessionLineItemsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCheckoutSessionsSessionLineItemsBodySchema = z.object({}).optional()
@@ -21594,7 +21711,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_item)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -21659,10 +21776,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getClimateOrdersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getClimateOrdersBodySchema = z.object({}).optional()
@@ -21675,7 +21792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_climate_order),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/climate/orders")),
         }),
       ],
     ],
@@ -21730,12 +21847,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postClimateOrdersBodySchema = z.object({
     amount: z.coerce.number().optional(),
-    beneficiary: z.object({ public_name: z.string() }).optional(),
-    currency: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    beneficiary: z.object({ public_name: z.string().max(5000) }).optional(),
+    currency: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
     metric_tons: z.string().optional(),
-    product: z.string(),
+    product: z.string().max(5000),
   })
 
   const postClimateOrdersResponseValidator = responseValidationFactory(
@@ -21780,10 +21897,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getClimateOrdersOrderParamSchema = z.object({ order: z.string() })
+  const getClimateOrdersOrderParamSchema = z.object({
+    order: z.string().max(5000),
+  })
 
   const getClimateOrdersOrderQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getClimateOrdersOrderBodySchema = z.object({}).optional()
@@ -21842,17 +21961,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postClimateOrdersOrderParamSchema = z.object({ order: z.string() })
+  const postClimateOrdersOrderParamSchema = z.object({
+    order: z.string().max(5000),
+  })
 
   const postClimateOrdersOrderBodySchema = z
     .object({
       beneficiary: z
         .union([
-          z.object({ public_name: z.union([z.string(), z.enum([""])]) }),
+          z.object({
+            public_name: z.union([z.string().max(5000), z.enum([""])]),
+          }),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -21908,11 +22031,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postClimateOrdersOrderCancelParamSchema = z.object({
-    order: z.string(),
+    order: z.string().max(5000),
   })
 
   const postClimateOrdersOrderCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postClimateOrdersOrderCancelResponseValidator =
@@ -21964,10 +22087,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getClimateProductsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getClimateProductsBodySchema = z.object({}).optional()
@@ -21980,7 +22103,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_climate_product),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/climate/products")),
         }),
       ],
     ],
@@ -22037,10 +22160,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getClimateProductsProductParamSchema = z.object({ product: z.string() })
+  const getClimateProductsProductParamSchema = z.object({
+    product: z.string().max(5000),
+  })
 
   const getClimateProductsProductQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getClimateProductsProductBodySchema = z.object({}).optional()
@@ -22100,10 +22225,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getClimateSuppliersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getClimateSuppliersBodySchema = z.object({}).optional()
@@ -22116,7 +22241,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_climate_supplier),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/climate/suppliers")),
         }),
       ],
     ],
@@ -22174,11 +22299,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getClimateSuppliersSupplierParamSchema = z.object({
-    supplier: z.string(),
+    supplier: z.string().max(5000),
   })
 
   const getClimateSuppliersSupplierQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getClimateSuppliersSupplierBodySchema = z.object({}).optional()
@@ -22236,11 +22361,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getConfirmationTokensConfirmationTokenParamSchema = z.object({
-    confirmation_token: z.string(),
+    confirmation_token: z.string().max(5000),
   })
 
   const getConfirmationTokensConfirmationTokenQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getConfirmationTokensConfirmationTokenBodySchema = z
@@ -22303,10 +22428,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCountrySpecsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCountrySpecsBodySchema = z.object({}).optional()
@@ -22319,7 +22444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_country_spec),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/country_specs")),
         }),
       ],
     ],
@@ -22372,10 +22497,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getCountrySpecsCountryParamSchema = z.object({ country: z.string() })
+  const getCountrySpecsCountryParamSchema = z.object({
+    country: z.string().max(5000),
+  })
 
   const getCountrySpecsCountryQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCountrySpecsCountryBodySchema = z.object({}).optional()
@@ -22446,10 +22573,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCouponsBodySchema = z.object({}).optional()
@@ -22462,7 +22589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_coupon),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/coupons")),
         }),
       ],
     ],
@@ -22519,7 +22646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       amount_off: z.coerce.number().optional(),
       applies_to: z
-        .object({ products: z.array(z.string()).optional() })
+        .object({ products: z.array(z.string().max(5000)).optional() })
         .optional(),
       currency: z.string().optional(),
       currency_options: z
@@ -22527,11 +22654,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       duration: z.enum(["forever", "once", "repeating"]).optional(),
       duration_in_months: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
-      id: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      id: z.string().max(5000).optional(),
       max_redemptions: z.coerce.number().optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(40).optional(),
       percent_off: z.coerce.number().optional(),
       redeem_by: z.coerce.number().optional(),
     })
@@ -22579,7 +22706,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteCouponsCouponParamSchema = z.object({ coupon: z.string() })
+  const deleteCouponsCouponParamSchema = z.object({
+    coupon: z.string().max(5000),
+  })
 
   const deleteCouponsCouponBodySchema = z.object({}).optional()
 
@@ -22633,10 +22762,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getCouponsCouponParamSchema = z.object({ coupon: z.string() })
+  const getCouponsCouponParamSchema = z.object({ coupon: z.string().max(5000) })
 
   const getCouponsCouponQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCouponsCouponBodySchema = z.object({}).optional()
@@ -22691,16 +22820,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postCouponsCouponParamSchema = z.object({ coupon: z.string() })
+  const postCouponsCouponParamSchema = z.object({
+    coupon: z.string().max(5000),
+  })
 
   const postCouponsCouponBodySchema = z
     .object({
       currency_options: z
         .record(z.object({ amount_off: z.coerce.number() }))
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(40).optional(),
     })
     .optional()
 
@@ -22762,12 +22893,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
-    invoice: z.string().optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    invoice: z.string().max(5000).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCreditNotesBodySchema = z.object({}).optional()
@@ -22780,7 +22911,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_credit_note)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -22837,35 +22968,37 @@ export function createRouter(implementation: Implementation): KoaRouter {
     amount: z.coerce.number().optional(),
     credit_amount: z.coerce.number().optional(),
     effective_at: z.coerce.number().optional(),
-    expand: z.array(z.string()).optional(),
-    invoice: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    invoice: z.string().max(5000),
     lines: z
       .array(
         z.object({
           amount: z.coerce.number().optional(),
-          description: z.string().optional(),
-          invoice_line_item: z.string().optional(),
+          description: z.string().max(5000).optional(),
+          invoice_line_item: z.string().max(5000).optional(),
           quantity: z.coerce.number().optional(),
           tax_amounts: z
             .union([
               z.array(
                 z.object({
                   amount: z.coerce.number(),
-                  tax_rate: z.string(),
+                  tax_rate: z.string().max(5000),
                   taxable_amount: z.coerce.number(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
           type: z.enum(["custom_line_item", "invoice_line_item"]),
           unit_amount: z.coerce.number().optional(),
           unit_amount_decimal: z.string().optional(),
         }),
       )
       .optional(),
-    memo: z.string().optional(),
+    memo: z.string().max(5000).optional(),
     metadata: z.record(z.string()).optional(),
     out_of_band_amount: z.coerce.number().optional(),
     reason: z
@@ -22879,7 +23012,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     refund: z.string().optional(),
     refund_amount: z.coerce.number().optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().optional() })
+      .object({ shipping_rate: z.string().max(5000).optional() })
       .optional(),
   })
 
@@ -22929,35 +23062,37 @@ export function createRouter(implementation: Implementation): KoaRouter {
     amount: z.coerce.number().optional(),
     credit_amount: z.coerce.number().optional(),
     effective_at: z.coerce.number().optional(),
-    expand: z.array(z.string()).optional(),
-    invoice: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    invoice: z.string().max(5000),
     lines: z
       .array(
         z.object({
           amount: z.coerce.number().optional(),
-          description: z.string().optional(),
-          invoice_line_item: z.string().optional(),
+          description: z.string().max(5000).optional(),
+          invoice_line_item: z.string().max(5000).optional(),
           quantity: z.coerce.number().optional(),
           tax_amounts: z
             .union([
               z.array(
                 z.object({
                   amount: z.coerce.number(),
-                  tax_rate: z.string(),
+                  tax_rate: z.string().max(5000),
                   taxable_amount: z.coerce.number(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
           type: z.enum(["custom_line_item", "invoice_line_item"]),
           unit_amount: z.coerce.number().optional(),
           unit_amount_decimal: z.string().optional(),
         }),
       )
       .optional(),
-    memo: z.string().optional(),
+    memo: z.string().max(5000).optional(),
     metadata: z.record(z.string()).optional(),
     out_of_band_amount: z.coerce.number().optional(),
     reason: z
@@ -22971,7 +23106,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     refund: z.string().optional(),
     refund_amount: z.coerce.number().optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().optional() })
+      .object({ shipping_rate: z.string().max(5000).optional() })
       .optional(),
   })
 
@@ -23031,37 +23166,39 @@ export function createRouter(implementation: Implementation): KoaRouter {
     amount: z.coerce.number().optional(),
     credit_amount: z.coerce.number().optional(),
     effective_at: z.coerce.number().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
-    invoice: z.string(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    invoice: z.string().max(5000),
     limit: z.coerce.number().optional(),
     lines: z
       .array(
         z.object({
           amount: z.coerce.number().optional(),
-          description: z.string().optional(),
-          invoice_line_item: z.string().optional(),
+          description: z.string().max(5000).optional(),
+          invoice_line_item: z.string().max(5000).optional(),
           quantity: z.coerce.number().optional(),
           tax_amounts: z
             .union([
               z.array(
                 z.object({
                   amount: z.coerce.number(),
-                  tax_rate: z.string(),
+                  tax_rate: z.string().max(5000),
                   taxable_amount: z.coerce.number(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
           type: z.enum(["custom_line_item", "invoice_line_item"]),
           unit_amount: z.coerce.number().optional(),
           unit_amount_decimal: z.string().optional(),
         }),
       )
       .optional(),
-    memo: z.string().optional(),
+    memo: z.string().max(5000).optional(),
     metadata: z.record(z.string()).optional(),
     out_of_band_amount: z.coerce.number().optional(),
     reason: z
@@ -23075,9 +23212,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     refund: z.string().optional(),
     refund_amount: z.coerce.number().optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().optional() })
+      .object({ shipping_rate: z.string().max(5000).optional() })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCreditNotesPreviewLinesBodySchema = z.object({}).optional()
@@ -23090,7 +23227,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_credit_note_line_item)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -23148,14 +23285,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCreditNotesCreditNoteLinesParamSchema = z.object({
-    credit_note: z.string(),
+    credit_note: z.string().max(5000),
   })
 
   const getCreditNotesCreditNoteLinesQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCreditNotesCreditNoteLinesBodySchema = z.object({}).optional()
@@ -23169,7 +23306,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_credit_note_line_item)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -23230,10 +23367,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getCreditNotesIdParamSchema = z.object({ id: z.string() })
+  const getCreditNotesIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getCreditNotesIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCreditNotesIdBodySchema = z.object({}).optional()
@@ -23288,12 +23425,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postCreditNotesIdParamSchema = z.object({ id: z.string() })
+  const postCreditNotesIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const postCreditNotesIdBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
-      memo: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      memo: z.string().max(5000).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -23348,10 +23485,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postCreditNotesIdVoidParamSchema = z.object({ id: z.string() })
+  const postCreditNotesIdVoidParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postCreditNotesIdVoidBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postCreditNotesIdVoidResponseValidator = responseValidationFactory(
@@ -23409,8 +23548,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       buy_button: z.object({ enabled: z.coerce.boolean() }).optional(),
       pricing_table: z.object({ enabled: z.coerce.boolean() }).optional(),
     }),
-    customer: z.string(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const postCustomerSessionsResponseValidator = responseValidationFactory(
@@ -23471,12 +23610,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    email: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    email: z.string().max(512).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
-    test_clock: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
+    test_clock: z.string().max(5000).optional(),
   })
 
   const getCustomersBodySchema = z.object({}).optional()
@@ -23489,7 +23628,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_customer)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/customers")),
         }),
       ],
     ],
@@ -23547,12 +23686,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
       address: z
         .union([
           z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
           z.enum([""]),
         ])
@@ -23569,21 +23708,26 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      coupon: z.string().optional(),
-      description: z.string().optional(),
-      email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      invoice_prefix: z.string().optional(),
+      coupon: z.string().max(5000).optional(),
+      description: z.string().max(5000).optional(),
+      email: z.string().max(512).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      invoice_prefix: z.string().max(5000).optional(),
       invoice_settings: z
         .object({
           custom_fields: z
             .union([
-              z.array(z.object({ name: z.string(), value: z.string() })),
+              z.array(
+                z.object({
+                  name: z.string().max(40),
+                  value: z.string().max(140),
+                }),
+              ),
               z.enum([""]),
             ])
             .optional(),
-          default_payment_method: z.string().optional(),
-          footer: z.string().optional(),
+          default_payment_method: z.string().max(5000).optional(),
+          footer: z.string().max(5000).optional(),
           rendering_options: z
             .union([
               z.object({
@@ -23597,30 +23741,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(256).optional(),
       next_invoice_sequence: z.coerce.number().optional(),
-      payment_method: z.string().optional(),
-      phone: z.string().optional(),
-      preferred_locales: z.array(z.string()).optional(),
-      promotion_code: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
+      phone: z.string().max(20).optional(),
+      preferred_locales: z.array(z.string().max(5000)).optional(),
+      promotion_code: z.string().max(5000).optional(),
       shipping: z
         .union([
           z.object({
             address: z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
-            name: z.string(),
-            phone: z.string().optional(),
+            name: z.string().max(5000),
+            phone: z.string().max(5000).optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
-      source: z.string().optional(),
+      source: z.string().max(5000).optional(),
       tax: z
         .object({
           ip_address: z.union([z.string(), z.enum([""])]).optional(),
@@ -23704,7 +23848,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           }),
         )
         .optional(),
-      test_clock: z.string().optional(),
+      test_clock: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -23751,10 +23895,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getCustomersSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getCustomersSearchBodySchema = z.object({}).optional()
@@ -23766,10 +23910,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_customer)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -23828,7 +23972,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const deleteCustomersCustomerParamSchema = z.object({ customer: z.string() })
+  const deleteCustomersCustomerParamSchema = z.object({
+    customer: z.string().max(5000),
+  })
 
   const deleteCustomersCustomerBodySchema = z.object({}).optional()
 
@@ -23882,10 +24028,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getCustomersCustomerParamSchema = z.object({ customer: z.string() })
+  const getCustomersCustomerParamSchema = z.object({
+    customer: z.string().max(5000),
+  })
 
   const getCustomersCustomerQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerBodySchema = z.object({}).optional()
@@ -23944,19 +24092,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postCustomersCustomerParamSchema = z.object({ customer: z.string() })
+  const postCustomersCustomerParamSchema = z.object({
+    customer: z.string().max(5000),
+  })
 
   const postCustomersCustomerBodySchema = z
     .object({
       address: z
         .union([
           z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
           z.enum([""]),
         ])
@@ -23965,35 +24115,35 @@ export function createRouter(implementation: Implementation): KoaRouter {
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
-            country: z.string(),
+            account_number: z.string().max(5000),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       card: z
         .union([
           z.object({
-            address_city: z.string().optional(),
-            address_country: z.string().optional(),
-            address_line1: z.string().optional(),
-            address_line2: z.string().optional(),
-            address_state: z.string().optional(),
-            address_zip: z.string().optional(),
-            cvc: z.string().optional(),
+            address_city: z.string().max(5000).optional(),
+            address_country: z.string().max(5000).optional(),
+            address_line1: z.string().max(5000).optional(),
+            address_line2: z.string().max(5000).optional(),
+            address_state: z.string().max(5000).optional(),
+            address_zip: z.string().max(5000).optional(),
+            cvc: z.string().max(5000).optional(),
             exp_month: z.coerce.number(),
             exp_year: z.coerce.number(),
             metadata: z.record(z.string()).optional(),
-            name: z.string().optional(),
-            number: z.string(),
+            name: z.string().max(5000).optional(),
+            number: z.string().max(5000),
             object: z.enum(["card"]).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       cash_balance: z
@@ -24007,25 +24157,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      coupon: z.string().optional(),
-      default_alipay_account: z.string().optional(),
-      default_bank_account: z.string().optional(),
-      default_card: z.string().optional(),
-      default_source: z.string().optional(),
-      description: z.string().optional(),
-      email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      invoice_prefix: z.string().optional(),
+      coupon: z.string().max(5000).optional(),
+      default_alipay_account: z.string().max(500).optional(),
+      default_bank_account: z.string().max(500).optional(),
+      default_card: z.string().max(500).optional(),
+      default_source: z.string().max(500).optional(),
+      description: z.string().max(5000).optional(),
+      email: z.string().max(512).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      invoice_prefix: z.string().max(5000).optional(),
       invoice_settings: z
         .object({
           custom_fields: z
             .union([
-              z.array(z.object({ name: z.string(), value: z.string() })),
+              z.array(
+                z.object({
+                  name: z.string().max(40),
+                  value: z.string().max(140),
+                }),
+              ),
               z.enum([""]),
             ])
             .optional(),
-          default_payment_method: z.string().optional(),
-          footer: z.string().optional(),
+          default_payment_method: z.string().max(5000).optional(),
+          footer: z.string().max(5000).optional(),
           rendering_options: z
             .union([
               z.object({
@@ -24039,29 +24194,29 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(256).optional(),
       next_invoice_sequence: z.coerce.number().optional(),
-      phone: z.string().optional(),
-      preferred_locales: z.array(z.string()).optional(),
-      promotion_code: z.string().optional(),
+      phone: z.string().max(20).optional(),
+      preferred_locales: z.array(z.string().max(5000)).optional(),
+      promotion_code: z.string().max(5000).optional(),
       shipping: z
         .union([
           z.object({
             address: z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
-            name: z.string(),
-            phone: z.string().optional(),
+            name: z.string().max(5000),
+            phone: z.string().max(5000).optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
-      source: z.string().optional(),
+      source: z.string().max(5000).optional(),
       tax: z
         .object({
           ip_address: z.union([z.string(), z.enum([""])]).optional(),
@@ -24123,14 +24278,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerBalanceTransactionsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerBalanceTransactionsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCustomersCustomerBalanceTransactionsBodySchema = z
@@ -24146,7 +24301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_customer_balance_transaction)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -24211,14 +24366,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerBalanceTransactionsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerBalanceTransactionsBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    description: z.string().max(350).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
   })
 
@@ -24277,10 +24432,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string(), transaction: z.string() })
+    z.object({ customer: z.string().max(5000), transaction: z.string() })
 
   const getCustomersCustomerBalanceTransactionsTransactionQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getCustomersCustomerBalanceTransactionsTransactionBodySchema = z
     .object({})
@@ -24350,12 +24505,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string(), transaction: z.string() })
+    z.object({
+      customer: z.string().max(5000),
+      transaction: z.string().max(5000),
+    })
 
   const postCustomersCustomerBalanceTransactionsTransactionBodySchema = z
     .object({
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      description: z.string().max(350).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -24420,12 +24578,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerBankAccountsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerBankAccountsQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
   })
@@ -24441,7 +24599,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_bank_account)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -24503,49 +24661,49 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerBankAccountsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerBankAccountsBodySchema = z
     .object({
-      alipay_account: z.string().optional(),
+      alipay_account: z.string().max(5000).optional(),
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
-            country: z.string(),
+            account_number: z.string().max(5000),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       card: z
         .union([
           z.object({
-            address_city: z.string().optional(),
-            address_country: z.string().optional(),
-            address_line1: z.string().optional(),
-            address_line2: z.string().optional(),
-            address_state: z.string().optional(),
-            address_zip: z.string().optional(),
-            cvc: z.string().optional(),
+            address_city: z.string().max(5000).optional(),
+            address_country: z.string().max(5000).optional(),
+            address_line1: z.string().max(5000).optional(),
+            address_line2: z.string().max(5000).optional(),
+            address_state: z.string().max(5000).optional(),
+            address_zip: z.string().max(5000).optional(),
+            cvc: z.string().max(5000).optional(),
             exp_month: z.coerce.number(),
             exp_year: z.coerce.number(),
             metadata: z.record(z.string()).optional(),
-            name: z.string().optional(),
-            number: z.string(),
+            name: z.string().max(5000).optional(),
+            number: z.string().max(5000),
             object: z.enum(["card"]).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
-      source: z.string().optional(),
+      source: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -24601,12 +24759,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerBankAccountsIdParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
     id: z.string(),
   })
 
   const deleteCustomersCustomerBankAccountsIdBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const deleteCustomersCustomerBankAccountsIdResponseValidator =
@@ -24671,12 +24829,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerBankAccountsIdParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const getCustomersCustomerBankAccountsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerBankAccountsIdBodySchema = z.object({}).optional()
@@ -24737,40 +24895,40 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerBankAccountsIdParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const postCustomersCustomerBankAccountsIdBodySchema = z
     .object({
-      account_holder_name: z.string().optional(),
+      account_holder_name: z.string().max(5000).optional(),
       account_holder_type: z.enum(["company", "individual"]).optional(),
-      address_city: z.string().optional(),
-      address_country: z.string().optional(),
-      address_line1: z.string().optional(),
-      address_line2: z.string().optional(),
-      address_state: z.string().optional(),
-      address_zip: z.string().optional(),
-      exp_month: z.string().optional(),
-      exp_year: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      address_city: z.string().max(5000).optional(),
+      address_country: z.string().max(5000).optional(),
+      address_line1: z.string().max(5000).optional(),
+      address_line2: z.string().max(5000).optional(),
+      address_state: z.string().max(5000).optional(),
+      address_zip: z.string().max(5000).optional(),
+      exp_month: z.string().max(5000).optional(),
+      exp_year: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(5000).optional(),
       owner: z
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           email: z.string().optional(),
-          name: z.string().optional(),
-          phone: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          phone: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -24840,14 +24998,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerBankAccountsIdVerifyParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const postCustomersCustomerBankAccountsIdVerifyBodySchema = z
     .object({
       amounts: z.array(z.coerce.number()).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -24903,12 +25061,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerCardsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerCardsQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
   })
@@ -24923,7 +25081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_card)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -24985,49 +25143,49 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerCardsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerCardsBodySchema = z
     .object({
-      alipay_account: z.string().optional(),
+      alipay_account: z.string().max(5000).optional(),
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
-            country: z.string(),
+            account_number: z.string().max(5000),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       card: z
         .union([
           z.object({
-            address_city: z.string().optional(),
-            address_country: z.string().optional(),
-            address_line1: z.string().optional(),
-            address_line2: z.string().optional(),
-            address_state: z.string().optional(),
-            address_zip: z.string().optional(),
-            cvc: z.string().optional(),
+            address_city: z.string().max(5000).optional(),
+            address_country: z.string().max(5000).optional(),
+            address_line1: z.string().max(5000).optional(),
+            address_line2: z.string().max(5000).optional(),
+            address_state: z.string().max(5000).optional(),
+            address_zip: z.string().max(5000).optional(),
+            cvc: z.string().max(5000).optional(),
             exp_month: z.coerce.number(),
             exp_year: z.coerce.number(),
             metadata: z.record(z.string()).optional(),
-            name: z.string().optional(),
-            number: z.string(),
+            name: z.string().max(5000).optional(),
+            number: z.string().max(5000),
             object: z.enum(["card"]).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
-      source: z.string().optional(),
+      source: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -25082,12 +25240,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerCardsIdParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
     id: z.string(),
   })
 
   const deleteCustomersCustomerCardsIdBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const deleteCustomersCustomerCardsIdResponseValidator =
@@ -25149,12 +25307,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerCardsIdParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const getCustomersCustomerCardsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerCardsIdBodySchema = z.object({}).optional()
@@ -25212,40 +25370,40 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerCardsIdParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const postCustomersCustomerCardsIdBodySchema = z
     .object({
-      account_holder_name: z.string().optional(),
+      account_holder_name: z.string().max(5000).optional(),
       account_holder_type: z.enum(["company", "individual"]).optional(),
-      address_city: z.string().optional(),
-      address_country: z.string().optional(),
-      address_line1: z.string().optional(),
-      address_line2: z.string().optional(),
-      address_state: z.string().optional(),
-      address_zip: z.string().optional(),
-      exp_month: z.string().optional(),
-      exp_year: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      address_city: z.string().max(5000).optional(),
+      address_country: z.string().max(5000).optional(),
+      address_line1: z.string().max(5000).optional(),
+      address_line2: z.string().max(5000).optional(),
+      address_state: z.string().max(5000).optional(),
+      address_zip: z.string().max(5000).optional(),
+      exp_month: z.string().max(5000).optional(),
+      exp_year: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(5000).optional(),
       owner: z
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           email: z.string().optional(),
-          name: z.string().optional(),
-          phone: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          phone: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -25312,11 +25470,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerCashBalanceParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerCashBalanceQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerCashBalanceBodySchema = z.object({}).optional()
@@ -25374,12 +25532,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerCashBalanceParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerCashBalanceBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       settings: z
         .object({
           reconciliation_mode: z
@@ -25439,14 +25597,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerCashBalanceTransactionsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerCashBalanceTransactionsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCustomersCustomerCashBalanceTransactionsBodySchema = z
@@ -25462,7 +25620,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_customer_cash_balance_transaction)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -25527,10 +25685,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerCashBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string(), transaction: z.string() })
+    z.object({ customer: z.string().max(5000), transaction: z.string() })
 
   const getCustomersCustomerCashBalanceTransactionsTransactionQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getCustomersCustomerCashBalanceTransactionsTransactionBodySchema = z
     .object({})
@@ -25602,7 +25760,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerDiscountParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const deleteCustomersCustomerDiscountBodySchema = z.object({}).optional()
@@ -25656,11 +25814,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerDiscountParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerDiscountQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerDiscountBodySchema = z.object({}).optional()
@@ -25718,12 +25876,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerFundingInstructionsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerFundingInstructionsBodySchema = z.object({
     bank_transfer: z.object({
-      eu_bank_transfer: z.object({ country: z.string() }).optional(),
+      eu_bank_transfer: z.object({ country: z.string().max(5000) }).optional(),
       requested_address_types: z
         .array(z.enum(["iban", "sort_code", "spei", "zengin"]))
         .optional(),
@@ -25736,7 +25894,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ]),
     }),
     currency: z.string(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     funding_type: z.enum(["bank_transfer"]),
   })
 
@@ -25792,12 +25950,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerPaymentMethodsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerPaymentMethodsQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
     type: z
@@ -25851,7 +26009,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_payment_method)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -25916,12 +26074,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerPaymentMethodsPaymentMethodParamSchema = z.object({
-    customer: z.string(),
-    payment_method: z.string(),
+    customer: z.string().max(5000),
+    payment_method: z.string().max(5000),
   })
 
   const getCustomersCustomerPaymentMethodsPaymentMethodQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerPaymentMethodsPaymentMethodBodySchema = z
@@ -25985,14 +26143,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerSourcesParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerSourcesQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    object: z.string().optional(),
+    object: z.string().max(5000).optional(),
     starting_after: z.string().optional(),
   })
 
@@ -26013,7 +26171,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -26075,49 +26233,49 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerSourcesParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerSourcesBodySchema = z
     .object({
-      alipay_account: z.string().optional(),
+      alipay_account: z.string().max(5000).optional(),
       bank_account: z
         .union([
           z.object({
-            account_holder_name: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string(),
-            country: z.string(),
+            account_number: z.string().max(5000),
+            country: z.string().max(5000),
             currency: z.string().optional(),
             object: z.enum(["bank_account"]).optional(),
-            routing_number: z.string().optional(),
+            routing_number: z.string().max(5000).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
       card: z
         .union([
           z.object({
-            address_city: z.string().optional(),
-            address_country: z.string().optional(),
-            address_line1: z.string().optional(),
-            address_line2: z.string().optional(),
-            address_state: z.string().optional(),
-            address_zip: z.string().optional(),
-            cvc: z.string().optional(),
+            address_city: z.string().max(5000).optional(),
+            address_country: z.string().max(5000).optional(),
+            address_line1: z.string().max(5000).optional(),
+            address_line2: z.string().max(5000).optional(),
+            address_state: z.string().max(5000).optional(),
+            address_zip: z.string().max(5000).optional(),
+            cvc: z.string().max(5000).optional(),
             exp_month: z.coerce.number(),
             exp_year: z.coerce.number(),
             metadata: z.record(z.string()).optional(),
-            name: z.string().optional(),
-            number: z.string(),
+            name: z.string().max(5000).optional(),
+            number: z.string().max(5000),
             object: z.enum(["card"]).optional(),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
-      source: z.string().optional(),
+      source: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -26170,12 +26328,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerSourcesIdParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
     id: z.string(),
   })
 
   const deleteCustomersCustomerSourcesIdBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const deleteCustomersCustomerSourcesIdResponseValidator =
@@ -26237,12 +26395,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerSourcesIdParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(500),
   })
 
   const getCustomersCustomerSourcesIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerSourcesIdBodySchema = z.object({}).optional()
@@ -26300,40 +26458,40 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerSourcesIdParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const postCustomersCustomerSourcesIdBodySchema = z
     .object({
-      account_holder_name: z.string().optional(),
+      account_holder_name: z.string().max(5000).optional(),
       account_holder_type: z.enum(["company", "individual"]).optional(),
-      address_city: z.string().optional(),
-      address_country: z.string().optional(),
-      address_line1: z.string().optional(),
-      address_line2: z.string().optional(),
-      address_state: z.string().optional(),
-      address_zip: z.string().optional(),
-      exp_month: z.string().optional(),
-      exp_year: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      address_city: z.string().max(5000).optional(),
+      address_country: z.string().max(5000).optional(),
+      address_line1: z.string().max(5000).optional(),
+      address_line2: z.string().max(5000).optional(),
+      address_state: z.string().max(5000).optional(),
+      address_zip: z.string().max(5000).optional(),
+      exp_month: z.string().max(5000).optional(),
+      exp_year: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(5000).optional(),
       owner: z
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           email: z.string().optional(),
-          name: z.string().optional(),
-          phone: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          phone: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -26400,14 +26558,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerSourcesIdVerifyParamSchema = z.object({
-    customer: z.string(),
-    id: z.string(),
+    customer: z.string().max(5000),
+    id: z.string().max(5000),
   })
 
   const postCustomersCustomerSourcesIdVerifyBodySchema = z
     .object({
       amounts: z.array(z.coerce.number()).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -26463,14 +26621,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerSubscriptionsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerSubscriptionsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCustomersCustomerSubscriptionsBodySchema = z.object({}).optional()
@@ -26484,7 +26642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_subscription)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -26549,7 +26707,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerSubscriptionsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerSubscriptionsBodySchema = z
@@ -26560,17 +26718,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
             discounts: z
               .array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               )
               .optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 tax_behavior: z
                   .enum(["exclusive", "inclusive", "unspecified"])
                   .optional(),
@@ -26579,7 +26737,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -26613,31 +26773,31 @@ export function createRouter(implementation: Implementation): KoaRouter {
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
-      coupon: z.string().optional(),
+      coupon: z.string().max(5000).optional(),
       currency: z.string().optional(),
       days_until_due: z.coerce.number().optional(),
-      default_payment_method: z.string().optional(),
-      default_source: z.string().optional(),
+      default_payment_method: z.string().max(5000).optional(),
+      default_source: z.string().max(5000).optional(),
       default_tax_rates: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string()), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.enum([""])])
             .optional(),
           issuer: z
             .object({
@@ -26657,20 +26817,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
               ])
               .optional(),
             metadata: z.record(z.string()).optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 recurring: z.object({
                   interval: z.enum(["day", "month", "week", "year"]),
                   interval_count: z.coerce.number().optional(),
@@ -26683,7 +26843,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -26735,7 +26897,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       .object({
                         amount: z.coerce.number().optional(),
                         amount_type: z.enum(["fixed", "maximum"]).optional(),
-                        description: z.string().optional(),
+                        description: z.string().max(200).optional(),
                       })
                       .optional(),
                     network: z
@@ -26766,7 +26928,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string() })
+                          .object({ country: z.string().max(5000) })
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -26855,7 +27017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      promotion_code: z.string().optional(),
+      promotion_code: z.string().max(5000).optional(),
       proration_behavior: z
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
@@ -26934,11 +27096,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema =
-    z.object({ customer: z.string(), subscription_exposed_id: z.string() })
+    z.object({
+      customer: z.string().max(5000),
+      subscription_exposed_id: z.string().max(5000),
+    })
 
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       invoice_now: z.coerce.boolean().optional(),
       prorate: z.coerce.boolean().optional(),
     })
@@ -27001,10 +27166,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema =
-    z.object({ customer: z.string(), subscription_exposed_id: z.string() })
+    z.object({
+      customer: z.string().max(5000),
+      subscription_exposed_id: z.string().max(5000),
+    })
 
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema = z
     .object({})
@@ -27071,7 +27239,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema =
-    z.object({ customer: z.string(), subscription_exposed_id: z.string() })
+    z.object({
+      customer: z.string().max(5000),
+      subscription_exposed_id: z.string().max(5000),
+    })
 
   const postCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema = z
     .object({
@@ -27081,17 +27252,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
             discounts: z
               .array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               )
               .optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 tax_behavior: z
                   .enum(["exclusive", "inclusive", "unspecified"])
                   .optional(),
@@ -27100,7 +27271,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -27132,7 +27305,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       cancel_at_period_end: z.coerce.boolean().optional(),
       cancellation_details: z
         .object({
-          comment: z.union([z.string(), z.enum([""])]).optional(),
+          comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
           feedback: z
             .enum([
               "",
@@ -27151,30 +27324,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
-      coupon: z.string().optional(),
+      coupon: z.string().max(5000).optional(),
       days_until_due: z.coerce.number().optional(),
-      default_payment_method: z.string().optional(),
-      default_source: z.union([z.string(), z.enum([""])]).optional(),
+      default_payment_method: z.string().max(5000).optional(),
+      default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
       default_tax_rates: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string()), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.enum([""])])
             .optional(),
           issuer: z
             .object({
@@ -27196,21 +27369,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
               ])
               .optional(),
-            id: z.string().optional(),
+            id: z.string().max(5000).optional(),
             metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 recurring: z.object({
                   interval: z.enum(["day", "month", "week", "year"]),
                   interval_count: z.coerce.number().optional(),
@@ -27223,7 +27396,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -27284,7 +27459,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       .object({
                         amount: z.coerce.number().optional(),
                         amount_type: z.enum(["fixed", "maximum"]).optional(),
-                        description: z.string().optional(),
+                        description: z.string().max(200).optional(),
                       })
                       .optional(),
                     network: z
@@ -27315,7 +27490,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string() })
+                          .object({ country: z.string().max(5000) })
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -27404,7 +27579,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      promotion_code: z.string().optional(),
+      promotion_code: z.string().max(5000).optional(),
       proration_behavior: z
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
@@ -27491,7 +27666,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema =
-    z.object({ customer: z.string(), subscription_exposed_id: z.string() })
+    z.object({
+      customer: z.string().max(5000),
+      subscription_exposed_id: z.string().max(5000),
+    })
 
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema =
     z.object({}).optional()
@@ -27553,10 +27731,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema =
-    z.object({ customer: z.string(), subscription_exposed_id: z.string() })
+    z.object({
+      customer: z.string().max(5000),
+      subscription_exposed_id: z.string().max(5000),
+    })
 
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema =
     z.object({}).optional()
@@ -27622,14 +27803,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerTaxIdsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const getCustomersCustomerTaxIdsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getCustomersCustomerTaxIdsBodySchema = z.object({}).optional()
@@ -27642,7 +27823,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_tax_id)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -27704,11 +27885,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postCustomersCustomerTaxIdsParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postCustomersCustomerTaxIdsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     type: z.enum([
       "ad_nrt",
       "ae_trn",
@@ -27830,7 +28011,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteCustomersCustomerTaxIdsIdParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
     id: z.string(),
   })
 
@@ -27885,12 +28066,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerTaxIdsIdParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
     id: z.string(),
   })
 
   const getCustomersCustomerTaxIdsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getCustomersCustomerTaxIdsIdBodySchema = z.object({}).optional()
@@ -27948,7 +28129,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getDisputesQuerySchema = z.object({
-    charge: z.string().optional(),
+    charge: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -27960,11 +28141,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payment_intent: z.string().optional(),
-    starting_after: z.string().optional(),
+    payment_intent: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getDisputesBodySchema = z.object({}).optional()
@@ -27977,7 +28158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_dispute)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/disputes")),
         }),
       ],
     ],
@@ -28030,10 +28211,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getDisputesDisputeParamSchema = z.object({ dispute: z.string() })
+  const getDisputesDisputeParamSchema = z.object({
+    dispute: z.string().max(5000),
+  })
 
   const getDisputesDisputeQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getDisputesDisputeBodySchema = z.object({}).optional()
@@ -28092,42 +28275,44 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postDisputesDisputeParamSchema = z.object({ dispute: z.string() })
+  const postDisputesDisputeParamSchema = z.object({
+    dispute: z.string().max(5000),
+  })
 
   const postDisputesDisputeBodySchema = z
     .object({
       evidence: z
         .object({
-          access_activity_log: z.string().optional(),
-          billing_address: z.string().optional(),
+          access_activity_log: z.string().max(20000).optional(),
+          billing_address: z.string().max(5000).optional(),
           cancellation_policy: z.string().optional(),
-          cancellation_policy_disclosure: z.string().optional(),
-          cancellation_rebuttal: z.string().optional(),
+          cancellation_policy_disclosure: z.string().max(20000).optional(),
+          cancellation_rebuttal: z.string().max(20000).optional(),
           customer_communication: z.string().optional(),
-          customer_email_address: z.string().optional(),
-          customer_name: z.string().optional(),
-          customer_purchase_ip: z.string().optional(),
+          customer_email_address: z.string().max(5000).optional(),
+          customer_name: z.string().max(5000).optional(),
+          customer_purchase_ip: z.string().max(5000).optional(),
           customer_signature: z.string().optional(),
           duplicate_charge_documentation: z.string().optional(),
-          duplicate_charge_explanation: z.string().optional(),
-          duplicate_charge_id: z.string().optional(),
-          product_description: z.string().optional(),
+          duplicate_charge_explanation: z.string().max(20000).optional(),
+          duplicate_charge_id: z.string().max(5000).optional(),
+          product_description: z.string().max(20000).optional(),
           receipt: z.string().optional(),
           refund_policy: z.string().optional(),
-          refund_policy_disclosure: z.string().optional(),
-          refund_refusal_explanation: z.string().optional(),
-          service_date: z.string().optional(),
+          refund_policy_disclosure: z.string().max(20000).optional(),
+          refund_refusal_explanation: z.string().max(20000).optional(),
+          service_date: z.string().max(5000).optional(),
           service_documentation: z.string().optional(),
-          shipping_address: z.string().optional(),
-          shipping_carrier: z.string().optional(),
-          shipping_date: z.string().optional(),
+          shipping_address: z.string().max(5000).optional(),
+          shipping_carrier: z.string().max(5000).optional(),
+          shipping_date: z.string().max(5000).optional(),
           shipping_documentation: z.string().optional(),
-          shipping_tracking_number: z.string().optional(),
+          shipping_tracking_number: z.string().max(5000).optional(),
           uncategorized_file: z.string().optional(),
-          uncategorized_text: z.string().optional(),
+          uncategorized_text: z.string().max(20000).optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       submit: z.coerce.boolean().optional(),
     })
@@ -28183,10 +28368,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postDisputesDisputeCloseParamSchema = z.object({ dispute: z.string() })
+  const postDisputesDisputeCloseParamSchema = z.object({
+    dispute: z.string().max(5000),
+  })
 
   const postDisputesDisputeCloseBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postDisputesDisputeCloseResponseValidator = responseValidationFactory(
@@ -28241,11 +28428,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postEphemeralKeysBodySchema = z
     .object({
-      customer: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      issuing_card: z.string().optional(),
-      nonce: z.string().optional(),
-      verification_session: z.string().optional(),
+      customer: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      issuing_card: z.string().max(5000).optional(),
+      nonce: z.string().max(5000).optional(),
+      verification_session: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -28291,10 +28478,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteEphemeralKeysKeyParamSchema = z.object({ key: z.string() })
+  const deleteEphemeralKeysKeyParamSchema = z.object({
+    key: z.string().max(5000),
+  })
 
   const deleteEphemeralKeysKeyBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const deleteEphemeralKeysKeyResponseValidator = responseValidationFactory(
@@ -28360,12 +28549,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     delivery_success: z.coerce.boolean().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
-    type: z.string().optional(),
-    types: z.array(z.string()).optional(),
+    starting_after: z.string().max(5000).optional(),
+    type: z.string().max(5000).optional(),
+    types: z.array(z.string().max(5000)).optional(),
   })
 
   const getEventsBodySchema = z.object({}).optional()
@@ -28378,7 +28567,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_event),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/events")),
         }),
       ],
     ],
@@ -28431,10 +28620,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getEventsIdParamSchema = z.object({ id: z.string() })
+  const getEventsIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getEventsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getEventsIdBodySchema = z.object({}).optional()
@@ -28490,10 +28679,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getExchangeRatesQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getExchangeRatesBodySchema = z.object({}).optional()
@@ -28506,7 +28695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_exchange_rate),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/exchange_rates")),
         }),
       ],
     ],
@@ -28559,10 +28748,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getExchangeRatesRateIdParamSchema = z.object({ rate_id: z.string() })
+  const getExchangeRatesRateIdParamSchema = z.object({
+    rate_id: z.string().max(5000),
+  })
 
   const getExchangeRatesRateIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getExchangeRatesRateIdBodySchema = z.object({}).optional()
@@ -28634,9 +28825,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     expired: z.coerce.boolean().optional(),
-    file: z.string().optional(),
+    file: z.string().max(5000).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
   })
@@ -28651,7 +28842,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_file_link)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
         }),
       ],
     ],
@@ -28705,9 +28896,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postFileLinksBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     expires_at: z.coerce.number().optional(),
-    file: z.string(),
+    file: z.string().max(5000),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
   })
 
@@ -28756,7 +28947,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getFileLinksLinkParamSchema = z.object({ link: z.string() })
 
   const getFileLinksLinkQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getFileLinksLinkBodySchema = z.object({}).optional()
@@ -28815,7 +29006,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postFileLinksLinkBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       expires_at: z
         .union([z.enum(["now"]), z.coerce.number(), z.enum([""])])
         .optional(),
@@ -28885,8 +29076,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     purpose: z
       .enum([
@@ -28907,7 +29098,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "terminal_reader_splashscreen",
       ])
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getFilesBodySchema = z.object({}).optional()
@@ -28920,7 +29111,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_file)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/files")),
         }),
       ],
     ],
@@ -28974,7 +29165,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postFilesBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     file: z.string(),
     file_link_data: z
       .object({
@@ -29039,10 +29230,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getFilesFileParamSchema = z.object({ file: z.string() })
+  const getFilesFileParamSchema = z.object({ file: z.string().max(5000) })
 
   const getFilesFileQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getFilesFileBodySchema = z.object({}).optional()
@@ -29100,15 +29291,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getFinancialConnectionsAccountsQuerySchema = z.object({
     account_holder: z
       .object({
-        account: z.string().optional(),
-        customer: z.string().optional(),
+        account: z.string().max(5000).optional(),
+        customer: z.string().max(5000).optional(),
       })
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    session: z.string().optional(),
-    starting_after: z.string().optional(),
+    session: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getFinancialConnectionsAccountsBodySchema = z.object({}).optional()
@@ -29122,7 +29313,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_financial_connections_account)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/financial_connections/accounts")),
           }),
         ],
       ],
@@ -29180,11 +29374,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getFinancialConnectionsAccountsAccountParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const getFinancialConnectionsAccountsAccountQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getFinancialConnectionsAccountsAccountBodySchema = z
@@ -29250,11 +29444,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postFinancialConnectionsAccountsAccountDisconnectParamSchema = z.object(
-    { account: z.string() },
+    { account: z.string().max(5000) },
   )
 
   const postFinancialConnectionsAccountsAccountDisconnectBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postFinancialConnectionsAccountsAccountDisconnectResponseValidator =
@@ -29317,15 +29511,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getFinancialConnectionsAccountsAccountOwnersParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const getFinancialConnectionsAccountsAccountOwnersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    ownership: z.string(),
-    starting_after: z.string().optional(),
+    ownership: z.string().max(5000),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getFinancialConnectionsAccountsAccountOwnersBodySchema = z
@@ -29341,7 +29535,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_financial_connections_account_owner),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -29406,11 +29600,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postFinancialConnectionsAccountsAccountRefreshParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postFinancialConnectionsAccountsAccountRefreshBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     features: z.array(z.enum(["balance", "ownership", "transactions"])),
   })
 
@@ -29470,11 +29664,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postFinancialConnectionsAccountsAccountSubscribeParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postFinancialConnectionsAccountsAccountSubscribeBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     features: z.array(z.enum(["transactions"])),
   })
 
@@ -29534,11 +29728,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postFinancialConnectionsAccountsAccountUnsubscribeParamSchema =
-    z.object({ account: z.string() })
+    z.object({ account: z.string().max(5000) })
 
   const postFinancialConnectionsAccountsAccountUnsubscribeBodySchema = z.object(
     {
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       features: z.array(z.enum(["transactions"])),
     },
   )
@@ -29604,19 +29798,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postFinancialConnectionsSessionsBodySchema = z.object({
     account_holder: z.object({
-      account: z.string().optional(),
-      customer: z.string().optional(),
+      account: z.string().max(5000).optional(),
+      customer: z.string().max(5000).optional(),
       type: z.enum(["account", "customer"]),
     }),
-    expand: z.array(z.string()).optional(),
-    filters: z.object({ countries: z.array(z.string()) }).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    filters: z.object({ countries: z.array(z.string().max(5000)) }).optional(),
     permissions: z.array(
       z.enum(["balances", "ownership", "payment_method", "transactions"]),
     ),
     prefetch: z
       .array(z.enum(["balances", "ownership", "transactions"]))
       .optional(),
-    return_url: z.string().optional(),
+    return_url: z.string().max(5000).optional(),
   })
 
   const postFinancialConnectionsSessionsResponseValidator =
@@ -29667,11 +29861,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getFinancialConnectionsSessionsSessionParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const getFinancialConnectionsSessionsSessionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getFinancialConnectionsSessionsSessionBodySchema = z
@@ -29737,11 +29931,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getFinancialConnectionsTransactionsQuerySchema = z.object({
-    account: z.string(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    account: z.string().max(5000),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     transacted_at: z
       .union([
         z.object({
@@ -29753,7 +29947,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    transaction_refresh: z.object({ after: z.string() }).optional(),
+    transaction_refresh: z.object({ after: z.string().max(5000) }).optional(),
   })
 
   const getFinancialConnectionsTransactionsBodySchema = z.object({}).optional()
@@ -29767,7 +29961,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_financial_connections_transaction),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/financial_connections/transactions")),
           }),
         ],
       ],
@@ -29828,11 +30025,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getFinancialConnectionsTransactionsTransactionParamSchema = z.object({
-    transaction: z.string(),
+    transaction: z.string().max(5000),
   })
 
   const getFinancialConnectionsTransactionsTransactionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getFinancialConnectionsTransactionsTransactionBodySchema = z
@@ -29909,10 +30106,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         lte: z.coerce.number().optional(),
       })
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getForwardingRequestsBodySchema = z.object({}).optional()
@@ -29925,7 +30122,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_forwarding_request),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -29983,21 +30180,26 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postForwardingRequestsBodySchema = z.object({
-    config: z.string(),
-    expand: z.array(z.string()).optional(),
-    payment_method: z.string(),
+    config: z.string().max(5000),
+    expand: z.array(z.string().max(5000)).optional(),
+    payment_method: z.string().max(5000),
     replacements: z.array(
       z.enum(["card_cvc", "card_expiry", "card_number", "cardholder_name"]),
     ),
     request: z
       .object({
-        body: z.string().optional(),
+        body: z.string().max(5000).optional(),
         headers: z
-          .array(z.object({ name: z.string(), value: z.string() }))
+          .array(
+            z.object({
+              name: z.string().max(5000),
+              value: z.string().max(5000),
+            }),
+          )
           .optional(),
       })
       .optional(),
-    url: z.string(),
+    url: z.string().max(5000),
   })
 
   const postForwardingRequestsResponseValidator = responseValidationFactory(
@@ -30046,10 +30248,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getForwardingRequestsIdParamSchema = z.object({ id: z.string() })
+  const getForwardingRequestsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getForwardingRequestsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getForwardingRequestsIdBodySchema = z.object({}).optional()
@@ -30109,7 +30313,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIdentityVerificationReportsQuerySchema = z.object({
-    client_reference_id: z.string().optional(),
+    client_reference_id: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -30121,12 +30325,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     type: z.enum(["document", "id_number"]).optional(),
-    verification_session: z.string().optional(),
+    verification_session: z.string().max(5000).optional(),
   })
 
   const getIdentityVerificationReportsBodySchema = z.object({}).optional()
@@ -30140,7 +30344,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_identity_verification_report),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/identity/verification_reports")),
           }),
         ],
       ],
@@ -30198,11 +30405,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIdentityVerificationReportsReportParamSchema = z.object({
-    report: z.string(),
+    report: z.string().max(5000),
   })
 
   const getIdentityVerificationReportsReportQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIdentityVerificationReportsReportBodySchema = z.object({}).optional()
@@ -30266,7 +30473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIdentityVerificationSessionsQuerySchema = z.object({
-    client_reference_id: z.string().optional(),
+    client_reference_id: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -30278,10 +30485,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum(["canceled", "processing", "requires_input", "verified"])
       .optional(),
@@ -30298,7 +30505,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_identity_verification_session),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/identity/verification_sessions")),
           }),
         ],
       ],
@@ -30357,8 +30567,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postIdentityVerificationSessionsBodySchema = z
     .object({
-      client_reference_id: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      client_reference_id: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
       options: z
         .object({
@@ -30394,7 +30604,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       return_url: z.string().optional(),
       type: z.enum(["document", "id_number"]).optional(),
-      verification_flow: z.string().optional(),
+      verification_flow: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -30446,11 +30656,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIdentityVerificationSessionsSessionParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const getIdentityVerificationSessionsSessionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIdentityVerificationSessionsSessionBodySchema = z
@@ -30516,12 +30726,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIdentityVerificationSessionsSessionParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const postIdentityVerificationSessionsSessionBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
       options: z
         .object({
@@ -30614,11 +30824,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIdentityVerificationSessionsSessionCancelParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const postIdentityVerificationSessionsSessionCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postIdentityVerificationSessionsSessionCancelResponseValidator =
@@ -30676,11 +30886,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIdentityVerificationSessionsSessionRedactParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const postIdentityVerificationSessionsSessionRedactBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postIdentityVerificationSessionsSessionRedactResponseValidator =
@@ -30749,13 +30959,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
-    invoice: z.string().optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    invoice: z.string().max(5000).optional(),
     limit: z.coerce.number().optional(),
     pending: z.coerce.boolean().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getInvoiceitemsBodySchema = z.object({}).optional()
@@ -30768,7 +30978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_invoiceitem)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/invoiceitems")),
         }),
       ],
     ],
@@ -30824,32 +31034,32 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postInvoiceitemsBodySchema = z.object({
     amount: z.coerce.number().optional(),
     currency: z.string().optional(),
-    customer: z.string(),
-    description: z.string().optional(),
+    customer: z.string().max(5000),
+    description: z.string().max(5000).optional(),
     discountable: z.coerce.boolean().optional(),
     discounts: z
       .union([
         z.array(
           z.object({
-            coupon: z.string().optional(),
-            discount: z.string().optional(),
-            promotion_code: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            discount: z.string().max(5000).optional(),
+            promotion_code: z.string().max(5000).optional(),
           }),
         ),
         z.enum([""]),
       ])
       .optional(),
-    expand: z.array(z.string()).optional(),
-    invoice: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    invoice: z.string().max(5000).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     period: z
       .object({ end: z.coerce.number(), start: z.coerce.number() })
       .optional(),
-    price: z.string().optional(),
+    price: z.string().max(5000).optional(),
     price_data: z
       .object({
         currency: z.string(),
-        product: z.string(),
+        product: z.string().max(5000),
         tax_behavior: z
           .enum(["exclusive", "inclusive", "unspecified"])
           .optional(),
@@ -30858,10 +31068,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     quantity: z.coerce.number().optional(),
-    subscription: z.string().optional(),
+    subscription: z.string().max(5000).optional(),
     tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
     tax_code: z.union([z.string(), z.enum([""])]).optional(),
-    tax_rates: z.array(z.string()).optional(),
+    tax_rates: z.array(z.string().max(5000)).optional(),
     unit_amount: z.coerce.number().optional(),
     unit_amount_decimal: z.string().optional(),
   })
@@ -30909,7 +31119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const deleteInvoiceitemsInvoiceitemParamSchema = z.object({
-    invoiceitem: z.string(),
+    invoiceitem: z.string().max(5000),
   })
 
   const deleteInvoiceitemsInvoiceitemBodySchema = z.object({}).optional()
@@ -30963,11 +31173,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getInvoiceitemsInvoiceitemParamSchema = z.object({
-    invoiceitem: z.string(),
+    invoiceitem: z.string().max(5000),
   })
 
   const getInvoiceitemsInvoiceitemQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getInvoiceitemsInvoiceitemBodySchema = z.object({}).optional()
@@ -31027,36 +31237,36 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postInvoiceitemsInvoiceitemParamSchema = z.object({
-    invoiceitem: z.string(),
+    invoiceitem: z.string().max(5000),
   })
 
   const postInvoiceitemsInvoiceitemBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      description: z.string().optional(),
+      description: z.string().max(5000).optional(),
       discountable: z.coerce.boolean().optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       period: z
         .object({ end: z.coerce.number(), start: z.coerce.number() })
         .optional(),
-      price: z.string().optional(),
+      price: z.string().max(5000).optional(),
       price_data: z
         .object({
           currency: z.string(),
-          product: z.string(),
+          product: z.string().max(5000),
           tax_behavior: z
             .enum(["exclusive", "inclusive", "unspecified"])
             .optional(),
@@ -31069,7 +31279,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .enum(["exclusive", "inclusive", "unspecified"])
         .optional(),
       tax_code: z.union([z.string(), z.enum([""])]).optional(),
-      tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+      tax_rates: z
+        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .optional(),
       unit_amount: z.coerce.number().optional(),
       unit_amount_decimal: z.string().optional(),
     })
@@ -31138,7 +31350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     due_date: z
       .union([
         z.object({
@@ -31150,14 +31362,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum(["draft", "open", "paid", "uncollectible", "void"])
       .optional(),
-    subscription: z.string().optional(),
+    subscription: z.string().max(5000).optional(),
   })
 
   const getInvoicesBodySchema = z.object({}).optional()
@@ -31170,7 +31382,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_invoice)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/invoices")),
         }),
       ],
     ],
@@ -31225,7 +31437,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postInvoicesBodySchema = z
     .object({
-      account_tax_ids: z.union([z.array(z.string()), z.enum([""])]).optional(),
+      account_tax_ids: z
+        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .optional(),
       application_fee_amount: z.coerce.number().optional(),
       auto_advance: z.coerce.boolean().optional(),
       automatic_tax: z
@@ -31245,23 +31459,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
       currency: z.string().optional(),
       custom_fields: z
         .union([
-          z.array(z.object({ name: z.string(), value: z.string() })),
+          z.array(
+            z.object({ name: z.string().max(40), value: z.string().max(140) }),
+          ),
           z.enum([""]),
         ])
         .optional(),
-      customer: z.string().optional(),
+      customer: z.string().max(5000).optional(),
       days_until_due: z.coerce.number().optional(),
-      default_payment_method: z.string().optional(),
-      default_source: z.string().optional(),
-      default_tax_rates: z.array(z.string()).optional(),
-      description: z.string().optional(),
+      default_payment_method: z.string().max(5000).optional(),
+      default_source: z.string().max(5000).optional(),
+      default_tax_rates: z.array(z.string().max(5000)).optional(),
+      description: z.string().max(1500).optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
@@ -31269,10 +31485,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       due_date: z.coerce.number().optional(),
       effective_at: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
-      footer: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      footer: z.string().max(5000).optional(),
       from_invoice: z
-        .object({ action: z.enum(["revision"]), invoice: z.string() })
+        .object({ action: z.enum(["revision"]), invoice: z.string().max(5000) })
         .optional(),
       issuer: z
         .object({
@@ -31281,11 +31497,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      number: z.string().optional(),
+      number: z.string().max(26).optional(),
       on_behalf_of: z.string().optional(),
       payment_settings: z
         .object({
-          default_mandate: z.union([z.string(), z.enum([""])]).optional(),
+          default_mandate: z
+            .union([z.string().max(5000), z.enum([""])])
+            .optional(),
           payment_method_options: z
             .object({
               acss_debit: z
@@ -31346,7 +31564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string() })
+                          .object({ country: z.string().max(5000) })
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -31436,7 +31654,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       shipping_cost: z
         .object({
-          shipping_rate: z.string().optional(),
+          shipping_rate: z.string().max(5000).optional(),
           shipping_rate_data: z
             .object({
               delivery_estimate: z
@@ -31467,7 +31685,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .optional(),
                 })
                 .optional(),
-              display_name: z.string(),
+              display_name: z.string().max(100),
               fixed_amount: z
                 .object({
                   amount: z.coerce.number(),
@@ -31497,19 +31715,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
       shipping_details: z
         .object({
           address: z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
-          name: z.string(),
-          phone: z.union([z.string(), z.enum([""])]).optional(),
+          name: z.string().max(5000),
+          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
         })
         .optional(),
-      statement_descriptor: z.string().optional(),
-      subscription: z.string().optional(),
+      statement_descriptor: z.string().max(22).optional(),
+      subscription: z.string().max(5000).optional(),
       transfer_data: z
         .object({
           amount: z.coerce.number().optional(),
@@ -31562,10 +31780,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getInvoicesSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getInvoicesSearchBodySchema = z.object({}).optional()
@@ -31577,10 +31795,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_invoice)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -31647,20 +31865,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    coupon: z.string().optional(),
+    coupon: z.string().max(5000).optional(),
     currency: z.string().optional(),
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     customer_details: z
       .object({
         address: z
           .union([
             z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
             z.enum([""]),
           ])
@@ -31669,15 +31887,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               address: z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string().optional(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000).optional(),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
-              name: z.string(),
-              phone: z.string().optional(),
+              name: z.string().max(5000),
+              phone: z.string().max(5000).optional(),
             }),
             z.enum([""]),
           ])
@@ -31770,44 +31988,44 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .union([
         z.array(
           z.object({
-            coupon: z.string().optional(),
-            discount: z.string().optional(),
-            promotion_code: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            discount: z.string().max(5000).optional(),
+            promotion_code: z.string().max(5000).optional(),
           }),
         ),
         z.enum([""]),
       ])
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     invoice_items: z
       .array(
         z.object({
           amount: z.coerce.number().optional(),
           currency: z.string().optional(),
-          description: z.string().optional(),
+          description: z.string().max(5000).optional(),
           discountable: z.coerce.boolean().optional(),
           discounts: z
             .union([
               z.array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          invoiceitem: z.string().optional(),
+          invoiceitem: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
           period: z
             .object({ end: z.coerce.number(), start: z.coerce.number() })
             .optional(),
-          price: z.string().optional(),
+          price: z.string().max(5000).optional(),
           price_data: z
             .object({
               currency: z.string(),
-              product: z.string(),
+              product: z.string().max(5000),
               tax_behavior: z
                 .enum(["exclusive", "inclusive", "unspecified"])
                 .optional(),
@@ -31820,7 +32038,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .enum(["exclusive", "inclusive", "unspecified"])
             .optional(),
           tax_code: z.union([z.string(), z.enum([""])]).optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
           unit_amount: z.coerce.number().optional(),
           unit_amount_decimal: z.string().optional(),
         }),
@@ -31833,8 +32053,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
-    schedule: z.string().optional(),
-    subscription: z.string().optional(),
+    schedule: z.string().max(5000).optional(),
+    subscription: z.string().max(5000).optional(),
     subscription_billing_cycle_anchor: z
       .union([z.enum(["now", "unchanged"]), z.coerce.number()])
       .optional(),
@@ -31844,7 +32064,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_cancel_at_period_end: z.coerce.boolean().optional(),
     subscription_cancel_now: z.coerce.boolean().optional(),
     subscription_default_tax_rates: z
-      .union([z.array(z.string()), z.enum([""])])
+      .union([z.array(z.string().max(5000)), z.enum([""])])
       .optional(),
     subscription_items: z
       .array(
@@ -31858,21 +32078,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          id: z.string().optional(),
+          id: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-          price: z.string().optional(),
+          price: z.string().max(5000).optional(),
           price_data: z
             .object({
               currency: z.string(),
-              product: z.string(),
+              product: z.string().max(5000),
               recurring: z.object({
                 interval: z.enum(["day", "month", "week", "year"]),
                 interval_count: z.coerce.number().optional(),
@@ -31885,7 +32105,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           quantity: z.coerce.number().optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
         }),
       )
       .optional(),
@@ -31965,20 +32187,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    coupon: z.string().optional(),
+    coupon: z.string().max(5000).optional(),
     currency: z.string().optional(),
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     customer_details: z
       .object({
         address: z
           .union([
             z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
             z.enum([""]),
           ])
@@ -31987,15 +32209,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               address: z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string().optional(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000).optional(),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
-              name: z.string(),
-              phone: z.string().optional(),
+              name: z.string().max(5000),
+              phone: z.string().max(5000).optional(),
             }),
             z.enum([""]),
           ])
@@ -32088,45 +32310,45 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .union([
         z.array(
           z.object({
-            coupon: z.string().optional(),
-            discount: z.string().optional(),
-            promotion_code: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            discount: z.string().max(5000).optional(),
+            promotion_code: z.string().max(5000).optional(),
           }),
         ),
         z.enum([""]),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     invoice_items: z
       .array(
         z.object({
           amount: z.coerce.number().optional(),
           currency: z.string().optional(),
-          description: z.string().optional(),
+          description: z.string().max(5000).optional(),
           discountable: z.coerce.boolean().optional(),
           discounts: z
             .union([
               z.array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          invoiceitem: z.string().optional(),
+          invoiceitem: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
           period: z
             .object({ end: z.coerce.number(), start: z.coerce.number() })
             .optional(),
-          price: z.string().optional(),
+          price: z.string().max(5000).optional(),
           price_data: z
             .object({
               currency: z.string(),
-              product: z.string(),
+              product: z.string().max(5000),
               tax_behavior: z
                 .enum(["exclusive", "inclusive", "unspecified"])
                 .optional(),
@@ -32139,7 +32361,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .enum(["exclusive", "inclusive", "unspecified"])
             .optional(),
           tax_code: z.union([z.string(), z.enum([""])]).optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
           unit_amount: z.coerce.number().optional(),
           unit_amount_decimal: z.string().optional(),
         }),
@@ -32153,9 +32377,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     limit: z.coerce.number().optional(),
     on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
-    schedule: z.string().optional(),
-    starting_after: z.string().optional(),
-    subscription: z.string().optional(),
+    schedule: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
+    subscription: z.string().max(5000).optional(),
     subscription_billing_cycle_anchor: z
       .union([z.enum(["now", "unchanged"]), z.coerce.number()])
       .optional(),
@@ -32165,7 +32389,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_cancel_at_period_end: z.coerce.boolean().optional(),
     subscription_cancel_now: z.coerce.boolean().optional(),
     subscription_default_tax_rates: z
-      .union([z.array(z.string()), z.enum([""])])
+      .union([z.array(z.string().max(5000)), z.enum([""])])
       .optional(),
     subscription_items: z
       .array(
@@ -32179,21 +32403,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
-          id: z.string().optional(),
+          id: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-          price: z.string().optional(),
+          price: z.string().max(5000).optional(),
           price_data: z
             .object({
               currency: z.string(),
-              product: z.string(),
+              product: z.string().max(5000),
               recurring: z.object({
                 interval: z.enum(["day", "month", "week", "year"]),
                 interval_count: z.coerce.number().optional(),
@@ -32206,7 +32430,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           quantity: z.coerce.number().optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
         }),
       )
       .optional(),
@@ -32232,7 +32458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_line_item)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -32289,7 +32515,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const deleteInvoicesInvoiceParamSchema = z.object({ invoice: z.string() })
+  const deleteInvoicesInvoiceParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const deleteInvoicesInvoiceBodySchema = z.object({}).optional()
 
@@ -32343,10 +32571,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getInvoicesInvoiceParamSchema = z.object({ invoice: z.string() })
+  const getInvoicesInvoiceParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const getInvoicesInvoiceQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getInvoicesInvoiceBodySchema = z.object({}).optional()
@@ -32405,11 +32635,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postInvoicesInvoiceParamSchema = z.object({ invoice: z.string() })
+  const postInvoicesInvoiceParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const postInvoicesInvoiceBodySchema = z
     .object({
-      account_tax_ids: z.union([z.array(z.string()), z.enum([""])]).optional(),
+      account_tax_ids: z
+        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .optional(),
       application_fee_amount: z.coerce.number().optional(),
       auto_advance: z.coerce.boolean().optional(),
       automatic_tax: z
@@ -32428,24 +32662,26 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       custom_fields: z
         .union([
-          z.array(z.object({ name: z.string(), value: z.string() })),
+          z.array(
+            z.object({ name: z.string().max(40), value: z.string().max(140) }),
+          ),
           z.enum([""]),
         ])
         .optional(),
       days_until_due: z.coerce.number().optional(),
-      default_payment_method: z.string().optional(),
-      default_source: z.union([z.string(), z.enum([""])]).optional(),
+      default_payment_method: z.string().max(5000).optional(),
+      default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
       default_tax_rates: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
-      description: z.string().optional(),
+      description: z.string().max(1500).optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
@@ -32453,8 +32689,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       due_date: z.coerce.number().optional(),
       effective_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
-      expand: z.array(z.string()).optional(),
-      footer: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      footer: z.string().max(5000).optional(),
       issuer: z
         .object({
           account: z.string().optional(),
@@ -32462,11 +32698,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      number: z.union([z.string(), z.enum([""])]).optional(),
+      number: z.union([z.string().max(26), z.enum([""])]).optional(),
       on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
       payment_settings: z
         .object({
-          default_mandate: z.union([z.string(), z.enum([""])]).optional(),
+          default_mandate: z
+            .union([z.string().max(5000), z.enum([""])])
+            .optional(),
           payment_method_options: z
             .object({
               acss_debit: z
@@ -32527,7 +32765,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string() })
+                          .object({ country: z.string().max(5000) })
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -32617,7 +32855,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       shipping_cost: z
         .union([
           z.object({
-            shipping_rate: z.string().optional(),
+            shipping_rate: z.string().max(5000).optional(),
             shipping_rate_data: z
               .object({
                 delivery_estimate: z
@@ -32648,7 +32886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       .optional(),
                   })
                   .optional(),
-                display_name: z.string(),
+                display_name: z.string().max(100),
                 fixed_amount: z
                   .object({
                     amount: z.coerce.number(),
@@ -32681,20 +32919,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([
           z.object({
             address: z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
-            name: z.string(),
-            phone: z.union([z.string(), z.enum([""])]).optional(),
+            name: z.string().max(5000),
+            phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
-      statement_descriptor: z.string().optional(),
+      statement_descriptor: z.string().max(22).optional(),
       transfer_data: z
         .union([
           z.object({
@@ -32758,13 +32996,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postInvoicesInvoiceFinalizeParamSchema = z.object({
-    invoice: z.string(),
+    invoice: z.string().max(5000),
   })
 
   const postInvoicesInvoiceFinalizeBodySchema = z
     .object({
       auto_advance: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -32816,13 +33054,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getInvoicesInvoiceLinesParamSchema = z.object({ invoice: z.string() })
+  const getInvoicesInvoiceLinesParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const getInvoicesInvoiceLinesQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getInvoicesInvoiceLinesBodySchema = z.object({}).optional()
@@ -32835,7 +33075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_line_item)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -32897,44 +33137,44 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postInvoicesInvoiceLinesLineItemIdParamSchema = z.object({
-    invoice: z.string(),
-    line_item_id: z.string(),
+    invoice: z.string().max(5000),
+    line_item_id: z.string().max(5000),
   })
 
   const postInvoicesInvoiceLinesLineItemIdBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      description: z.string().optional(),
+      description: z.string().max(5000).optional(),
       discountable: z.coerce.boolean().optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       period: z
         .object({ end: z.coerce.number(), start: z.coerce.number() })
         .optional(),
-      price: z.string().optional(),
+      price: z.string().max(5000).optional(),
       price_data: z
         .object({
           currency: z.string(),
-          product: z.string().optional(),
+          product: z.string().max(5000).optional(),
           product_data: z
             .object({
-              description: z.string().optional(),
+              description: z.string().max(40000).optional(),
               images: z.array(z.string()).optional(),
               metadata: z.record(z.string()).optional(),
-              name: z.string(),
-              tax_code: z.string().optional(),
+              name: z.string().max(5000),
+              tax_code: z.string().max(5000).optional(),
             })
             .optional(),
           tax_behavior: z
@@ -32951,13 +33191,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
             z.object({
               amount: z.coerce.number(),
               tax_rate_data: z.object({
-                country: z.string().optional(),
-                description: z.string().optional(),
-                display_name: z.string(),
+                country: z.string().max(5000).optional(),
+                description: z.string().max(5000).optional(),
+                display_name: z.string().max(50),
                 inclusive: z.coerce.boolean(),
-                jurisdiction: z.string().optional(),
+                jurisdiction: z.string().max(50).optional(),
                 percentage: z.coerce.number(),
-                state: z.string().optional(),
+                state: z.string().max(2).optional(),
                 tax_type: z
                   .enum([
                     "amusement_tax",
@@ -32981,7 +33221,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+      tax_rates: z
+        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .optional(),
     })
     .optional()
 
@@ -33037,11 +33279,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postInvoicesInvoiceMarkUncollectibleParamSchema = z.object({
-    invoice: z.string(),
+    invoice: z.string().max(5000),
   })
 
   const postInvoicesInvoiceMarkUncollectibleBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postInvoicesInvoiceMarkUncollectibleResponseValidator =
@@ -33095,17 +33337,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postInvoicesInvoicePayParamSchema = z.object({ invoice: z.string() })
+  const postInvoicesInvoicePayParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const postInvoicesInvoicePayBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       forgive: z.coerce.boolean().optional(),
-      mandate: z.union([z.string(), z.enum([""])]).optional(),
+      mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
       off_session: z.coerce.boolean().optional(),
       paid_out_of_band: z.coerce.boolean().optional(),
-      payment_method: z.string().optional(),
-      source: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
+      source: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -33159,10 +33403,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postInvoicesInvoiceSendParamSchema = z.object({ invoice: z.string() })
+  const postInvoicesInvoiceSendParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const postInvoicesInvoiceSendBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postInvoicesInvoiceSendResponseValidator = responseValidationFactory(
@@ -33215,10 +33461,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postInvoicesInvoiceVoidParamSchema = z.object({ invoice: z.string() })
+  const postInvoicesInvoiceVoidParamSchema = z.object({
+    invoice: z.string().max(5000),
+  })
 
   const postInvoicesInvoiceVoidBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postInvoicesInvoiceVoidResponseValidator = responseValidationFactory(
@@ -33272,8 +33520,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingAuthorizationsQuerySchema = z.object({
-    card: z.string().optional(),
-    cardholder: z.string().optional(),
+    card: z.string().max(5000).optional(),
+    cardholder: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -33285,10 +33533,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["closed", "pending", "reversed"]).optional(),
   })
 
@@ -33302,7 +33550,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_issuing_authorization)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/issuing/authorizations")),
         }),
       ],
     ],
@@ -33360,11 +33611,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingAuthorizationsAuthorizationParamSchema = z.object({
-    authorization: z.string(),
+    authorization: z.string().max(5000),
   })
 
   const getIssuingAuthorizationsAuthorizationQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingAuthorizationsAuthorizationBodySchema = z
@@ -33427,12 +33678,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingAuthorizationsAuthorizationParamSchema = z.object({
-    authorization: z.string(),
+    authorization: z.string().max(5000),
   })
 
   const postIssuingAuthorizationsAuthorizationBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -33489,13 +33740,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingAuthorizationsAuthorizationApproveParamSchema = z.object({
-    authorization: z.string(),
+    authorization: z.string().max(5000),
   })
 
   const postIssuingAuthorizationsAuthorizationApproveBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -33552,12 +33803,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingAuthorizationsAuthorizationDeclineParamSchema = z.object({
-    authorization: z.string(),
+    authorization: z.string().max(5000),
   })
 
   const postIssuingAuthorizationsAuthorizationDeclineBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -33626,11 +33877,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     email: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     phone_number: z.string().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "blocked", "inactive"]).optional(),
     type: z.enum(["company", "individual"]).optional(),
   })
@@ -33645,7 +33896,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_issuing_cardholder)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/issuing/cardholders")),
         }),
       ],
     ],
@@ -33705,17 +33959,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postIssuingCardholdersBodySchema = z.object({
     billing: z.object({
       address: z.object({
-        city: z.string(),
-        country: z.string(),
-        line1: z.string(),
-        line2: z.string().optional(),
-        postal_code: z.string(),
-        state: z.string().optional(),
+        city: z.string().max(5000),
+        country: z.string().max(5000),
+        line1: z.string().max(5000),
+        line2: z.string().max(5000).optional(),
+        postal_code: z.string().max(5000),
+        state: z.string().max(5000).optional(),
       }),
     }),
-    company: z.object({ tax_id: z.string().optional() }).optional(),
+    company: z.object({ tax_id: z.string().max(5000).optional() }).optional(),
     email: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     individual: z
       .object({
         card_issuing: z
@@ -33724,7 +33978,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .object({
                 date: z.coerce.number().optional(),
                 ip: z.string().optional(),
-                user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                user_agent: z
+                  .union([z.string().max(5000), z.enum([""])])
+                  .optional(),
               })
               .optional(),
           })
@@ -33742,8 +33998,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .object({
             document: z
               .object({
-                back: z.string().optional(),
-                front: z.string().optional(),
+                back: z.string().max(5000).optional(),
+                front: z.string().max(5000).optional(),
               })
               .optional(),
           })
@@ -34059,7 +34315,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ]),
           )
           .optional(),
-        allowed_merchant_countries: z.array(z.string()).optional(),
+        allowed_merchant_countries: z.array(z.string().max(5000)).optional(),
         blocked_categories: z
           .array(
             z.enum([
@@ -34361,7 +34617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ]),
           )
           .optional(),
-        blocked_merchant_countries: z.array(z.string()).optional(),
+        blocked_merchant_countries: z.array(z.string().max(5000)).optional(),
         spending_limits: z
           .array(
             z.object({
@@ -34732,11 +34988,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingCardholdersCardholderParamSchema = z.object({
-    cardholder: z.string(),
+    cardholder: z.string().max(5000),
   })
 
   const getIssuingCardholdersCardholderQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingCardholdersCardholderBodySchema = z.object({}).optional()
@@ -34794,7 +35050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingCardholdersCardholderParamSchema = z.object({
-    cardholder: z.string(),
+    cardholder: z.string().max(5000),
   })
 
   const postIssuingCardholdersCardholderBodySchema = z
@@ -34802,18 +35058,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
       billing: z
         .object({
           address: z.object({
-            city: z.string(),
-            country: z.string(),
-            line1: z.string(),
-            line2: z.string().optional(),
-            postal_code: z.string(),
-            state: z.string().optional(),
+            city: z.string().max(5000),
+            country: z.string().max(5000),
+            line1: z.string().max(5000),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000),
+            state: z.string().max(5000).optional(),
           }),
         })
         .optional(),
-      company: z.object({ tax_id: z.string().optional() }).optional(),
+      company: z.object({ tax_id: z.string().max(5000).optional() }).optional(),
       email: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       individual: z
         .object({
           card_issuing: z
@@ -34822,7 +35078,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                  user_agent: z
+                    .union([z.string().max(5000), z.enum([""])])
+                    .optional(),
                 })
                 .optional(),
             })
@@ -34840,8 +35098,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(5000).optional(),
+                  front: z.string().max(5000).optional(),
                 })
                 .optional(),
             })
@@ -35156,7 +35414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               ]),
             )
             .optional(),
-          allowed_merchant_countries: z.array(z.string()).optional(),
+          allowed_merchant_countries: z.array(z.string().max(5000)).optional(),
           blocked_categories: z
             .array(
               z.enum([
@@ -35458,7 +35716,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               ]),
             )
             .optional(),
-          blocked_merchant_countries: z.array(z.string()).optional(),
+          blocked_merchant_countries: z.array(z.string().max(5000)).optional(),
           spending_limits: z
             .array(
               z.object({
@@ -35831,7 +36089,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingCardsQuerySchema = z.object({
-    cardholder: z.string().optional(),
+    cardholder: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -35843,14 +36101,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
+    ending_before: z.string().max(5000).optional(),
     exp_month: z.coerce.number().optional(),
     exp_year: z.coerce.number().optional(),
-    expand: z.array(z.string()).optional(),
-    last4: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    last4: z.string().max(5000).optional(),
     limit: z.coerce.number().optional(),
-    personalization_design: z.string().optional(),
-    starting_after: z.string().optional(),
+    personalization_design: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "canceled", "inactive"]).optional(),
     type: z.enum(["physical", "virtual"]).optional(),
   })
@@ -35865,7 +36123,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_issuing_card)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/issuing/cards")),
         }),
       ],
     ],
@@ -35919,30 +36177,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postIssuingCardsBodySchema = z.object({
-    cardholder: z.string().optional(),
+    cardholder: z.string().max(5000).optional(),
     currency: z.string(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string().optional(),
     metadata: z.record(z.string()).optional(),
-    personalization_design: z.string().optional(),
-    pin: z.object({ encrypted_number: z.string().optional() }).optional(),
-    replacement_for: z.string().optional(),
+    personalization_design: z.string().max(5000).optional(),
+    pin: z
+      .object({ encrypted_number: z.string().max(5000).optional() })
+      .optional(),
+    replacement_for: z.string().max(5000).optional(),
     replacement_reason: z
       .enum(["damaged", "expired", "lost", "stolen"])
       .optional(),
-    second_line: z.union([z.string(), z.enum([""])]).optional(),
+    second_line: z.union([z.string().max(5000), z.enum([""])]).optional(),
     shipping: z
       .object({
         address: z.object({
-          city: z.string(),
-          country: z.string(),
-          line1: z.string(),
-          line2: z.string().optional(),
-          postal_code: z.string(),
-          state: z.string().optional(),
+          city: z.string().max(5000),
+          country: z.string().max(5000),
+          line1: z.string().max(5000),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000),
+          state: z.string().max(5000).optional(),
         }),
-        customs: z.object({ eori_number: z.string().optional() }).optional(),
-        name: z.string(),
+        customs: z
+          .object({ eori_number: z.string().max(5000).optional() })
+          .optional(),
+        name: z.string().max(5000),
         phone_number: z.string().optional(),
         require_signature: z.coerce.boolean().optional(),
         service: z.enum(["express", "priority", "standard"]).optional(),
@@ -36252,7 +36514,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ]),
           )
           .optional(),
-        allowed_merchant_countries: z.array(z.string()).optional(),
+        allowed_merchant_countries: z.array(z.string().max(5000)).optional(),
         blocked_categories: z
           .array(
             z.enum([
@@ -36554,7 +36816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             ]),
           )
           .optional(),
-        blocked_merchant_countries: z.array(z.string()).optional(),
+        blocked_merchant_countries: z.array(z.string().max(5000)).optional(),
         spending_limits: z
           .array(
             z.object({
@@ -36919,10 +37181,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getIssuingCardsCardParamSchema = z.object({ card: z.string() })
+  const getIssuingCardsCardParamSchema = z.object({
+    card: z.string().max(5000),
+  })
 
   const getIssuingCardsCardQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingCardsCardBodySchema = z.object({}).optional()
@@ -36981,15 +37245,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postIssuingCardsCardParamSchema = z.object({ card: z.string() })
+  const postIssuingCardsCardParamSchema = z.object({
+    card: z.string().max(5000),
+  })
 
   const postIssuingCardsCardBodySchema = z
     .object({
       cancellation_reason: z.enum(["lost", "stolen"]).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      personalization_design: z.string().optional(),
-      pin: z.object({ encrypted_number: z.string().optional() }).optional(),
+      personalization_design: z.string().max(5000).optional(),
+      pin: z
+        .object({ encrypted_number: z.string().max(5000).optional() })
+        .optional(),
       spending_controls: z
         .object({
           allowed_categories: z
@@ -37293,7 +37561,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               ]),
             )
             .optional(),
-          allowed_merchant_countries: z.array(z.string()).optional(),
+          allowed_merchant_countries: z.array(z.string().max(5000)).optional(),
           blocked_categories: z
             .array(
               z.enum([
@@ -37595,7 +37863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               ]),
             )
             .optional(),
-          blocked_merchant_countries: z.array(z.string()).optional(),
+          blocked_merchant_countries: z.array(z.string().max(5000)).optional(),
           spending_limits: z
             .array(
               z.object({
@@ -37980,14 +38248,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum(["expired", "lost", "submitted", "unsubmitted", "won"])
       .optional(),
-    transaction: z.string().optional(),
+    transaction: z.string().max(5000).optional(),
   })
 
   const getIssuingDisputesBodySchema = z.object({}).optional()
@@ -38000,7 +38268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_issuing_dispute)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/issuing/disputes")),
         }),
       ],
     ],
@@ -38075,14 +38343,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.boolean(), z.enum([""])])
                   .optional(),
                 cancellation_reason: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 expected_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 product_type: z.enum(["", "merchandise", "service"]).optional(),
                 return_status: z
@@ -38104,8 +38374,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 card_statement: z.union([z.string(), z.enum([""])]).optional(),
                 cash_receipt: z.union([z.string(), z.enum([""])]).optional(),
                 check_image: z.union([z.string(), z.enum([""])]).optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
-                original_transaction: z.string().optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
+                original_transaction: z.string().max(5000).optional(),
               }),
               z.enum([""]),
             ])
@@ -38116,7 +38388,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 additional_documentation: z
                   .union([z.string(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
               }),
               z.enum([""]),
             ])
@@ -38127,12 +38401,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 additional_documentation: z
                   .union([z.string(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 received_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 return_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 return_status: z
                   .enum(["", "merchant_rejected", "successful"])
@@ -38153,9 +38429,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 expected_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 product_type: z.enum(["", "merchandise", "service"]).optional(),
               }),
@@ -38168,9 +38446,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 additional_documentation: z
                   .union([z.string(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 product_type: z.enum(["", "merchandise", "service"]).optional(),
               }),
@@ -38198,9 +38478,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 cancellation_reason: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 received_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
@@ -38210,10 +38492,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
-      transaction: z.string().optional(),
-      treasury: z.object({ received_debit: z.string() }).optional(),
+      transaction: z.string().max(5000).optional(),
+      treasury: z.object({ received_debit: z.string().max(5000) }).optional(),
     })
     .optional()
 
@@ -38263,10 +38545,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getIssuingDisputesDisputeParamSchema = z.object({ dispute: z.string() })
+  const getIssuingDisputesDisputeParamSchema = z.object({
+    dispute: z.string().max(5000),
+  })
 
   const getIssuingDisputesDisputeQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingDisputesDisputeBodySchema = z.object({}).optional()
@@ -38326,7 +38610,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingDisputesDisputeParamSchema = z.object({
-    dispute: z.string(),
+    dispute: z.string().max(5000),
   })
 
   const postIssuingDisputesDisputeBodySchema = z
@@ -38347,14 +38631,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.boolean(), z.enum([""])])
                   .optional(),
                 cancellation_reason: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 expected_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 product_type: z.enum(["", "merchandise", "service"]).optional(),
                 return_status: z
@@ -38376,8 +38662,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 card_statement: z.union([z.string(), z.enum([""])]).optional(),
                 cash_receipt: z.union([z.string(), z.enum([""])]).optional(),
                 check_image: z.union([z.string(), z.enum([""])]).optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
-                original_transaction: z.string().optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
+                original_transaction: z.string().max(5000).optional(),
               }),
               z.enum([""]),
             ])
@@ -38388,7 +38676,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 additional_documentation: z
                   .union([z.string(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
               }),
               z.enum([""]),
             ])
@@ -38399,12 +38689,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 additional_documentation: z
                   .union([z.string(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 received_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 return_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 return_status: z
                   .enum(["", "merchant_rejected", "successful"])
@@ -38425,9 +38717,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 expected_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 product_type: z.enum(["", "merchandise", "service"]).optional(),
               }),
@@ -38440,9 +38734,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 additional_documentation: z
                   .union([z.string(), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
                 product_type: z.enum(["", "merchandise", "service"]).optional(),
               }),
@@ -38470,9 +38766,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 cancellation_reason: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(1500), z.enum([""])])
                   .optional(),
-                explanation: z.union([z.string(), z.enum([""])]).optional(),
+                explanation: z
+                  .union([z.string().max(1500), z.enum([""])])
+                  .optional(),
                 received_at: z
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
@@ -38482,7 +38780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -38538,12 +38836,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingDisputesDisputeSubmitParamSchema = z.object({
-    dispute: z.string(),
+    dispute: z.string().max(5000),
   })
 
   const postIssuingDisputesDisputeSubmitBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -38597,17 +38895,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingPersonalizationDesignsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    lookup_keys: z.array(z.string()).optional(),
+    lookup_keys: z.array(z.string().max(200)).optional(),
     preferences: z
       .object({
         is_default: z.coerce.boolean().optional(),
         is_platform_default: z.coerce.boolean().optional(),
       })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "inactive", "rejected", "review"]).optional(),
   })
 
@@ -38622,7 +38920,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_issuing_personalization_design)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/issuing/personalization_designs")),
           }),
         ],
       ],
@@ -38683,17 +38984,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
     card_logo: z.string().optional(),
     carrier_text: z
       .object({
-        footer_body: z.union([z.string(), z.enum([""])]).optional(),
-        footer_title: z.union([z.string(), z.enum([""])]).optional(),
-        header_body: z.union([z.string(), z.enum([""])]).optional(),
-        header_title: z.union([z.string(), z.enum([""])]).optional(),
+        footer_body: z.union([z.string().max(200), z.enum([""])]).optional(),
+        footer_title: z.union([z.string().max(30), z.enum([""])]).optional(),
+        header_body: z.union([z.string().max(200), z.enum([""])]).optional(),
+        header_title: z.union([z.string().max(30), z.enum([""])]).optional(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
-    lookup_key: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    lookup_key: z.string().max(200).optional(),
     metadata: z.record(z.string()).optional(),
-    name: z.string().optional(),
-    physical_bundle: z.string(),
+    name: z.string().max(200).optional(),
+    physical_bundle: z.string().max(5000),
     preferences: z.object({ is_default: z.coerce.boolean() }).optional(),
     transfer_lookup_key: z.coerce.boolean().optional(),
   })
@@ -38749,10 +39050,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
-    z.object({ personalization_design: z.string() })
+    z.object({ personalization_design: z.string().max(5000) })
 
   const getIssuingPersonalizationDesignsPersonalizationDesignQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getIssuingPersonalizationDesignsPersonalizationDesignBodySchema = z
     .object({})
@@ -38822,7 +39123,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
-    z.object({ personalization_design: z.string() })
+    z.object({ personalization_design: z.string().max(5000) })
 
   const postIssuingPersonalizationDesignsPersonalizationDesignBodySchema = z
     .object({
@@ -38830,19 +39131,27 @@ export function createRouter(implementation: Implementation): KoaRouter {
       carrier_text: z
         .union([
           z.object({
-            footer_body: z.union([z.string(), z.enum([""])]).optional(),
-            footer_title: z.union([z.string(), z.enum([""])]).optional(),
-            header_body: z.union([z.string(), z.enum([""])]).optional(),
-            header_title: z.union([z.string(), z.enum([""])]).optional(),
+            footer_body: z
+              .union([z.string().max(200), z.enum([""])])
+              .optional(),
+            footer_title: z
+              .union([z.string().max(30), z.enum([""])])
+              .optional(),
+            header_body: z
+              .union([z.string().max(200), z.enum([""])])
+              .optional(),
+            header_title: z
+              .union([z.string().max(30), z.enum([""])])
+              .optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
-      lookup_key: z.union([z.string(), z.enum([""])]).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      lookup_key: z.union([z.string().max(200), z.enum([""])]).optional(),
       metadata: z.record(z.string()).optional(),
-      name: z.union([z.string(), z.enum([""])]).optional(),
-      physical_bundle: z.string().optional(),
+      name: z.union([z.string().max(200), z.enum([""])]).optional(),
+      physical_bundle: z.string().max(5000).optional(),
       preferences: z.object({ is_default: z.coerce.boolean() }).optional(),
       transfer_lookup_key: z.coerce.boolean().optional(),
     })
@@ -38908,10 +39217,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingPhysicalBundlesQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "inactive", "review"]).optional(),
     type: z.enum(["custom", "standard"]).optional(),
   })
@@ -38926,7 +39235,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_issuing_physical_bundle),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/issuing/physical_bundles")),
         }),
       ],
     ],
@@ -38984,11 +39296,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingPhysicalBundlesPhysicalBundleParamSchema = z.object({
-    physical_bundle: z.string(),
+    physical_bundle: z.string().max(5000),
   })
 
   const getIssuingPhysicalBundlesPhysicalBundleQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingPhysicalBundlesPhysicalBundleBodySchema = z
@@ -39062,10 +39374,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getIssuingSettlementsBodySchema = z.object({}).optional()
@@ -39078,7 +39390,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_issuing_settlement),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/issuing/settlements")),
         }),
       ],
     ],
@@ -39136,11 +39451,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingSettlementsSettlementParamSchema = z.object({
-    settlement: z.string(),
+    settlement: z.string().max(5000),
   })
 
   const getIssuingSettlementsSettlementQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingSettlementsSettlementBodySchema = z.object({}).optional()
@@ -39198,12 +39513,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingSettlementsSettlementParamSchema = z.object({
-    settlement: z.string(),
+    settlement: z.string().max(5000),
   })
 
   const postIssuingSettlementsSettlementBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -39257,7 +39572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingTokensQuerySchema = z.object({
-    card: z.string(),
+    card: z.string().max(5000),
     created: z
       .union([
         z.object({
@@ -39269,10 +39584,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "deleted", "requested", "suspended"]).optional(),
   })
 
@@ -39286,7 +39601,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_issuing_token)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -39339,10 +39654,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getIssuingTokensTokenParamSchema = z.object({ token: z.string() })
+  const getIssuingTokensTokenParamSchema = z.object({
+    token: z.string().max(5000),
+  })
 
   const getIssuingTokensTokenQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingTokensTokenBodySchema = z.object({}).optional()
@@ -39401,10 +39718,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postIssuingTokensTokenParamSchema = z.object({ token: z.string() })
+  const postIssuingTokensTokenParamSchema = z.object({
+    token: z.string().max(5000),
+  })
 
   const postIssuingTokensTokenBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     status: z.enum(["active", "deleted", "suspended"]),
   })
 
@@ -39459,8 +39778,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingTransactionsQuerySchema = z.object({
-    card: z.string().optional(),
-    cardholder: z.string().optional(),
+    card: z.string().max(5000).optional(),
+    cardholder: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -39472,10 +39791,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     type: z.enum(["capture", "refund"]).optional(),
   })
 
@@ -39489,7 +39808,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_issuing_transaction)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/issuing/transactions")),
         }),
       ],
     ],
@@ -39547,11 +39869,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingTransactionsTransactionParamSchema = z.object({
-    transaction: z.string(),
+    transaction: z.string().max(5000),
   })
 
   const getIssuingTransactionsTransactionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getIssuingTransactionsTransactionBodySchema = z.object({}).optional()
@@ -39612,12 +39934,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingTransactionsTransactionParamSchema = z.object({
-    transaction: z.string(),
+    transaction: z.string().max(5000),
   })
 
   const postIssuingTransactionsTransactionBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -39675,19 +39997,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postLinkAccountSessionsBodySchema = z.object({
     account_holder: z.object({
-      account: z.string().optional(),
-      customer: z.string().optional(),
+      account: z.string().max(5000).optional(),
+      customer: z.string().max(5000).optional(),
       type: z.enum(["account", "customer"]),
     }),
-    expand: z.array(z.string()).optional(),
-    filters: z.object({ countries: z.array(z.string()) }).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    filters: z.object({ countries: z.array(z.string().max(5000)) }).optional(),
     permissions: z.array(
       z.enum(["balances", "ownership", "payment_method", "transactions"]),
     ),
     prefetch: z
       .array(z.enum(["balances", "ownership", "transactions"]))
       .optional(),
-    return_url: z.string().optional(),
+    return_url: z.string().max(5000).optional(),
   })
 
   const postLinkAccountSessionsResponseValidator = responseValidationFactory(
@@ -39737,11 +40059,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getLinkAccountSessionsSessionParamSchema = z.object({
-    session: z.string(),
+    session: z.string().max(5000),
   })
 
   const getLinkAccountSessionsSessionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getLinkAccountSessionsSessionBodySchema = z.object({}).optional()
@@ -39804,15 +40126,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getLinkedAccountsQuerySchema = z.object({
     account_holder: z
       .object({
-        account: z.string().optional(),
-        customer: z.string().optional(),
+        account: z.string().max(5000).optional(),
+        customer: z.string().max(5000).optional(),
       })
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    session: z.string().optional(),
-    starting_after: z.string().optional(),
+    session: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getLinkedAccountsBodySchema = z.object({}).optional()
@@ -39825,7 +40147,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_financial_connections_account)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/financial_connections/accounts")),
         }),
       ],
     ],
@@ -39878,10 +40203,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getLinkedAccountsAccountParamSchema = z.object({ account: z.string() })
+  const getLinkedAccountsAccountParamSchema = z.object({
+    account: z.string().max(5000),
+  })
 
   const getLinkedAccountsAccountQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getLinkedAccountsAccountBodySchema = z.object({}).optional()
@@ -39941,11 +40268,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postLinkedAccountsAccountDisconnectParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postLinkedAccountsAccountDisconnectBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postLinkedAccountsAccountDisconnectResponseValidator =
@@ -40003,15 +40330,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getLinkedAccountsAccountOwnersParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const getLinkedAccountsAccountOwnersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    ownership: z.string(),
-    starting_after: z.string().optional(),
+    ownership: z.string().max(5000),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getLinkedAccountsAccountOwnersBodySchema = z.object({}).optional()
@@ -40025,7 +40352,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_financial_connections_account_owner),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -40087,11 +40414,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postLinkedAccountsAccountRefreshParamSchema = z.object({
-    account: z.string(),
+    account: z.string().max(5000),
   })
 
   const postLinkedAccountsAccountRefreshBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     features: z.array(z.enum(["balance", "ownership", "transactions"])),
   })
 
@@ -40149,7 +40476,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getMandatesMandateParamSchema = z.object({ mandate: z.string() })
 
   const getMandatesMandateQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getMandatesMandateBodySchema = z.object({}).optional()
@@ -40220,11 +40547,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getPaymentIntentsBodySchema = z.object({}).optional()
@@ -40237,7 +40564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_payment_intent)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/payment_intents")),
         }),
       ],
     ],
@@ -40304,13 +40631,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     confirm: z.coerce.boolean().optional(),
     confirmation_method: z.enum(["automatic", "manual"]).optional(),
-    confirmation_token: z.string().optional(),
+    confirmation_token: z.string().max(5000).optional(),
     currency: z.string(),
-    customer: z.string().optional(),
-    description: z.string().optional(),
+    customer: z.string().max(5000).optional(),
+    description: z.string().max(1000).optional(),
     error_on_requires_action: z.coerce.boolean().optional(),
-    expand: z.array(z.string()).optional(),
-    mandate: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    mandate: z.string().max(5000).optional(),
     mandate_data: z
       .union([
         z.object({
@@ -40318,7 +40645,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             accepted_at: z.coerce.number().optional(),
             offline: z.object({}).optional(),
             online: z
-              .object({ ip_address: z.string(), user_agent: z.string() })
+              .object({
+                ip_address: z.string(),
+                user_agent: z.string().max(5000),
+              })
               .optional(),
             type: z.enum(["offline", "online"]),
           }),
@@ -40331,27 +40661,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .union([z.coerce.boolean(), z.enum(["one_off", "recurring"])])
       .optional(),
     on_behalf_of: z.string().optional(),
-    payment_method: z.string().optional(),
-    payment_method_configuration: z.string().optional(),
+    payment_method: z.string().max(5000).optional(),
+    payment_method_configuration: z.string().max(100).optional(),
     payment_method_data: z
       .object({
         acss_debit: z
           .object({
-            account_number: z.string(),
-            institution_number: z.string(),
-            transit_number: z.string(),
+            account_number: z.string().max(5000),
+            institution_number: z.string().max(5000),
+            transit_number: z.string().max(5000),
           })
           .optional(),
         affirm: z.object({}).optional(),
         afterpay_clearpay: z.object({}).optional(),
         alipay: z.object({}).optional(),
         au_becs_debit: z
-          .object({ account_number: z.string(), bsb_number: z.string() })
+          .object({
+            account_number: z.string().max(5000),
+            bsb_number: z.string().max(5000),
+          })
           .optional(),
         bacs_debit: z
           .object({
-            account_number: z.string().optional(),
-            sort_code: z.string().optional(),
+            account_number: z.string().max(5000).optional(),
+            sort_code: z.string().max(5000).optional(),
           })
           .optional(),
         bancontact: z.object({}).optional(),
@@ -40360,23 +40693,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
             address: z
               .union([
                 z.object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
+                  city: z.string().max(5000).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(5000).optional(),
+                  line2: z.string().max(5000).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
                 }),
                 z.enum([""]),
               ])
               .optional(),
             email: z.union([z.string(), z.enum([""])]).optional(),
-            name: z.union([z.string(), z.enum([""])]).optional(),
-            phone: z.union([z.string(), z.enum([""])]).optional(),
+            name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+            phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
           })
           .optional(),
         blik: z.object({}).optional(),
-        boleto: z.object({ tax_id: z.string() }).optional(),
+        boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
         cashapp: z.object({}).optional(),
         customer_balance: z.object({}).optional(),
         eps: z
@@ -40524,9 +40857,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         paypal: z.object({}).optional(),
         pix: z.object({}).optional(),
         promptpay: z.object({}).optional(),
-        radar_options: z.object({ session: z.string().optional() }).optional(),
+        radar_options: z
+          .object({ session: z.string().max(5000).optional() })
+          .optional(),
         revolut_pay: z.object({}).optional(),
-        sepa_debit: z.object({ iban: z.string() }).optional(),
+        sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
         sofort: z
           .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
           .optional(),
@@ -40569,10 +40904,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         us_bank_account: z
           .object({
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string().optional(),
+            account_number: z.string().max(5000).optional(),
             account_type: z.enum(["checking", "savings"]).optional(),
-            financial_connections_account: z.string().optional(),
-            routing_number: z.string().optional(),
+            financial_connections_account: z.string().max(5000).optional(),
+            routing_number: z.string().max(5000).optional(),
           })
           .optional(),
         wechat_pay: z.object({}).optional(),
@@ -40589,7 +40924,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   custom_mandate_url: z
                     .union([z.string(), z.enum([""])])
                     .optional(),
-                  interval_description: z.string().optional(),
+                  interval_description: z.string().max(500).optional(),
                   payment_schedule: z
                     .enum(["combined", "interval", "sporadic"])
                     .optional(),
@@ -40610,7 +40945,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               capture_method: z.enum(["", "manual"]).optional(),
-              preferred_locale: z.string().optional(),
+              preferred_locale: z.string().max(30).optional(),
               setup_future_usage: z.enum(["none"]).optional(),
             }),
             z.enum([""]),
@@ -40620,7 +40955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               capture_method: z.enum(["", "manual"]).optional(),
-              reference: z.string().optional(),
+              reference: z.string().max(128).optional(),
               setup_future_usage: z.enum(["none"]).optional(),
             }),
             z.enum([""]),
@@ -40670,7 +41005,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         blik: z
           .union([
             z.object({
-              code: z.string().optional(),
+              code: z.string().max(5000).optional(),
               setup_future_usage: z.enum(["", "none"]).optional(),
             }),
             z.enum([""]),
@@ -40691,7 +41026,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               capture_method: z.enum(["", "manual"]).optional(),
-              cvc_token: z.string().optional(),
+              cvc_token: z.string().max(5000).optional(),
               installments: z
                 .object({
                   enabled: z.coerce.boolean().optional(),
@@ -40711,7 +41046,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   amount: z.coerce.number(),
                   amount_type: z.enum(["fixed", "maximum"]),
-                  description: z.string().optional(),
+                  description: z.string().max(200).optional(),
                   end_date: z.coerce.number().optional(),
                   interval: z.enum([
                     "day",
@@ -40721,7 +41056,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     "year",
                   ]),
                   interval_count: z.coerce.number().optional(),
-                  reference: z.string(),
+                  reference: z.string().max(80),
                   start_date: z.coerce.number(),
                   supported_types: z.array(z.enum(["india"])).optional(),
                 })
@@ -40759,17 +41094,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .enum(["", "none", "off_session", "on_session"])
                 .optional(),
               statement_descriptor_suffix_kana: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(22), z.enum([""])])
                 .optional(),
               statement_descriptor_suffix_kanji: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(17), z.enum([""])])
                 .optional(),
               three_d_secure: z
                 .object({
                   ares_trans_status: z
                     .enum(["A", "C", "I", "N", "R", "U", "Y"])
                     .optional(),
-                  cryptogram: z.string(),
+                  cryptogram: z.string().max(5000),
                   electronic_commerce_indicator: z
                     .enum(["01", "02", "05", "06", "07"])
                     .optional(),
@@ -40779,14 +41114,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       cartes_bancaires: z
                         .object({
                           cb_avalgo: z.enum(["0", "1", "2", "3", "4", "A"]),
-                          cb_exemption: z.string().optional(),
+                          cb_exemption: z.string().max(4).optional(),
                           cb_score: z.coerce.number().optional(),
                         })
                         .optional(),
                     })
                     .optional(),
-                  requestor_challenge_indicator: z.string().optional(),
-                  transaction_id: z.string(),
+                  requestor_challenge_indicator: z.string().max(2).optional(),
+                  transaction_id: z.string().max(5000),
                   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]),
                 })
                 .optional(),
@@ -40822,7 +41157,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               bank_transfer: z
                 .object({
                   eu_bank_transfer: z
-                    .object({ country: z.string() })
+                    .object({ country: z.string().max(5000) })
                     .optional(),
                   requested_address_types: z
                     .array(
@@ -40948,14 +41283,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               confirmation_number: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(11), z.enum([""])])
                 .optional(),
               expires_after_days: z
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
               expires_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
               product_description: z
-                .union([z.string(), z.enum([""])])
+                .union([z.string().max(22), z.enum([""])])
                 .optional(),
               setup_future_usage: z.enum(["none"]).optional(),
             }),
@@ -41035,8 +41370,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   "sv-SE",
                 ])
                 .optional(),
-              reference: z.string().optional(),
-              risk_correlation_id: z.string().optional(),
+              reference: z.string().max(127).optional(),
+              risk_correlation_id: z.string().max(32).optional(),
               setup_future_usage: z
                 .enum(["", "none", "off_session"])
                 .optional(),
@@ -41097,7 +41432,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         swish: z
           .union([
             z.object({
-              reference: z.union([z.string(), z.enum([""])]).optional(),
+              reference: z
+                .union([z.string().max(5000), z.enum([""])])
+                .optional(),
               setup_future_usage: z.enum(["none"]).optional(),
             }),
             z.enum([""]),
@@ -41121,7 +41458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   prefetch: z
                     .array(z.enum(["balances", "transactions"]))
                     .optional(),
-                  return_url: z.string().optional(),
+                  return_url: z.string().max(5000).optional(),
                 })
                 .optional(),
               mandate_options: z
@@ -41150,7 +41487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         wechat_pay: z
           .union([
             z.object({
-              app_id: z.string().optional(),
+              app_id: z.string().max(5000).optional(),
               client: z.enum(["android", "ios", "web"]),
               setup_future_usage: z.enum(["none"]).optional(),
             }),
@@ -41165,29 +41502,31 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    payment_method_types: z.array(z.string()).optional(),
-    radar_options: z.object({ session: z.string().optional() }).optional(),
+    payment_method_types: z.array(z.string().max(5000)).optional(),
+    radar_options: z
+      .object({ session: z.string().max(5000).optional() })
+      .optional(),
     receipt_email: z.string().optional(),
     return_url: z.string().optional(),
     setup_future_usage: z.enum(["off_session", "on_session"]).optional(),
     shipping: z
       .object({
         address: z.object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         }),
-        carrier: z.string().optional(),
-        name: z.string(),
-        phone: z.string().optional(),
-        tracking_number: z.string().optional(),
+        carrier: z.string().max(5000).optional(),
+        name: z.string().max(5000),
+        phone: z.string().max(5000).optional(),
+        tracking_number: z.string().max(5000).optional(),
       })
       .optional(),
-    statement_descriptor: z.string().optional(),
-    statement_descriptor_suffix: z.string().optional(),
+    statement_descriptor: z.string().max(22).optional(),
+    statement_descriptor_suffix: z.string().max(22).optional(),
     transfer_data: z
       .object({ amount: z.coerce.number().optional(), destination: z.string() })
       .optional(),
@@ -41242,10 +41581,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentIntentsSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getPaymentIntentsSearchBodySchema = z.object({}).optional()
@@ -41257,10 +41596,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_payment_intent)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -41319,11 +41658,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getPaymentIntentsIntentParamSchema = z.object({ intent: z.string() })
+  const getPaymentIntentsIntentParamSchema = z.object({
+    intent: z.string().max(5000),
+  })
 
   const getPaymentIntentsIntentQuerySchema = z.object({
-    client_secret: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    client_secret: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPaymentIntentsIntentBodySchema = z.object({}).optional()
@@ -41382,7 +41723,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postPaymentIntentsIntentParamSchema = z.object({ intent: z.string() })
+  const postPaymentIntentsIntentParamSchema = z.object({
+    intent: z.string().max(5000),
+  })
 
   const postPaymentIntentsIntentBodySchema = z
     .object({
@@ -41394,31 +41737,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .enum(["automatic", "automatic_async", "manual"])
         .optional(),
       currency: z.string().optional(),
-      customer: z.string().optional(),
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(5000).optional(),
+      description: z.string().max(1000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      payment_method: z.string().optional(),
-      payment_method_configuration: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
+      payment_method_configuration: z.string().max(100).optional(),
       payment_method_data: z
         .object({
           acss_debit: z
             .object({
-              account_number: z.string(),
-              institution_number: z.string(),
-              transit_number: z.string(),
+              account_number: z.string().max(5000),
+              institution_number: z.string().max(5000),
+              transit_number: z.string().max(5000),
             })
             .optional(),
           affirm: z.object({}).optional(),
           afterpay_clearpay: z.object({}).optional(),
           alipay: z.object({}).optional(),
           au_becs_debit: z
-            .object({ account_number: z.string(), bsb_number: z.string() })
+            .object({
+              account_number: z.string().max(5000),
+              bsb_number: z.string().max(5000),
+            })
             .optional(),
           bacs_debit: z
             .object({
-              account_number: z.string().optional(),
-              sort_code: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
+              sort_code: z.string().max(5000).optional(),
             })
             .optional(),
           bancontact: z.object({}).optional(),
@@ -41427,23 +41773,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
               address: z
                 .union([
                   z.object({
-                    city: z.string().optional(),
-                    country: z.string().optional(),
-                    line1: z.string().optional(),
-                    line2: z.string().optional(),
-                    postal_code: z.string().optional(),
-                    state: z.string().optional(),
+                    city: z.string().max(5000).optional(),
+                    country: z.string().max(5000).optional(),
+                    line1: z.string().max(5000).optional(),
+                    line2: z.string().max(5000).optional(),
+                    postal_code: z.string().max(5000).optional(),
+                    state: z.string().max(5000).optional(),
                   }),
                   z.enum([""]),
                 ])
                 .optional(),
               email: z.union([z.string(), z.enum([""])]).optional(),
-              name: z.union([z.string(), z.enum([""])]).optional(),
-              phone: z.union([z.string(), z.enum([""])]).optional(),
+              name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+              phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string() }).optional(),
+          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
           cashapp: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
           eps: z
@@ -41592,10 +41938,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().optional() })
+            .object({ session: z.string().max(5000).optional() })
             .optional(),
           revolut_pay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string() }).optional(),
+          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
           sofort: z
             .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
             .optional(),
@@ -41638,10 +41984,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           us_bank_account: z
             .object({
               account_holder_type: z.enum(["company", "individual"]).optional(),
-              account_number: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
               account_type: z.enum(["checking", "savings"]).optional(),
-              financial_connections_account: z.string().optional(),
-              routing_number: z.string().optional(),
+              financial_connections_account: z.string().max(5000).optional(),
+              routing_number: z.string().max(5000).optional(),
             })
             .optional(),
           wechat_pay: z.object({}).optional(),
@@ -41658,7 +42004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     custom_mandate_url: z
                       .union([z.string(), z.enum([""])])
                       .optional(),
-                    interval_description: z.string().optional(),
+                    interval_description: z.string().max(500).optional(),
                     payment_schedule: z
                       .enum(["combined", "interval", "sporadic"])
                       .optional(),
@@ -41681,7 +42027,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 capture_method: z.enum(["", "manual"]).optional(),
-                preferred_locale: z.string().optional(),
+                preferred_locale: z.string().max(30).optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
               z.enum([""]),
@@ -41691,7 +42037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 capture_method: z.enum(["", "manual"]).optional(),
-                reference: z.string().optional(),
+                reference: z.string().max(128).optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
               z.enum([""]),
@@ -41741,7 +42087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           blik: z
             .union([
               z.object({
-                code: z.string().optional(),
+                code: z.string().max(5000).optional(),
                 setup_future_usage: z.enum(["", "none"]).optional(),
               }),
               z.enum([""]),
@@ -41762,7 +42108,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 capture_method: z.enum(["", "manual"]).optional(),
-                cvc_token: z.string().optional(),
+                cvc_token: z.string().max(5000).optional(),
                 installments: z
                   .object({
                     enabled: z.coerce.boolean().optional(),
@@ -41782,7 +42128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .object({
                     amount: z.coerce.number(),
                     amount_type: z.enum(["fixed", "maximum"]),
-                    description: z.string().optional(),
+                    description: z.string().max(200).optional(),
                     end_date: z.coerce.number().optional(),
                     interval: z.enum([
                       "day",
@@ -41792,7 +42138,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       "year",
                     ]),
                     interval_count: z.coerce.number().optional(),
-                    reference: z.string(),
+                    reference: z.string().max(80),
                     start_date: z.coerce.number(),
                     supported_types: z.array(z.enum(["india"])).optional(),
                   })
@@ -41832,17 +42178,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .enum(["", "none", "off_session", "on_session"])
                   .optional(),
                 statement_descriptor_suffix_kana: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(22), z.enum([""])])
                   .optional(),
                 statement_descriptor_suffix_kanji: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(17), z.enum([""])])
                   .optional(),
                 three_d_secure: z
                   .object({
                     ares_trans_status: z
                       .enum(["A", "C", "I", "N", "R", "U", "Y"])
                       .optional(),
-                    cryptogram: z.string(),
+                    cryptogram: z.string().max(5000),
                     electronic_commerce_indicator: z
                       .enum(["01", "02", "05", "06", "07"])
                       .optional(),
@@ -41854,14 +42200,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                         cartes_bancaires: z
                           .object({
                             cb_avalgo: z.enum(["0", "1", "2", "3", "4", "A"]),
-                            cb_exemption: z.string().optional(),
+                            cb_exemption: z.string().max(4).optional(),
                             cb_score: z.coerce.number().optional(),
                           })
                           .optional(),
                       })
                       .optional(),
-                    requestor_challenge_indicator: z.string().optional(),
-                    transaction_id: z.string(),
+                    requestor_challenge_indicator: z.string().max(2).optional(),
+                    transaction_id: z.string().max(5000),
                     version: z.enum(["1.0.2", "2.1.0", "2.2.0"]),
                   })
                   .optional(),
@@ -41897,7 +42243,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 bank_transfer: z
                   .object({
                     eu_bank_transfer: z
-                      .object({ country: z.string() })
+                      .object({ country: z.string().max(5000) })
                       .optional(),
                     requested_address_types: z
                       .array(
@@ -42023,7 +42369,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 confirmation_number: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(11), z.enum([""])])
                   .optional(),
                 expires_after_days: z
                   .union([z.coerce.number(), z.enum([""])])
@@ -42032,7 +42378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(22), z.enum([""])])
                   .optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
@@ -42112,8 +42458,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     "sv-SE",
                   ])
                   .optional(),
-                reference: z.string().optional(),
-                risk_correlation_id: z.string().optional(),
+                reference: z.string().max(127).optional(),
+                risk_correlation_id: z.string().max(32).optional(),
                 setup_future_usage: z
                   .enum(["", "none", "off_session"])
                   .optional(),
@@ -42174,7 +42520,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           swish: z
             .union([
               z.object({
-                reference: z.union([z.string(), z.enum([""])]).optional(),
+                reference: z
+                  .union([z.string().max(5000), z.enum([""])])
+                  .optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
               z.enum([""]),
@@ -42198,7 +42546,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     prefetch: z
                       .array(z.enum(["balances", "transactions"]))
                       .optional(),
-                    return_url: z.string().optional(),
+                    return_url: z.string().max(5000).optional(),
                   })
                   .optional(),
                 mandate_options: z
@@ -42229,7 +42577,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           wechat_pay: z
             .union([
               z.object({
-                app_id: z.string().optional(),
+                app_id: z.string().max(5000).optional(),
                 client: z.enum(["android", "ios", "web"]),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
@@ -42244,30 +42592,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      payment_method_types: z.array(z.string()).optional(),
+      payment_method_types: z.array(z.string().max(5000)).optional(),
       receipt_email: z.union([z.string(), z.enum([""])]).optional(),
       setup_future_usage: z.enum(["", "off_session", "on_session"]).optional(),
       shipping: z
         .union([
           z.object({
             address: z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
-            carrier: z.string().optional(),
-            name: z.string(),
-            phone: z.string().optional(),
-            tracking_number: z.string().optional(),
+            carrier: z.string().max(5000).optional(),
+            name: z.string().max(5000),
+            phone: z.string().max(5000).optional(),
+            tracking_number: z.string().max(5000).optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
-      statement_descriptor: z.string().optional(),
-      statement_descriptor_suffix: z.string().optional(),
+      statement_descriptor: z.string().max(22).optional(),
+      statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
         .object({ amount: z.coerce.number().optional() })
         .optional(),
@@ -42326,14 +42674,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentIntentsIntentApplyCustomerBalanceParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postPaymentIntentsIntentApplyCustomerBalanceBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
       currency: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -42389,7 +42737,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentIntentsIntentCancelParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postPaymentIntentsIntentCancelBodySchema = z
@@ -42397,7 +42745,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       cancellation_reason: z
         .enum(["abandoned", "duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -42450,18 +42798,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentIntentsIntentCaptureParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postPaymentIntentsIntentCaptureBodySchema = z
     .object({
       amount_to_capture: z.coerce.number().optional(),
       application_fee_amount: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       final_capture: z.coerce.boolean().optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      statement_descriptor: z.string().optional(),
-      statement_descriptor_suffix: z.string().optional(),
+      statement_descriptor: z.string().max(22).optional(),
+      statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
         .object({ amount: z.coerce.number().optional() })
         .optional(),
@@ -42517,7 +42865,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentIntentsIntentConfirmParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postPaymentIntentsIntentConfirmBodySchema = z
@@ -42525,11 +42873,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       capture_method: z
         .enum(["automatic", "automatic_async", "manual"])
         .optional(),
-      client_secret: z.string().optional(),
-      confirmation_token: z.string().optional(),
+      client_secret: z.string().max(5000).optional(),
+      confirmation_token: z.string().max(5000).optional(),
       error_on_requires_action: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
-      mandate: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      mandate: z.string().max(5000).optional(),
       mandate_data: z
         .union([
           z.object({
@@ -42537,7 +42885,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
               accepted_at: z.coerce.number().optional(),
               offline: z.object({}).optional(),
               online: z
-                .object({ ip_address: z.string(), user_agent: z.string() })
+                .object({
+                  ip_address: z.string(),
+                  user_agent: z.string().max(5000),
+                })
                 .optional(),
               type: z.enum(["offline", "online"]),
             }),
@@ -42547,7 +42898,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             customer_acceptance: z.object({
               online: z.object({
                 ip_address: z.string().optional(),
-                user_agent: z.string().optional(),
+                user_agent: z.string().max(5000).optional(),
               }),
               type: z.enum(["online"]),
             }),
@@ -42557,26 +42908,29 @@ export function createRouter(implementation: Implementation): KoaRouter {
       off_session: z
         .union([z.coerce.boolean(), z.enum(["one_off", "recurring"])])
         .optional(),
-      payment_method: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
       payment_method_data: z
         .object({
           acss_debit: z
             .object({
-              account_number: z.string(),
-              institution_number: z.string(),
-              transit_number: z.string(),
+              account_number: z.string().max(5000),
+              institution_number: z.string().max(5000),
+              transit_number: z.string().max(5000),
             })
             .optional(),
           affirm: z.object({}).optional(),
           afterpay_clearpay: z.object({}).optional(),
           alipay: z.object({}).optional(),
           au_becs_debit: z
-            .object({ account_number: z.string(), bsb_number: z.string() })
+            .object({
+              account_number: z.string().max(5000),
+              bsb_number: z.string().max(5000),
+            })
             .optional(),
           bacs_debit: z
             .object({
-              account_number: z.string().optional(),
-              sort_code: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
+              sort_code: z.string().max(5000).optional(),
             })
             .optional(),
           bancontact: z.object({}).optional(),
@@ -42585,23 +42939,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
               address: z
                 .union([
                   z.object({
-                    city: z.string().optional(),
-                    country: z.string().optional(),
-                    line1: z.string().optional(),
-                    line2: z.string().optional(),
-                    postal_code: z.string().optional(),
-                    state: z.string().optional(),
+                    city: z.string().max(5000).optional(),
+                    country: z.string().max(5000).optional(),
+                    line1: z.string().max(5000).optional(),
+                    line2: z.string().max(5000).optional(),
+                    postal_code: z.string().max(5000).optional(),
+                    state: z.string().max(5000).optional(),
                   }),
                   z.enum([""]),
                 ])
                 .optional(),
               email: z.union([z.string(), z.enum([""])]).optional(),
-              name: z.union([z.string(), z.enum([""])]).optional(),
-              phone: z.union([z.string(), z.enum([""])]).optional(),
+              name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+              phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string() }).optional(),
+          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
           cashapp: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
           eps: z
@@ -42750,10 +43104,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().optional() })
+            .object({ session: z.string().max(5000).optional() })
             .optional(),
           revolut_pay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string() }).optional(),
+          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
           sofort: z
             .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
             .optional(),
@@ -42796,10 +43150,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           us_bank_account: z
             .object({
               account_holder_type: z.enum(["company", "individual"]).optional(),
-              account_number: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
               account_type: z.enum(["checking", "savings"]).optional(),
-              financial_connections_account: z.string().optional(),
-              routing_number: z.string().optional(),
+              financial_connections_account: z.string().max(5000).optional(),
+              routing_number: z.string().max(5000).optional(),
             })
             .optional(),
           wechat_pay: z.object({}).optional(),
@@ -42816,7 +43170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     custom_mandate_url: z
                       .union([z.string(), z.enum([""])])
                       .optional(),
-                    interval_description: z.string().optional(),
+                    interval_description: z.string().max(500).optional(),
                     payment_schedule: z
                       .enum(["combined", "interval", "sporadic"])
                       .optional(),
@@ -42839,7 +43193,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 capture_method: z.enum(["", "manual"]).optional(),
-                preferred_locale: z.string().optional(),
+                preferred_locale: z.string().max(30).optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
               z.enum([""]),
@@ -42849,7 +43203,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 capture_method: z.enum(["", "manual"]).optional(),
-                reference: z.string().optional(),
+                reference: z.string().max(128).optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
               z.enum([""]),
@@ -42899,7 +43253,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           blik: z
             .union([
               z.object({
-                code: z.string().optional(),
+                code: z.string().max(5000).optional(),
                 setup_future_usage: z.enum(["", "none"]).optional(),
               }),
               z.enum([""]),
@@ -42920,7 +43274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 capture_method: z.enum(["", "manual"]).optional(),
-                cvc_token: z.string().optional(),
+                cvc_token: z.string().max(5000).optional(),
                 installments: z
                   .object({
                     enabled: z.coerce.boolean().optional(),
@@ -42940,7 +43294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .object({
                     amount: z.coerce.number(),
                     amount_type: z.enum(["fixed", "maximum"]),
-                    description: z.string().optional(),
+                    description: z.string().max(200).optional(),
                     end_date: z.coerce.number().optional(),
                     interval: z.enum([
                       "day",
@@ -42950,7 +43304,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       "year",
                     ]),
                     interval_count: z.coerce.number().optional(),
-                    reference: z.string(),
+                    reference: z.string().max(80),
                     start_date: z.coerce.number(),
                     supported_types: z.array(z.enum(["india"])).optional(),
                   })
@@ -42990,17 +43344,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .enum(["", "none", "off_session", "on_session"])
                   .optional(),
                 statement_descriptor_suffix_kana: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(22), z.enum([""])])
                   .optional(),
                 statement_descriptor_suffix_kanji: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(17), z.enum([""])])
                   .optional(),
                 three_d_secure: z
                   .object({
                     ares_trans_status: z
                       .enum(["A", "C", "I", "N", "R", "U", "Y"])
                       .optional(),
-                    cryptogram: z.string(),
+                    cryptogram: z.string().max(5000),
                     electronic_commerce_indicator: z
                       .enum(["01", "02", "05", "06", "07"])
                       .optional(),
@@ -43012,14 +43366,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                         cartes_bancaires: z
                           .object({
                             cb_avalgo: z.enum(["0", "1", "2", "3", "4", "A"]),
-                            cb_exemption: z.string().optional(),
+                            cb_exemption: z.string().max(4).optional(),
                             cb_score: z.coerce.number().optional(),
                           })
                           .optional(),
                       })
                       .optional(),
-                    requestor_challenge_indicator: z.string().optional(),
-                    transaction_id: z.string(),
+                    requestor_challenge_indicator: z.string().max(2).optional(),
+                    transaction_id: z.string().max(5000),
                     version: z.enum(["1.0.2", "2.1.0", "2.2.0"]),
                   })
                   .optional(),
@@ -43055,7 +43409,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 bank_transfer: z
                   .object({
                     eu_bank_transfer: z
-                      .object({ country: z.string() })
+                      .object({ country: z.string().max(5000) })
                       .optional(),
                     requested_address_types: z
                       .array(
@@ -43181,7 +43535,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 confirmation_number: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(11), z.enum([""])])
                   .optional(),
                 expires_after_days: z
                   .union([z.coerce.number(), z.enum([""])])
@@ -43190,7 +43544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 product_description: z
-                  .union([z.string(), z.enum([""])])
+                  .union([z.string().max(22), z.enum([""])])
                   .optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
@@ -43270,8 +43624,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     "sv-SE",
                   ])
                   .optional(),
-                reference: z.string().optional(),
-                risk_correlation_id: z.string().optional(),
+                reference: z.string().max(127).optional(),
+                risk_correlation_id: z.string().max(32).optional(),
                 setup_future_usage: z
                   .enum(["", "none", "off_session"])
                   .optional(),
@@ -43332,7 +43686,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           swish: z
             .union([
               z.object({
-                reference: z.union([z.string(), z.enum([""])]).optional(),
+                reference: z
+                  .union([z.string().max(5000), z.enum([""])])
+                  .optional(),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
               z.enum([""]),
@@ -43356,7 +43712,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     prefetch: z
                       .array(z.enum(["balances", "transactions"]))
                       .optional(),
-                    return_url: z.string().optional(),
+                    return_url: z.string().max(5000).optional(),
                   })
                   .optional(),
                 mandate_options: z
@@ -43387,7 +43743,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           wechat_pay: z
             .union([
               z.object({
-                app_id: z.string().optional(),
+                app_id: z.string().max(5000).optional(),
                 client: z.enum(["android", "ios", "web"]),
                 setup_future_usage: z.enum(["none"]).optional(),
               }),
@@ -43402,8 +43758,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      payment_method_types: z.array(z.string()).optional(),
-      radar_options: z.object({ session: z.string().optional() }).optional(),
+      payment_method_types: z.array(z.string().max(5000)).optional(),
+      radar_options: z
+        .object({ session: z.string().max(5000).optional() })
+        .optional(),
       receipt_email: z.union([z.string(), z.enum([""])]).optional(),
       return_url: z.string().optional(),
       setup_future_usage: z.enum(["", "off_session", "on_session"]).optional(),
@@ -43411,17 +43769,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([
           z.object({
             address: z.object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             }),
-            carrier: z.string().optional(),
-            name: z.string(),
-            phone: z.string().optional(),
-            tracking_number: z.string().optional(),
+            carrier: z.string().max(5000).optional(),
+            name: z.string().max(5000),
+            phone: z.string().max(5000).optional(),
+            tracking_number: z.string().max(5000).optional(),
           }),
           z.enum([""]),
         ])
@@ -43479,16 +43837,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentIntentsIntentIncrementAuthorizationParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postPaymentIntentsIntentIncrementAuthorizationBodySchema = z.object({
     amount: z.coerce.number(),
     application_fee_amount: z.coerce.number().optional(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    description: z.string().max(1000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
-    statement_descriptor: z.string().optional(),
+    statement_descriptor: z.string().max(22).optional(),
     transfer_data: z
       .object({ amount: z.coerce.number().optional() })
       .optional(),
@@ -43547,15 +43905,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentIntentsIntentVerifyMicrodepositsParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postPaymentIntentsIntentVerifyMicrodepositsBodySchema = z
     .object({
       amounts: z.array(z.coerce.number()).optional(),
-      client_secret: z.string().optional(),
-      descriptor_code: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      client_secret: z.string().max(5000).optional(),
+      descriptor_code: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -43612,10 +43970,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getPaymentLinksQuerySchema = z.object({
     active: z.coerce.boolean().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getPaymentLinksBodySchema = z.object({}).optional()
@@ -43628,7 +43986,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_payment_link)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/payment_links")),
         }),
       ],
     ],
@@ -43685,9 +44043,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     after_completion: z
       .object({
         hosted_confirmation: z
-          .object({ custom_message: z.string().optional() })
+          .object({ custom_message: z.string().max(500).optional() })
           .optional(),
-        redirect: z.object({ url: z.string() }).optional(),
+        redirect: z.object({ url: z.string().max(2048) }).optional(),
         type: z.enum(["hosted_confirmation", "redirect"]),
       })
       .optional(),
@@ -43722,12 +44080,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
           dropdown: z
             .object({
               options: z.array(
-                z.object({ label: z.string(), value: z.string() }),
+                z.object({
+                  label: z.string().max(100),
+                  value: z.string().max(100),
+                }),
               ),
             })
             .optional(),
-          key: z.string(),
-          label: z.object({ custom: z.string(), type: z.enum(["custom"]) }),
+          key: z.string().max(200),
+          label: z.object({
+            custom: z.string().max(50),
+            type: z.enum(["custom"]),
+          }),
           numeric: z
             .object({
               maximum_length: z.coerce.number().optional(),
@@ -43748,38 +44112,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
     custom_text: z
       .object({
         after_submit: z
-          .union([z.object({ message: z.string() }), z.enum([""])])
+          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
           .optional(),
         shipping_address: z
-          .union([z.object({ message: z.string() }), z.enum([""])])
+          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
           .optional(),
         submit: z
-          .union([z.object({ message: z.string() }), z.enum([""])])
+          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
           .optional(),
         terms_of_service_acceptance: z
-          .union([z.object({ message: z.string() }), z.enum([""])])
+          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
           .optional(),
       })
       .optional(),
     customer_creation: z.enum(["always", "if_required"]).optional(),
-    expand: z.array(z.string()).optional(),
-    inactive_message: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    inactive_message: z.string().max(500).optional(),
     invoice_creation: z
       .object({
         enabled: z.coerce.boolean(),
         invoice_data: z
           .object({
             account_tax_ids: z
-              .union([z.array(z.string()), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.enum([""])])
               .optional(),
             custom_fields: z
               .union([
-                z.array(z.object({ name: z.string(), value: z.string() })),
+                z.array(
+                  z.object({
+                    name: z.string().max(40),
+                    value: z.string().max(140),
+                  }),
+                ),
                 z.enum([""]),
               ])
               .optional(),
-            description: z.string().optional(),
-            footer: z.string().optional(),
+            description: z.string().max(1500).optional(),
+            footer: z.string().max(5000).optional(),
             issuer: z
               .object({
                 account: z.string().optional(),
@@ -43810,7 +44179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             minimum: z.coerce.number().optional(),
           })
           .optional(),
-        price: z.string(),
+        price: z.string().max(5000),
         quantity: z.coerce.number(),
       }),
     ),
@@ -43821,12 +44190,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         capture_method: z
           .enum(["automatic", "automatic_async", "manual"])
           .optional(),
-        description: z.string().optional(),
+        description: z.string().max(1000).optional(),
         metadata: z.record(z.string()).optional(),
         setup_future_usage: z.enum(["off_session", "on_session"]).optional(),
-        statement_descriptor: z.string().optional(),
-        statement_descriptor_suffix: z.string().optional(),
-        transfer_group: z.string().optional(),
+        statement_descriptor: z.string().max(22).optional(),
+        statement_descriptor_suffix: z.string().max(22).optional(),
+        transfer_group: z.string().max(5000).optional(),
       })
       .optional(),
     payment_method_collection: z.enum(["always", "if_required"]).optional(),
@@ -44117,12 +44486,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     shipping_options: z
-      .array(z.object({ shipping_rate: z.string().optional() }))
+      .array(z.object({ shipping_rate: z.string().max(5000).optional() }))
       .optional(),
     submit_type: z.enum(["auto", "book", "donate", "pay"]).optional(),
     subscription_data: z
       .object({
-        description: z.string().optional(),
+        description: z.string().max(500).optional(),
         invoice_settings: z
           .object({
             issuer: z
@@ -44197,11 +44566,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getPaymentLinksPaymentLinkParamSchema = z.object({
-    payment_link: z.string(),
+    payment_link: z.string().max(5000),
   })
 
   const getPaymentLinksPaymentLinkQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPaymentLinksPaymentLinkBodySchema = z.object({}).optional()
@@ -44261,7 +44630,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentLinksPaymentLinkParamSchema = z.object({
-    payment_link: z.string(),
+    payment_link: z.string().max(5000),
   })
 
   const postPaymentLinksPaymentLinkBodySchema = z
@@ -44270,9 +44639,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
       after_completion: z
         .object({
           hosted_confirmation: z
-            .object({ custom_message: z.string().optional() })
+            .object({ custom_message: z.string().max(500).optional() })
             .optional(),
-          redirect: z.object({ url: z.string() }).optional(),
+          redirect: z.object({ url: z.string().max(2048) }).optional(),
           type: z.enum(["hosted_confirmation", "redirect"]),
         })
         .optional(),
@@ -44296,12 +44665,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
               dropdown: z
                 .object({
                   options: z.array(
-                    z.object({ label: z.string(), value: z.string() }),
+                    z.object({
+                      label: z.string().max(100),
+                      value: z.string().max(100),
+                    }),
                   ),
                 })
                 .optional(),
-              key: z.string(),
-              label: z.object({ custom: z.string(), type: z.enum(["custom"]) }),
+              key: z.string().max(200),
+              label: z.object({
+                custom: z.string().max(50),
+                type: z.enum(["custom"]),
+              }),
               numeric: z
                 .object({
                   maximum_length: z.coerce.number().optional(),
@@ -44324,38 +44699,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
       custom_text: z
         .object({
           after_submit: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
           shipping_address: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
           submit: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
           terms_of_service_acceptance: z
-            .union([z.object({ message: z.string() }), z.enum([""])])
+            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
             .optional(),
         })
         .optional(),
       customer_creation: z.enum(["always", "if_required"]).optional(),
-      expand: z.array(z.string()).optional(),
-      inactive_message: z.union([z.string(), z.enum([""])]).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      inactive_message: z.union([z.string().max(500), z.enum([""])]).optional(),
       invoice_creation: z
         .object({
           enabled: z.coerce.boolean(),
           invoice_data: z
             .object({
               account_tax_ids: z
-                .union([z.array(z.string()), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.enum([""])])
                 .optional(),
               custom_fields: z
                 .union([
-                  z.array(z.object({ name: z.string(), value: z.string() })),
+                  z.array(
+                    z.object({
+                      name: z.string().max(40),
+                      value: z.string().max(140),
+                    }),
+                  ),
                   z.enum([""]),
                 ])
                 .optional(),
-              description: z.string().optional(),
-              footer: z.string().optional(),
+              description: z.string().max(1500).optional(),
+              footer: z.string().max(5000).optional(),
               issuer: z
                 .object({
                   account: z.string().optional(),
@@ -44389,7 +44769,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 minimum: z.coerce.number().optional(),
               })
               .optional(),
-            id: z.string(),
+            id: z.string().max(5000),
             quantity: z.coerce.number().optional(),
           }),
         )
@@ -44397,13 +44777,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
       metadata: z.record(z.string()).optional(),
       payment_intent_data: z
         .object({
-          description: z.union([z.string(), z.enum([""])]).optional(),
+          description: z.union([z.string().max(1000), z.enum([""])]).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-          statement_descriptor: z.union([z.string(), z.enum([""])]).optional(),
-          statement_descriptor_suffix: z
-            .union([z.string(), z.enum([""])])
+          statement_descriptor: z
+            .union([z.string().max(22), z.enum([""])])
             .optional(),
-          transfer_group: z.union([z.string(), z.enum([""])]).optional(),
+          statement_descriptor_suffix: z
+            .union([z.string().max(22), z.enum([""])])
+            .optional(),
+          transfer_group: z
+            .union([z.string().max(5000), z.enum([""])])
+            .optional(),
         })
         .optional(),
       payment_method_collection: z.enum(["always", "if_required"]).optional(),
@@ -44782,14 +45166,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentLinksPaymentLinkLineItemsParamSchema = z.object({
-    payment_link: z.string(),
+    payment_link: z.string().max(5000),
   })
 
   const getPaymentLinksPaymentLinkLineItemsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getPaymentLinksPaymentLinkLineItemsBodySchema = z.object({}).optional()
@@ -44803,7 +45187,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_item)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -44868,8 +45252,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentMethodConfigurationsQuerySchema = z.object({
-    application: z.union([z.string(), z.enum([""])]).optional(),
-    expand: z.array(z.string()).optional(),
+    application: z.union([z.string().max(100), z.enum([""])]).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPaymentMethodConfigurationsBodySchema = z.object({}).optional()
@@ -44883,7 +45267,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_payment_method_configuration),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -45054,7 +45438,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       fpx: z
         .object({
           display_preference: z
@@ -45118,7 +45502,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      name: z.string().optional(),
+      name: z.string().max(100).optional(),
       oxxo: z
         .object({
           display_preference: z
@@ -45133,7 +45517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      parent: z.string().optional(),
+      parent: z.string().max(100).optional(),
       paynow: z
         .object({
           display_preference: z
@@ -45248,11 +45632,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentMethodConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const getPaymentMethodConfigurationsConfigurationQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPaymentMethodConfigurationsConfigurationBodySchema = z
@@ -45318,7 +45702,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const postPaymentMethodConfigurationsConfigurationBodySchema = z
@@ -45436,7 +45820,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       fpx: z
         .object({
           display_preference: z
@@ -45500,7 +45884,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      name: z.string().optional(),
+      name: z.string().max(100).optional(),
       oxxo: z
         .object({
           display_preference: z
@@ -45636,12 +46020,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentMethodDomainsQuerySchema = z.object({
-    domain_name: z.string().optional(),
+    domain_name: z.string().max(5000).optional(),
     enabled: z.coerce.boolean().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getPaymentMethodDomainsBodySchema = z.object({}).optional()
@@ -45654,7 +46038,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_payment_method_domain),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/payment_method_domains")),
         }),
       ],
     ],
@@ -45712,9 +46099,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodDomainsBodySchema = z.object({
-    domain_name: z.string(),
+    domain_name: z.string().max(5000),
     enabled: z.coerce.boolean().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const postPaymentMethodDomainsResponseValidator = responseValidationFactory(
@@ -45764,11 +46151,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentMethodDomainsPaymentMethodDomainParamSchema = z.object({
-    payment_method_domain: z.string(),
+    payment_method_domain: z.string().max(5000),
   })
 
   const getPaymentMethodDomainsPaymentMethodDomainQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPaymentMethodDomainsPaymentMethodDomainBodySchema = z
@@ -45831,13 +46218,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodDomainsPaymentMethodDomainParamSchema = z.object({
-    payment_method_domain: z.string(),
+    payment_method_domain: z.string().max(5000),
   })
 
   const postPaymentMethodDomainsPaymentMethodDomainBodySchema = z
     .object({
       enabled: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -45893,10 +46280,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateParamSchema =
-    z.object({ payment_method_domain: z.string() })
+    z.object({ payment_method_domain: z.string().max(5000) })
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateResponseValidator =
@@ -45956,9 +46343,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentMethodsQuerySchema = z.object({
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
     type: z
@@ -46011,7 +46398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_payment_method)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/payment_methods")),
         }),
       ],
     ],
@@ -46068,21 +46455,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       acss_debit: z
         .object({
-          account_number: z.string(),
-          institution_number: z.string(),
-          transit_number: z.string(),
+          account_number: z.string().max(5000),
+          institution_number: z.string().max(5000),
+          transit_number: z.string().max(5000),
         })
         .optional(),
       affirm: z.object({}).optional(),
       afterpay_clearpay: z.object({}).optional(),
       alipay: z.object({}).optional(),
       au_becs_debit: z
-        .object({ account_number: z.string(), bsb_number: z.string() })
+        .object({
+          account_number: z.string().max(5000),
+          bsb_number: z.string().max(5000),
+        })
         .optional(),
       bacs_debit: z
         .object({
-          account_number: z.string().optional(),
-          sort_code: z.string().optional(),
+          account_number: z.string().max(5000).optional(),
+          sort_code: z.string().max(5000).optional(),
         })
         .optional(),
       bancontact: z.object({}).optional(),
@@ -46091,27 +46481,27 @@ export function createRouter(implementation: Implementation): KoaRouter {
           address: z
             .union([
               z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string().optional(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000).optional(),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
               z.enum([""]),
             ])
             .optional(),
           email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string(), z.enum([""])]).optional(),
-          phone: z.union([z.string(), z.enum([""])]).optional(),
+          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
         })
         .optional(),
       blik: z.object({}).optional(),
-      boleto: z.object({ tax_id: z.string() }).optional(),
+      boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
       card: z
         .union([
           z.object({
-            cvc: z.string().optional(),
+            cvc: z.string().max(5000).optional(),
             exp_month: z.coerce.number(),
             exp_year: z.coerce.number(),
             networks: z
@@ -46121,13 +46511,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .optional(),
               })
               .optional(),
-            number: z.string(),
+            number: z.string().max(5000),
           }),
-          z.object({ token: z.string() }),
+          z.object({ token: z.string().max(5000) }),
         ])
         .optional(),
       cashapp: z.object({}).optional(),
-      customer: z.string().optional(),
+      customer: z.string().max(5000).optional(),
       customer_balance: z.object({}).optional(),
       eps: z
         .object({
@@ -46165,7 +46555,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       fpx: z
         .object({
           bank: z.enum([
@@ -46271,14 +46661,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      payment_method: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
       paynow: z.object({}).optional(),
       paypal: z.object({}).optional(),
       pix: z.object({}).optional(),
       promptpay: z.object({}).optional(),
-      radar_options: z.object({ session: z.string().optional() }).optional(),
+      radar_options: z
+        .object({ session: z.string().max(5000).optional() })
+        .optional(),
       revolut_pay: z.object({}).optional(),
-      sepa_debit: z.object({ iban: z.string() }).optional(),
+      sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
       sofort: z
         .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
         .optional(),
@@ -46324,10 +46716,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       us_bank_account: z
         .object({
           account_holder_type: z.enum(["company", "individual"]).optional(),
-          account_number: z.string().optional(),
+          account_number: z.string().max(5000).optional(),
           account_type: z.enum(["checking", "savings"]).optional(),
-          financial_connections_account: z.string().optional(),
-          routing_number: z.string().optional(),
+          financial_connections_account: z.string().max(5000).optional(),
+          routing_number: z.string().max(5000).optional(),
         })
         .optional(),
       wechat_pay: z.object({}).optional(),
@@ -46382,11 +46774,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentMethodsPaymentMethodParamSchema = z.object({
-    payment_method: z.string(),
+    payment_method: z.string().max(5000),
   })
 
   const getPaymentMethodsPaymentMethodQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPaymentMethodsPaymentMethodBodySchema = z.object({}).optional()
@@ -46444,7 +46836,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodsPaymentMethodParamSchema = z.object({
-    payment_method: z.string(),
+    payment_method: z.string().max(5000),
   })
 
   const postPaymentMethodsPaymentMethodBodySchema = z
@@ -46454,19 +46846,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
           address: z
             .union([
               z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string().optional(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000).optional(),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
               z.enum([""]),
             ])
             .optional(),
           email: z.union([z.string(), z.enum([""])]).optional(),
-          name: z.union([z.string(), z.enum([""])]).optional(),
-          phone: z.union([z.string(), z.enum([""])]).optional(),
+          name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
         })
         .optional(),
       card: z
@@ -46482,7 +46874,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       link: z.object({}).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       us_bank_account: z
@@ -46543,12 +46935,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodsPaymentMethodAttachParamSchema = z.object({
-    payment_method: z.string(),
+    payment_method: z.string().max(5000),
   })
 
   const postPaymentMethodsPaymentMethodAttachBodySchema = z.object({
-    customer: z.string(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const postPaymentMethodsPaymentMethodAttachResponseValidator =
@@ -46603,11 +46995,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodsPaymentMethodDetachParamSchema = z.object({
-    payment_method: z.string(),
+    payment_method: z.string().max(5000),
   })
 
   const postPaymentMethodsPaymentMethodDetachBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postPaymentMethodsPaymentMethodDetachResponseValidator =
@@ -46685,11 +47077,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     destination: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
-    status: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
+    status: z.string().max(5000).optional(),
   })
 
   const getPayoutsBodySchema = z.object({}).optional()
@@ -46702,7 +47094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_payout)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/payouts")),
         }),
       ],
     ],
@@ -46758,13 +47150,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postPayoutsBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
+    description: z.string().max(5000).optional(),
     destination: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
     method: z.enum(["instant", "standard"]).optional(),
     source_type: z.enum(["bank_account", "card", "fpx"]).optional(),
-    statement_descriptor: z.string().optional(),
+    statement_descriptor: z.string().max(22).optional(),
   })
 
   const postPayoutsResponseValidator = responseValidationFactory(
@@ -46809,10 +47201,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPayoutsPayoutParamSchema = z.object({ payout: z.string() })
+  const getPayoutsPayoutParamSchema = z.object({ payout: z.string().max(5000) })
 
   const getPayoutsPayoutQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPayoutsPayoutBodySchema = z.object({}).optional()
@@ -46867,11 +47259,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPayoutsPayoutParamSchema = z.object({ payout: z.string() })
+  const postPayoutsPayoutParamSchema = z.object({
+    payout: z.string().max(5000),
+  })
 
   const postPayoutsPayoutBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -46922,10 +47316,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPayoutsPayoutCancelParamSchema = z.object({ payout: z.string() })
+  const postPayoutsPayoutCancelParamSchema = z.object({
+    payout: z.string().max(5000),
+  })
 
   const postPayoutsPayoutCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postPayoutsPayoutCancelResponseValidator = responseValidationFactory(
@@ -46978,11 +47374,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postPayoutsPayoutReverseParamSchema = z.object({ payout: z.string() })
+  const postPayoutsPayoutReverseParamSchema = z.object({
+    payout: z.string().max(5000),
+  })
 
   const postPayoutsPayoutReverseBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
     })
     .optional()
@@ -47050,11 +47448,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    product: z.string().optional(),
-    starting_after: z.string().optional(),
+    product: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getPlansBodySchema = z.object({}).optional()
@@ -47067,7 +47465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_plan)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/plans")),
         }),
       ],
     ],
@@ -47129,25 +47527,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
     amount_decimal: z.string().optional(),
     billing_scheme: z.enum(["per_unit", "tiered"]).optional(),
     currency: z.string(),
-    expand: z.array(z.string()).optional(),
-    id: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    id: z.string().max(5000).optional(),
     interval: z.enum(["day", "month", "week", "year"]),
     interval_count: z.coerce.number().optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-    meter: z.string().optional(),
-    nickname: z.string().optional(),
+    meter: z.string().max(5000).optional(),
+    nickname: z.string().max(5000).optional(),
     product: z
       .union([
         z.object({
           active: z.coerce.boolean().optional(),
-          id: z.string().optional(),
+          id: z.string().max(5000).optional(),
           metadata: z.record(z.string()).optional(),
-          name: z.string(),
-          statement_descriptor: z.string().optional(),
-          tax_code: z.string().optional(),
-          unit_label: z.string().optional(),
+          name: z.string().max(5000),
+          statement_descriptor: z.string().max(22).optional(),
+          tax_code: z.string().max(5000).optional(),
+          unit_label: z.string().max(12).optional(),
         }),
-        z.string(),
+        z.string().max(5000),
       ])
       .optional(),
     tiers: z
@@ -47211,7 +47609,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deletePlansPlanParamSchema = z.object({ plan: z.string() })
+  const deletePlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
 
   const deletePlansPlanBodySchema = z.object({}).optional()
 
@@ -47261,10 +47659,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPlansPlanParamSchema = z.object({ plan: z.string() })
+  const getPlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
 
   const getPlansPlanQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPlansPlanBodySchema = z.object({}).optional()
@@ -47319,15 +47717,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPlansPlanParamSchema = z.object({ plan: z.string() })
+  const postPlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
 
   const postPlansPlanBodySchema = z
     .object({
       active: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      nickname: z.string().optional(),
-      product: z.string().optional(),
+      nickname: z.string().max(5000).optional(),
+      product: z.string().max(5000).optional(),
       trial_period_days: z.coerce.number().optional(),
     })
     .optional()
@@ -47392,19 +47790,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     currency: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    lookup_keys: z.array(z.string()).optional(),
-    product: z.string().optional(),
+    lookup_keys: z.array(z.string().max(5000)).optional(),
+    product: z.string().max(5000).optional(),
     recurring: z
       .object({
         interval: z.enum(["day", "month", "week", "year"]).optional(),
-        meter: z.string().optional(),
+        meter: z.string().max(5000).optional(),
         usage_type: z.enum(["licensed", "metered"]).optional(),
       })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     type: z.enum(["one_time", "recurring"]).optional(),
   })
 
@@ -47418,7 +47816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_price)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/prices")),
         }),
       ],
     ],
@@ -47513,20 +47911,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
         preset: z.coerce.number().optional(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
-    lookup_key: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    lookup_key: z.string().max(200).optional(),
     metadata: z.record(z.string()).optional(),
-    nickname: z.string().optional(),
-    product: z.string().optional(),
+    nickname: z.string().max(5000).optional(),
+    product: z.string().max(5000).optional(),
     product_data: z
       .object({
         active: z.coerce.boolean().optional(),
-        id: z.string().optional(),
+        id: z.string().max(5000).optional(),
         metadata: z.record(z.string()).optional(),
-        name: z.string(),
-        statement_descriptor: z.string().optional(),
-        tax_code: z.string().optional(),
-        unit_label: z.string().optional(),
+        name: z.string().max(5000),
+        statement_descriptor: z.string().max(22).optional(),
+        tax_code: z.string().max(5000).optional(),
+        unit_label: z.string().max(12).optional(),
       })
       .optional(),
     recurring: z
@@ -47536,7 +47934,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         interval: z.enum(["day", "month", "week", "year"]),
         interval_count: z.coerce.number().optional(),
-        meter: z.string().optional(),
+        meter: z.string().max(5000).optional(),
         usage_type: z.enum(["licensed", "metered"]).optional(),
       })
       .optional(),
@@ -47604,10 +48002,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getPricesSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getPricesSearchBodySchema = z.object({}).optional()
@@ -47619,10 +48017,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_price)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -47677,10 +48075,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPricesPriceParamSchema = z.object({ price: z.string() })
+  const getPricesPriceParamSchema = z.object({ price: z.string().max(5000) })
 
   const getPricesPriceQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPricesPriceBodySchema = z.object({}).optional()
@@ -47735,7 +48133,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPricesPriceParamSchema = z.object({ price: z.string() })
+  const postPricesPriceParamSchema = z.object({ price: z.string().max(5000) })
 
   const postPricesPriceBodySchema = z
     .object({
@@ -47773,10 +48171,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
-      lookup_key: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      lookup_key: z.string().max(200).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      nickname: z.string().optional(),
+      nickname: z.string().max(5000).optional(),
       tax_behavior: z
         .enum(["exclusive", "inclusive", "unspecified"])
         .optional(),
@@ -47843,13 +48241,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
-    ids: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    ids: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     shippable: z.coerce.boolean().optional(),
-    starting_after: z.string().optional(),
-    url: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
+    url: z.string().max(5000).optional(),
   })
 
   const getProductsBodySchema = z.object({}).optional()
@@ -47862,7 +48260,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_product)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/products")),
         }),
       ],
     ],
@@ -47963,13 +48361,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         unit_amount_decimal: z.string().optional(),
       })
       .optional(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
-    features: z.array(z.object({ name: z.string() })).optional(),
-    id: z.string().optional(),
+    description: z.string().max(40000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    features: z.array(z.object({ name: z.string().max(5000) })).optional(),
+    id: z.string().max(5000).optional(),
     images: z.array(z.string()).optional(),
     metadata: z.record(z.string()).optional(),
-    name: z.string(),
+    name: z.string().max(5000),
     package_dimensions: z
       .object({
         height: z.coerce.number(),
@@ -47979,10 +48377,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     shippable: z.coerce.boolean().optional(),
-    statement_descriptor: z.string().optional(),
+    statement_descriptor: z.string().max(22).optional(),
     tax_code: z.string().optional(),
-    unit_label: z.string().optional(),
-    url: z.string().optional(),
+    unit_label: z.string().max(12).optional(),
+    url: z.string().max(5000).optional(),
   })
 
   const postProductsResponseValidator = responseValidationFactory(
@@ -48028,10 +48426,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getProductsSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getProductsSearchBodySchema = z.object({}).optional()
@@ -48043,10 +48441,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_product)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -48101,7 +48499,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteProductsIdParamSchema = z.object({ id: z.string() })
+  const deleteProductsIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const deleteProductsIdBodySchema = z.object({}).optional()
 
@@ -48151,10 +48549,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getProductsIdParamSchema = z.object({ id: z.string() })
+  const getProductsIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getProductsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getProductsIdBodySchema = z.object({}).optional()
@@ -48209,20 +48607,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postProductsIdParamSchema = z.object({ id: z.string() })
+  const postProductsIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const postProductsIdBodySchema = z
     .object({
       active: z.coerce.boolean().optional(),
-      default_price: z.string().optional(),
-      description: z.union([z.string(), z.enum([""])]).optional(),
-      expand: z.array(z.string()).optional(),
+      default_price: z.string().max(5000).optional(),
+      description: z.union([z.string().max(40000), z.enum([""])]).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       features: z
-        .union([z.array(z.object({ name: z.string() })), z.enum([""])])
+        .union([
+          z.array(z.object({ name: z.string().max(5000) })),
+          z.enum([""]),
+        ])
         .optional(),
       images: z.union([z.array(z.string()), z.enum([""])]).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      name: z.string().optional(),
+      name: z.string().max(5000).optional(),
       package_dimensions: z
         .union([
           z.object({
@@ -48235,9 +48636,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       shippable: z.coerce.boolean().optional(),
-      statement_descriptor: z.string().optional(),
+      statement_descriptor: z.string().max(22).optional(),
       tax_code: z.union([z.string(), z.enum([""])]).optional(),
-      unit_label: z.union([z.string(), z.enum([""])]).optional(),
+      unit_label: z.union([z.string().max(12), z.enum([""])]).optional(),
       url: z.union([z.string(), z.enum([""])]).optional(),
     })
     .optional()
@@ -48290,8 +48691,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getPromotionCodesQuerySchema = z.object({
     active: z.coerce.boolean().optional(),
-    code: z.string().optional(),
-    coupon: z.string().optional(),
+    code: z.string().max(5000).optional(),
+    coupon: z.string().max(5000).optional(),
     created: z
       .union([
         z.object({
@@ -48303,11 +48704,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getPromotionCodesBodySchema = z.object({}).optional()
@@ -48320,7 +48721,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_promotion_code)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/promotion_codes")),
         }),
       ],
     ],
@@ -48375,10 +48776,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPromotionCodesBodySchema = z.object({
     active: z.coerce.boolean().optional(),
-    code: z.string().optional(),
-    coupon: z.string(),
-    customer: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    code: z.string().max(500).optional(),
+    coupon: z.string().max(5000),
+    customer: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     expires_at: z.coerce.number().optional(),
     max_redemptions: z.coerce.number().optional(),
     metadata: z.record(z.string()).optional(),
@@ -48441,11 +48842,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPromotionCodesPromotionCodeParamSchema = z.object({
-    promotion_code: z.string(),
+    promotion_code: z.string().max(5000),
   })
 
   const getPromotionCodesPromotionCodeQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getPromotionCodesPromotionCodeBodySchema = z.object({}).optional()
@@ -48503,13 +48904,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPromotionCodesPromotionCodeParamSchema = z.object({
-    promotion_code: z.string(),
+    promotion_code: z.string().max(5000),
   })
 
   const postPromotionCodesPromotionCodeBodySchema = z
     .object({
       active: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       restrictions: z
         .object({
@@ -48570,13 +48971,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getQuotesQuerySchema = z.object({
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["accepted", "canceled", "draft", "open"]).optional(),
-    test_clock: z.string().optional(),
+    test_clock: z.string().max(5000).optional(),
   })
 
   const getQuotesBodySchema = z.object({}).optional()
@@ -48589,7 +48990,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_quote)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/quotes")),
         }),
       ],
     ],
@@ -48664,33 +49065,33 @@ export function createRouter(implementation: Implementation): KoaRouter {
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
-      customer: z.string().optional(),
+      customer: z.string().max(5000).optional(),
       default_tax_rates: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
-      description: z.union([z.string(), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.enum([""])]).optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       expires_at: z.coerce.number().optional(),
-      footer: z.union([z.string(), z.enum([""])]).optional(),
+      footer: z.union([z.string().max(500), z.enum([""])]).optional(),
       from_quote: z
         .object({
           is_revision: z.coerce.boolean().optional(),
-          quote: z.string(),
+          quote: z.string().max(5000),
         })
         .optional(),
-      header: z.union([z.string(), z.enum([""])]).optional(),
+      header: z.union([z.string().max(50), z.enum([""])]).optional(),
       invoice_settings: z
         .object({
           days_until_due: z.coerce.number().optional(),
@@ -48709,19 +49110,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
               ])
               .optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 recurring: z
                   .object({
                     interval: z.enum(["day", "month", "week", "year"]),
@@ -48736,7 +49137,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -48744,7 +49147,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
       subscription_data: z
         .object({
-          description: z.string().optional(),
+          description: z.string().max(500).optional(),
           effective_date: z
             .union([
               z.enum(["current_period_end"]),
@@ -48758,7 +49161,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      test_clock: z.string().optional(),
+      test_clock: z.string().max(5000).optional(),
       transfer_data: z
         .union([
           z.object({
@@ -48814,10 +49217,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getQuotesQuoteParamSchema = z.object({ quote: z.string() })
+  const getQuotesQuoteParamSchema = z.object({ quote: z.string().max(5000) })
 
   const getQuotesQuoteQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getQuotesQuoteBodySchema = z.object({}).optional()
@@ -48872,7 +49275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postQuotesQuoteParamSchema = z.object({ quote: z.string() })
+  const postQuotesQuoteParamSchema = z.object({ quote: z.string().max(5000) })
 
   const postQuotesQuoteBodySchema = z
     .object({
@@ -48896,27 +49299,27 @@ export function createRouter(implementation: Implementation): KoaRouter {
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
-      customer: z.string().optional(),
+      customer: z.string().max(5000).optional(),
       default_tax_rates: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
-      description: z.union([z.string(), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.enum([""])]).optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       expires_at: z.coerce.number().optional(),
-      footer: z.union([z.string(), z.enum([""])]).optional(),
-      header: z.union([z.string(), z.enum([""])]).optional(),
+      footer: z.union([z.string().max(500), z.enum([""])]).optional(),
+      header: z.union([z.string().max(50), z.enum([""])]).optional(),
       invoice_settings: z
         .object({
           days_until_due: z.coerce.number().optional(),
@@ -48935,20 +49338,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
               ])
               .optional(),
-            id: z.string().optional(),
-            price: z.string().optional(),
+            id: z.string().max(5000).optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 recurring: z
                   .object({
                     interval: z.enum(["day", "month", "week", "year"]),
@@ -48963,7 +49366,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -48971,7 +49376,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
       subscription_data: z
         .object({
-          description: z.union([z.string(), z.enum([""])]).optional(),
+          description: z.union([z.string().max(500), z.enum([""])]).optional(),
           effective_date: z
             .union([
               z.enum(["current_period_end"]),
@@ -49044,10 +49449,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postQuotesQuoteAcceptParamSchema = z.object({ quote: z.string() })
+  const postQuotesQuoteAcceptParamSchema = z.object({
+    quote: z.string().max(5000),
+  })
 
   const postQuotesQuoteAcceptBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postQuotesQuoteAcceptResponseValidator = responseValidationFactory(
@@ -49100,10 +49507,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postQuotesQuoteCancelParamSchema = z.object({ quote: z.string() })
+  const postQuotesQuoteCancelParamSchema = z.object({
+    quote: z.string().max(5000),
+  })
 
   const postQuotesQuoteCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postQuotesQuoteCancelResponseValidator = responseValidationFactory(
@@ -49157,14 +49566,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getQuotesQuoteComputedUpfrontLineItemsParamSchema = z.object({
-    quote: z.string(),
+    quote: z.string().max(5000),
   })
 
   const getQuotesQuoteComputedUpfrontLineItemsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getQuotesQuoteComputedUpfrontLineItemsBodySchema = z
@@ -49180,7 +49589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_item)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -49244,11 +49653,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postQuotesQuoteFinalizeParamSchema = z.object({ quote: z.string() })
+  const postQuotesQuoteFinalizeParamSchema = z.object({
+    quote: z.string().max(5000),
+  })
 
   const postQuotesQuoteFinalizeBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       expires_at: z.coerce.number().optional(),
     })
     .optional()
@@ -49303,13 +49714,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getQuotesQuoteLineItemsParamSchema = z.object({ quote: z.string() })
+  const getQuotesQuoteLineItemsParamSchema = z.object({
+    quote: z.string().max(5000),
+  })
 
   const getQuotesQuoteLineItemsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getQuotesQuoteLineItemsBodySchema = z.object({}).optional()
@@ -49322,7 +49735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_item)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -49383,10 +49796,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getQuotesQuotePdfParamSchema = z.object({ quote: z.string() })
+  const getQuotesQuotePdfParamSchema = z.object({ quote: z.string().max(5000) })
 
   const getQuotesQuotePdfQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getQuotesQuotePdfBodySchema = z.object({}).optional()
@@ -49458,11 +49871,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payment_intent: z.string().optional(),
-    starting_after: z.string().optional(),
+    payment_intent: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getRadarEarlyFraudWarningsBodySchema = z.object({}).optional()
@@ -49475,7 +49888,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_radar_early_fraud_warning)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/radar/early_fraud_warnings")),
         }),
       ],
     ],
@@ -49533,11 +49949,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getRadarEarlyFraudWarningsEarlyFraudWarningParamSchema = z.object({
-    early_fraud_warning: z.string(),
+    early_fraud_warning: z.string().max(5000),
   })
 
   const getRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getRadarEarlyFraudWarningsEarlyFraudWarningBodySchema = z
@@ -49611,12 +50027,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
-    value: z.string().optional(),
-    value_list: z.string(),
+    starting_after: z.string().max(5000).optional(),
+    value: z.string().max(800).optional(),
+    value_list: z.string().max(5000),
   })
 
   const getRadarValueListItemsBodySchema = z.object({}).optional()
@@ -49629,7 +50045,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_radar_value_list_item),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/radar/value_list_items")),
         }),
       ],
     ],
@@ -49687,9 +50106,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postRadarValueListItemsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    value: z.string(),
-    value_list: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    value: z.string().max(800),
+    value_list: z.string().max(5000),
   })
 
   const postRadarValueListItemsResponseValidator = responseValidationFactory(
@@ -49739,7 +50158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteRadarValueListItemsItemParamSchema = z.object({
-    item: z.string(),
+    item: z.string().max(5000),
   })
 
   const deleteRadarValueListItemsItemBodySchema = z.object({}).optional()
@@ -49795,10 +50214,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getRadarValueListItemsItemParamSchema = z.object({ item: z.string() })
+  const getRadarValueListItemsItemParamSchema = z.object({
+    item: z.string().max(5000),
+  })
 
   const getRadarValueListItemsItemQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getRadarValueListItemsItemBodySchema = z.object({}).optional()
@@ -49858,8 +50279,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getRadarValueListsQuerySchema = z.object({
-    alias: z.string().optional(),
-    contains: z.string().optional(),
+    alias: z.string().max(100).optional(),
+    contains: z.string().max(800).optional(),
     created: z
       .union([
         z.object({
@@ -49871,10 +50292,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getRadarValueListsBodySchema = z.object({}).optional()
@@ -49887,7 +50308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_radar_value_list),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/radar/value_lists")),
         }),
       ],
     ],
@@ -49945,8 +50366,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postRadarValueListsBodySchema = z.object({
-    alias: z.string(),
-    expand: z.array(z.string()).optional(),
+    alias: z.string().max(100),
+    expand: z.array(z.string().max(5000)).optional(),
     item_type: z
       .enum([
         "card_bin",
@@ -49962,7 +50383,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     metadata: z.record(z.string()).optional(),
-    name: z.string(),
+    name: z.string().max(100),
   })
 
   const postRadarValueListsResponseValidator = responseValidationFactory(
@@ -50012,7 +50433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteRadarValueListsValueListParamSchema = z.object({
-    value_list: z.string(),
+    value_list: z.string().max(5000),
   })
 
   const deleteRadarValueListsValueListBodySchema = z.object({}).optional()
@@ -50066,11 +50487,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getRadarValueListsValueListParamSchema = z.object({
-    value_list: z.string(),
+    value_list: z.string().max(5000),
   })
 
   const getRadarValueListsValueListQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getRadarValueListsValueListBodySchema = z.object({}).optional()
@@ -50128,15 +50549,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postRadarValueListsValueListParamSchema = z.object({
-    value_list: z.string(),
+    value_list: z.string().max(5000),
   })
 
   const postRadarValueListsValueListBodySchema = z
     .object({
-      alias: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      alias: z.string().max(100).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
-      name: z.string().optional(),
+      name: z.string().max(100).optional(),
     })
     .optional()
 
@@ -50202,9 +50623,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payment_intent: z.string().optional(),
+    payment_intent: z.string().max(5000).optional(),
     starting_after: z.string().optional(),
   })
 
@@ -50218,7 +50639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_refund)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/refunds")),
         }),
       ],
     ],
@@ -50274,14 +50695,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postRefundsBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      charge: z.string().optional(),
+      charge: z.string().max(5000).optional(),
       currency: z.string().optional(),
-      customer: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       instructions_email: z.string().optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       origin: z.enum(["customer_balance"]).optional(),
-      payment_intent: z.string().optional(),
+      payment_intent: z.string().max(5000).optional(),
       reason: z
         .enum(["duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
@@ -50335,7 +50756,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getRefundsRefundParamSchema = z.object({ refund: z.string() })
 
   const getRefundsRefundQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getRefundsRefundBodySchema = z.object({}).optional()
@@ -50394,7 +50815,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postRefundsRefundBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -50448,7 +50869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postRefundsRefundCancelParamSchema = z.object({ refund: z.string() })
 
   const postRefundsRefundCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postRefundsRefundCancelResponseValidator = responseValidationFactory(
@@ -50513,10 +50934,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getReportingReportRunsBodySchema = z.object({}).optional()
@@ -50529,7 +50950,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_reporting_report_run)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/reporting/report_runs")),
         }),
       ],
     ],
@@ -50587,10 +51011,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postReportingReportRunsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     parameters: z
       .object({
-        columns: z.array(z.string()).optional(),
+        columns: z.array(z.string().max(5000)).optional(),
         connected_account: z.string().optional(),
         currency: z.string().optional(),
         interval_end: z.coerce.number().optional(),
@@ -51291,11 +51715,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getReportingReportRunsReportRunParamSchema = z.object({
-    report_run: z.string(),
+    report_run: z.string().max(5000),
   })
 
   const getReportingReportRunsReportRunQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getReportingReportRunsReportRunBodySchema = z.object({}).optional()
@@ -51353,7 +51777,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getReportingReportTypesQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getReportingReportTypesBodySchema = z.object({}).optional()
@@ -51366,7 +51790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_reporting_report_type),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -51428,7 +51852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getReportingReportTypesReportTypeQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getReportingReportTypesReportTypeBodySchema = z.object({}).optional()
@@ -51500,10 +51924,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getReviewsBodySchema = z.object({}).optional()
@@ -51516,7 +51940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_review)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -51569,10 +51993,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getReviewsReviewParamSchema = z.object({ review: z.string() })
+  const getReviewsReviewParamSchema = z.object({ review: z.string().max(5000) })
 
   const getReviewsReviewQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getReviewsReviewBodySchema = z.object({}).optional()
@@ -51627,10 +52051,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postReviewsReviewApproveParamSchema = z.object({ review: z.string() })
+  const postReviewsReviewApproveParamSchema = z.object({
+    review: z.string().max(5000),
+  })
 
   const postReviewsReviewApproveBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postReviewsReviewApproveResponseValidator = responseValidationFactory(
@@ -51695,11 +52121,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    setup_intent: z.string(),
-    starting_after: z.string().optional(),
+    setup_intent: z.string().max(5000),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getSetupAttemptsBodySchema = z.object({}).optional()
@@ -51712,7 +52138,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_setup_attempt)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/setup_attempts")),
         }),
       ],
     ],
@@ -51778,12 +52204,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    payment_method: z.string().optional(),
-    starting_after: z.string().optional(),
+    payment_method: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getSetupIntentsBodySchema = z.object({}).optional()
@@ -51796,7 +52222,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_setup_intent)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/setup_intents")),
         }),
       ],
     ],
@@ -51859,10 +52285,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       confirm: z.coerce.boolean().optional(),
-      confirmation_token: z.string().optional(),
-      customer: z.string().optional(),
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      confirmation_token: z.string().max(5000).optional(),
+      customer: z.string().max(5000).optional(),
+      description: z.string().max(1000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       flow_directions: z.array(z.enum(["inbound", "outbound"])).optional(),
       mandate_data: z
         .union([
@@ -51871,7 +52297,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
               accepted_at: z.coerce.number().optional(),
               offline: z.object({}).optional(),
               online: z
-                .object({ ip_address: z.string(), user_agent: z.string() })
+                .object({
+                  ip_address: z.string(),
+                  user_agent: z.string().max(5000),
+                })
                 .optional(),
               type: z.enum(["offline", "online"]),
             }),
@@ -51881,27 +52310,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       metadata: z.record(z.string()).optional(),
       on_behalf_of: z.string().optional(),
-      payment_method: z.string().optional(),
-      payment_method_configuration: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
+      payment_method_configuration: z.string().max(100).optional(),
       payment_method_data: z
         .object({
           acss_debit: z
             .object({
-              account_number: z.string(),
-              institution_number: z.string(),
-              transit_number: z.string(),
+              account_number: z.string().max(5000),
+              institution_number: z.string().max(5000),
+              transit_number: z.string().max(5000),
             })
             .optional(),
           affirm: z.object({}).optional(),
           afterpay_clearpay: z.object({}).optional(),
           alipay: z.object({}).optional(),
           au_becs_debit: z
-            .object({ account_number: z.string(), bsb_number: z.string() })
+            .object({
+              account_number: z.string().max(5000),
+              bsb_number: z.string().max(5000),
+            })
             .optional(),
           bacs_debit: z
             .object({
-              account_number: z.string().optional(),
-              sort_code: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
+              sort_code: z.string().max(5000).optional(),
             })
             .optional(),
           bancontact: z.object({}).optional(),
@@ -51910,23 +52342,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
               address: z
                 .union([
                   z.object({
-                    city: z.string().optional(),
-                    country: z.string().optional(),
-                    line1: z.string().optional(),
-                    line2: z.string().optional(),
-                    postal_code: z.string().optional(),
-                    state: z.string().optional(),
+                    city: z.string().max(5000).optional(),
+                    country: z.string().max(5000).optional(),
+                    line1: z.string().max(5000).optional(),
+                    line2: z.string().max(5000).optional(),
+                    postal_code: z.string().max(5000).optional(),
+                    state: z.string().max(5000).optional(),
                   }),
                   z.enum([""]),
                 ])
                 .optional(),
               email: z.union([z.string(), z.enum([""])]).optional(),
-              name: z.union([z.string(), z.enum([""])]).optional(),
-              phone: z.union([z.string(), z.enum([""])]).optional(),
+              name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+              phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string() }).optional(),
+          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
           cashapp: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
           eps: z
@@ -52075,10 +52507,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().optional() })
+            .object({ session: z.string().max(5000).optional() })
             .optional(),
           revolut_pay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string() }).optional(),
+          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
           sofort: z
             .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
             .optional(),
@@ -52121,10 +52553,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           us_bank_account: z
             .object({
               account_holder_type: z.enum(["company", "individual"]).optional(),
-              account_number: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
               account_type: z.enum(["checking", "savings"]).optional(),
-              financial_connections_account: z.string().optional(),
-              routing_number: z.string().optional(),
+              financial_connections_account: z.string().max(5000).optional(),
+              routing_number: z.string().max(5000).optional(),
             })
             .optional(),
           wechat_pay: z.object({}).optional(),
@@ -52144,7 +52576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   default_for: z
                     .array(z.enum(["invoice", "subscription"]))
                     .optional(),
-                  interval_description: z.string().optional(),
+                  interval_description: z.string().max(500).optional(),
                   payment_schedule: z
                     .enum(["combined", "interval", "sporadic"])
                     .optional(),
@@ -52163,7 +52595,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   amount: z.coerce.number(),
                   amount_type: z.enum(["fixed", "maximum"]),
                   currency: z.string(),
-                  description: z.string().optional(),
+                  description: z.string().max(200).optional(),
                   end_date: z.coerce.number().optional(),
                   interval: z.enum([
                     "day",
@@ -52173,7 +52605,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     "year",
                   ]),
                   interval_count: z.coerce.number().optional(),
-                  reference: z.string(),
+                  reference: z.string().max(80),
                   start_date: z.coerce.number(),
                   supported_types: z.array(z.enum(["india"])).optional(),
                 })
@@ -52201,7 +52633,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   ares_trans_status: z
                     .enum(["A", "C", "I", "N", "R", "U", "Y"])
                     .optional(),
-                  cryptogram: z.string().optional(),
+                  cryptogram: z.string().max(5000).optional(),
                   electronic_commerce_indicator: z
                     .enum(["01", "02", "05", "06", "07"])
                     .optional(),
@@ -52210,14 +52642,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       cartes_bancaires: z
                         .object({
                           cb_avalgo: z.enum(["0", "1", "2", "3", "4", "A"]),
-                          cb_exemption: z.string().optional(),
+                          cb_exemption: z.string().max(4).optional(),
                           cb_score: z.coerce.number().optional(),
                         })
                         .optional(),
                     })
                     .optional(),
-                  requestor_challenge_indicator: z.string().optional(),
-                  transaction_id: z.string().optional(),
+                  requestor_challenge_indicator: z.string().max(2).optional(),
+                  transaction_id: z.string().max(5000).optional(),
                   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).optional(),
                 })
                 .optional(),
@@ -52226,7 +52658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card_present: z.object({}).optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().optional() })
+            .object({ billing_agreement_id: z.string().max(5000).optional() })
             .optional(),
           sepa_debit: z
             .object({ mandate_options: z.object({}).optional() })
@@ -52248,7 +52680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   prefetch: z
                     .array(z.enum(["balances", "transactions"]))
                     .optional(),
-                  return_url: z.string().optional(),
+                  return_url: z.string().max(5000).optional(),
                 })
                 .optional(),
               mandate_options: z
@@ -52268,7 +52700,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      payment_method_types: z.array(z.string()).optional(),
+      payment_method_types: z.array(z.string().max(5000)).optional(),
       return_url: z.string().optional(),
       single_use: z
         .object({ amount: z.coerce.number(), currency: z.string() })
@@ -52320,11 +52752,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getSetupIntentsIntentParamSchema = z.object({ intent: z.string() })
+  const getSetupIntentsIntentParamSchema = z.object({
+    intent: z.string().max(5000),
+  })
 
   const getSetupIntentsIntentQuerySchema = z.object({
-    client_secret: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    client_secret: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getSetupIntentsIntentBodySchema = z.object({}).optional()
@@ -52383,37 +52817,42 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postSetupIntentsIntentParamSchema = z.object({ intent: z.string() })
+  const postSetupIntentsIntentParamSchema = z.object({
+    intent: z.string().max(5000),
+  })
 
   const postSetupIntentsIntentBodySchema = z
     .object({
       attach_to_self: z.coerce.boolean().optional(),
-      customer: z.string().optional(),
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(5000).optional(),
+      description: z.string().max(1000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       flow_directions: z.array(z.enum(["inbound", "outbound"])).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      payment_method: z.string().optional(),
-      payment_method_configuration: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
+      payment_method_configuration: z.string().max(100).optional(),
       payment_method_data: z
         .object({
           acss_debit: z
             .object({
-              account_number: z.string(),
-              institution_number: z.string(),
-              transit_number: z.string(),
+              account_number: z.string().max(5000),
+              institution_number: z.string().max(5000),
+              transit_number: z.string().max(5000),
             })
             .optional(),
           affirm: z.object({}).optional(),
           afterpay_clearpay: z.object({}).optional(),
           alipay: z.object({}).optional(),
           au_becs_debit: z
-            .object({ account_number: z.string(), bsb_number: z.string() })
+            .object({
+              account_number: z.string().max(5000),
+              bsb_number: z.string().max(5000),
+            })
             .optional(),
           bacs_debit: z
             .object({
-              account_number: z.string().optional(),
-              sort_code: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
+              sort_code: z.string().max(5000).optional(),
             })
             .optional(),
           bancontact: z.object({}).optional(),
@@ -52422,23 +52861,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
               address: z
                 .union([
                   z.object({
-                    city: z.string().optional(),
-                    country: z.string().optional(),
-                    line1: z.string().optional(),
-                    line2: z.string().optional(),
-                    postal_code: z.string().optional(),
-                    state: z.string().optional(),
+                    city: z.string().max(5000).optional(),
+                    country: z.string().max(5000).optional(),
+                    line1: z.string().max(5000).optional(),
+                    line2: z.string().max(5000).optional(),
+                    postal_code: z.string().max(5000).optional(),
+                    state: z.string().max(5000).optional(),
                   }),
                   z.enum([""]),
                 ])
                 .optional(),
               email: z.union([z.string(), z.enum([""])]).optional(),
-              name: z.union([z.string(), z.enum([""])]).optional(),
-              phone: z.union([z.string(), z.enum([""])]).optional(),
+              name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+              phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string() }).optional(),
+          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
           cashapp: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
           eps: z
@@ -52587,10 +53026,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().optional() })
+            .object({ session: z.string().max(5000).optional() })
             .optional(),
           revolut_pay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string() }).optional(),
+          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
           sofort: z
             .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
             .optional(),
@@ -52633,10 +53072,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           us_bank_account: z
             .object({
               account_holder_type: z.enum(["company", "individual"]).optional(),
-              account_number: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
               account_type: z.enum(["checking", "savings"]).optional(),
-              financial_connections_account: z.string().optional(),
-              routing_number: z.string().optional(),
+              financial_connections_account: z.string().max(5000).optional(),
+              routing_number: z.string().max(5000).optional(),
             })
             .optional(),
           wechat_pay: z.object({}).optional(),
@@ -52656,7 +53095,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   default_for: z
                     .array(z.enum(["invoice", "subscription"]))
                     .optional(),
-                  interval_description: z.string().optional(),
+                  interval_description: z.string().max(500).optional(),
                   payment_schedule: z
                     .enum(["combined", "interval", "sporadic"])
                     .optional(),
@@ -52675,7 +53114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   amount: z.coerce.number(),
                   amount_type: z.enum(["fixed", "maximum"]),
                   currency: z.string(),
-                  description: z.string().optional(),
+                  description: z.string().max(200).optional(),
                   end_date: z.coerce.number().optional(),
                   interval: z.enum([
                     "day",
@@ -52685,7 +53124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     "year",
                   ]),
                   interval_count: z.coerce.number().optional(),
-                  reference: z.string(),
+                  reference: z.string().max(80),
                   start_date: z.coerce.number(),
                   supported_types: z.array(z.enum(["india"])).optional(),
                 })
@@ -52713,7 +53152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   ares_trans_status: z
                     .enum(["A", "C", "I", "N", "R", "U", "Y"])
                     .optional(),
-                  cryptogram: z.string().optional(),
+                  cryptogram: z.string().max(5000).optional(),
                   electronic_commerce_indicator: z
                     .enum(["01", "02", "05", "06", "07"])
                     .optional(),
@@ -52722,14 +53161,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       cartes_bancaires: z
                         .object({
                           cb_avalgo: z.enum(["0", "1", "2", "3", "4", "A"]),
-                          cb_exemption: z.string().optional(),
+                          cb_exemption: z.string().max(4).optional(),
                           cb_score: z.coerce.number().optional(),
                         })
                         .optional(),
                     })
                     .optional(),
-                  requestor_challenge_indicator: z.string().optional(),
-                  transaction_id: z.string().optional(),
+                  requestor_challenge_indicator: z.string().max(2).optional(),
+                  transaction_id: z.string().max(5000).optional(),
                   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).optional(),
                 })
                 .optional(),
@@ -52738,7 +53177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card_present: z.object({}).optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().optional() })
+            .object({ billing_agreement_id: z.string().max(5000).optional() })
             .optional(),
           sepa_debit: z
             .object({ mandate_options: z.object({}).optional() })
@@ -52760,7 +53199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   prefetch: z
                     .array(z.enum(["balances", "transactions"]))
                     .optional(),
-                  return_url: z.string().optional(),
+                  return_url: z.string().max(5000).optional(),
                 })
                 .optional(),
               mandate_options: z
@@ -52780,7 +53219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      payment_method_types: z.array(z.string()).optional(),
+      payment_method_types: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -52835,7 +53274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSetupIntentsIntentCancelParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postSetupIntentsIntentCancelBodySchema = z
@@ -52843,7 +53282,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       cancellation_reason: z
         .enum(["abandoned", "duplicate", "requested_by_customer"])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -52896,14 +53335,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSetupIntentsIntentConfirmParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postSetupIntentsIntentConfirmBodySchema = z
     .object({
-      client_secret: z.string().optional(),
-      confirmation_token: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      client_secret: z.string().max(5000).optional(),
+      confirmation_token: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       mandate_data: z
         .union([
           z.object({
@@ -52911,7 +53350,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
               accepted_at: z.coerce.number().optional(),
               offline: z.object({}).optional(),
               online: z
-                .object({ ip_address: z.string(), user_agent: z.string() })
+                .object({
+                  ip_address: z.string(),
+                  user_agent: z.string().max(5000),
+                })
                 .optional(),
               type: z.enum(["offline", "online"]),
             }),
@@ -52921,33 +53363,36 @@ export function createRouter(implementation: Implementation): KoaRouter {
             customer_acceptance: z.object({
               online: z.object({
                 ip_address: z.string().optional(),
-                user_agent: z.string().optional(),
+                user_agent: z.string().max(5000).optional(),
               }),
               type: z.enum(["online"]),
             }),
           }),
         ])
         .optional(),
-      payment_method: z.string().optional(),
+      payment_method: z.string().max(5000).optional(),
       payment_method_data: z
         .object({
           acss_debit: z
             .object({
-              account_number: z.string(),
-              institution_number: z.string(),
-              transit_number: z.string(),
+              account_number: z.string().max(5000),
+              institution_number: z.string().max(5000),
+              transit_number: z.string().max(5000),
             })
             .optional(),
           affirm: z.object({}).optional(),
           afterpay_clearpay: z.object({}).optional(),
           alipay: z.object({}).optional(),
           au_becs_debit: z
-            .object({ account_number: z.string(), bsb_number: z.string() })
+            .object({
+              account_number: z.string().max(5000),
+              bsb_number: z.string().max(5000),
+            })
             .optional(),
           bacs_debit: z
             .object({
-              account_number: z.string().optional(),
-              sort_code: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
+              sort_code: z.string().max(5000).optional(),
             })
             .optional(),
           bancontact: z.object({}).optional(),
@@ -52956,23 +53401,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
               address: z
                 .union([
                   z.object({
-                    city: z.string().optional(),
-                    country: z.string().optional(),
-                    line1: z.string().optional(),
-                    line2: z.string().optional(),
-                    postal_code: z.string().optional(),
-                    state: z.string().optional(),
+                    city: z.string().max(5000).optional(),
+                    country: z.string().max(5000).optional(),
+                    line1: z.string().max(5000).optional(),
+                    line2: z.string().max(5000).optional(),
+                    postal_code: z.string().max(5000).optional(),
+                    state: z.string().max(5000).optional(),
                   }),
                   z.enum([""]),
                 ])
                 .optional(),
               email: z.union([z.string(), z.enum([""])]).optional(),
-              name: z.union([z.string(), z.enum([""])]).optional(),
-              phone: z.union([z.string(), z.enum([""])]).optional(),
+              name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+              phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string() }).optional(),
+          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
           cashapp: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
           eps: z
@@ -53121,10 +53566,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().optional() })
+            .object({ session: z.string().max(5000).optional() })
             .optional(),
           revolut_pay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string() }).optional(),
+          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
           sofort: z
             .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
             .optional(),
@@ -53167,10 +53612,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           us_bank_account: z
             .object({
               account_holder_type: z.enum(["company", "individual"]).optional(),
-              account_number: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
               account_type: z.enum(["checking", "savings"]).optional(),
-              financial_connections_account: z.string().optional(),
-              routing_number: z.string().optional(),
+              financial_connections_account: z.string().max(5000).optional(),
+              routing_number: z.string().max(5000).optional(),
             })
             .optional(),
           wechat_pay: z.object({}).optional(),
@@ -53190,7 +53635,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   default_for: z
                     .array(z.enum(["invoice", "subscription"]))
                     .optional(),
-                  interval_description: z.string().optional(),
+                  interval_description: z.string().max(500).optional(),
                   payment_schedule: z
                     .enum(["combined", "interval", "sporadic"])
                     .optional(),
@@ -53209,7 +53654,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   amount: z.coerce.number(),
                   amount_type: z.enum(["fixed", "maximum"]),
                   currency: z.string(),
-                  description: z.string().optional(),
+                  description: z.string().max(200).optional(),
                   end_date: z.coerce.number().optional(),
                   interval: z.enum([
                     "day",
@@ -53219,7 +53664,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     "year",
                   ]),
                   interval_count: z.coerce.number().optional(),
-                  reference: z.string(),
+                  reference: z.string().max(80),
                   start_date: z.coerce.number(),
                   supported_types: z.array(z.enum(["india"])).optional(),
                 })
@@ -53247,7 +53692,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   ares_trans_status: z
                     .enum(["A", "C", "I", "N", "R", "U", "Y"])
                     .optional(),
-                  cryptogram: z.string().optional(),
+                  cryptogram: z.string().max(5000).optional(),
                   electronic_commerce_indicator: z
                     .enum(["01", "02", "05", "06", "07"])
                     .optional(),
@@ -53256,14 +53701,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       cartes_bancaires: z
                         .object({
                           cb_avalgo: z.enum(["0", "1", "2", "3", "4", "A"]),
-                          cb_exemption: z.string().optional(),
+                          cb_exemption: z.string().max(4).optional(),
                           cb_score: z.coerce.number().optional(),
                         })
                         .optional(),
                     })
                     .optional(),
-                  requestor_challenge_indicator: z.string().optional(),
-                  transaction_id: z.string().optional(),
+                  requestor_challenge_indicator: z.string().max(2).optional(),
+                  transaction_id: z.string().max(5000).optional(),
                   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).optional(),
                 })
                 .optional(),
@@ -53272,7 +53717,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card_present: z.object({}).optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().optional() })
+            .object({ billing_agreement_id: z.string().max(5000).optional() })
             .optional(),
           sepa_debit: z
             .object({ mandate_options: z.object({}).optional() })
@@ -53294,7 +53739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   prefetch: z
                     .array(z.enum(["balances", "transactions"]))
                     .optional(),
-                  return_url: z.string().optional(),
+                  return_url: z.string().max(5000).optional(),
                 })
                 .optional(),
               mandate_options: z
@@ -53368,15 +53813,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSetupIntentsIntentVerifyMicrodepositsParamSchema = z.object({
-    intent: z.string(),
+    intent: z.string().max(5000),
   })
 
   const postSetupIntentsIntentVerifyMicrodepositsBodySchema = z
     .object({
       amounts: z.array(z.coerce.number()).optional(),
-      client_secret: z.string().optional(),
-      descriptor_code: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      client_secret: z.string().max(5000).optional(),
+      descriptor_code: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
 
@@ -53445,10 +53890,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     currency: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getShippingRatesBodySchema = z.object({}).optional()
@@ -53461,7 +53906,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_shipping_rate),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/shipping_rates")),
         }),
       ],
     ],
@@ -53531,8 +53976,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    display_name: z.string(),
-    expand: z.array(z.string()).optional(),
+    display_name: z.string().max(100),
+    expand: z.array(z.string().max(5000)).optional(),
     fixed_amount: z
       .object({
         amount: z.coerce.number(),
@@ -53598,11 +54043,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getShippingRatesShippingRateTokenParamSchema = z.object({
-    shipping_rate_token: z.string(),
+    shipping_rate_token: z.string().max(5000),
   })
 
   const getShippingRatesShippingRateTokenQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getShippingRatesShippingRateTokenBodySchema = z.object({}).optional()
@@ -53663,13 +54108,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postShippingRatesShippingRateTokenParamSchema = z.object({
-    shipping_rate_token: z.string(),
+    shipping_rate_token: z.string().max(5000),
   })
 
   const postShippingRatesShippingRateTokenBodySchema = z
     .object({
       active: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       fixed_amount: z
         .object({
           currency_options: z
@@ -53743,10 +54188,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSigmaScheduledQueryRunsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getSigmaScheduledQueryRunsBodySchema = z.object({}).optional()
@@ -53759,7 +54204,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_scheduled_query_run)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/sigma/scheduled_query_runs")),
         }),
       ],
     ],
@@ -53817,11 +54265,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSigmaScheduledQueryRunsScheduledQueryRunParamSchema = z.object({
-    scheduled_query_run: z.string(),
+    scheduled_query_run: z.string().max(5000),
   })
 
   const getSigmaScheduledQueryRunsScheduledQueryRunQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getSigmaScheduledQueryRunsScheduledQueryRunBodySchema = z
@@ -53887,8 +54335,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       amount: z.coerce.number().optional(),
       currency: z.string().optional(),
-      customer: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(500).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       flow: z
         .enum(["code_verification", "none", "receiver", "redirect"])
         .optional(),
@@ -53903,12 +54351,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.string().optional(),
+                  user_agent: z.string().max(5000).optional(),
                 })
                 .optional(),
               status: z.enum(["accepted", "pending", "refused", "revoked"]),
               type: z.enum(["offline", "online"]).optional(),
-              user_agent: z.string().optional(),
+              user_agent: z.string().max(5000).optional(),
             })
             .optional(),
           amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
@@ -53926,22 +54374,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       metadata: z.record(z.string()).optional(),
-      original_source: z.string().optional(),
+      original_source: z.string().max(5000).optional(),
       owner: z
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           email: z.string().optional(),
-          name: z.string().optional(),
-          phone: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          phone: z.string().max(5000).optional(),
         })
         .optional(),
       receiver: z
@@ -53959,8 +54407,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
               z.object({
                 amount: z.coerce.number().optional(),
                 currency: z.string().optional(),
-                description: z.string().optional(),
-                parent: z.string().optional(),
+                description: z.string().max(1000).optional(),
+                parent: z.string().max(5000).optional(),
                 quantity: z.coerce.number().optional(),
                 type: z.enum(["discount", "shipping", "sku", "tax"]).optional(),
               }),
@@ -53969,24 +54417,24 @@ export function createRouter(implementation: Implementation): KoaRouter {
           shipping: z
             .object({
               address: z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
-              carrier: z.string().optional(),
-              name: z.string().optional(),
-              phone: z.string().optional(),
-              tracking_number: z.string().optional(),
+              carrier: z.string().max(5000).optional(),
+              name: z.string().max(5000).optional(),
+              phone: z.string().max(5000).optional(),
+              tracking_number: z.string().max(5000).optional(),
             })
             .optional(),
         })
         .optional(),
-      statement_descriptor: z.string().optional(),
-      token: z.string().optional(),
-      type: z.string().optional(),
+      statement_descriptor: z.string().max(5000).optional(),
+      token: z.string().max(5000).optional(),
+      type: z.string().max(5000).optional(),
       usage: z.enum(["reusable", "single_use"]).optional(),
     })
     .optional()
@@ -54033,11 +54481,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getSourcesSourceParamSchema = z.object({ source: z.string() })
+  const getSourcesSourceParamSchema = z.object({ source: z.string().max(5000) })
 
   const getSourcesSourceQuerySchema = z.object({
-    client_secret: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    client_secret: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getSourcesSourceBodySchema = z.object({}).optional()
@@ -54092,12 +54540,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postSourcesSourceParamSchema = z.object({ source: z.string() })
+  const postSourcesSourceParamSchema = z.object({
+    source: z.string().max(5000),
+  })
 
   const postSourcesSourceBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       mandate: z
         .object({
           acceptance: z
@@ -54109,12 +54559,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.string().optional(),
+                  user_agent: z.string().max(5000).optional(),
                 })
                 .optional(),
               status: z.enum(["accepted", "pending", "refused", "revoked"]),
               type: z.enum(["offline", "online"]).optional(),
-              user_agent: z.string().optional(),
+              user_agent: z.string().max(5000).optional(),
             })
             .optional(),
           amount: z.union([z.coerce.number(), z.enum([""])]).optional(),
@@ -54136,17 +54586,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           email: z.string().optional(),
-          name: z.string().optional(),
-          phone: z.string().optional(),
+          name: z.string().max(5000).optional(),
+          phone: z.string().max(5000).optional(),
         })
         .optional(),
       source_order: z
@@ -54156,8 +54606,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
               z.object({
                 amount: z.coerce.number().optional(),
                 currency: z.string().optional(),
-                description: z.string().optional(),
-                parent: z.string().optional(),
+                description: z.string().max(1000).optional(),
+                parent: z.string().max(5000).optional(),
                 quantity: z.coerce.number().optional(),
                 type: z.enum(["discount", "shipping", "sku", "tax"]).optional(),
               }),
@@ -54166,17 +54616,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
           shipping: z
             .object({
               address: z.object({
-                city: z.string().optional(),
-                country: z.string().optional(),
-                line1: z.string(),
-                line2: z.string().optional(),
-                postal_code: z.string().optional(),
-                state: z.string().optional(),
+                city: z.string().max(5000).optional(),
+                country: z.string().max(5000).optional(),
+                line1: z.string().max(5000),
+                line2: z.string().max(5000).optional(),
+                postal_code: z.string().max(5000).optional(),
+                state: z.string().max(5000).optional(),
               }),
-              carrier: z.string().optional(),
-              name: z.string().optional(),
-              phone: z.string().optional(),
-              tracking_number: z.string().optional(),
+              carrier: z.string().max(5000).optional(),
+              name: z.string().max(5000).optional(),
+              phone: z.string().max(5000).optional(),
+              tracking_number: z.string().max(5000).optional(),
             })
             .optional(),
         })
@@ -54231,10 +54681,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getSourcesSourceMandateNotificationsMandateNotificationParamSchema =
-    z.object({ mandate_notification: z.string(), source: z.string() })
+    z.object({
+      mandate_notification: z.string().max(5000),
+      source: z.string().max(5000),
+    })
 
   const getSourcesSourceMandateNotificationsMandateNotificationQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getSourcesSourceMandateNotificationsMandateNotificationBodySchema = z
     .object({})
@@ -54301,14 +54754,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSourcesSourceSourceTransactionsParamSchema = z.object({
-    source: z.string(),
+    source: z.string().max(5000),
   })
 
   const getSourcesSourceSourceTransactionsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getSourcesSourceSourceTransactionsBodySchema = z.object({}).optional()
@@ -54322,7 +54775,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_source_transaction),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -54387,10 +54840,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSourcesSourceSourceTransactionsSourceTransactionParamSchema =
-    z.object({ source: z.string(), source_transaction: z.string() })
+    z.object({
+      source: z.string().max(5000),
+      source_transaction: z.string().max(5000),
+    })
 
   const getSourcesSourceSourceTransactionsSourceTransactionQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getSourcesSourceSourceTransactionsSourceTransactionBodySchema = z
     .object({})
@@ -54456,11 +54912,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postSourcesSourceVerifyParamSchema = z.object({ source: z.string() })
+  const postSourcesSourceVerifyParamSchema = z.object({
+    source: z.string().max(5000),
+  })
 
   const postSourcesSourceVerifyBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    values: z.array(z.string()),
+    expand: z.array(z.string().max(5000)).optional(),
+    values: z.array(z.string().max(5000)),
   })
 
   const postSourcesSourceVerifyResponseValidator = responseValidationFactory(
@@ -54515,10 +54973,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getSubscriptionItemsQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
-    subscription: z.string(),
+    subscription: z.string().max(5000),
   })
 
   const getSubscriptionItemsBodySchema = z.object({}).optional()
@@ -54531,7 +54989,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_subscription_item)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/subscription_items")),
         }),
       ],
     ],
@@ -54596,15 +55057,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .union([
         z.array(
           z.object({
-            coupon: z.string().optional(),
-            discount: z.string().optional(),
-            promotion_code: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            discount: z.string().max(5000).optional(),
+            promotion_code: z.string().max(5000).optional(),
           }),
         ),
         z.enum([""]),
       ])
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
     payment_behavior: z
       .enum([
@@ -54614,11 +55075,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "pending_if_incomplete",
       ])
       .optional(),
-    price: z.string().optional(),
+    price: z.string().max(5000).optional(),
     price_data: z
       .object({
         currency: z.string(),
-        product: z.string(),
+        product: z.string().max(5000),
         recurring: z.object({
           interval: z.enum(["day", "month", "week", "year"]),
           interval_count: z.coerce.number().optional(),
@@ -54635,8 +55096,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     proration_date: z.coerce.number().optional(),
     quantity: z.coerce.number().optional(),
-    subscription: z.string(),
-    tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+    subscription: z.string().max(5000),
+    tax_rates: z
+      .union([z.array(z.string().max(5000)), z.enum([""])])
+      .optional(),
   })
 
   const postSubscriptionItemsResponseValidator = responseValidationFactory(
@@ -54685,7 +55148,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const deleteSubscriptionItemsItemParamSchema = z.object({ item: z.string() })
+  const deleteSubscriptionItemsItemParamSchema = z.object({
+    item: z.string().max(5000),
+  })
 
   const deleteSubscriptionItemsItemBodySchema = z
     .object({
@@ -54745,10 +55210,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getSubscriptionItemsItemParamSchema = z.object({ item: z.string() })
+  const getSubscriptionItemsItemParamSchema = z.object({
+    item: z.string().max(5000),
+  })
 
   const getSubscriptionItemsItemQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getSubscriptionItemsItemBodySchema = z.object({}).optional()
@@ -54807,7 +55274,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postSubscriptionItemsItemParamSchema = z.object({ item: z.string() })
+  const postSubscriptionItemsItemParamSchema = z.object({
+    item: z.string().max(5000),
+  })
 
   const postSubscriptionItemsItemBodySchema = z
     .object({
@@ -54818,15 +55287,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       off_session: z.coerce.boolean().optional(),
       payment_behavior: z
@@ -54837,11 +55306,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "pending_if_incomplete",
         ])
         .optional(),
-      price: z.string().optional(),
+      price: z.string().max(5000).optional(),
       price_data: z
         .object({
           currency: z.string(),
-          product: z.string(),
+          product: z.string().max(5000),
           recurring: z.object({
             interval: z.enum(["day", "month", "week", "year"]),
             interval_count: z.coerce.number().optional(),
@@ -54858,7 +55327,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       proration_date: z.coerce.number().optional(),
       quantity: z.coerce.number().optional(),
-      tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+      tax_rates: z
+        .union([z.array(z.string().max(5000)), z.enum([""])])
+        .optional(),
     })
     .optional()
 
@@ -54917,10 +55388,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getSubscriptionItemsSubscriptionItemUsageRecordSummariesQuerySchema =
     z.object({
-      ending_before: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      ending_before: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       limit: z.coerce.number().optional(),
-      starting_after: z.string().optional(),
+      starting_after: z.string().max(5000).optional(),
     })
 
   const getSubscriptionItemsSubscriptionItemUsageRecordSummariesBodySchema = z
@@ -54936,7 +55407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_usage_record_summary),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -55011,7 +55482,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postSubscriptionItemsSubscriptionItemUsageRecordsBodySchema = z.object({
     action: z.enum(["increment", "set"]).optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     quantity: z.coerce.number(),
     timestamp: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
   })
@@ -55106,9 +55577,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     released_at: z
       .union([
@@ -55122,7 +55593,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     scheduled: z.coerce.boolean().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getSubscriptionSchedulesBodySchema = z.object({}).optional()
@@ -55135,7 +55606,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_subscription_schedule)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/subscription_schedules")),
         }),
       ],
     ],
@@ -55194,7 +55668,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postSubscriptionSchedulesBodySchema = z
     .object({
-      customer: z.string().optional(),
+      customer: z.string().max(5000).optional(),
       default_settings: z
         .object({
           application_fee_percent: z.coerce.number().optional(),
@@ -55222,12 +55696,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
           collection_method: z
             .enum(["charge_automatically", "send_invoice"])
             .optional(),
-          default_payment_method: z.string().optional(),
-          description: z.union([z.string(), z.enum([""])]).optional(),
+          default_payment_method: z.string().max(5000).optional(),
+          description: z.union([z.string().max(500), z.enum([""])]).optional(),
           invoice_settings: z
             .object({
               account_tax_ids: z
-                .union([z.array(z.string()), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.enum([""])])
                 .optional(),
               days_until_due: z.coerce.number().optional(),
               issuer: z
@@ -55251,8 +55725,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       end_behavior: z.enum(["cancel", "none", "release", "renew"]).optional(),
-      expand: z.array(z.string()).optional(),
-      from_subscription: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      from_subscription: z.string().max(5000).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       phases: z
         .array(
@@ -55263,17 +55737,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   discounts: z
                     .array(
                       z.object({
-                        coupon: z.string().optional(),
-                        discount: z.string().optional(),
-                        promotion_code: z.string().optional(),
+                        coupon: z.string().max(5000).optional(),
+                        discount: z.string().max(5000).optional(),
+                        promotion_code: z.string().max(5000).optional(),
                       }),
                     )
                     .optional(),
-                  price: z.string().optional(),
+                  price: z.string().max(5000).optional(),
                   price_data: z
                     .object({
                       currency: z.string(),
-                      product: z.string(),
+                      product: z.string().max(5000),
                       tax_behavior: z
                         .enum(["exclusive", "inclusive", "unspecified"])
                         .optional(),
@@ -55283,7 +55757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .optional(),
                   quantity: z.coerce.number().optional(),
                   tax_rates: z
-                    .union([z.array(z.string()), z.enum([""])])
+                    .union([z.array(z.string().max(5000)), z.enum([""])])
                     .optional(),
                 }),
               )
@@ -55315,20 +55789,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
             collection_method: z
               .enum(["charge_automatically", "send_invoice"])
               .optional(),
-            coupon: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
             currency: z.string().optional(),
-            default_payment_method: z.string().optional(),
+            default_payment_method: z.string().max(5000).optional(),
             default_tax_rates: z
-              .union([z.array(z.string()), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.enum([""])])
               .optional(),
-            description: z.union([z.string(), z.enum([""])]).optional(),
+            description: z
+              .union([z.string().max(500), z.enum([""])])
+              .optional(),
             discounts: z
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
@@ -55338,7 +55814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             invoice_settings: z
               .object({
                 account_tax_ids: z
-                  .union([z.array(z.string()), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.enum([""])])
                   .optional(),
                 days_until_due: z.coerce.number().optional(),
                 issuer: z
@@ -55361,20 +55837,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([
                     z.array(
                       z.object({
-                        coupon: z.string().optional(),
-                        discount: z.string().optional(),
-                        promotion_code: z.string().optional(),
+                        coupon: z.string().max(5000).optional(),
+                        discount: z.string().max(5000).optional(),
+                        promotion_code: z.string().max(5000).optional(),
                       }),
                     ),
                     z.enum([""]),
                   ])
                   .optional(),
                 metadata: z.record(z.string()).optional(),
-                price: z.string().optional(),
+                price: z.string().max(5000).optional(),
                 price_data: z
                   .object({
                     currency: z.string(),
-                    product: z.string(),
+                    product: z.string().max(5000),
                     recurring: z.object({
                       interval: z.enum(["day", "month", "week", "year"]),
                       interval_count: z.coerce.number().optional(),
@@ -55388,7 +55864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .optional(),
                 quantity: z.coerce.number().optional(),
                 tax_rates: z
-                  .union([z.array(z.string()), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.enum([""])])
                   .optional(),
               }),
             ),
@@ -55460,11 +55936,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSubscriptionSchedulesScheduleParamSchema = z.object({
-    schedule: z.string(),
+    schedule: z.string().max(5000),
   })
 
   const getSubscriptionSchedulesScheduleQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getSubscriptionSchedulesScheduleBodySchema = z.object({}).optional()
@@ -55522,7 +55998,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSubscriptionSchedulesScheduleParamSchema = z.object({
-    schedule: z.string(),
+    schedule: z.string().max(5000),
   })
 
   const postSubscriptionSchedulesScheduleBodySchema = z
@@ -55554,12 +56030,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
           collection_method: z
             .enum(["charge_automatically", "send_invoice"])
             .optional(),
-          default_payment_method: z.string().optional(),
-          description: z.union([z.string(), z.enum([""])]).optional(),
+          default_payment_method: z.string().max(5000).optional(),
+          description: z.union([z.string().max(500), z.enum([""])]).optional(),
           invoice_settings: z
             .object({
               account_tax_ids: z
-                .union([z.array(z.string()), z.enum([""])])
+                .union([z.array(z.string().max(5000)), z.enum([""])])
                 .optional(),
               days_until_due: z.coerce.number().optional(),
               issuer: z
@@ -55583,7 +56059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       end_behavior: z.enum(["cancel", "none", "release", "renew"]).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       phases: z
         .array(
@@ -55594,17 +56070,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   discounts: z
                     .array(
                       z.object({
-                        coupon: z.string().optional(),
-                        discount: z.string().optional(),
-                        promotion_code: z.string().optional(),
+                        coupon: z.string().max(5000).optional(),
+                        discount: z.string().max(5000).optional(),
+                        promotion_code: z.string().max(5000).optional(),
                       }),
                     )
                     .optional(),
-                  price: z.string().optional(),
+                  price: z.string().max(5000).optional(),
                   price_data: z
                     .object({
                       currency: z.string(),
-                      product: z.string(),
+                      product: z.string().max(5000),
                       tax_behavior: z
                         .enum(["exclusive", "inclusive", "unspecified"])
                         .optional(),
@@ -55614,7 +56090,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .optional(),
                   quantity: z.coerce.number().optional(),
                   tax_rates: z
-                    .union([z.array(z.string()), z.enum([""])])
+                    .union([z.array(z.string().max(5000)), z.enum([""])])
                     .optional(),
                 }),
               )
@@ -55646,19 +56122,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
             collection_method: z
               .enum(["charge_automatically", "send_invoice"])
               .optional(),
-            coupon: z.string().optional(),
-            default_payment_method: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            default_payment_method: z.string().max(5000).optional(),
             default_tax_rates: z
-              .union([z.array(z.string()), z.enum([""])])
+              .union([z.array(z.string().max(5000)), z.enum([""])])
               .optional(),
-            description: z.union([z.string(), z.enum([""])]).optional(),
+            description: z
+              .union([z.string().max(500), z.enum([""])])
+              .optional(),
             discounts: z
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
@@ -55668,7 +56146,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             invoice_settings: z
               .object({
                 account_tax_ids: z
-                  .union([z.array(z.string()), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.enum([""])])
                   .optional(),
                 days_until_due: z.coerce.number().optional(),
                 issuer: z
@@ -55691,20 +56169,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([
                     z.array(
                       z.object({
-                        coupon: z.string().optional(),
-                        discount: z.string().optional(),
-                        promotion_code: z.string().optional(),
+                        coupon: z.string().max(5000).optional(),
+                        discount: z.string().max(5000).optional(),
+                        promotion_code: z.string().max(5000).optional(),
                       }),
                     ),
                     z.enum([""]),
                   ])
                   .optional(),
                 metadata: z.record(z.string()).optional(),
-                price: z.string().optional(),
+                price: z.string().max(5000).optional(),
                 price_data: z
                   .object({
                     currency: z.string(),
-                    product: z.string(),
+                    product: z.string().max(5000),
                     recurring: z.object({
                       interval: z.enum(["day", "month", "week", "year"]),
                       interval_count: z.coerce.number().optional(),
@@ -55718,7 +56196,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .optional(),
                 quantity: z.coerce.number().optional(),
                 tax_rates: z
-                  .union([z.array(z.string()), z.enum([""])])
+                  .union([z.array(z.string().max(5000)), z.enum([""])])
                   .optional(),
               }),
             ),
@@ -55800,12 +56278,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSubscriptionSchedulesScheduleCancelParamSchema = z.object({
-    schedule: z.string(),
+    schedule: z.string().max(5000),
   })
 
   const postSubscriptionSchedulesScheduleCancelBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       invoice_now: z.coerce.boolean().optional(),
       prorate: z.coerce.boolean().optional(),
     })
@@ -55863,12 +56341,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSubscriptionSchedulesScheduleReleaseParamSchema = z.object({
-    schedule: z.string(),
+    schedule: z.string().max(5000),
   })
 
   const postSubscriptionSchedulesScheduleReleaseBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       preserve_cancel_date: z.coerce.boolean().optional(),
     })
     .optional()
@@ -55962,12 +56440,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    price: z.string().optional(),
-    starting_after: z.string().optional(),
+    price: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum([
         "active",
@@ -55982,7 +56460,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "unpaid",
       ])
       .optional(),
-    test_clock: z.string().optional(),
+    test_clock: z.string().max(5000).optional(),
   })
 
   const getSubscriptionsBodySchema = z.object({}).optional()
@@ -55995,7 +56473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_subscription)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/subscriptions")),
         }),
       ],
     ],
@@ -56055,17 +56533,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
           discounts: z
             .array(
               z.object({
-                coupon: z.string().optional(),
-                discount: z.string().optional(),
-                promotion_code: z.string().optional(),
+                coupon: z.string().max(5000).optional(),
+                discount: z.string().max(5000).optional(),
+                promotion_code: z.string().max(5000).optional(),
               }),
             )
             .optional(),
-          price: z.string().optional(),
+          price: z.string().max(5000).optional(),
           price_data: z
             .object({
               currency: z.string(),
-              product: z.string(),
+              product: z.string().max(5000),
               tax_behavior: z
                 .enum(["exclusive", "inclusive", "unspecified"])
                 .optional(),
@@ -56074,7 +56552,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           quantity: z.coerce.number().optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
         }),
       )
       .optional(),
@@ -56117,31 +56597,33 @@ export function createRouter(implementation: Implementation): KoaRouter {
     collection_method: z
       .enum(["charge_automatically", "send_invoice"])
       .optional(),
-    coupon: z.string().optional(),
+    coupon: z.string().max(5000).optional(),
     currency: z.string().optional(),
-    customer: z.string(),
+    customer: z.string().max(5000),
     days_until_due: z.coerce.number().optional(),
-    default_payment_method: z.string().optional(),
-    default_source: z.string().optional(),
-    default_tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
-    description: z.string().optional(),
+    default_payment_method: z.string().max(5000).optional(),
+    default_source: z.string().max(5000).optional(),
+    default_tax_rates: z
+      .union([z.array(z.string().max(5000)), z.enum([""])])
+      .optional(),
+    description: z.string().max(500).optional(),
     discounts: z
       .union([
         z.array(
           z.object({
-            coupon: z.string().optional(),
-            discount: z.string().optional(),
-            promotion_code: z.string().optional(),
+            coupon: z.string().max(5000).optional(),
+            discount: z.string().max(5000).optional(),
+            promotion_code: z.string().max(5000).optional(),
           }),
         ),
         z.enum([""]),
       ])
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     invoice_settings: z
       .object({
         account_tax_ids: z
-          .union([z.array(z.string()), z.enum([""])])
+          .union([z.array(z.string().max(5000)), z.enum([""])])
           .optional(),
         issuer: z
           .object({
@@ -56161,20 +56643,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               ),
               z.enum([""]),
             ])
             .optional(),
           metadata: z.record(z.string()).optional(),
-          price: z.string().optional(),
+          price: z.string().max(5000).optional(),
           price_data: z
             .object({
               currency: z.string(),
-              product: z.string(),
+              product: z.string().max(5000),
               recurring: z.object({
                 interval: z.enum(["day", "month", "week", "year"]),
                 interval_count: z.coerce.number().optional(),
@@ -56187,7 +56669,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           quantity: z.coerce.number().optional(),
-          tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+          tax_rates: z
+            .union([z.array(z.string().max(5000)), z.enum([""])])
+            .optional(),
         }),
       )
       .optional(),
@@ -56240,7 +56724,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .object({
                       amount: z.coerce.number().optional(),
                       amount_type: z.enum(["fixed", "maximum"]).optional(),
-                      description: z.string().optional(),
+                      description: z.string().max(200).optional(),
                     })
                     .optional(),
                   network: z
@@ -56271,7 +56755,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   bank_transfer: z
                     .object({
                       eu_bank_transfer: z
-                        .object({ country: z.string() })
+                        .object({ country: z.string().max(5000) })
                         .optional(),
                       type: z.string().optional(),
                     })
@@ -56360,7 +56844,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.enum([""]),
       ])
       .optional(),
-    promotion_code: z.string().optional(),
+    promotion_code: z.string().max(5000).optional(),
     proration_behavior: z
       .enum(["always_invoice", "create_prorations", "none"])
       .optional(),
@@ -56425,10 +56909,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getSubscriptionsSearchQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    page: z.string().optional(),
-    query: z.string(),
+    page: z.string().max(5000).optional(),
+    query: z.string().max(5000),
   })
 
   const getSubscriptionsSearchBodySchema = z.object({}).optional()
@@ -56440,10 +56924,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           data: z.array(z.lazy(() => s_subscription)),
           has_more: z.coerce.boolean(),
-          next_page: z.string().nullable().optional(),
+          next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -56503,14 +56987,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteSubscriptionsSubscriptionExposedIdParamSchema = z.object({
-    subscription_exposed_id: z.string(),
+    subscription_exposed_id: z.string().max(5000),
   })
 
   const deleteSubscriptionsSubscriptionExposedIdBodySchema = z
     .object({
       cancellation_details: z
         .object({
-          comment: z.union([z.string(), z.enum([""])]).optional(),
+          comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
           feedback: z
             .enum([
               "",
@@ -56526,7 +57010,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       invoice_now: z.coerce.boolean().optional(),
       prorate: z.coerce.boolean().optional(),
     })
@@ -56584,11 +57068,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSubscriptionsSubscriptionExposedIdParamSchema = z.object({
-    subscription_exposed_id: z.string(),
+    subscription_exposed_id: z.string().max(5000),
   })
 
   const getSubscriptionsSubscriptionExposedIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getSubscriptionsSubscriptionExposedIdBodySchema = z
@@ -56651,7 +57135,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSubscriptionsSubscriptionExposedIdParamSchema = z.object({
-    subscription_exposed_id: z.string(),
+    subscription_exposed_id: z.string().max(5000),
   })
 
   const postSubscriptionsSubscriptionExposedIdBodySchema = z
@@ -56662,17 +57146,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
             discounts: z
               .array(
                 z.object({
-                  coupon: z.string().optional(),
-                  discount: z.string().optional(),
-                  promotion_code: z.string().optional(),
+                  coupon: z.string().max(5000).optional(),
+                  discount: z.string().max(5000).optional(),
+                  promotion_code: z.string().max(5000).optional(),
                 }),
               )
               .optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 tax_behavior: z
                   .enum(["exclusive", "inclusive", "unspecified"])
                   .optional(),
@@ -56681,7 +57165,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -56713,7 +57199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       cancel_at_period_end: z.coerce.boolean().optional(),
       cancellation_details: z
         .object({
-          comment: z.union([z.string(), z.enum([""])]).optional(),
+          comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
           feedback: z
             .enum([
               "",
@@ -56732,31 +57218,31 @@ export function createRouter(implementation: Implementation): KoaRouter {
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
-      coupon: z.string().optional(),
+      coupon: z.string().max(5000).optional(),
       days_until_due: z.coerce.number().optional(),
-      default_payment_method: z.string().optional(),
-      default_source: z.union([z.string(), z.enum([""])]).optional(),
+      default_payment_method: z.string().max(5000).optional(),
+      default_source: z.union([z.string().max(5000), z.enum([""])]).optional(),
       default_tax_rates: z
-        .union([z.array(z.string()), z.enum([""])])
+        .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
-      description: z.union([z.string(), z.enum([""])]).optional(),
+      description: z.union([z.string().max(500), z.enum([""])]).optional(),
       discounts: z
         .union([
           z.array(
             z.object({
-              coupon: z.string().optional(),
-              discount: z.string().optional(),
-              promotion_code: z.string().optional(),
+              coupon: z.string().max(5000).optional(),
+              discount: z.string().max(5000).optional(),
+              promotion_code: z.string().max(5000).optional(),
             }),
           ),
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       invoice_settings: z
         .object({
           account_tax_ids: z
-            .union([z.array(z.string()), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.enum([""])])
             .optional(),
           issuer: z
             .object({
@@ -56778,21 +57264,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.array(
                   z.object({
-                    coupon: z.string().optional(),
-                    discount: z.string().optional(),
-                    promotion_code: z.string().optional(),
+                    coupon: z.string().max(5000).optional(),
+                    discount: z.string().max(5000).optional(),
+                    promotion_code: z.string().max(5000).optional(),
                   }),
                 ),
                 z.enum([""]),
               ])
               .optional(),
-            id: z.string().optional(),
+            id: z.string().max(5000).optional(),
             metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-            price: z.string().optional(),
+            price: z.string().max(5000).optional(),
             price_data: z
               .object({
                 currency: z.string(),
-                product: z.string(),
+                product: z.string().max(5000),
                 recurring: z.object({
                   interval: z.enum(["day", "month", "week", "year"]),
                   interval_count: z.coerce.number().optional(),
@@ -56805,7 +57291,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               })
               .optional(),
             quantity: z.coerce.number().optional(),
-            tax_rates: z.union([z.array(z.string()), z.enum([""])]).optional(),
+            tax_rates: z
+              .union([z.array(z.string().max(5000)), z.enum([""])])
+              .optional(),
           }),
         )
         .optional(),
@@ -56867,7 +57355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                       .object({
                         amount: z.coerce.number().optional(),
                         amount_type: z.enum(["fixed", "maximum"]).optional(),
-                        description: z.string().optional(),
+                        description: z.string().max(200).optional(),
                       })
                       .optional(),
                     network: z
@@ -56898,7 +57386,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string() })
+                          .object({ country: z.string().max(5000) })
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -56987,7 +57475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      promotion_code: z.string().optional(),
+      promotion_code: z.string().max(5000).optional(),
       proration_behavior: z
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
@@ -57069,7 +57557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteSubscriptionsSubscriptionExposedIdDiscountParamSchema = z.object({
-    subscription_exposed_id: z.string(),
+    subscription_exposed_id: z.string().max(5000),
   })
 
   const deleteSubscriptionsSubscriptionExposedIdDiscountBodySchema = z
@@ -57129,13 +57617,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postSubscriptionsSubscriptionResumeParamSchema = z.object({
-    subscription: z.string(),
+    subscription: z.string().max(5000),
   })
 
   const postSubscriptionsSubscriptionResumeBodySchema = z
     .object({
       billing_cycle_anchor: z.enum(["now", "unchanged"]).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       proration_behavior: z
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
@@ -57196,17 +57684,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTaxCalculationsBodySchema = z.object({
     currency: z.string(),
-    customer: z.string().optional(),
+    customer: z.string().max(5000).optional(),
     customer_details: z
       .object({
         address: z
           .object({
-            city: z.union([z.string(), z.enum([""])]).optional(),
-            country: z.string(),
-            line1: z.union([z.string(), z.enum([""])]).optional(),
-            line2: z.union([z.string(), z.enum([""])]).optional(),
-            postal_code: z.union([z.string(), z.enum([""])]).optional(),
-            state: z.union([z.string(), z.enum([""])]).optional(),
+            city: z.union([z.string().max(5000), z.enum([""])]).optional(),
+            country: z.string().max(5000),
+            line1: z.union([z.string().max(5000), z.enum([""])]).optional(),
+            line2: z.union([z.string().max(5000), z.enum([""])]).optional(),
+            postal_code: z
+              .union([z.string().max(5000), z.enum([""])])
+              .optional(),
+            state: z.union([z.string().max(5000), z.enum([""])]).optional(),
           })
           .optional(),
         address_source: z.enum(["billing", "shipping"]).optional(),
@@ -57292,13 +57782,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     line_items: z.array(
       z.object({
         amount: z.coerce.number(),
-        product: z.string().optional(),
+        product: z.string().max(5000).optional(),
         quantity: z.coerce.number().optional(),
-        reference: z.string().optional(),
+        reference: z.string().max(500).optional(),
         tax_behavior: z.enum(["exclusive", "inclusive"]).optional(),
         tax_code: z.string().optional(),
       }),
@@ -57306,7 +57796,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     shipping_cost: z
       .object({
         amount: z.coerce.number().optional(),
-        shipping_rate: z.string().optional(),
+        shipping_rate: z.string().max(5000).optional(),
         tax_behavior: z.enum(["exclusive", "inclusive"]).optional(),
         tax_code: z.string().optional(),
       })
@@ -57361,14 +57851,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTaxCalculationsCalculationLineItemsParamSchema = z.object({
-    calculation: z.string(),
+    calculation: z.string().max(5000),
   })
 
   const getTaxCalculationsCalculationLineItemsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(500).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(500).optional(),
   })
 
   const getTaxCalculationsCalculationLineItemsBodySchema = z
@@ -57384,7 +57874,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_tax_calculation_line_item),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/tax/calculations/[^/]+/line_items")),
           }),
         ],
       ],
@@ -57449,10 +57942,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTaxRegistrationsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["active", "all", "expired", "scheduled"]).optional(),
   })
 
@@ -57466,7 +57959,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_tax_registration),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/tax/registrations")),
         }),
       ],
     ],
@@ -57525,7 +58018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTaxRegistrationsBodySchema = z.object({
     active_from: z.union([z.enum(["now"]), z.coerce.number()]),
-    country: z.string(),
+    country: z.string().max(5000),
     country_options: z.object({
       ae: z.object({ type: z.enum(["standard"]) }).optional(),
       at: z
@@ -57561,7 +58054,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       ca: z
         .object({
-          province_standard: z.object({ province: z.string() }).optional(),
+          province_standard: z
+            .object({ province: z.string().max(5000) })
+            .optional(),
           type: z.enum(["province_standard", "simplified", "standard"]),
         })
         .optional(),
@@ -57824,10 +58319,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
       us: z
         .object({
           local_amusement_tax: z
-            .object({ jurisdiction: z.string() })
+            .object({ jurisdiction: z.string().max(5000) })
             .optional(),
-          local_lease_tax: z.object({ jurisdiction: z.string() }).optional(),
-          state: z.string(),
+          local_lease_tax: z
+            .object({ jurisdiction: z.string().max(5000) })
+            .optional(),
+          state: z.string().max(5000),
           type: z.enum([
             "local_amusement_tax",
             "local_lease_tax",
@@ -57839,7 +58336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       vn: z.object({ type: z.enum(["simplified"]) }).optional(),
       za: z.object({ type: z.enum(["standard"]) }).optional(),
     }),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     expires_at: z.coerce.number().optional(),
   })
 
@@ -57889,10 +58386,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTaxRegistrationsIdParamSchema = z.object({ id: z.string() })
+  const getTaxRegistrationsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTaxRegistrationsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTaxRegistrationsIdBodySchema = z.object({}).optional()
@@ -57951,12 +58450,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postTaxRegistrationsIdParamSchema = z.object({ id: z.string() })
+  const postTaxRegistrationsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postTaxRegistrationsIdBodySchema = z
     .object({
       active_from: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       expires_at: z
         .union([z.enum(["now"]), z.coerce.number(), z.enum([""])])
         .optional(),
@@ -58014,7 +58515,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTaxSettingsQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTaxSettingsBodySchema = z.object({}).optional()
@@ -58075,16 +58576,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
           tax_code: z.string().optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       head_office: z
         .object({
           address: z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
         })
         .optional(),
@@ -58134,10 +58635,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTaxTransactionsCreateFromCalculationBodySchema = z.object({
-    calculation: z.string(),
-    expand: z.array(z.string()).optional(),
+    calculation: z.string().max(5000),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
-    reference: z.string(),
+    reference: z.string().max(500),
   })
 
   const postTaxTransactionsCreateFromCalculationResponseValidator =
@@ -58188,7 +58689,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTaxTransactionsCreateReversalBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     flat_amount: z.coerce.number().optional(),
     line_items: z
       .array(
@@ -58196,16 +58697,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
           amount: z.coerce.number(),
           amount_tax: z.coerce.number(),
           metadata: z.record(z.string()).optional(),
-          original_line_item: z.string(),
+          original_line_item: z.string().max(5000),
           quantity: z.coerce.number().optional(),
-          reference: z.string(),
+          reference: z.string().max(500),
         }),
       )
       .optional(),
     metadata: z.record(z.string()).optional(),
     mode: z.enum(["full", "partial"]),
-    original_transaction: z.string(),
-    reference: z.string(),
+    original_transaction: z.string().max(5000),
+    reference: z.string().max(500),
     shipping_cost: z
       .object({ amount: z.coerce.number(), amount_tax: z.coerce.number() })
       .optional(),
@@ -58259,11 +58760,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTaxTransactionsTransactionParamSchema = z.object({
-    transaction: z.string(),
+    transaction: z.string().max(5000),
   })
 
   const getTaxTransactionsTransactionQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTaxTransactionsTransactionBodySchema = z.object({}).optional()
@@ -58321,14 +58822,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTaxTransactionsTransactionLineItemsParamSchema = z.object({
-    transaction: z.string(),
+    transaction: z.string().max(5000),
   })
 
   const getTaxTransactionsTransactionLineItemsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(500).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(500).optional(),
   })
 
   const getTaxTransactionsTransactionLineItemsBodySchema = z
@@ -58344,7 +58845,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_tax_transaction_line_item),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/tax/transactions/[^/]+/line_items")),
           }),
         ],
       ],
@@ -58410,7 +58914,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getTaxCodesQuerySchema = z.object({
     ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
   })
@@ -58425,7 +58929,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_tax_code),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -58478,10 +58982,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTaxCodesIdParamSchema = z.object({ id: z.string() })
+  const getTaxCodesIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getTaxCodesIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTaxCodesIdBodySchema = z.object({}).optional()
@@ -58537,17 +59041,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getTaxIdsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
     owner: z
       .object({
         account: z.string().optional(),
-        customer: z.string().optional(),
+        customer: z.string().max(5000).optional(),
         type: z.enum(["account", "application", "customer", "self"]),
       })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTaxIdsBodySchema = z.object({}).optional()
@@ -58560,7 +59064,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_tax_id)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -58614,11 +59118,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTaxIdsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     owner: z
       .object({
         account: z.string().optional(),
-        customer: z.string().optional(),
+        customer: z.string().max(5000).optional(),
         type: z.enum(["account", "application", "customer", "self"]),
       })
       .optional(),
@@ -58736,7 +59240,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteTaxIdsIdParamSchema = z.object({ id: z.string() })
+  const deleteTaxIdsIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const deleteTaxIdsIdBodySchema = z.object({}).optional()
 
@@ -58786,10 +59290,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTaxIdsIdParamSchema = z.object({ id: z.string() })
+  const getTaxIdsIdParamSchema = z.object({ id: z.string().max(5000) })
 
   const getTaxIdsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTaxIdsIdBodySchema = z.object({}).optional()
@@ -58857,11 +59361,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     inclusive: z.coerce.boolean().optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTaxRatesBodySchema = z.object({}).optional()
@@ -58874,7 +59378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_tax_rate),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/tax_rates")),
         }),
       ],
     ],
@@ -58929,15 +59433,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTaxRatesBodySchema = z.object({
     active: z.coerce.boolean().optional(),
-    country: z.string().optional(),
-    description: z.string().optional(),
-    display_name: z.string(),
-    expand: z.array(z.string()).optional(),
+    country: z.string().max(5000).optional(),
+    description: z.string().max(5000).optional(),
+    display_name: z.string().max(50),
+    expand: z.array(z.string().max(5000)).optional(),
     inclusive: z.coerce.boolean(),
-    jurisdiction: z.string().optional(),
+    jurisdiction: z.string().max(50).optional(),
     metadata: z.record(z.string()).optional(),
     percentage: z.coerce.number(),
-    state: z.string().optional(),
+    state: z.string().max(2).optional(),
     tax_type: z
       .enum([
         "amusement_tax",
@@ -58998,10 +59502,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTaxRatesTaxRateParamSchema = z.object({ tax_rate: z.string() })
+  const getTaxRatesTaxRateParamSchema = z.object({
+    tax_rate: z.string().max(5000),
+  })
 
   const getTaxRatesTaxRateQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTaxRatesTaxRateBodySchema = z.object({}).optional()
@@ -59060,18 +59566,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postTaxRatesTaxRateParamSchema = z.object({ tax_rate: z.string() })
+  const postTaxRatesTaxRateParamSchema = z.object({
+    tax_rate: z.string().max(5000),
+  })
 
   const postTaxRatesTaxRateBodySchema = z
     .object({
       active: z.coerce.boolean().optional(),
-      country: z.string().optional(),
-      description: z.string().optional(),
-      display_name: z.string().optional(),
-      expand: z.array(z.string()).optional(),
-      jurisdiction: z.string().optional(),
+      country: z.string().max(5000).optional(),
+      description: z.string().max(5000).optional(),
+      display_name: z.string().max(50).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      jurisdiction: z.string().max(50).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      state: z.string().optional(),
+      state: z.string().max(2).optional(),
       tax_type: z
         .enum([
           "amusement_tax",
@@ -59142,11 +59650,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTerminalConfigurationsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     is_account_default: z.coerce.boolean().optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTerminalConfigurationsBodySchema = z.object({}).optional()
@@ -59159,7 +59667,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_terminal_configuration)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/terminal/configurations")),
         }),
       ],
     ],
@@ -59223,8 +59734,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           splashscreen: z.union([z.string(), z.enum([""])]).optional(),
         })
         .optional(),
-      expand: z.array(z.string()).optional(),
-      name: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      name: z.string().max(100).optional(),
       offline: z
         .union([z.object({ enabled: z.coerce.boolean() }), z.enum([""])])
         .optional(),
@@ -59388,7 +59899,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteTerminalConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const deleteTerminalConfigurationsConfigurationBodySchema = z
@@ -59450,11 +59961,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTerminalConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const getTerminalConfigurationsConfigurationQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTerminalConfigurationsConfigurationBodySchema = z
@@ -59530,7 +60041,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalConfigurationsConfigurationParamSchema = z.object({
-    configuration: z.string(),
+    configuration: z.string().max(5000),
   })
 
   const postTerminalConfigurationsConfigurationBodySchema = z
@@ -59543,8 +60054,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      expand: z.array(z.string()).optional(),
-      name: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      name: z.string().max(100).optional(),
       offline: z
         .union([z.object({ enabled: z.coerce.boolean() }), z.enum([""])])
         .optional(),
@@ -59730,8 +60241,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTerminalConnectionTokensBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
-      location: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      location: z.string().max(5000).optional(),
     })
     .optional()
 
@@ -59780,10 +60291,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTerminalLocationsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTerminalLocationsBodySchema = z.object({}).optional()
@@ -59796,7 +60307,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_terminal_location),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/terminal/locations")),
         }),
       ],
     ],
@@ -59855,16 +60369,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTerminalLocationsBodySchema = z.object({
     address: z.object({
-      city: z.string().optional(),
-      country: z.string(),
-      line1: z.string().optional(),
-      line2: z.string().optional(),
-      postal_code: z.string().optional(),
-      state: z.string().optional(),
+      city: z.string().max(5000).optional(),
+      country: z.string().max(5000),
+      line1: z.string().max(5000).optional(),
+      line2: z.string().max(5000).optional(),
+      postal_code: z.string().max(5000).optional(),
+      state: z.string().max(5000).optional(),
     }),
-    configuration_overrides: z.string().optional(),
-    display_name: z.string(),
-    expand: z.array(z.string()).optional(),
+    configuration_overrides: z.string().max(1000).optional(),
+    display_name: z.string().max(1000),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
   })
 
@@ -59915,7 +60429,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteTerminalLocationsLocationParamSchema = z.object({
-    location: z.string(),
+    location: z.string().max(5000),
   })
 
   const deleteTerminalLocationsLocationBodySchema = z.object({}).optional()
@@ -59969,11 +60483,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTerminalLocationsLocationParamSchema = z.object({
-    location: z.string(),
+    location: z.string().max(5000),
   })
 
   const getTerminalLocationsLocationQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTerminalLocationsLocationBodySchema = z.object({}).optional()
@@ -60036,24 +60550,26 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalLocationsLocationParamSchema = z.object({
-    location: z.string(),
+    location: z.string().max(5000),
   })
 
   const postTerminalLocationsLocationBodySchema = z
     .object({
       address: z
         .object({
-          city: z.string().optional(),
-          country: z.string().optional(),
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          line1: z.string().max(5000).optional(),
+          line2: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
         })
         .optional(),
-      configuration_overrides: z.union([z.string(), z.enum([""])]).optional(),
-      display_name: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      configuration_overrides: z
+        .union([z.string().max(1000), z.enum([""])])
+        .optional(),
+      display_name: z.string().max(1000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -60123,12 +60639,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "verifone_P400",
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    location: z.string().optional(),
-    serial_number: z.string().optional(),
-    starting_after: z.string().optional(),
+    location: z.string().max(5000).optional(),
+    serial_number: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["offline", "online"]).optional(),
   })
 
@@ -60142,7 +60658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_terminal_reader)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -60200,11 +60716,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalReadersBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    label: z.string().optional(),
-    location: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    label: z.string().max(5000).optional(),
+    location: z.string().max(5000).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-    registration_code: z.string(),
+    registration_code: z.string().max(5000),
   })
 
   const postTerminalReadersResponseValidator = responseValidationFactory(
@@ -60254,7 +60770,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteTerminalReadersReaderParamSchema = z.object({
-    reader: z.string(),
+    reader: z.string().max(5000),
   })
 
   const deleteTerminalReadersReaderBodySchema = z.object({}).optional()
@@ -60307,10 +60823,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTerminalReadersReaderParamSchema = z.object({ reader: z.string() })
+  const getTerminalReadersReaderParamSchema = z.object({
+    reader: z.string().max(5000),
+  })
 
   const getTerminalReadersReaderQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTerminalReadersReaderBodySchema = z.object({}).optional()
@@ -60376,12 +60894,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postTerminalReadersReaderParamSchema = z.object({ reader: z.string() })
+  const postTerminalReadersReaderParamSchema = z.object({
+    reader: z.string().max(5000),
+  })
 
   const postTerminalReadersReaderBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
-      label: z.union([z.string(), z.enum([""])]).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      label: z.union([z.string().max(5000), z.enum([""])]).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -60444,11 +60964,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalReadersReaderCancelActionParamSchema = z.object({
-    reader: z.string(),
+    reader: z.string().max(5000),
   })
 
   const postTerminalReadersReaderCancelActionBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTerminalReadersReaderCancelActionResponseValidator =
@@ -60503,12 +61023,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalReadersReaderProcessPaymentIntentParamSchema = z.object({
-    reader: z.string(),
+    reader: z.string().max(5000),
   })
 
   const postTerminalReadersReaderProcessPaymentIntentBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
-    payment_intent: z.string(),
+    expand: z.array(z.string().max(5000)).optional(),
+    payment_intent: z.string().max(5000),
     process_config: z
       .object({
         enable_customer_cancellation: z.coerce.boolean().optional(),
@@ -60572,16 +61092,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalReadersReaderProcessSetupIntentParamSchema = z.object({
-    reader: z.string(),
+    reader: z.string().max(5000),
   })
 
   const postTerminalReadersReaderProcessSetupIntentBodySchema = z.object({
     customer_consent_collected: z.coerce.boolean(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     process_config: z
       .object({ enable_customer_cancellation: z.coerce.boolean().optional() })
       .optional(),
-    setup_intent: z.string(),
+    setup_intent: z.string().max(5000),
   })
 
   const postTerminalReadersReaderProcessSetupIntentResponseValidator =
@@ -60636,16 +61156,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalReadersReaderRefundPaymentParamSchema = z.object({
-    reader: z.string(),
+    reader: z.string().max(5000),
   })
 
   const postTerminalReadersReaderRefundPaymentBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      charge: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      charge: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
-      payment_intent: z.string().optional(),
+      payment_intent: z.string().max(5000).optional(),
       refund_application_fee: z.coerce.boolean().optional(),
       refund_payment_config: z
         .object({ enable_customer_cancellation: z.coerce.boolean().optional() })
@@ -60706,7 +61226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTerminalReadersReaderSetReaderDisplayParamSchema = z.object({
-    reader: z.string(),
+    reader: z.string().max(5000),
   })
 
   const postTerminalReadersReaderSetReaderDisplayBodySchema = z.object({
@@ -60716,7 +61236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         line_items: z.array(
           z.object({
             amount: z.coerce.number(),
-            description: z.string(),
+            description: z.string().max(5000),
             quantity: z.coerce.number(),
           }),
         ),
@@ -60724,7 +61244,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         total: z.coerce.number(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     type: z.enum(["cart"]),
   })
 
@@ -60781,27 +61301,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTestHelpersConfirmationTokensBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
-      payment_method: z.string().optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      payment_method: z.string().max(5000).optional(),
       payment_method_data: z
         .object({
           acss_debit: z
             .object({
-              account_number: z.string(),
-              institution_number: z.string(),
-              transit_number: z.string(),
+              account_number: z.string().max(5000),
+              institution_number: z.string().max(5000),
+              transit_number: z.string().max(5000),
             })
             .optional(),
           affirm: z.object({}).optional(),
           afterpay_clearpay: z.object({}).optional(),
           alipay: z.object({}).optional(),
           au_becs_debit: z
-            .object({ account_number: z.string(), bsb_number: z.string() })
+            .object({
+              account_number: z.string().max(5000),
+              bsb_number: z.string().max(5000),
+            })
             .optional(),
           bacs_debit: z
             .object({
-              account_number: z.string().optional(),
-              sort_code: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
+              sort_code: z.string().max(5000).optional(),
             })
             .optional(),
           bancontact: z.object({}).optional(),
@@ -60810,23 +61333,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
               address: z
                 .union([
                   z.object({
-                    city: z.string().optional(),
-                    country: z.string().optional(),
-                    line1: z.string().optional(),
-                    line2: z.string().optional(),
-                    postal_code: z.string().optional(),
-                    state: z.string().optional(),
+                    city: z.string().max(5000).optional(),
+                    country: z.string().max(5000).optional(),
+                    line1: z.string().max(5000).optional(),
+                    line2: z.string().max(5000).optional(),
+                    postal_code: z.string().max(5000).optional(),
+                    state: z.string().max(5000).optional(),
                   }),
                   z.enum([""]),
                 ])
                 .optional(),
               email: z.union([z.string(), z.enum([""])]).optional(),
-              name: z.union([z.string(), z.enum([""])]).optional(),
-              phone: z.union([z.string(), z.enum([""])]).optional(),
+              name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+              phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string() }).optional(),
+          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
           cashapp: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
           eps: z
@@ -60975,10 +61498,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().optional() })
+            .object({ session: z.string().max(5000).optional() })
             .optional(),
           revolut_pay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string() }).optional(),
+          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
           sofort: z
             .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
             .optional(),
@@ -61021,10 +61544,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           us_bank_account: z
             .object({
               account_holder_type: z.enum(["company", "individual"]).optional(),
-              account_number: z.string().optional(),
+              account_number: z.string().max(5000).optional(),
               account_type: z.enum(["checking", "savings"]).optional(),
-              financial_connections_account: z.string().optional(),
-              routing_number: z.string().optional(),
+              financial_connections_account: z.string().max(5000).optional(),
+              routing_number: z.string().max(5000).optional(),
             })
             .optional(),
           wechat_pay: z.object({}).optional(),
@@ -61036,15 +61559,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
       shipping: z
         .object({
           address: z.object({
-            city: z.string().optional(),
-            country: z.string().optional(),
-            line1: z.string().optional(),
-            line2: z.string().optional(),
-            postal_code: z.string().optional(),
-            state: z.string().optional(),
+            city: z.string().max(5000).optional(),
+            country: z.string().max(5000).optional(),
+            line1: z.string().max(5000).optional(),
+            line2: z.string().max(5000).optional(),
+            postal_code: z.string().max(5000).optional(),
+            state: z.string().max(5000).optional(),
           }),
-          name: z.string(),
-          phone: z.union([z.string(), z.enum([""])]).optional(),
+          name: z.string().max(5000),
+          phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
         })
         .optional(),
     })
@@ -61098,14 +61621,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersCustomersCustomerFundCashBalanceParamSchema = z.object({
-    customer: z.string(),
+    customer: z.string().max(5000),
   })
 
   const postTestHelpersCustomersCustomerFundCashBalanceBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    expand: z.array(z.string()).optional(),
-    reference: z.string().optional(),
+    expand: z.array(z.string().max(5000)).optional(),
+    reference: z.string().max(5000).optional(),
   })
 
   const postTestHelpersCustomersCustomerFundCashBalanceResponseValidator =
@@ -61176,9 +61699,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     authorization_method: z
       .enum(["chip", "contactless", "keyed_in", "online", "swipe"])
       .optional(),
-    card: z.string(),
+    card: z.string().max(5000),
     currency: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     is_amount_controllable: z.coerce.boolean().optional(),
     merchant_data: z
       .object({
@@ -61480,18 +62003,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
             "wrecking_and_salvage_yards",
           ])
           .optional(),
-        city: z.string().optional(),
-        country: z.string().optional(),
-        name: z.string().optional(),
-        network_id: z.string().optional(),
-        postal_code: z.string().optional(),
-        state: z.string().optional(),
-        terminal_id: z.string().optional(),
-        url: z.string().optional(),
+        city: z.string().max(5000).optional(),
+        country: z.string().max(5000).optional(),
+        name: z.string().max(5000).optional(),
+        network_id: z.string().max(5000).optional(),
+        postal_code: z.string().max(5000).optional(),
+        state: z.string().max(5000).optional(),
+        terminal_id: z.string().max(5000).optional(),
+        url: z.string().max(5000).optional(),
       })
       .optional(),
     network_data: z
-      .object({ acquiring_institution_id: z.string().optional() })
+      .object({ acquiring_institution_id: z.string().max(5000).optional() })
       .optional(),
     verification_data: z
       .object({
@@ -61576,33 +62099,33 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureParamSchema =
-    z.object({ authorization: z.string() })
+    z.object({ authorization: z.string().max(5000) })
 
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureBodySchema = z
     .object({
       capture_amount: z.coerce.number().optional(),
       close_authorization: z.coerce.boolean().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       purchase_details: z
         .object({
           flight: z
             .object({
               departure_at: z.coerce.number().optional(),
-              passenger_name: z.string().optional(),
+              passenger_name: z.string().max(5000).optional(),
               refundable: z.coerce.boolean().optional(),
               segments: z
                 .array(
                   z.object({
-                    arrival_airport_code: z.string().optional(),
-                    carrier: z.string().optional(),
-                    departure_airport_code: z.string().optional(),
-                    flight_number: z.string().optional(),
-                    service_class: z.string().optional(),
+                    arrival_airport_code: z.string().max(3).optional(),
+                    carrier: z.string().max(5000).optional(),
+                    departure_airport_code: z.string().max(3).optional(),
+                    flight_number: z.string().max(5000).optional(),
+                    service_class: z.string().max(5000).optional(),
                     stopover_allowed: z.coerce.boolean().optional(),
                   }),
                 )
                 .optional(),
-              travel_agency: z.string().optional(),
+              travel_agency: z.string().max(5000).optional(),
             })
             .optional(),
           fuel: z
@@ -61630,14 +62153,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           receipt: z
             .array(
               z.object({
-                description: z.string().optional(),
+                description: z.string().max(26).optional(),
                 quantity: z.string().optional(),
                 total: z.coerce.number().optional(),
                 unit_cost: z.coerce.number().optional(),
               }),
             )
             .optional(),
-          reference: z.string().optional(),
+          reference: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -61700,10 +62223,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireParamSchema =
-    z.object({ authorization: z.string() })
+    z.object({ authorization: z.string().max(5000) })
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireResponseValidator =
@@ -61763,11 +62286,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementParamSchema =
-    z.object({ authorization: z.string() })
+    z.object({ authorization: z.string().max(5000) })
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementBodySchema =
     z.object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       increment_amount: z.coerce.number(),
       is_amount_controllable: z.coerce.boolean().optional(),
     })
@@ -61829,11 +62352,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationReverseParamSchema =
-    z.object({ authorization: z.string() })
+    z.object({ authorization: z.string().max(5000) })
 
   const postTestHelpersIssuingAuthorizationsAuthorizationReverseBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       reverse_amount: z.coerce.number().optional(),
     })
     .optional()
@@ -61895,11 +62418,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingCardsCardShippingDeliverParamSchema = z.object({
-    card: z.string(),
+    card: z.string().max(5000),
   })
 
   const postTestHelpersIssuingCardsCardShippingDeliverBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingDeliverResponseValidator =
@@ -61955,11 +62478,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingCardsCardShippingFailParamSchema = z.object({
-    card: z.string(),
+    card: z.string().max(5000),
   })
 
   const postTestHelpersIssuingCardsCardShippingFailBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingFailResponseValidator =
@@ -62014,11 +62537,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingCardsCardShippingReturnParamSchema = z.object({
-    card: z.string(),
+    card: z.string().max(5000),
   })
 
   const postTestHelpersIssuingCardsCardShippingReturnBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingReturnResponseValidator =
@@ -62073,11 +62596,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingCardsCardShippingShipParamSchema = z.object({
-    card: z.string(),
+    card: z.string().max(5000),
   })
 
   const postTestHelpersIssuingCardsCardShippingShipBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingShipResponseValidator =
@@ -62132,10 +62655,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateParamSchema =
-    z.object({ personalization_design: z.string() })
+    z.object({ personalization_design: z.string().max(5000) })
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateBodySchema =
-    z.object({ expand: z.array(z.string()).optional() }).optional()
+    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateResponseValidator =
     responseValidationFactory(
@@ -62197,10 +62720,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateParamSchema =
-    z.object({ personalization_design: z.string() })
+    z.object({ personalization_design: z.string().max(5000) })
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateBodySchema =
-    z.object({ expand: z.array(z.string()).optional() }).optional()
+    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateResponseValidator =
     responseValidationFactory(
@@ -62262,11 +62785,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectParamSchema =
-    z.object({ personalization_design: z.string() })
+    z.object({ personalization_design: z.string().max(5000) })
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectBodySchema =
     z.object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       rejection_reasons: z.object({
         card_logo: z
           .array(
@@ -62360,9 +62883,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTestHelpersIssuingTransactionsCreateForceCaptureBodySchema =
     z.object({
       amount: z.coerce.number(),
-      card: z.string(),
+      card: z.string().max(5000),
       currency: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       merchant_data: z
         .object({
           category: z
@@ -62663,14 +63186,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
               "wrecking_and_salvage_yards",
             ])
             .optional(),
-          city: z.string().optional(),
-          country: z.string().optional(),
-          name: z.string().optional(),
-          network_id: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          terminal_id: z.string().optional(),
-          url: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          name: z.string().max(5000).optional(),
+          network_id: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          terminal_id: z.string().max(5000).optional(),
+          url: z.string().max(5000).optional(),
         })
         .optional(),
       purchase_details: z
@@ -62678,21 +63201,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
           flight: z
             .object({
               departure_at: z.coerce.number().optional(),
-              passenger_name: z.string().optional(),
+              passenger_name: z.string().max(5000).optional(),
               refundable: z.coerce.boolean().optional(),
               segments: z
                 .array(
                   z.object({
-                    arrival_airport_code: z.string().optional(),
-                    carrier: z.string().optional(),
-                    departure_airport_code: z.string().optional(),
-                    flight_number: z.string().optional(),
-                    service_class: z.string().optional(),
+                    arrival_airport_code: z.string().max(3).optional(),
+                    carrier: z.string().max(5000).optional(),
+                    departure_airport_code: z.string().max(3).optional(),
+                    flight_number: z.string().max(5000).optional(),
+                    service_class: z.string().max(5000).optional(),
                     stopover_allowed: z.coerce.boolean().optional(),
                   }),
                 )
                 .optional(),
-              travel_agency: z.string().optional(),
+              travel_agency: z.string().max(5000).optional(),
             })
             .optional(),
           fuel: z
@@ -62720,14 +63243,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           receipt: z
             .array(
               z.object({
-                description: z.string().optional(),
+                description: z.string().max(26).optional(),
                 quantity: z.string().optional(),
                 total: z.coerce.number().optional(),
                 unit_cost: z.coerce.number().optional(),
               }),
             )
             .optional(),
-          reference: z.string().optional(),
+          reference: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -62787,9 +63310,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTestHelpersIssuingTransactionsCreateUnlinkedRefundBodySchema =
     z.object({
       amount: z.coerce.number(),
-      card: z.string(),
+      card: z.string().max(5000),
       currency: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       merchant_data: z
         .object({
           category: z
@@ -63090,14 +63613,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
               "wrecking_and_salvage_yards",
             ])
             .optional(),
-          city: z.string().optional(),
-          country: z.string().optional(),
-          name: z.string().optional(),
-          network_id: z.string().optional(),
-          postal_code: z.string().optional(),
-          state: z.string().optional(),
-          terminal_id: z.string().optional(),
-          url: z.string().optional(),
+          city: z.string().max(5000).optional(),
+          country: z.string().max(5000).optional(),
+          name: z.string().max(5000).optional(),
+          network_id: z.string().max(5000).optional(),
+          postal_code: z.string().max(5000).optional(),
+          state: z.string().max(5000).optional(),
+          terminal_id: z.string().max(5000).optional(),
+          url: z.string().max(5000).optional(),
         })
         .optional(),
       purchase_details: z
@@ -63105,21 +63628,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
           flight: z
             .object({
               departure_at: z.coerce.number().optional(),
-              passenger_name: z.string().optional(),
+              passenger_name: z.string().max(5000).optional(),
               refundable: z.coerce.boolean().optional(),
               segments: z
                 .array(
                   z.object({
-                    arrival_airport_code: z.string().optional(),
-                    carrier: z.string().optional(),
-                    departure_airport_code: z.string().optional(),
-                    flight_number: z.string().optional(),
-                    service_class: z.string().optional(),
+                    arrival_airport_code: z.string().max(3).optional(),
+                    carrier: z.string().max(5000).optional(),
+                    departure_airport_code: z.string().max(3).optional(),
+                    flight_number: z.string().max(5000).optional(),
+                    service_class: z.string().max(5000).optional(),
                     stopover_allowed: z.coerce.boolean().optional(),
                   }),
                 )
                 .optional(),
-              travel_agency: z.string().optional(),
+              travel_agency: z.string().max(5000).optional(),
             })
             .optional(),
           fuel: z
@@ -63147,14 +63670,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           receipt: z
             .array(
               z.object({
-                description: z.string().optional(),
+                description: z.string().max(26).optional(),
                 quantity: z.string().optional(),
                 total: z.coerce.number().optional(),
                 unit_cost: z.coerce.number().optional(),
               }),
             )
             .optional(),
-          reference: z.string().optional(),
+          reference: z.string().max(5000).optional(),
         })
         .optional(),
     })
@@ -63212,11 +63735,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingTransactionsTransactionRefundParamSchema =
-    z.object({ transaction: z.string() })
+    z.object({ transaction: z.string().max(5000) })
 
   const postTestHelpersIssuingTransactionsTransactionRefundBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       refund_amount: z.coerce.number().optional(),
     })
     .optional()
@@ -63282,7 +63805,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersRefundsRefundExpireBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersRefundsRefundExpireResponseValidator =
@@ -63337,14 +63860,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTerminalReadersReaderPresentPaymentMethodParamSchema =
-    z.object({ reader: z.string() })
+    z.object({ reader: z.string().max(5000) })
 
   const postTestHelpersTerminalReadersReaderPresentPaymentMethodBodySchema = z
     .object({
       amount_tip: z.coerce.number().optional(),
-      card_present: z.object({ number: z.string().optional() }).optional(),
-      expand: z.array(z.string()).optional(),
-      interac_present: z.object({ number: z.string().optional() }).optional(),
+      card_present: z
+        .object({ number: z.string().max(5000).optional() })
+        .optional(),
+      expand: z.array(z.string().max(5000)).optional(),
+      interac_present: z
+        .object({ number: z.string().max(5000).optional() })
+        .optional(),
       type: z.enum(["card_present", "interac_present"]).optional(),
     })
     .optional()
@@ -63406,10 +63933,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTestHelpersTestClocksQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTestHelpersTestClocksBodySchema = z.object({}).optional()
@@ -63422,7 +63949,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_test_helpers_test_clock),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z
+            .string()
+            .max(5000)
+            .regex(new RegExp("^/v1/test_helpers/test_clocks")),
         }),
       ],
     ],
@@ -63480,9 +64010,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTestClocksBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     frozen_time: z.coerce.number(),
-    name: z.string().optional(),
+    name: z.string().max(300).optional(),
   })
 
   const postTestHelpersTestClocksResponseValidator = responseValidationFactory(
@@ -63532,7 +64062,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteTestHelpersTestClocksTestClockParamSchema = z.object({
-    test_clock: z.string(),
+    test_clock: z.string().max(5000),
   })
 
   const deleteTestHelpersTestClocksTestClockBodySchema = z.object({}).optional()
@@ -63592,11 +64122,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTestHelpersTestClocksTestClockParamSchema = z.object({
-    test_clock: z.string(),
+    test_clock: z.string().max(5000),
   })
 
   const getTestHelpersTestClocksTestClockQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTestHelpersTestClocksTestClockBodySchema = z.object({}).optional()
@@ -63657,11 +64187,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTestClocksTestClockAdvanceParamSchema = z.object({
-    test_clock: z.string(),
+    test_clock: z.string().max(5000),
   })
 
   const postTestHelpersTestClocksTestClockAdvanceBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     frozen_time: z.coerce.number(),
   })
 
@@ -63717,12 +64247,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryInboundTransfersIdFailParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTestHelpersTreasuryInboundTransfersIdFailBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       failure_details: z
         .object({
           code: z
@@ -63799,11 +64329,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryInboundTransfersIdReturnParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTestHelpersTreasuryInboundTransfersIdReturnBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersTreasuryInboundTransfersIdReturnResponseValidator =
@@ -63859,11 +64389,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedResponseValidator =
@@ -63919,11 +64449,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailResponseValidator =
@@ -63978,11 +64508,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostResponseValidator =
@@ -64037,12 +64567,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundPaymentsIdReturnParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdReturnBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       returned_details: z
         .object({
           code: z
@@ -64117,10 +64647,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailParamSchema =
-    z.object({ outbound_transfer: z.string() })
+    z.object({ outbound_transfer: z.string().max(5000) })
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailBodySchema =
-    z.object({ expand: z.array(z.string()).optional() }).optional()
+    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailResponseValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
@@ -64179,10 +64709,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostParamSchema =
-    z.object({ outbound_transfer: z.string() })
+    z.object({ outbound_transfer: z.string().max(5000) })
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostBodySchema =
-    z.object({ expand: z.array(z.string()).optional() }).optional()
+    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostResponseValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
@@ -64241,12 +64771,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnParamSchema =
-    z.object({ outbound_transfer: z.string() })
+    z.object({ outbound_transfer: z.string().max(5000) })
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnBodySchema =
     z
       .object({
-        expand: z.array(z.string()).optional(),
+        expand: z.array(z.string().max(5000)).optional(),
         returned_details: z
           .object({
             code: z
@@ -64327,17 +64857,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTestHelpersTreasuryReceivedCreditsBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    description: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     initiating_payment_method_details: z
       .object({
         type: z.enum(["us_bank_account"]),
         us_bank_account: z
           .object({
-            account_holder_name: z.string().optional(),
-            account_number: z.string().optional(),
-            routing_number: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
+            account_number: z.string().max(5000).optional(),
+            routing_number: z.string().max(5000).optional(),
           })
           .optional(),
       })
@@ -64395,17 +64925,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTestHelpersTreasuryReceivedDebitsBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    description: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     initiating_payment_method_details: z
       .object({
         type: z.enum(["us_bank_account"]),
         us_bank_account: z
           .object({
-            account_holder_name: z.string().optional(),
-            account_number: z.string().optional(),
-            routing_number: z.string().optional(),
+            account_holder_name: z.string().max(5000).optional(),
+            account_number: z.string().max(5000).optional(),
+            routing_number: z.string().max(5000).optional(),
           })
           .optional(),
       })
@@ -64471,56 +65001,56 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               address: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
+                  city: z.string().max(100).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(200).optional(),
+                  line2: z.string().max(200).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
                 })
                 .optional(),
               address_kana: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
-                  town: z.string().optional(),
+                  city: z.string().max(5000).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(5000).optional(),
+                  line2: z.string().max(5000).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
+                  town: z.string().max(5000).optional(),
                 })
                 .optional(),
               address_kanji: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
-                  town: z.string().optional(),
+                  city: z.string().max(5000).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(5000).optional(),
+                  line2: z.string().max(5000).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
+                  town: z.string().max(5000).optional(),
                 })
                 .optional(),
               directors_provided: z.coerce.boolean().optional(),
               executives_provided: z.coerce.boolean().optional(),
-              export_license_id: z.string().optional(),
-              export_purpose_code: z.string().optional(),
-              name: z.string().optional(),
-              name_kana: z.string().optional(),
-              name_kanji: z.string().optional(),
+              export_license_id: z.string().max(5000).optional(),
+              export_purpose_code: z.string().max(5000).optional(),
+              name: z.string().max(100).optional(),
+              name_kana: z.string().max(100).optional(),
+              name_kanji: z.string().max(100).optional(),
               owners_provided: z.coerce.boolean().optional(),
               ownership_declaration: z
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.string().optional(),
+                  user_agent: z.string().max(5000).optional(),
                 })
                 .optional(),
               ownership_declaration_shown_and_signed: z.coerce
                 .boolean()
                 .optional(),
-              phone: z.string().optional(),
-              registration_number: z.string().optional(),
+              phone: z.string().max(5000).optional(),
+              registration_number: z.string().max(5000).optional(),
               structure: z
                 .enum([
                   "",
@@ -64549,15 +65079,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   "unincorporated_partnership",
                 ])
                 .optional(),
-              tax_id: z.string().optional(),
-              tax_id_registrar: z.string().optional(),
-              vat_id: z.string().optional(),
+              tax_id: z.string().max(5000).optional(),
+              tax_id_registrar: z.string().max(5000).optional(),
+              vat_id: z.string().max(5000).optional(),
               verification: z
                 .object({
                   document: z
                     .object({
-                      back: z.string().optional(),
-                      front: z.string().optional(),
+                      back: z.string().max(500).optional(),
+                      front: z.string().max(500).optional(),
                     })
                     .optional(),
                 })
@@ -64568,34 +65098,34 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               address: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
+                  city: z.string().max(100).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(200).optional(),
+                  line2: z.string().max(200).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
                 })
                 .optional(),
               address_kana: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
-                  town: z.string().optional(),
+                  city: z.string().max(5000).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(5000).optional(),
+                  line2: z.string().max(5000).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
+                  town: z.string().max(5000).optional(),
                 })
                 .optional(),
               address_kanji: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
-                  town: z.string().optional(),
+                  city: z.string().max(5000).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(5000).optional(),
+                  line2: z.string().max(5000).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
+                  town: z.string().max(5000).optional(),
                 })
                 .optional(),
               dob: z
@@ -64609,19 +65139,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 ])
                 .optional(),
               email: z.string().optional(),
-              first_name: z.string().optional(),
-              first_name_kana: z.string().optional(),
-              first_name_kanji: z.string().optional(),
+              first_name: z.string().max(100).optional(),
+              first_name_kana: z.string().max(5000).optional(),
+              first_name_kanji: z.string().max(5000).optional(),
               full_name_aliases: z
-                .union([z.array(z.string()), z.enum([""])])
+                .union([z.array(z.string().max(300)), z.enum([""])])
                 .optional(),
               gender: z.string().optional(),
-              id_number: z.string().optional(),
-              id_number_secondary: z.string().optional(),
-              last_name: z.string().optional(),
-              last_name_kana: z.string().optional(),
-              last_name_kanji: z.string().optional(),
-              maiden_name: z.string().optional(),
+              id_number: z.string().max(5000).optional(),
+              id_number_secondary: z.string().max(5000).optional(),
+              last_name: z.string().max(100).optional(),
+              last_name_kana: z.string().max(5000).optional(),
+              last_name_kanji: z.string().max(5000).optional(),
+              maiden_name: z.string().max(5000).optional(),
               metadata: z
                 .union([z.record(z.string()), z.enum([""])])
                 .optional(),
@@ -64629,12 +65159,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
               political_exposure: z.enum(["existing", "none"]).optional(),
               registered_address: z
                 .object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
+                  city: z.string().max(100).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(200).optional(),
+                  line2: z.string().max(200).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
                 })
                 .optional(),
               relationship: z
@@ -64645,22 +65175,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   percent_ownership: z
                     .union([z.coerce.number(), z.enum([""])])
                     .optional(),
-                  title: z.string().optional(),
+                  title: z.string().max(5000).optional(),
                 })
                 .optional(),
-              ssn_last_4: z.string().optional(),
+              ssn_last_4: z.string().max(5000).optional(),
               verification: z
                 .object({
                   additional_document: z
                     .object({
-                      back: z.string().optional(),
-                      front: z.string().optional(),
+                      back: z.string().max(500).optional(),
+                      front: z.string().max(500).optional(),
                     })
                     .optional(),
                   document: z
                     .object({
-                      back: z.string().optional(),
-                      front: z.string().optional(),
+                      back: z.string().max(500).optional(),
+                      front: z.string().max(500).optional(),
                     })
                     .optional(),
                 })
@@ -64672,32 +65202,32 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       bank_account: z
         .object({
-          account_holder_name: z.string().optional(),
+          account_holder_name: z.string().max(5000).optional(),
           account_holder_type: z.enum(["company", "individual"]).optional(),
-          account_number: z.string(),
+          account_number: z.string().max(5000),
           account_type: z
             .enum(["checking", "futsu", "savings", "toza"])
             .optional(),
-          country: z.string(),
+          country: z.string().max(5000),
           currency: z.string().optional(),
-          payment_method: z.string().optional(),
-          routing_number: z.string().optional(),
+          payment_method: z.string().max(5000).optional(),
+          routing_number: z.string().max(5000).optional(),
         })
         .optional(),
       card: z
         .union([
           z.object({
-            address_city: z.string().optional(),
-            address_country: z.string().optional(),
-            address_line1: z.string().optional(),
-            address_line2: z.string().optional(),
-            address_state: z.string().optional(),
-            address_zip: z.string().optional(),
-            currency: z.string().optional(),
-            cvc: z.string().optional(),
-            exp_month: z.string(),
-            exp_year: z.string(),
-            name: z.string().optional(),
+            address_city: z.string().max(5000).optional(),
+            address_country: z.string().max(5000).optional(),
+            address_line1: z.string().max(5000).optional(),
+            address_line2: z.string().max(5000).optional(),
+            address_state: z.string().max(5000).optional(),
+            address_zip: z.string().max(5000).optional(),
+            currency: z.string().max(5000).optional(),
+            cvc: z.string().max(5000).optional(),
+            exp_month: z.string().max(5000),
+            exp_year: z.string().max(5000),
+            name: z.string().max(5000).optional(),
             networks: z
               .object({
                 preferred: z
@@ -64705,14 +65235,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .optional(),
               })
               .optional(),
-            number: z.string(),
+            number: z.string().max(5000),
           }),
-          z.string(),
+          z.string().max(5000),
         ])
         .optional(),
-      customer: z.string().optional(),
-      cvc_update: z.object({ cvc: z.string() }).optional(),
-      expand: z.array(z.string()).optional(),
+      customer: z.string().max(5000).optional(),
+      cvc_update: z.object({ cvc: z.string().max(5000) }).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       person: z
         .object({
           additional_tos_acceptances: z
@@ -64721,41 +65251,43 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .object({
                   date: z.coerce.number().optional(),
                   ip: z.string().optional(),
-                  user_agent: z.union([z.string(), z.enum([""])]).optional(),
+                  user_agent: z
+                    .union([z.string().max(5000), z.enum([""])])
+                    .optional(),
                 })
                 .optional(),
             })
             .optional(),
           address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           address_kana: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           address_kanji: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
-              town: z.string().optional(),
+              city: z.string().max(5000).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(5000).optional(),
+              line2: z.string().max(5000).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
+              town: z.string().max(5000).optional(),
             })
             .optional(),
           dob: z
@@ -64773,52 +65305,52 @@ export function createRouter(implementation: Implementation): KoaRouter {
               company_authorization: z
                 .object({
                   files: z
-                    .array(z.union([z.string(), z.enum([""])]))
+                    .array(z.union([z.string().max(500), z.enum([""])]))
                     .optional(),
                 })
                 .optional(),
               passport: z
                 .object({
                   files: z
-                    .array(z.union([z.string(), z.enum([""])]))
+                    .array(z.union([z.string().max(500), z.enum([""])]))
                     .optional(),
                 })
                 .optional(),
               visa: z
                 .object({
                   files: z
-                    .array(z.union([z.string(), z.enum([""])]))
+                    .array(z.union([z.string().max(500), z.enum([""])]))
                     .optional(),
                 })
                 .optional(),
             })
             .optional(),
           email: z.string().optional(),
-          first_name: z.string().optional(),
-          first_name_kana: z.string().optional(),
-          first_name_kanji: z.string().optional(),
+          first_name: z.string().max(5000).optional(),
+          first_name_kana: z.string().max(5000).optional(),
+          first_name_kanji: z.string().max(5000).optional(),
           full_name_aliases: z
-            .union([z.array(z.string()), z.enum([""])])
+            .union([z.array(z.string().max(5000)), z.enum([""])])
             .optional(),
           gender: z.string().optional(),
-          id_number: z.string().optional(),
-          id_number_secondary: z.string().optional(),
-          last_name: z.string().optional(),
-          last_name_kana: z.string().optional(),
-          last_name_kanji: z.string().optional(),
-          maiden_name: z.string().optional(),
+          id_number: z.string().max(5000).optional(),
+          id_number_secondary: z.string().max(5000).optional(),
+          last_name: z.string().max(5000).optional(),
+          last_name_kana: z.string().max(5000).optional(),
+          last_name_kanji: z.string().max(5000).optional(),
+          maiden_name: z.string().max(5000).optional(),
           metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-          nationality: z.string().optional(),
+          nationality: z.string().max(5000).optional(),
           phone: z.string().optional(),
-          political_exposure: z.string().optional(),
+          political_exposure: z.string().max(5000).optional(),
           registered_address: z
             .object({
-              city: z.string().optional(),
-              country: z.string().optional(),
-              line1: z.string().optional(),
-              line2: z.string().optional(),
-              postal_code: z.string().optional(),
-              state: z.string().optional(),
+              city: z.string().max(100).optional(),
+              country: z.string().max(5000).optional(),
+              line1: z.string().max(200).optional(),
+              line2: z.string().max(200).optional(),
+              postal_code: z.string().max(5000).optional(),
+              state: z.string().max(5000).optional(),
             })
             .optional(),
           relationship: z
@@ -64831,7 +65363,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
               representative: z.coerce.boolean().optional(),
-              title: z.string().optional(),
+              title: z.string().max(5000).optional(),
             })
             .optional(),
           ssn_last_4: z.string().optional(),
@@ -64839,21 +65371,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               additional_document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
               document: z
                 .object({
-                  back: z.string().optional(),
-                  front: z.string().optional(),
+                  back: z.string().max(500).optional(),
+                  front: z.string().max(500).optional(),
                 })
                 .optional(),
             })
             .optional(),
         })
         .optional(),
-      pii: z.object({ id_number: z.string().optional() }).optional(),
+      pii: z.object({ id_number: z.string().max(5000).optional() }).optional(),
     })
     .optional()
 
@@ -64899,10 +65431,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTokensTokenParamSchema = z.object({ token: z.string() })
+  const getTokensTokenParamSchema = z.object({ token: z.string().max(5000) })
 
   const getTokensTokenQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTokensTokenBodySchema = z.object({}).optional()
@@ -64980,10 +65512,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["canceled", "failed", "pending", "succeeded"]).optional(),
   })
 
@@ -64997,7 +65529,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_topup)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/topups")),
         }),
       ],
     ],
@@ -65053,11 +65585,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTopupsBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    description: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-    source: z.string().optional(),
-    statement_descriptor: z.string().optional(),
+    source: z.string().max(5000).optional(),
+    statement_descriptor: z.string().max(15).optional(),
     transfer_group: z.string().optional(),
   })
 
@@ -65103,10 +65635,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTopupsTopupParamSchema = z.object({ topup: z.string() })
+  const getTopupsTopupParamSchema = z.object({ topup: z.string().max(5000) })
 
   const getTopupsTopupQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTopupsTopupBodySchema = z.object({}).optional()
@@ -65161,12 +65693,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postTopupsTopupParamSchema = z.object({ topup: z.string() })
+  const postTopupsTopupParamSchema = z.object({ topup: z.string().max(5000) })
 
   const postTopupsTopupBodySchema = z
     .object({
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      description: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -65217,10 +65749,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postTopupsTopupCancelParamSchema = z.object({ topup: z.string() })
+  const postTopupsTopupCancelParamSchema = z.object({
+    topup: z.string().max(5000),
+  })
 
   const postTopupsTopupCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTopupsTopupCancelResponseValidator = responseValidationFactory(
@@ -65285,12 +65819,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    destination: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    destination: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
-    transfer_group: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
+    transfer_group: z.string().max(5000).optional(),
   })
 
   const getTransfersBodySchema = z.object({}).optional()
@@ -65303,7 +65837,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_transfer)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/transfers")),
         }),
       ],
     ],
@@ -65359,9 +65893,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTransfersBodySchema = z.object({
     amount: z.coerce.number().optional(),
     currency: z.string(),
-    description: z.string().optional(),
+    description: z.string().max(5000).optional(),
     destination: z.string(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
     source_transaction: z.string().optional(),
     source_type: z.enum(["bank_account", "card", "fpx"]).optional(),
@@ -65410,13 +65944,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTransfersIdReversalsParamSchema = z.object({ id: z.string() })
+  const getTransfersIdReversalsParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTransfersIdReversalsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTransfersIdReversalsBodySchema = z.object({}).optional()
@@ -65429,7 +65965,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_transfer_reversal)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -65490,13 +66026,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postTransfersIdReversalsParamSchema = z.object({ id: z.string() })
+  const postTransfersIdReversalsParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const postTransfersIdReversalsBodySchema = z
     .object({
       amount: z.coerce.number().optional(),
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      description: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       refund_application_fee: z.coerce.boolean().optional(),
     })
@@ -65552,10 +66090,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTransfersTransferParamSchema = z.object({ transfer: z.string() })
+  const getTransfersTransferParamSchema = z.object({
+    transfer: z.string().max(5000),
+  })
 
   const getTransfersTransferQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTransfersTransferBodySchema = z.object({}).optional()
@@ -65614,12 +66154,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postTransfersTransferParamSchema = z.object({ transfer: z.string() })
+  const postTransfersTransferParamSchema = z.object({
+    transfer: z.string().max(5000),
+  })
 
   const postTransfersTransferBodySchema = z
     .object({
-      description: z.string().optional(),
-      expand: z.array(z.string()).optional(),
+      description: z.string().max(5000).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -65675,12 +66217,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTransfersTransferReversalsIdParamSchema = z.object({
-    id: z.string(),
-    transfer: z.string(),
+    id: z.string().max(5000),
+    transfer: z.string().max(5000),
   })
 
   const getTransfersTransferReversalsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTransfersTransferReversalsIdBodySchema = z.object({}).optional()
@@ -65738,13 +66280,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTransfersTransferReversalsIdParamSchema = z.object({
-    id: z.string(),
-    transfer: z.string(),
+    id: z.string().max(5000),
+    transfer: z.string().max(5000),
   })
 
   const postTransfersTransferReversalsIdBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -65798,12 +66340,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryCreditReversalsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
-    received_credit: z.string().optional(),
-    starting_after: z.string().optional(),
+    received_credit: z.string().max(5000).optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["canceled", "posted", "processing"]).optional(),
   })
 
@@ -65817,7 +66359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_treasury_credit_reversal)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -65875,9 +66417,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryCreditReversalsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
-    received_credit: z.string(),
+    received_credit: z.string().max(5000),
   })
 
   const postTreasuryCreditReversalsResponseValidator =
@@ -65925,11 +66467,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryCreditReversalsCreditReversalParamSchema = z.object({
-    credit_reversal: z.string(),
+    credit_reversal: z.string().max(5000),
   })
 
   const getTreasuryCreditReversalsCreditReversalQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryCreditReversalsCreditReversalBodySchema = z
@@ -65992,13 +66534,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryDebitReversalsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
-    received_debit: z.string().optional(),
+    received_debit: z.string().max(5000).optional(),
     resolution: z.enum(["lost", "won"]).optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["canceled", "completed", "processing"]).optional(),
   })
 
@@ -66012,7 +66554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_treasury_debit_reversal)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -66070,9 +66612,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryDebitReversalsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
-    received_debit: z.string(),
+    received_debit: z.string().max(5000),
   })
 
   const postTreasuryDebitReversalsResponseValidator = responseValidationFactory(
@@ -66122,11 +66664,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryDebitReversalsDebitReversalParamSchema = z.object({
-    debit_reversal: z.string(),
+    debit_reversal: z.string().max(5000),
   })
 
   const getTreasuryDebitReversalsDebitReversalQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryDebitReversalsDebitReversalBodySchema = z
@@ -66200,10 +66742,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getTreasuryFinancialAccountsBodySchema = z.object({}).optional()
@@ -66217,7 +66759,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(s_treasury_financial_account),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/treasury/financial_accounts")),
           }),
         ],
       ],
@@ -66275,7 +66820,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryFinancialAccountsBodySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     features: z
       .object({
         card_issuing: z.object({ requested: z.coerce.boolean() }).optional(),
@@ -66320,7 +66865,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         outbound_flows: z.enum(["restricted", "unrestricted"]).optional(),
       })
       .optional(),
-    supported_currencies: z.array(z.string()),
+    supported_currencies: z.array(z.string().max(5000)),
   })
 
   const postTreasuryFinancialAccountsResponseValidator =
@@ -66368,11 +66913,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryFinancialAccountsFinancialAccountParamSchema = z.object({
-    financial_account: z.string(),
+    financial_account: z.string().max(5000),
   })
 
   const getTreasuryFinancialAccountsFinancialAccountQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryFinancialAccountsFinancialAccountBodySchema = z
@@ -66435,12 +66980,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryFinancialAccountsFinancialAccountParamSchema = z.object({
-    financial_account: z.string(),
+    financial_account: z.string().max(5000),
   })
 
   const postTreasuryFinancialAccountsFinancialAccountBodySchema = z
     .object({
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       features: z
         .object({
           card_issuing: z.object({ requested: z.coerce.boolean() }).optional(),
@@ -66540,10 +67085,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
-    z.object({ financial_account: z.string() })
+    z.object({ financial_account: z.string().max(5000) })
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema =
-    z.object({ expand: z.array(z.string()).optional() })
+    z.object({ expand: z.array(z.string().max(5000)).optional() })
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema = z
     .object({})
@@ -66615,13 +67160,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
-    z.object({ financial_account: z.string() })
+    z.object({ financial_account: z.string().max(5000) })
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema = z
     .object({
       card_issuing: z.object({ requested: z.coerce.boolean() }).optional(),
       deposit_insurance: z.object({ requested: z.coerce.boolean() }).optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       financial_addresses: z
         .object({ aba: z.object({ requested: z.coerce.boolean() }).optional() })
         .optional(),
@@ -66712,11 +67257,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryInboundTransfersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum(["canceled", "failed", "processing", "succeeded"])
       .optional(),
@@ -66733,7 +67278,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_treasury_inbound_transfer)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -66793,12 +67338,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTreasuryInboundTransfersBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    description: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     metadata: z.record(z.string()).optional(),
-    origin_payment_method: z.string(),
-    statement_descriptor: z.string().optional(),
+    origin_payment_method: z.string().max(5000),
+    statement_descriptor: z.string().max(10).optional(),
   })
 
   const postTreasuryInboundTransfersResponseValidator =
@@ -66845,10 +67390,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTreasuryInboundTransfersIdParamSchema = z.object({ id: z.string() })
+  const getTreasuryInboundTransfersIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTreasuryInboundTransfersIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryInboundTransfersIdBodySchema = z.object({}).optional()
@@ -66906,11 +67453,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryInboundTransfersInboundTransferCancelParamSchema = z.object(
-    { inbound_transfer: z.string() },
+    { inbound_transfer: z.string().max(5000) },
   )
 
   const postTreasuryInboundTransfersInboundTransferCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTreasuryInboundTransfersInboundTransferCancelResponseValidator =
@@ -66981,12 +67528,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    customer: z.string().optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    customer: z.string().max(5000).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum(["canceled", "failed", "posted", "processing", "returned"])
       .optional(),
@@ -67003,7 +67550,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_treasury_outbound_payment)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/treasury/outbound_payments")),
           }),
         ],
       ],
@@ -67063,9 +67613,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTreasuryOutboundPaymentsBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    customer: z.string().optional(),
-    description: z.string().optional(),
-    destination_payment_method: z.string().optional(),
+    customer: z.string().max(5000).optional(),
+    description: z.string().max(5000).optional(),
+    destination_payment_method: z.string().max(5000).optional(),
     destination_payment_method_data: z
       .object({
         billing_details: z
@@ -67073,19 +67623,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
             address: z
               .union([
                 z.object({
-                  city: z.string().optional(),
-                  country: z.string().optional(),
-                  line1: z.string().optional(),
-                  line2: z.string().optional(),
-                  postal_code: z.string().optional(),
-                  state: z.string().optional(),
+                  city: z.string().max(5000).optional(),
+                  country: z.string().max(5000).optional(),
+                  line1: z.string().max(5000).optional(),
+                  line2: z.string().max(5000).optional(),
+                  postal_code: z.string().max(5000).optional(),
+                  state: z.string().max(5000).optional(),
                 }),
                 z.enum([""]),
               ])
               .optional(),
             email: z.union([z.string(), z.enum([""])]).optional(),
-            name: z.union([z.string(), z.enum([""])]).optional(),
-            phone: z.union([z.string(), z.enum([""])]).optional(),
+            name: z.union([z.string().max(5000), z.enum([""])]).optional(),
+            phone: z.union([z.string().max(5000), z.enum([""])]).optional(),
           })
           .optional(),
         financial_account: z.string().optional(),
@@ -67094,10 +67644,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         us_bank_account: z
           .object({
             account_holder_type: z.enum(["company", "individual"]).optional(),
-            account_number: z.string().optional(),
+            account_number: z.string().max(5000).optional(),
             account_type: z.enum(["checking", "savings"]).optional(),
-            financial_connections_account: z.string().optional(),
-            routing_number: z.string().optional(),
+            financial_connections_account: z.string().max(5000).optional(),
+            routing_number: z.string().max(5000).optional(),
           })
           .optional(),
       })
@@ -67120,10 +67670,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         present: z.coerce.boolean(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     metadata: z.record(z.string()).optional(),
-    statement_descriptor: z.string().optional(),
+    statement_descriptor: z.string().max(5000).optional(),
   })
 
   const postTreasuryOutboundPaymentsResponseValidator =
@@ -67170,10 +67720,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTreasuryOutboundPaymentsIdParamSchema = z.object({ id: z.string() })
+  const getTreasuryOutboundPaymentsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTreasuryOutboundPaymentsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryOutboundPaymentsIdBodySchema = z.object({}).optional()
@@ -67231,11 +67783,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryOutboundPaymentsIdCancelParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const postTreasuryOutboundPaymentsIdCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTreasuryOutboundPaymentsIdCancelResponseValidator =
@@ -67290,11 +67842,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryOutboundTransfersQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z
       .enum(["canceled", "failed", "posted", "processing", "returned"])
       .optional(),
@@ -67311,7 +67863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_treasury_outbound_transfer)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z.string().max(5000),
           }),
         ],
       ],
@@ -67371,8 +67923,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTreasuryOutboundTransfersBodySchema = z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    description: z.string().optional(),
-    destination_payment_method: z.string().optional(),
+    description: z.string().max(5000).optional(),
+    destination_payment_method: z.string().max(5000).optional(),
     destination_payment_method_options: z
       .object({
         us_bank_account: z
@@ -67385,10 +67937,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     metadata: z.record(z.string()).optional(),
-    statement_descriptor: z.string().optional(),
+    statement_descriptor: z.string().max(5000).optional(),
   })
 
   const postTreasuryOutboundTransfersResponseValidator =
@@ -67436,11 +67988,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryOutboundTransfersOutboundTransferParamSchema = z.object({
-    outbound_transfer: z.string(),
+    outbound_transfer: z.string().max(5000),
   })
 
   const getTreasuryOutboundTransfersOutboundTransferQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryOutboundTransfersOutboundTransferBodySchema = z
@@ -67503,10 +68055,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryOutboundTransfersOutboundTransferCancelParamSchema =
-    z.object({ outbound_transfer: z.string() })
+    z.object({ outbound_transfer: z.string().max(5000) })
 
   const postTreasuryOutboundTransfersOutboundTransferCancelBodySchema = z
-    .object({ expand: z.array(z.string()).optional() })
+    .object({ expand: z.array(z.string().max(5000)).optional() })
     .optional()
 
   const postTreasuryOutboundTransfersOutboundTransferCancelResponseValidator =
@@ -67566,8 +68118,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryReceivedCreditsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
     linked_flows: z
@@ -67580,7 +68132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ]),
       })
       .optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["failed", "succeeded"]).optional(),
   })
 
@@ -67594,7 +68146,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_treasury_received_credit)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -67651,10 +68203,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTreasuryReceivedCreditsIdParamSchema = z.object({ id: z.string() })
+  const getTreasuryReceivedCreditsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTreasuryReceivedCreditsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryReceivedCreditsIdBodySchema = z.object({}).optional()
@@ -67712,11 +68266,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryReceivedDebitsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["failed", "succeeded"]).optional(),
   })
 
@@ -67730,7 +68284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_treasury_received_debit)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -67787,10 +68341,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTreasuryReceivedDebitsIdParamSchema = z.object({ id: z.string() })
+  const getTreasuryReceivedDebitsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTreasuryReceivedDebitsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryReceivedDebitsIdBodySchema = z.object({}).optional()
@@ -67870,13 +68426,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
     order_by: z.enum(["created", "effective_at"]).optional(),
-    starting_after: z.string().optional(),
-    transaction: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
+    transaction: z.string().max(5000).optional(),
   })
 
   const getTreasuryTransactionEntriesBodySchema = z.object({}).optional()
@@ -67890,7 +68446,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(z.lazy(() => s_treasury_transaction_entry)),
             has_more: z.coerce.boolean(),
             object: z.enum(["list"]),
-            url: z.string(),
+            url: z
+              .string()
+              .max(5000)
+              .regex(new RegExp("^/v1/treasury/transaction_entries")),
           }),
         ],
       ],
@@ -67948,11 +68507,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryTransactionEntriesIdParamSchema = z.object({
-    id: z.string(),
+    id: z.string().max(5000),
   })
 
   const getTreasuryTransactionEntriesIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryTransactionEntriesIdBodySchema = z.object({}).optional()
@@ -68021,12 +68580,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
     limit: z.coerce.number().optional(),
     order_by: z.enum(["created", "posted_at"]).optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
     status: z.enum(["open", "posted", "void"]).optional(),
     status_transitions: z
       .object({
@@ -68055,7 +68614,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(z.lazy(() => s_treasury_transaction)),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000),
         }),
       ],
     ],
@@ -68112,10 +68671,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTreasuryTransactionsIdParamSchema = z.object({ id: z.string() })
+  const getTreasuryTransactionsIdParamSchema = z.object({
+    id: z.string().max(5000),
+  })
 
   const getTreasuryTransactionsIdQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getTreasuryTransactionsIdBodySchema = z.object({}).optional()
@@ -68175,10 +68736,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getWebhookEndpointsQuerySchema = z.object({
-    ending_before: z.string().optional(),
-    expand: z.array(z.string()).optional(),
+    ending_before: z.string().max(5000).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    starting_after: z.string().optional(),
+    starting_after: z.string().max(5000).optional(),
   })
 
   const getWebhookEndpointsBodySchema = z.object({}).optional()
@@ -68191,7 +68752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           data: z.array(s_webhook_endpoint),
           has_more: z.coerce.boolean(),
           object: z.enum(["list"]),
-          url: z.string(),
+          url: z.string().max(5000).regex(new RegExp("^/v1/webhook_endpoints")),
         }),
       ],
     ],
@@ -68355,7 +68916,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     connect: z.coerce.boolean().optional(),
-    description: z.union([z.string(), z.enum([""])]).optional(),
+    description: z.union([z.string().max(5000), z.enum([""])]).optional(),
     enabled_events: z.array(
       z.enum([
         "*",
@@ -68587,7 +69148,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "treasury.received_debit.created",
       ]),
     ),
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     url: z.string(),
   })
@@ -68639,7 +69200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const deleteWebhookEndpointsWebhookEndpointParamSchema = z.object({
-    webhook_endpoint: z.string(),
+    webhook_endpoint: z.string().max(5000),
   })
 
   const deleteWebhookEndpointsWebhookEndpointBodySchema = z
@@ -68698,11 +69259,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getWebhookEndpointsWebhookEndpointParamSchema = z.object({
-    webhook_endpoint: z.string(),
+    webhook_endpoint: z.string().max(5000),
   })
 
   const getWebhookEndpointsWebhookEndpointQuerySchema = z.object({
-    expand: z.array(z.string()).optional(),
+    expand: z.array(z.string().max(5000)).optional(),
   })
 
   const getWebhookEndpointsWebhookEndpointBodySchema = z.object({}).optional()
@@ -68763,12 +69324,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postWebhookEndpointsWebhookEndpointParamSchema = z.object({
-    webhook_endpoint: z.string(),
+    webhook_endpoint: z.string().max(5000),
   })
 
   const postWebhookEndpointsWebhookEndpointBodySchema = z
     .object({
-      description: z.union([z.string(), z.enum([""])]).optional(),
+      description: z.union([z.string().max(5000), z.enum([""])]).optional(),
       disabled: z.coerce.boolean().optional(),
       enabled_events: z
         .array(
@@ -69003,7 +69564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ]),
         )
         .optional(),
-      expand: z.array(z.string()).optional(),
+      expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       url: z.string().optional(),
     })

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
@@ -184,12 +184,12 @@ import { z } from "zod"
 export const s_account_annual_revenue = z.object({
   amount: z.coerce.number().nullable().optional(),
   currency: z.string().nullable().optional(),
-  fiscal_year_end: z.string().nullable().optional(),
+  fiscal_year_end: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_bacs_debit_payments_settings = z.object({
-  display_name: z.string().nullable().optional(),
-  service_user_number: z.string().nullable().optional(),
+  display_name: z.string().max(5000).nullable().optional(),
+  service_user_number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_capabilities = z.object({
@@ -246,8 +246,8 @@ export const s_account_capabilities = z.object({
 })
 
 export const s_account_dashboard_settings = z.object({
-  display_name: z.string().nullable().optional(),
-  timezone: z.string().nullable().optional(),
+  display_name: z.string().max(5000).nullable().optional(),
+  timezone: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_decline_charge_on = z.object({
@@ -259,7 +259,7 @@ export const s_account_link = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number(),
   object: z.enum(["account_link"]),
-  url: z.string(),
+  url: z.string().max(5000),
 })
 
 export const s_account_monthly_estimated_revenue = z.object({
@@ -268,16 +268,16 @@ export const s_account_monthly_estimated_revenue = z.object({
 })
 
 export const s_account_payments_settings = z.object({
-  statement_descriptor: z.string().nullable().optional(),
-  statement_descriptor_kana: z.string().nullable().optional(),
-  statement_descriptor_kanji: z.string().nullable().optional(),
-  statement_descriptor_prefix_kana: z.string().nullable().optional(),
-  statement_descriptor_prefix_kanji: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  statement_descriptor_kana: z.string().max(5000).nullable().optional(),
+  statement_descriptor_kanji: z.string().max(5000).nullable().optional(),
+  statement_descriptor_prefix_kana: z.string().max(5000).nullable().optional(),
+  statement_descriptor_prefix_kanji: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_requirements_alternative = z.object({
-  alternative_fields_due: z.array(z.string()),
-  original_fields_due: z.array(z.string()),
+  alternative_fields_due: z.array(z.string().max(5000)),
+  original_fields_due: z.array(z.string().max(5000)),
 })
 
 export const s_account_requirements_error = z.object({
@@ -370,25 +370,25 @@ export const s_account_requirements_error = z.object({
     "verification_missing_owners",
     "verification_requires_additional_memorandum_of_associations",
   ]),
-  reason: z.string(),
-  requirement: z.string(),
+  reason: z.string().max(5000),
+  requirement: z.string().max(5000),
 })
 
 export const s_account_sepa_debit_payments_settings = z.object({
-  creditor_id: z.string().optional(),
+  creditor_id: z.string().max(5000).optional(),
 })
 
 export const s_account_terms_of_service = z.object({
   date: z.coerce.number().nullable().optional(),
-  ip: z.string().nullable().optional(),
-  user_agent: z.string().optional(),
+  ip: z.string().max(5000).nullable().optional(),
+  user_agent: z.string().max(5000).optional(),
 })
 
 export const s_account_tos_acceptance = z.object({
   date: z.coerce.number().nullable().optional(),
-  ip: z.string().nullable().optional(),
-  service_agreement: z.string().optional(),
-  user_agent: z.string().nullable().optional(),
+  ip: z.string().max(5000).nullable().optional(),
+  service_agreement: z.string().max(5000).optional(),
+  user_agent: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_unification_account_controller = z.object({
@@ -397,25 +397,25 @@ export const s_account_unification_account_controller = z.object({
 })
 
 export const s_address = z.object({
-  city: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  line1: z.string().nullable().optional(),
-  line2: z.string().nullable().optional(),
-  postal_code: z.string().nullable().optional(),
-  state: z.string().nullable().optional(),
+  city: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  line1: z.string().max(5000).nullable().optional(),
+  line2: z.string().max(5000).nullable().optional(),
+  postal_code: z.string().max(5000).nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
 })
 
 export const s_apple_pay_domain = z.object({
   created: z.coerce.number(),
-  domain_name: z.string(),
-  id: z.string(),
+  domain_name: z.string().max(5000),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["apple_pay_domain"]),
 })
 
 export const s_application = z.object({
-  id: z.string(),
-  name: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  name: z.string().max(5000).nullable().optional(),
   object: z.enum(["application"]),
 })
 
@@ -438,7 +438,7 @@ export const s_bank_connections_resource_balance_refresh = z.object({
 })
 
 export const s_bank_connections_resource_link_account_session_filters =
-  z.object({ countries: z.array(z.string()).nullable().optional() })
+  z.object({ countries: z.array(z.string().max(5000)).nullable().optional() })
 
 export const s_bank_connections_resource_ownership_refresh = z.object({
   last_attempted_at: z.coerce.number(),
@@ -446,7 +446,7 @@ export const s_bank_connections_resource_ownership_refresh = z.object({
 })
 
 export const s_bank_connections_resource_transaction_refresh = z.object({
-  id: z.string(),
+  id: z.string().max(5000),
   last_attempted_at: z.coerce.number(),
   next_refresh_available_at: z.coerce.number().nullable().optional(),
   status: z.enum(["failed", "pending", "succeeded"]),
@@ -460,20 +460,20 @@ export const s_bank_connections_resource_transaction_resource_status_transitions
 
 export const s_billing_meter_event = z.object({
   created: z.coerce.number(),
-  event_name: z.string(),
-  identifier: z.string(),
+  event_name: z.string().max(100),
+  identifier: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["billing.meter_event"]),
-  payload: z.record(z.string()),
+  payload: z.record(z.string().max(100)),
   timestamp: z.coerce.number(),
 })
 
 export const s_billing_meter_event_summary = z.object({
   aggregated_value: z.coerce.number(),
   end_time: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  meter: z.string(),
+  meter: z.string().max(5000),
   object: z.enum(["billing.meter_event_summary"]),
   start_time: z.coerce.number(),
 })
@@ -483,22 +483,22 @@ export const s_billing_meter_resource_aggregation_settings = z.object({
 })
 
 export const s_billing_meter_resource_billing_meter_event_adjustment_cancel =
-  z.object({ identifier: z.string() })
+  z.object({ identifier: z.string().max(100) })
 
 export const s_billing_meter_resource_billing_meter_status_transitions =
   z.object({ deactivated_at: z.coerce.number().nullable().optional() })
 
 export const s_billing_meter_resource_billing_meter_value = z.object({
-  event_payload_key: z.string(),
+  event_payload_key: z.string().max(5000),
 })
 
 export const s_billing_meter_resource_customer_mapping_settings = z.object({
-  event_payload_key: z.string(),
+  event_payload_key: z.string().max(5000),
   type: z.enum(["by_id"]),
 })
 
 export const s_cancellation_details = z.object({
-  comment: z.string().nullable().optional(),
+  comment: z.string().max(5000).nullable().optional(),
   feedback: z
     .enum([
       "customer_service",
@@ -520,21 +520,21 @@ export const s_cancellation_details = z.object({
 
 export const s_card_issuing_account_terms_of_service = z.object({
   date: z.coerce.number().nullable().optional(),
-  ip: z.string().nullable().optional(),
-  user_agent: z.string().optional(),
+  ip: z.string().max(5000).nullable().optional(),
+  user_agent: z.string().max(5000).optional(),
 })
 
 export const s_card_mandate_payment_method_details = z.object({})
 
 export const s_charge_fraud_details = z.object({
-  stripe_report: z.string().optional(),
-  user_report: z.string().optional(),
+  stripe_report: z.string().max(5000).optional(),
+  user_report: z.string().max(5000).optional(),
 })
 
 export const s_checkout_acss_debit_mandate_options = z.object({
-  custom_mandate_url: z.string().optional(),
+  custom_mandate_url: z.string().max(5000).optional(),
   default_for: z.array(z.enum(["invoice", "subscription"])).optional(),
-  interval_description: z.string().nullable().optional(),
+  interval_description: z.string().max(5000).nullable().optional(),
   payment_schedule: z
     .enum(["combined", "interval", "sporadic"])
     .nullable()
@@ -627,8 +627,8 @@ export const s_checkout_paynow_payment_method_options = z.object({
 
 export const s_checkout_paypal_payment_method_options = z.object({
   capture_method: z.enum(["manual"]).optional(),
-  preferred_locale: z.string().nullable().optional(),
-  reference: z.string().nullable().optional(),
+  preferred_locale: z.string().max(5000).nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -647,19 +647,19 @@ export const s_checkout_sofort_payment_method_options = z.object({
 })
 
 export const s_checkout_swish_payment_method_options = z.object({
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
 })
 
 export const s_climate_removals_beneficiary = z.object({
-  public_name: z.string(),
+  public_name: z.string().max(5000),
 })
 
 export const s_climate_removals_location = z.object({
-  city: z.string().nullable().optional(),
-  country: z.string(),
+  city: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000),
   latitude: z.coerce.number().nullable().optional(),
   longitude: z.coerce.number().nullable().optional(),
-  region: z.string().nullable().optional(),
+  region: z.string().max(5000).nullable().optional(),
 })
 
 export const s_climate_removals_products_price = z.object({
@@ -670,8 +670,8 @@ export const s_climate_removals_products_price = z.object({
 
 export const s_confirmation_tokens_resource_mandate_data_resource_customer_acceptance_resource_online =
   z.object({
-    ip_address: z.string().nullable().optional(),
-    user_agent: z.string().nullable().optional(),
+    ip_address: z.string().max(5000).nullable().optional(),
+    user_agent: z.string().max(5000).nullable().optional(),
   })
 
 export const s_connect_embedded_account_features = z.object({})
@@ -692,11 +692,13 @@ export const s_connect_embedded_payouts_features = z.object({
 })
 
 export const s_country_spec_verification_field_details = z.object({
-  additional: z.array(z.string()),
-  minimum: z.array(z.string()),
+  additional: z.array(z.string().max(5000)),
+  minimum: z.array(z.string().max(5000)),
 })
 
-export const s_coupon_applies_to = z.object({ products: z.array(z.string()) })
+export const s_coupon_applies_to = z.object({
+  products: z.array(z.string().max(5000)),
+})
 
 export const s_coupon_currency_option = z.object({
   amount_off: z.coerce.number(),
@@ -715,29 +717,29 @@ export const s_customer_balance_customer_balance_settings = z.object({
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_eu_bank_transfer =
   z.object({
-    bic: z.string().nullable().optional(),
-    iban_last4: z.string().nullable().optional(),
-    sender_name: z.string().nullable().optional(),
+    bic: z.string().max(5000).nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
+    sender_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_gb_bank_transfer =
   z.object({
-    account_number_last4: z.string().nullable().optional(),
-    sender_name: z.string().nullable().optional(),
-    sort_code: z.string().nullable().optional(),
+    account_number_last4: z.string().max(5000).nullable().optional(),
+    sender_name: z.string().max(5000).nullable().optional(),
+    sort_code: z.string().max(5000).nullable().optional(),
   })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_jp_bank_transfer =
   z.object({
-    sender_bank: z.string().nullable().optional(),
-    sender_branch: z.string().nullable().optional(),
-    sender_name: z.string().nullable().optional(),
+    sender_bank: z.string().max(5000).nullable().optional(),
+    sender_branch: z.string().max(5000).nullable().optional(),
+    sender_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_us_bank_transfer =
   z.object({
     network: z.enum(["ach", "domestic_wire_us", "swift"]).optional(),
-    sender_name: z.string().nullable().optional(),
+    sender_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_customer_session_resource_components_resource_buy_button =
@@ -747,148 +749,148 @@ export const s_customer_session_resource_components_resource_pricing_table =
   z.object({ enabled: z.coerce.boolean() })
 
 export const s_customer_tax_location = z.object({
-  country: z.string(),
+  country: z.string().max(5000),
   source: z.enum([
     "billing_address",
     "ip_address",
     "payment_method",
     "shipping_destination",
   ]),
-  state: z.string().nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
 })
 
 export const s_deleted_account = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["account"]),
 })
 
 export const s_deleted_apple_pay_domain = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["apple_pay_domain"]),
 })
 
 export const s_deleted_application = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
-  name: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  name: z.string().max(5000).nullable().optional(),
   object: z.enum(["application"]),
 })
 
 export const s_deleted_bank_account = z.object({
-  currency: z.string().nullable().optional(),
+  currency: z.string().max(5000).nullable().optional(),
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["bank_account"]),
 })
 
 export const s_deleted_card = z.object({
-  currency: z.string().nullable().optional(),
+  currency: z.string().max(5000).nullable().optional(),
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["card"]),
 })
 
 export const s_deleted_coupon = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["coupon"]),
 })
 
 export const s_deleted_customer = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["customer"]),
 })
 
 export const s_deleted_invoice = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["invoice"]),
 })
 
 export const s_deleted_invoiceitem = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["invoiceitem"]),
 })
 
 export const s_deleted_person = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["person"]),
 })
 
 export const s_deleted_plan = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["plan"]),
 })
 
 export const s_deleted_price = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["price"]),
 })
 
 export const s_deleted_product = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["product"]),
 })
 
 export const s_deleted_radar_value_list = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["radar.value_list"]),
 })
 
 export const s_deleted_radar_value_list_item = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["radar.value_list_item"]),
 })
 
 export const s_deleted_subscription_item = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["subscription_item"]),
 })
 
 export const s_deleted_tax_id = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["tax_id"]),
 })
 
 export const s_deleted_terminal_configuration = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["terminal.configuration"]),
 })
 
 export const s_deleted_terminal_location = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["terminal.location"]),
 })
 
 export const s_deleted_terminal_reader = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["terminal.reader"]),
 })
 
 export const s_deleted_test_helpers_test_clock = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["test_helpers.test_clock"]),
 })
 
 export const s_deleted_webhook_endpoint = z.object({
   deleted: z.coerce.boolean(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["webhook_endpoint"]),
 })
 
@@ -902,111 +904,111 @@ export const s_dispute_evidence_details = z.object({
 })
 
 export const s_dispute_payment_method_details_card = z.object({
-  brand: z.string(),
-  network_reason_code: z.string().nullable().optional(),
+  brand: z.string().max(5000),
+  network_reason_code: z.string().max(5000).nullable().optional(),
 })
 
 export const s_email_sent = z.object({
   email_sent_at: z.coerce.number(),
-  email_sent_to: z.string(),
+  email_sent_to: z.string().max(5000),
 })
 
 export const s_ephemeral_key = z.object({
   created: z.coerce.number(),
   expires: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["ephemeral_key"]),
-  secret: z.string().optional(),
+  secret: z.string().max(5000).optional(),
 })
 
 export const s_exchange_rate = z.object({
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["exchange_rate"]),
   rates: z.record(z.coerce.number()),
 })
 
 export const s_fee = z.object({
   amount: z.coerce.number(),
-  application: z.string().nullable().optional(),
+  application: z.string().max(5000).nullable().optional(),
   currency: z.string(),
-  description: z.string().nullable().optional(),
-  type: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  type: z.string().max(5000),
 })
 
 export const s_financial_connections_account_owner = z.object({
-  email: z.string().nullable().optional(),
-  id: z.string(),
-  name: z.string(),
+  email: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  name: z.string().max(5000),
   object: z.enum(["financial_connections.account_owner"]),
-  ownership: z.string(),
-  phone: z.string().nullable().optional(),
-  raw_address: z.string().nullable().optional(),
+  ownership: z.string().max(5000),
+  phone: z.string().max(5000).nullable().optional(),
+  raw_address: z.string().max(5000).nullable().optional(),
   refreshed_at: z.coerce.number().nullable().optional(),
 })
 
 export const s_financial_reporting_finance_report_run_run_parameters = z.object(
   {
-    columns: z.array(z.string()).optional(),
-    connected_account: z.string().optional(),
+    columns: z.array(z.string().max(5000)).optional(),
+    connected_account: z.string().max(5000).optional(),
     currency: z.string().optional(),
     interval_end: z.coerce.number().optional(),
     interval_start: z.coerce.number().optional(),
-    payout: z.string().optional(),
-    reporting_category: z.string().optional(),
-    timezone: z.string().optional(),
+    payout: z.string().max(5000).optional(),
+    reporting_category: z.string().max(5000).optional(),
+    timezone: z.string().max(5000).optional(),
   },
 )
 
 export const s_forwarded_request_context = z.object({
   destination_duration: z.coerce.number(),
-  destination_ip_address: z.string(),
+  destination_ip_address: z.string().max(5000),
 })
 
 export const s_forwarded_request_header = z.object({
-  name: z.string(),
-  value: z.string(),
+  name: z.string().max(5000),
+  value: z.string().max(5000),
 })
 
 export const s_funding_instructions_bank_transfer_aba_record = z.object({
-  account_number: z.string(),
-  bank_name: z.string(),
-  routing_number: z.string(),
+  account_number: z.string().max(5000),
+  bank_name: z.string().max(5000),
+  routing_number: z.string().max(5000),
 })
 
 export const s_funding_instructions_bank_transfer_iban_record = z.object({
-  account_holder_name: z.string(),
-  bic: z.string(),
-  country: z.string(),
-  iban: z.string(),
+  account_holder_name: z.string().max(5000),
+  bic: z.string().max(5000),
+  country: z.string().max(5000),
+  iban: z.string().max(5000),
 })
 
 export const s_funding_instructions_bank_transfer_sort_code_record = z.object({
-  account_holder_name: z.string(),
-  account_number: z.string(),
-  sort_code: z.string(),
+  account_holder_name: z.string().max(5000),
+  account_number: z.string().max(5000),
+  sort_code: z.string().max(5000),
 })
 
 export const s_funding_instructions_bank_transfer_spei_record = z.object({
-  bank_code: z.string(),
-  bank_name: z.string(),
-  clabe: z.string(),
+  bank_code: z.string().max(5000),
+  bank_name: z.string().max(5000),
+  clabe: z.string().max(5000),
 })
 
 export const s_funding_instructions_bank_transfer_swift_record = z.object({
-  account_number: z.string(),
-  bank_name: z.string(),
-  swift_code: z.string(),
+  account_number: z.string().max(5000),
+  bank_name: z.string().max(5000),
+  swift_code: z.string().max(5000),
 })
 
 export const s_funding_instructions_bank_transfer_zengin_record = z.object({
-  account_holder_name: z.string().nullable().optional(),
-  account_number: z.string().nullable().optional(),
-  account_type: z.string().nullable().optional(),
-  bank_code: z.string().nullable().optional(),
-  bank_name: z.string().nullable().optional(),
-  branch_code: z.string().nullable().optional(),
-  branch_name: z.string().nullable().optional(),
+  account_holder_name: z.string().max(5000).nullable().optional(),
+  account_number: z.string().max(5000).nullable().optional(),
+  account_type: z.string().max(5000).nullable().optional(),
+  bank_code: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  branch_code: z.string().max(5000).nullable().optional(),
+  branch_name: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_data_document_report_date_of_birth = z.object({
@@ -1048,7 +1050,7 @@ export const s_gelato_document_report_error = z.object({
     ])
     .nullable()
     .optional(),
-  reason: z.string().nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_email_report_error = z.object({
@@ -1056,7 +1058,7 @@ export const s_gelato_email_report_error = z.object({
     .enum(["email_unverified_other", "email_verification_declined"])
     .nullable()
     .optional(),
-  reason: z.string().nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_id_number_report_error = z.object({
@@ -1068,7 +1070,7 @@ export const s_gelato_id_number_report_error = z.object({
     ])
     .nullable()
     .optional(),
-  reason: z.string().nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_phone_report_error = z.object({
@@ -1076,12 +1078,12 @@ export const s_gelato_phone_report_error = z.object({
     .enum(["phone_unverified_other", "phone_verification_declined"])
     .nullable()
     .optional(),
-  reason: z.string().nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_provided_details = z.object({
-  email: z.string().optional(),
-  phone: z.string().optional(),
+  email: z.string().max(5000).optional(),
+  phone: z.string().max(5000).optional(),
 })
 
 export const s_gelato_report_document_options = z.object({
@@ -1105,7 +1107,7 @@ export const s_gelato_selfie_report_error = z.object({
     ])
     .nullable()
     .optional(),
-  reason: z.string().nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_session_document_options = z.object({
@@ -1148,7 +1150,7 @@ export const s_gelato_session_last_error = z.object({
     ])
     .nullable()
     .optional(),
-  reason: z.string().nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
 })
 
 export const s_gelato_session_phone_options = z.object({
@@ -1156,11 +1158,11 @@ export const s_gelato_session_phone_options = z.object({
 })
 
 export const s_internal_card = z.object({
-  brand: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number().nullable().optional(),
   exp_year: z.coerce.number().nullable().optional(),
-  last4: z.string().nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
 })
 
 export const s_invoice_installments_card = z.object({
@@ -1168,7 +1170,7 @@ export const s_invoice_installments_card = z.object({
 })
 
 export const s_invoice_item_threshold_reason = z.object({
-  line_item_ids: z.array(z.string()),
+  line_item_ids: z.array(z.string().max(5000)),
   usage_gte: z.coerce.number(),
 })
 
@@ -1180,7 +1182,7 @@ export const s_invoice_line_item_period = z.object({
 export const s_invoice_mandate_options_card = z.object({
   amount: z.coerce.number().nullable().optional(),
   amount_type: z.enum(["fixed", "maximum"]).nullable().optional(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(200).nullable().optional(),
 })
 
 export const s_invoice_payment_method_options_acss_debit_mandate_options =
@@ -1215,12 +1217,12 @@ export const s_invoice_rendering_pdf = z.object({
 })
 
 export const s_invoice_setting_custom_field = z.object({
-  name: z.string(),
-  value: z.string(),
+  name: z.string().max(5000),
+  value: z.string().max(5000),
 })
 
 export const s_invoice_setting_rendering_options = z.object({
-  amount_tax_display: z.string().nullable().optional(),
+  amount_tax_display: z.string().max(5000).nullable().optional(),
 })
 
 export const s_invoices_resource_invoice_tax_id = z.object({
@@ -1294,12 +1296,12 @@ export const s_invoices_resource_invoice_tax_id = z.object({
     "vn_tin",
     "za_vat",
   ]),
-  value: z.string().nullable().optional(),
+  value: z.string().max(5000).nullable().optional(),
 })
 
 export const s_invoices_resource_line_items_credited_items = z.object({
-  invoice: z.string(),
-  invoice_line_items: z.array(z.string()),
+  invoice: z.string().max(5000),
+  invoice_line_items: z.array(z.string().max(5000)),
 })
 
 export const s_invoices_resource_status_transitions = z.object({
@@ -1324,22 +1326,22 @@ export const s_issuing_authorization_authentication_exemption = z.object({
 })
 
 export const s_issuing_authorization_merchant_data = z.object({
-  category: z.string(),
-  category_code: z.string(),
-  city: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
-  network_id: z.string(),
-  postal_code: z.string().nullable().optional(),
-  state: z.string().nullable().optional(),
-  terminal_id: z.string().nullable().optional(),
-  url: z.string().nullable().optional(),
+  category: z.string().max(5000),
+  category_code: z.string().max(5000),
+  city: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
+  network_id: z.string().max(5000),
+  postal_code: z.string().max(5000).nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
+  terminal_id: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_authorization_network_data = z.object({
-  acquiring_institution_id: z.string().nullable().optional(),
-  system_trace_audit_number: z.string().nullable().optional(),
-  transaction_id: z.string().nullable().optional(),
+  acquiring_institution_id: z.string().max(5000).nullable().optional(),
+  system_trace_audit_number: z.string().max(5000).nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_authorization_three_d_secure = z.object({
@@ -1352,9 +1354,9 @@ export const s_issuing_authorization_three_d_secure = z.object({
 })
 
 export const s_issuing_authorization_treasury = z.object({
-  received_credits: z.array(z.string()),
-  received_debits: z.array(z.string()),
-  transaction: z.string().nullable().optional(),
+  received_credits: z.array(z.string().max(5000)),
+  received_debits: z.array(z.string().max(5000)),
+  transaction: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_card_apple_pay = z.object({
@@ -1382,7 +1384,7 @@ export const s_issuing_card_google_pay = z.object({
 })
 
 export const s_issuing_card_shipping_customs = z.object({
-  eori_number: z.string().nullable().optional(),
+  eori_number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_card_spending_limit = z.object({
@@ -2053,48 +2055,48 @@ export const s_issuing_cardholder_spending_limit = z.object({
 
 export const s_issuing_cardholder_user_terms_acceptance = z.object({
   date: z.coerce.number().nullable().optional(),
-  ip: z.string().nullable().optional(),
-  user_agent: z.string().nullable().optional(),
+  ip: z.string().max(5000).nullable().optional(),
+  user_agent: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_dispute_treasury = z.object({
-  debit_reversal: z.string().nullable().optional(),
-  received_debit: z.string(),
+  debit_reversal: z.string().max(5000).nullable().optional(),
+  received_debit: z.string().max(5000),
 })
 
 export const s_issuing_network_token_address = z.object({
-  line1: z.string(),
-  postal_code: z.string(),
+  line1: z.string().max(5000),
+  postal_code: z.string().max(5000),
 })
 
 export const s_issuing_network_token_device = z.object({
-  device_fingerprint: z.string().optional(),
-  ip_address: z.string().optional(),
-  location: z.string().optional(),
-  name: z.string().optional(),
-  phone_number: z.string().optional(),
+  device_fingerprint: z.string().max(5000).optional(),
+  ip_address: z.string().max(5000).optional(),
+  location: z.string().max(5000).optional(),
+  name: z.string().max(5000).optional(),
+  phone_number: z.string().max(5000).optional(),
   type: z.enum(["other", "phone", "watch"]).optional(),
 })
 
 export const s_issuing_network_token_mastercard = z.object({
-  card_reference_id: z.string().optional(),
-  token_reference_id: z.string(),
-  token_requestor_id: z.string(),
-  token_requestor_name: z.string().optional(),
+  card_reference_id: z.string().max(5000).optional(),
+  token_reference_id: z.string().max(5000),
+  token_requestor_id: z.string().max(5000),
+  token_requestor_name: z.string().max(5000).optional(),
 })
 
 export const s_issuing_network_token_visa = z.object({
-  card_reference_id: z.string(),
-  token_reference_id: z.string(),
-  token_requestor_id: z.string(),
-  token_risk_score: z.string().optional(),
+  card_reference_id: z.string().max(5000),
+  token_reference_id: z.string().max(5000),
+  token_requestor_id: z.string().max(5000),
+  token_risk_score: z.string().max(5000).optional(),
 })
 
 export const s_issuing_personalization_design_carrier_text = z.object({
-  footer_body: z.string().nullable().optional(),
-  footer_title: z.string().nullable().optional(),
-  header_body: z.string().nullable().optional(),
-  header_title: z.string().nullable().optional(),
+  footer_body: z.string().max(5000).nullable().optional(),
+  footer_title: z.string().max(5000).nullable().optional(),
+  header_body: z.string().max(5000).nullable().optional(),
+  header_title: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_personalization_design_preferences = z.object({
@@ -2141,20 +2143,20 @@ export const s_issuing_physical_bundle_features = z.object({
 })
 
 export const s_issuing_settlement = z.object({
-  bin: z.string(),
+  bin: z.string().max(5000),
   clearing_date: z.coerce.number(),
   created: z.coerce.number(),
   currency: z.string(),
-  id: z.string(),
+  id: z.string().max(5000),
   interchange_fees: z.coerce.number(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   net_total: z.coerce.number(),
   network: z.enum(["visa"]),
   network_fees: z.coerce.number(),
-  network_settlement_identifier: z.string(),
+  network_settlement_identifier: z.string().max(5000),
   object: z.enum(["issuing.settlement"]),
-  settlement_service: z.string(),
+  settlement_service: z.string().max(5000),
   transaction_count: z.coerce.number(),
   transaction_volume: z.coerce.number(),
 })
@@ -2165,17 +2167,17 @@ export const s_issuing_transaction_amount_details = z.object({
 })
 
 export const s_issuing_transaction_flight_data_leg = z.object({
-  arrival_airport_code: z.string().nullable().optional(),
-  carrier: z.string().nullable().optional(),
-  departure_airport_code: z.string().nullable().optional(),
-  flight_number: z.string().nullable().optional(),
-  service_class: z.string().nullable().optional(),
+  arrival_airport_code: z.string().max(5000).nullable().optional(),
+  carrier: z.string().max(5000).nullable().optional(),
+  departure_airport_code: z.string().max(5000).nullable().optional(),
+  flight_number: z.string().max(5000).nullable().optional(),
+  service_class: z.string().max(5000).nullable().optional(),
   stopover_allowed: z.coerce.boolean().nullable().optional(),
 })
 
 export const s_issuing_transaction_fuel_data = z.object({
-  type: z.string(),
-  unit: z.string(),
+  type: z.string().max(5000),
+  unit: z.string().max(5000),
   unit_cost_decimal: z.string(),
   volume_decimal: z.string().nullable().optional(),
 })
@@ -2186,21 +2188,21 @@ export const s_issuing_transaction_lodging_data = z.object({
 })
 
 export const s_issuing_transaction_network_data = z.object({
-  authorization_code: z.string().nullable().optional(),
-  processing_date: z.string().nullable().optional(),
-  transaction_id: z.string().nullable().optional(),
+  authorization_code: z.string().max(5000).nullable().optional(),
+  processing_date: z.string().max(5000).nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_transaction_receipt_data = z.object({
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number().nullable().optional(),
   total: z.coerce.number().nullable().optional(),
   unit_cost: z.coerce.number().nullable().optional(),
 })
 
 export const s_issuing_transaction_treasury = z.object({
-  received_credit: z.string().nullable().optional(),
-  received_debit: z.string().nullable().optional(),
+  received_credit: z.string().max(5000).nullable().optional(),
+  received_debit: z.string().max(5000).nullable().optional(),
 })
 
 export const s_legal_entity_dob = z.object({
@@ -2210,19 +2212,19 @@ export const s_legal_entity_dob = z.object({
 })
 
 export const s_legal_entity_japan_address = z.object({
-  city: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  line1: z.string().nullable().optional(),
-  line2: z.string().nullable().optional(),
-  postal_code: z.string().nullable().optional(),
-  state: z.string().nullable().optional(),
-  town: z.string().nullable().optional(),
+  city: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  line1: z.string().max(5000).nullable().optional(),
+  line2: z.string().max(5000).nullable().optional(),
+  postal_code: z.string().max(5000).nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
+  town: z.string().max(5000).nullable().optional(),
 })
 
 export const s_legal_entity_ubo_declaration = z.object({
   date: z.coerce.number().nullable().optional(),
-  ip: z.string().nullable().optional(),
-  user_agent: z.string().nullable().optional(),
+  ip: z.string().max(5000).nullable().optional(),
+  user_agent: z.string().max(5000).nullable().optional(),
 })
 
 export const s_linked_account_options_us_bank_account = z.object({
@@ -2233,27 +2235,27 @@ export const s_linked_account_options_us_bank_account = z.object({
     .array(z.enum(["balances", "transactions"]))
     .nullable()
     .optional(),
-  return_url: z.string().optional(),
+  return_url: z.string().max(5000).optional(),
 })
 
 export const s_login_link = z.object({
   created: z.coerce.number(),
   object: z.enum(["login_link"]),
-  url: z.string(),
+  url: z.string().max(5000),
 })
 
 export const s_mandate_acss_debit = z.object({
   default_for: z.array(z.enum(["invoice", "subscription"])).optional(),
-  interval_description: z.string().nullable().optional(),
+  interval_description: z.string().max(5000).nullable().optional(),
   payment_schedule: z.enum(["combined", "interval", "sporadic"]),
   transaction_type: z.enum(["business", "personal"]),
 })
 
-export const s_mandate_au_becs_debit = z.object({ url: z.string() })
+export const s_mandate_au_becs_debit = z.object({ url: z.string().max(5000) })
 
 export const s_mandate_bacs_debit = z.object({
   network_status: z.enum(["accepted", "pending", "refused", "revoked"]),
-  reference: z.string(),
+  reference: z.string().max(5000),
   revocation_reason: z
     .enum([
       "account_closed",
@@ -2264,7 +2266,7 @@ export const s_mandate_bacs_debit = z.object({
     ])
     .nullable()
     .optional(),
-  url: z.string(),
+  url: z.string().max(5000),
 })
 
 export const s_mandate_cashapp = z.object({})
@@ -2274,13 +2276,13 @@ export const s_mandate_link = z.object({})
 export const s_mandate_multi_use = z.object({})
 
 export const s_mandate_paypal = z.object({
-  billing_agreement_id: z.string().nullable().optional(),
-  payer_id: z.string().nullable().optional(),
+  billing_agreement_id: z.string().max(5000).nullable().optional(),
+  payer_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_mandate_sepa_debit = z.object({
-  reference: z.string(),
-  url: z.string(),
+  reference: z.string().max(5000),
+  url: z.string().max(5000),
 })
 
 export const s_mandate_single_use = z.object({
@@ -2293,8 +2295,8 @@ export const s_mandate_us_bank_account = z.object({
 })
 
 export const s_networks = z.object({
-  available: z.array(z.string()),
-  preferred: z.string().nullable().optional(),
+  available: z.array(z.string().max(5000)),
+  preferred: z.string().max(5000).nullable().optional(),
 })
 
 export const s_notification_event_data = z.object({
@@ -2303,19 +2305,19 @@ export const s_notification_event_data = z.object({
 })
 
 export const s_notification_event_request = z.object({
-  id: z.string().nullable().optional(),
-  idempotency_key: z.string().nullable().optional(),
+  id: z.string().max(5000).nullable().optional(),
+  idempotency_key: z.string().max(5000).nullable().optional(),
 })
 
 export const s_offline_acceptance = z.object({})
 
 export const s_online_acceptance = z.object({
-  ip_address: z.string().nullable().optional(),
-  user_agent: z.string().nullable().optional(),
+  ip_address: z.string().max(5000).nullable().optional(),
+  user_agent: z.string().max(5000).nullable().optional(),
 })
 
 export const s_outbound_payments_payment_method_details_financial_account =
-  z.object({ id: z.string(), network: z.enum(["stripe"]) })
+  z.object({ id: z.string().max(5000), network: z.enum(["stripe"]) })
 
 export const s_package_dimensions = z.object({
   height: z.coerce.number(),
@@ -2342,9 +2344,9 @@ export const s_payment_flows_automatic_payment_methods_setup_intent = z.object({
 export const s_payment_flows_private_payment_methods_alipay = z.object({})
 
 export const s_payment_flows_private_payment_methods_alipay_details = z.object({
-  buyer_id: z.string().optional(),
-  fingerprint: z.string().nullable().optional(),
-  transaction_id: z.string().nullable().optional(),
+  buyer_id: z.string().max(5000).optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_extended_authorization_extended_authorization =
@@ -2369,17 +2371,17 @@ export const s_payment_flows_private_payment_methods_klarna_dob = z.object({
 })
 
 export const s_payment_intent_next_action_alipay_handle_redirect = z.object({
-  native_data: z.string().nullable().optional(),
-  native_url: z.string().nullable().optional(),
-  return_url: z.string().nullable().optional(),
-  url: z.string().nullable().optional(),
+  native_data: z.string().max(5000).nullable().optional(),
+  native_url: z.string().max(5000).nullable().optional(),
+  return_url: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_intent_next_action_boleto = z.object({
   expires_at: z.coerce.number().nullable().optional(),
-  hosted_voucher_url: z.string().nullable().optional(),
-  number: z.string().nullable().optional(),
-  pdf: z.string().nullable().optional(),
+  hosted_voucher_url: z.string().max(5000).nullable().optional(),
+  number: z.string().max(5000).nullable().optional(),
+  pdf: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_intent_next_action_card_await_notification = z.object({
@@ -2389,72 +2391,72 @@ export const s_payment_intent_next_action_card_await_notification = z.object({
 
 export const s_payment_intent_next_action_cashapp_qr_code = z.object({
   expires_at: z.coerce.number(),
-  image_url_png: z.string(),
-  image_url_svg: z.string(),
+  image_url_png: z.string().max(5000),
+  image_url_svg: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_display_oxxo_details = z.object({
   expires_after: z.coerce.number().nullable().optional(),
-  hosted_voucher_url: z.string().nullable().optional(),
-  number: z.string().nullable().optional(),
+  hosted_voucher_url: z.string().max(5000).nullable().optional(),
+  number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_intent_next_action_konbini_familymart = z.object({
-  confirmation_number: z.string().optional(),
-  payment_code: z.string(),
+  confirmation_number: z.string().max(5000).optional(),
+  payment_code: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_konbini_lawson = z.object({
-  confirmation_number: z.string().optional(),
-  payment_code: z.string(),
+  confirmation_number: z.string().max(5000).optional(),
+  payment_code: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_konbini_ministop = z.object({
-  confirmation_number: z.string().optional(),
-  payment_code: z.string(),
+  confirmation_number: z.string().max(5000).optional(),
+  payment_code: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_konbini_seicomart = z.object({
-  confirmation_number: z.string().optional(),
-  payment_code: z.string(),
+  confirmation_number: z.string().max(5000).optional(),
+  payment_code: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_paynow_display_qr_code = z.object({
-  data: z.string(),
-  hosted_instructions_url: z.string().nullable().optional(),
-  image_url_png: z.string(),
-  image_url_svg: z.string(),
+  data: z.string().max(5000),
+  hosted_instructions_url: z.string().max(5000).nullable().optional(),
+  image_url_png: z.string().max(5000),
+  image_url_svg: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_pix_display_qr_code = z.object({
-  data: z.string().optional(),
+  data: z.string().max(5000).optional(),
   expires_at: z.coerce.number().optional(),
-  hosted_instructions_url: z.string().optional(),
-  image_url_png: z.string().optional(),
-  image_url_svg: z.string().optional(),
+  hosted_instructions_url: z.string().max(5000).optional(),
+  image_url_png: z.string().max(5000).optional(),
+  image_url_svg: z.string().max(5000).optional(),
 })
 
 export const s_payment_intent_next_action_promptpay_display_qr_code = z.object({
-  data: z.string(),
-  hosted_instructions_url: z.string(),
-  image_url_png: z.string(),
-  image_url_svg: z.string(),
+  data: z.string().max(5000),
+  hosted_instructions_url: z.string().max(5000),
+  image_url_png: z.string().max(5000),
+  image_url_svg: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_redirect_to_url = z.object({
-  return_url: z.string().nullable().optional(),
-  url: z.string().nullable().optional(),
+  return_url: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_intent_next_action_swish_qr_code = z.object({
-  data: z.string(),
-  image_url_png: z.string(),
-  image_url_svg: z.string(),
+  data: z.string().max(5000),
+  image_url_png: z.string().max(5000),
+  image_url_svg: z.string().max(5000),
 })
 
 export const s_payment_intent_next_action_verify_with_microdeposits = z.object({
   arrival_date: z.coerce.number(),
-  hosted_verification_url: z.string(),
+  hosted_verification_url: z.string().max(5000),
   microdeposit_type: z
     .enum(["amounts", "descriptor_code"])
     .nullable()
@@ -2463,27 +2465,27 @@ export const s_payment_intent_next_action_verify_with_microdeposits = z.object({
 
 export const s_payment_intent_next_action_wechat_pay_display_qr_code = z.object(
   {
-    data: z.string(),
-    hosted_instructions_url: z.string(),
-    image_data_url: z.string(),
-    image_url_png: z.string(),
-    image_url_svg: z.string(),
+    data: z.string().max(5000),
+    hosted_instructions_url: z.string().max(5000),
+    image_data_url: z.string().max(5000),
+    image_url_png: z.string().max(5000),
+    image_url_svg: z.string().max(5000),
   },
 )
 
 export const s_payment_intent_next_action_wechat_pay_redirect_to_android_app =
   z.object({
-    app_id: z.string(),
-    nonce_str: z.string(),
-    package: z.string(),
-    partner_id: z.string(),
-    prepay_id: z.string(),
-    sign: z.string(),
-    timestamp: z.string(),
+    app_id: z.string().max(5000),
+    nonce_str: z.string().max(5000),
+    package: z.string().max(5000),
+    partner_id: z.string().max(5000),
+    prepay_id: z.string().max(5000),
+    sign: z.string().max(5000),
+    timestamp: z.string().max(5000),
   })
 
 export const s_payment_intent_next_action_wechat_pay_redirect_to_ios_app =
-  z.object({ native_url: z.string() })
+  z.object({ native_url: z.string().max(5000) })
 
 export const s_payment_intent_payment_method_options_au_becs_debit = z.object({
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
@@ -2504,8 +2506,8 @@ export const s_payment_intent_payment_method_options_link = z.object({
 
 export const s_payment_intent_payment_method_options_mandate_options_acss_debit =
   z.object({
-    custom_mandate_url: z.string().optional(),
-    interval_description: z.string().nullable().optional(),
+    custom_mandate_url: z.string().max(5000).optional(),
+    interval_description: z.string().max(5000).nullable().optional(),
     payment_schedule: z
       .enum(["combined", "interval", "sporadic"])
       .nullable()
@@ -2522,7 +2524,7 @@ export const s_payment_intent_payment_method_options_mobilepay = z.object({
 })
 
 export const s_payment_intent_payment_method_options_swish = z.object({
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(35).nullable().optional(),
   setup_future_usage: z.enum(["none"]).optional(),
 })
 
@@ -2537,19 +2539,19 @@ export const s_payment_links_resource_completed_sessions = z.object({
 })
 
 export const s_payment_links_resource_completion_behavior_confirmation_page =
-  z.object({ custom_message: z.string().nullable().optional() })
+  z.object({ custom_message: z.string().max(5000).nullable().optional() })
 
 export const s_payment_links_resource_completion_behavior_redirect = z.object({
-  url: z.string(),
+  url: z.string().max(5000),
 })
 
 export const s_payment_links_resource_custom_fields_dropdown_option = z.object({
-  label: z.string(),
-  value: z.string(),
+  label: z.string().max(5000),
+  value: z.string().max(5000),
 })
 
 export const s_payment_links_resource_custom_fields_label = z.object({
-  custom: z.string().nullable().optional(),
+  custom: z.string().max(5000).nullable().optional(),
   type: z.enum(["custom"]),
 })
 
@@ -2564,7 +2566,7 @@ export const s_payment_links_resource_custom_fields_text = z.object({
 })
 
 export const s_payment_links_resource_custom_text_position = z.object({
-  message: z.string(),
+  message: z.string().max(500),
 })
 
 export const s_payment_links_resource_payment_intent_data = z.object({
@@ -2572,15 +2574,15 @@ export const s_payment_links_resource_payment_intent_data = z.object({
     .enum(["automatic", "automatic_async", "manual"])
     .nullable()
     .optional(),
-  description: z.string().nullable().optional(),
-  metadata: z.record(z.string()),
+  description: z.string().max(5000).nullable().optional(),
+  metadata: z.record(z.string().max(500)),
   setup_future_usage: z
     .enum(["off_session", "on_session"])
     .nullable()
     .optional(),
-  statement_descriptor: z.string().nullable().optional(),
-  statement_descriptor_suffix: z.string().nullable().optional(),
-  transfer_group: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  statement_descriptor_suffix: z.string().max(5000).nullable().optional(),
+  transfer_group: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_links_resource_payment_method_reuse_agreement = z.object(
@@ -2840,11 +2842,11 @@ export const s_payment_links_resource_tax_id_collection = z.object({
 })
 
 export const s_payment_method_acss_debit = z.object({
-  bank_name: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  institution_number: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  transit_number: z.string().nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  institution_number: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  transit_number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_affirm = z.object({})
@@ -2852,32 +2854,34 @@ export const s_payment_method_affirm = z.object({})
 export const s_payment_method_afterpay_clearpay = z.object({})
 
 export const s_payment_method_au_becs_debit = z.object({
-  bsb_number: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
+  bsb_number: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_bacs_debit = z.object({
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  sort_code: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  sort_code: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_bancontact = z.object({})
 
 export const s_payment_method_blik = z.object({})
 
-export const s_payment_method_boleto = z.object({ tax_id: z.string() })
+export const s_payment_method_boleto = z.object({
+  tax_id: z.string().max(5000),
+})
 
 export const s_payment_method_card_checks = z.object({
-  address_line1_check: z.string().nullable().optional(),
-  address_postal_code_check: z.string().nullable().optional(),
-  cvc_check: z.string().nullable().optional(),
+  address_line1_check: z.string().max(5000).nullable().optional(),
+  address_postal_code_check: z.string().max(5000).nullable().optional(),
+  cvc_check: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_card_present_networks = z.object({
-  available: z.array(z.string()),
-  preferred: z.string().nullable().optional(),
+  available: z.array(z.string().max(5000)),
+  preferred: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_card_wallet_amex_express_checkout = z.object({})
@@ -2891,12 +2895,15 @@ export const s_payment_method_card_wallet_link = z.object({})
 export const s_payment_method_card_wallet_samsung_pay = z.object({})
 
 export const s_payment_method_cashapp = z.object({
-  buyer_id: z.string().nullable().optional(),
-  cashtag: z.string().nullable().optional(),
+  buyer_id: z.string().max(5000).nullable().optional(),
+  cashtag: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_config_biz_payment_method_configuration_details =
-  z.object({ id: z.string(), parent: z.string().nullable().optional() })
+  z.object({
+    id: z.string().max(5000),
+    parent: z.string().max(5000).nullable().optional(),
+  })
 
 export const s_payment_method_config_resource_display_preference = z.object({
   overridable: z.coerce.boolean().nullable().optional(),
@@ -2907,59 +2914,61 @@ export const s_payment_method_config_resource_display_preference = z.object({
 export const s_payment_method_customer_balance = z.object({})
 
 export const s_payment_method_details_ach_credit_transfer = z.object({
-  account_number: z.string().nullable().optional(),
-  bank_name: z.string().nullable().optional(),
-  routing_number: z.string().nullable().optional(),
-  swift_code: z.string().nullable().optional(),
+  account_number: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  routing_number: z.string().max(5000).nullable().optional(),
+  swift_code: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_ach_debit = z.object({
   account_holder_type: z.enum(["company", "individual"]).nullable().optional(),
-  bank_name: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  routing_number: z.string().nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  routing_number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_acss_debit = z.object({
-  bank_name: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  institution_number: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  mandate: z.string().optional(),
-  transit_number: z.string().nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  institution_number: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.string().max(5000).optional(),
+  transit_number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_affirm = z.object({})
 
 export const s_payment_method_details_afterpay_clearpay = z.object({
-  order_id: z.string().nullable().optional(),
-  reference: z.string().nullable().optional(),
+  order_id: z.string().max(5000).nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_au_becs_debit = z.object({
-  bsb_number: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  mandate: z.string().optional(),
+  bsb_number: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.string().max(5000).optional(),
 })
 
 export const s_payment_method_details_bacs_debit = z.object({
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  mandate: z.string().nullable().optional(),
-  sort_code: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.string().max(5000).nullable().optional(),
+  sort_code: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_blik = z.object({})
 
-export const s_payment_method_details_boleto = z.object({ tax_id: z.string() })
+export const s_payment_method_details_boleto = z.object({
+  tax_id: z.string().max(5000),
+})
 
 export const s_payment_method_details_card_checks = z.object({
-  address_line1_check: z.string().nullable().optional(),
-  address_postal_code_check: z.string().nullable().optional(),
-  cvc_check: z.string().nullable().optional(),
+  address_line1_check: z.string().max(5000).nullable().optional(),
+  address_postal_code_check: z.string().max(5000).nullable().optional(),
+  cvc_check: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_card_installments_plan = z.object({
@@ -2978,14 +2987,14 @@ export const s_payment_method_details_card_present_offline = z.object({
 
 export const s_payment_method_details_card_present_receipt = z.object({
   account_type: z.enum(["checking", "credit", "prepaid", "unknown"]).optional(),
-  application_cryptogram: z.string().nullable().optional(),
-  application_preferred_name: z.string().nullable().optional(),
-  authorization_code: z.string().nullable().optional(),
-  authorization_response_code: z.string().nullable().optional(),
-  cardholder_verification_method: z.string().nullable().optional(),
-  dedicated_file_name: z.string().nullable().optional(),
-  terminal_verification_results: z.string().nullable().optional(),
-  transaction_status_information: z.string().nullable().optional(),
+  application_cryptogram: z.string().max(5000).nullable().optional(),
+  application_preferred_name: z.string().max(5000).nullable().optional(),
+  authorization_code: z.string().max(5000).nullable().optional(),
+  authorization_response_code: z.string().max(5000).nullable().optional(),
+  cardholder_verification_method: z.string().max(5000).nullable().optional(),
+  dedicated_file_name: z.string().max(5000).nullable().optional(),
+  terminal_verification_results: z.string().max(5000).nullable().optional(),
+  transaction_status_information: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_card_wallet_amex_express_checkout =
@@ -3000,8 +3009,8 @@ export const s_payment_method_details_card_wallet_link = z.object({})
 export const s_payment_method_details_card_wallet_samsung_pay = z.object({})
 
 export const s_payment_method_details_cashapp = z.object({
-  buyer_id: z.string().nullable().optional(),
-  cashtag: z.string().nullable().optional(),
+  buyer_id: z.string().max(5000).nullable().optional(),
+  cashtag: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_customer_balance = z.object({})
@@ -3040,7 +3049,7 @@ export const s_payment_method_details_eps = z.object({
     ])
     .nullable()
     .optional(),
-  verified_name: z.string().nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_fpx = z.object({
@@ -3068,35 +3077,35 @@ export const s_payment_method_details_fpx = z.object({
     "standard_chartered",
     "uob",
   ]),
-  transaction_id: z.string().nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_giropay = z.object({
-  bank_code: z.string().nullable().optional(),
-  bank_name: z.string().nullable().optional(),
-  bic: z.string().nullable().optional(),
-  verified_name: z.string().nullable().optional(),
+  bank_code: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  bic: z.string().max(5000).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_grabpay = z.object({
-  transaction_id: z.string().nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_interac_present_receipt = z.object({
   account_type: z.enum(["checking", "savings", "unknown"]).optional(),
-  application_cryptogram: z.string().nullable().optional(),
-  application_preferred_name: z.string().nullable().optional(),
-  authorization_code: z.string().nullable().optional(),
-  authorization_response_code: z.string().nullable().optional(),
-  cardholder_verification_method: z.string().nullable().optional(),
-  dedicated_file_name: z.string().nullable().optional(),
-  terminal_verification_results: z.string().nullable().optional(),
-  transaction_status_information: z.string().nullable().optional(),
+  application_cryptogram: z.string().max(5000).nullable().optional(),
+  application_preferred_name: z.string().max(5000).nullable().optional(),
+  authorization_code: z.string().max(5000).nullable().optional(),
+  authorization_response_code: z.string().max(5000).nullable().optional(),
+  cardholder_verification_method: z.string().max(5000).nullable().optional(),
+  dedicated_file_name: z.string().max(5000).nullable().optional(),
+  terminal_verification_results: z.string().max(5000).nullable().optional(),
+  transaction_status_information: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_klarna = z.object({
-  payment_method_category: z.string().nullable().optional(),
-  preferred_locale: z.string().nullable().optional(),
+  payment_method_category: z.string().max(5000).nullable().optional(),
+  preferred_locale: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_konbini_store = z.object({
@@ -3107,16 +3116,16 @@ export const s_payment_method_details_konbini_store = z.object({
 })
 
 export const s_payment_method_details_link = z.object({
-  country: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_multibanco = z.object({
-  entity: z.string().nullable().optional(),
-  reference: z.string().nullable().optional(),
+  entity: z.string().max(5000).nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_oxxo = z.object({
-  number: z.string().nullable().optional(),
+  number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_p24 = z.object({
@@ -3151,52 +3160,52 @@ export const s_payment_method_details_p24 = z.object({
     ])
     .nullable()
     .optional(),
-  reference: z.string().nullable().optional(),
-  verified_name: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_paynow = z.object({
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_pix = z.object({
-  bank_transaction_id: z.string().nullable().optional(),
+  bank_transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_promptpay = z.object({
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_revolut_pay = z.object({})
 
 export const s_payment_method_details_sepa_debit = z.object({
-  bank_code: z.string().nullable().optional(),
-  branch_code: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  mandate: z.string().nullable().optional(),
+  bank_code: z.string().max(5000).nullable().optional(),
+  branch_code: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_stripe_account = z.object({})
 
 export const s_payment_method_details_swish = z.object({
-  fingerprint: z.string().nullable().optional(),
-  payment_reference: z.string().nullable().optional(),
-  verified_phone_last4: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  payment_reference: z.string().max(5000).nullable().optional(),
+  verified_phone_last4: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_wechat = z.object({})
 
 export const s_payment_method_details_wechat_pay = z.object({
-  fingerprint: z.string().nullable().optional(),
-  transaction_id: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_details_zip = z.object({})
 
 export const s_payment_method_domain_resource_payment_method_status_details =
-  z.object({ error_message: z.string() })
+  z.object({ error_message: z.string().max(5000) })
 
 export const s_payment_method_eps = z.object({
   bank: z
@@ -3314,20 +3323,20 @@ export const s_payment_method_ideal = z.object({
 export const s_payment_method_konbini = z.object({})
 
 export const s_payment_method_link = z.object({
-  email: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_mobilepay = z.object({})
 
 export const s_payment_method_options_affirm = z.object({
   capture_method: z.enum(["manual"]).optional(),
-  preferred_locale: z.string().optional(),
+  preferred_locale: z.string().max(30).optional(),
   setup_future_usage: z.enum(["none"]).optional(),
 })
 
 export const s_payment_method_options_afterpay_clearpay = z.object({
   capture_method: z.enum(["manual"]).optional(),
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none"]).optional(),
 })
 
@@ -3352,11 +3361,11 @@ export const s_payment_method_options_boleto = z.object({
 export const s_payment_method_options_card_mandate_options = z.object({
   amount: z.coerce.number(),
   amount_type: z.enum(["fixed", "maximum"]),
-  description: z.string().nullable().optional(),
+  description: z.string().max(200).nullable().optional(),
   end_date: z.coerce.number().nullable().optional(),
   interval: z.enum(["day", "month", "sporadic", "week", "year"]),
   interval_count: z.coerce.number().nullable().optional(),
-  reference: z.string(),
+  reference: z.string().max(80),
   start_date: z.coerce.number(),
   supported_types: z
     .array(z.enum(["india"]))
@@ -3400,15 +3409,15 @@ export const s_payment_method_options_interac_present = z.object({})
 
 export const s_payment_method_options_klarna = z.object({
   capture_method: z.enum(["manual"]).optional(),
-  preferred_locale: z.string().nullable().optional(),
+  preferred_locale: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none"]).optional(),
 })
 
 export const s_payment_method_options_konbini = z.object({
-  confirmation_number: z.string().nullable().optional(),
+  confirmation_number: z.string().max(5000).nullable().optional(),
   expires_after_days: z.coerce.number().nullable().optional(),
   expires_at: z.coerce.number().nullable().optional(),
-  product_description: z.string().nullable().optional(),
+  product_description: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none"]).optional(),
 })
 
@@ -3427,8 +3436,8 @@ export const s_payment_method_options_paynow = z.object({
 
 export const s_payment_method_options_paypal = z.object({
   capture_method: z.enum(["manual"]).optional(),
-  preferred_locale: z.string().nullable().optional(),
-  reference: z.string().nullable().optional(),
+  preferred_locale: z.string().max(5000).nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
   setup_future_usage: z.enum(["none", "off_session"]).optional(),
 })
 
@@ -3456,7 +3465,7 @@ export const s_payment_method_options_us_bank_account_mandate_options =
   z.object({ collection_method: z.enum(["paper"]).optional() })
 
 export const s_payment_method_options_wechat_pay = z.object({
-  app_id: z.string().nullable().optional(),
+  app_id: z.string().max(5000).nullable().optional(),
   client: z.enum(["android", "ios", "web"]).nullable().optional(),
   setup_future_usage: z.enum(["none"]).optional(),
 })
@@ -3504,8 +3513,8 @@ export const s_payment_method_p24 = z.object({
 export const s_payment_method_paynow = z.object({})
 
 export const s_payment_method_paypal = z.object({
-  payer_email: z.string().nullable().optional(),
-  payer_id: z.string().nullable().optional(),
+  payer_email: z.string().max(5000).nullable().optional(),
+  payer_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_pix = z.object({})
@@ -3515,7 +3524,7 @@ export const s_payment_method_promptpay = z.object({})
 export const s_payment_method_revolut_pay = z.object({})
 
 export const s_payment_method_sofort = z.object({
-  country: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_swish = z.object({})
@@ -3560,7 +3569,7 @@ export const s_payment_pages_checkout_session_after_expiration_recovery =
     allow_promotion_codes: z.coerce.boolean(),
     enabled: z.coerce.boolean(),
     expires_at: z.coerce.number().nullable().optional(),
-    url: z.string().nullable().optional(),
+    url: z.string().max(5000).nullable().optional(),
   })
 
 export const s_payment_pages_checkout_session_consent = z.object({
@@ -3572,33 +3581,33 @@ export const s_payment_pages_checkout_session_currency_conversion = z.object({
   amount_subtotal: z.coerce.number(),
   amount_total: z.coerce.number(),
   fx_rate: z.string(),
-  source_currency: z.string(),
+  source_currency: z.string().max(5000),
 })
 
 export const s_payment_pages_checkout_session_custom_fields_label = z.object({
-  custom: z.string().nullable().optional(),
+  custom: z.string().max(5000).nullable().optional(),
   type: z.enum(["custom"]),
 })
 
 export const s_payment_pages_checkout_session_custom_fields_numeric = z.object({
   maximum_length: z.coerce.number().nullable().optional(),
   minimum_length: z.coerce.number().nullable().optional(),
-  value: z.string().nullable().optional(),
+  value: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_pages_checkout_session_custom_fields_option = z.object({
-  label: z.string(),
-  value: z.string(),
+  label: z.string().max(5000),
+  value: z.string().max(5000),
 })
 
 export const s_payment_pages_checkout_session_custom_fields_text = z.object({
   maximum_length: z.coerce.number().nullable().optional(),
   minimum_length: z.coerce.number().nullable().optional(),
-  value: z.string().nullable().optional(),
+  value: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_pages_checkout_session_custom_text_position = z.object({
-  message: z.string(),
+  message: z.string().max(500),
 })
 
 export const s_payment_pages_checkout_session_payment_method_reuse_agreement =
@@ -3923,7 +3932,7 @@ export const s_payment_pages_checkout_session_tax_id = z.object({
     "vn_tin",
     "za_vat",
   ]),
-  value: z.string().nullable().optional(),
+  value: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_pages_checkout_session_tax_id_collection = z.object({
@@ -3945,8 +3954,8 @@ export const s_period = z.object({
 
 export const s_person_additional_tos_acceptance = z.object({
   date: z.coerce.number().nullable().optional(),
-  ip: z.string().nullable().optional(),
-  user_agent: z.string().nullable().optional(),
+  ip: z.string().max(5000).nullable().optional(),
+  user_agent: z.string().max(5000).nullable().optional(),
 })
 
 export const s_person_relationship = z.object({
@@ -3956,7 +3965,7 @@ export const s_person_relationship = z.object({
   owner: z.coerce.boolean().nullable().optional(),
   percent_ownership: z.coerce.number().nullable().optional(),
   representative: z.coerce.boolean().nullable().optional(),
-  title: z.string().nullable().optional(),
+  title: z.string().max(5000).nullable().optional(),
 })
 
 export const s_plan_tier = z.object({
@@ -3968,17 +3977,17 @@ export const s_plan_tier = z.object({
 })
 
 export const s_platform_tax_fee = z.object({
-  account: z.string(),
-  id: z.string(),
+  account: z.string().max(5000),
+  id: z.string().max(5000),
   object: z.enum(["platform_tax_fee"]),
-  source_transaction: z.string(),
-  type: z.string(),
+  source_transaction: z.string().max(5000),
+  type: z.string().max(5000),
 })
 
 export const s_portal_business_profile = z.object({
-  headline: z.string().nullable().optional(),
-  privacy_policy_url: z.string().nullable().optional(),
-  terms_of_service_url: z.string().nullable().optional(),
+  headline: z.string().max(5000).nullable().optional(),
+  privacy_policy_url: z.string().max(5000).nullable().optional(),
+  terms_of_service_url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_portal_customer_update = z.object({
@@ -3989,27 +3998,29 @@ export const s_portal_customer_update = z.object({
 })
 
 export const s_portal_flows_after_completion_hosted_confirmation = z.object({
-  custom_message: z.string().nullable().optional(),
+  custom_message: z.string().max(5000).nullable().optional(),
 })
 
 export const s_portal_flows_after_completion_redirect = z.object({
-  return_url: z.string(),
+  return_url: z.string().max(5000),
 })
 
-export const s_portal_flows_coupon_offer = z.object({ coupon: z.string() })
+export const s_portal_flows_coupon_offer = z.object({
+  coupon: z.string().max(5000),
+})
 
 export const s_portal_flows_flow_subscription_update = z.object({
-  subscription: z.string(),
+  subscription: z.string().max(5000),
 })
 
 export const s_portal_flows_subscription_update_confirm_discount = z.object({
-  coupon: z.string().nullable().optional(),
-  promotion_code: z.string().nullable().optional(),
+  coupon: z.string().max(5000).nullable().optional(),
+  promotion_code: z.string().max(5000).nullable().optional(),
 })
 
 export const s_portal_flows_subscription_update_confirm_item = z.object({
-  id: z.string().nullable().optional(),
-  price: z.string().nullable().optional(),
+  id: z.string().max(5000).nullable().optional(),
+  price: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number().optional(),
 })
 
@@ -4017,7 +4028,7 @@ export const s_portal_invoice_list = z.object({ enabled: z.coerce.boolean() })
 
 export const s_portal_login_page = z.object({
   enabled: z.coerce.boolean(),
-  url: z.string().nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_portal_payment_method_update = z.object({
@@ -4041,8 +4052,8 @@ export const s_portal_subscription_cancellation_reason = z.object({
 })
 
 export const s_portal_subscription_update_product = z.object({
-  prices: z.array(z.string()),
-  product: z.string(),
+  prices: z.array(z.string().max(5000)),
+  product: z.string().max(5000),
 })
 
 export const s_price_tier = z.object({
@@ -4054,7 +4065,7 @@ export const s_price_tier = z.object({
 })
 
 export const s_product_marketing_feature = z.object({
-  name: z.string().optional(),
+  name: z.string().max(5000).optional(),
 })
 
 export const s_promotion_code_currency_option = z.object({
@@ -4068,43 +4079,43 @@ export const s_quotes_resource_status_transitions = z.object({
 })
 
 export const s_quotes_resource_subscription_data_subscription_data = z.object({
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   effective_date: z.coerce.number().nullable().optional(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   trial_period_days: z.coerce.number().nullable().optional(),
 })
 
 export const s_radar_radar_options = z.object({
-  session: z.string().optional(),
+  session: z.string().max(5000).optional(),
 })
 
 export const s_radar_review_resource_location = z.object({
-  city: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
+  city: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   latitude: z.coerce.number().nullable().optional(),
   longitude: z.coerce.number().nullable().optional(),
-  region: z.string().nullable().optional(),
+  region: z.string().max(5000).nullable().optional(),
 })
 
 export const s_radar_review_resource_session = z.object({
-  browser: z.string().nullable().optional(),
-  device: z.string().nullable().optional(),
-  platform: z.string().nullable().optional(),
-  version: z.string().nullable().optional(),
+  browser: z.string().max(5000).nullable().optional(),
+  device: z.string().max(5000).nullable().optional(),
+  platform: z.string().max(5000).nullable().optional(),
+  version: z.string().max(5000).nullable().optional(),
 })
 
 export const s_radar_value_list_item = z.object({
   created: z.coerce.number(),
-  created_by: z.string(),
-  id: z.string(),
+  created_by: z.string().max(5000),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["radar.value_list_item"]),
-  value: z.string(),
-  value_list: z.string(),
+  value: z.string().max(5000),
+  value_list: z.string().max(5000),
 })
 
 export const s_received_payment_method_details_financial_account = z.object({
-  id: z.string(),
+  id: z.string().max(5000),
   network: z.enum(["stripe"]),
 })
 
@@ -4115,29 +4126,29 @@ export const s_recurring = z.object({
     .optional(),
   interval: z.enum(["day", "month", "week", "year"]),
   interval_count: z.coerce.number(),
-  meter: z.string().nullable().optional(),
+  meter: z.string().max(5000).nullable().optional(),
   usage_type: z.enum(["licensed", "metered"]),
 })
 
 export const s_refund_destination_details_card = z.object({
-  reference: z.string().optional(),
-  reference_status: z.string().optional(),
-  reference_type: z.string().optional(),
+  reference: z.string().max(5000).optional(),
+  reference_status: z.string().max(5000).optional(),
+  reference_type: z.string().max(5000).optional(),
   type: z.enum(["pending", "refund", "reversal"]),
 })
 
 export const s_refund_destination_details_generic = z.object({
-  reference: z.string().nullable().optional(),
-  reference_status: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
+  reference_status: z.string().max(5000).nullable().optional(),
 })
 
 export const s_reporting_report_type = z.object({
   data_available_end: z.coerce.number(),
   data_available_start: z.coerce.number(),
-  default_columns: z.array(z.string()).nullable().optional(),
-  id: z.string(),
+  default_columns: z.array(z.string().max(5000)).nullable().optional(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  name: z.string(),
+  name: z.string().max(5000),
   object: z.enum(["reporting.report_type"]),
   updated: z.coerce.number(),
   version: z.coerce.number(),
@@ -4146,20 +4157,20 @@ export const s_reporting_report_type = z.object({
 export const s_reserve_transaction = z.object({
   amount: z.coerce.number(),
   currency: z.string(),
-  description: z.string().nullable().optional(),
-  id: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   object: z.enum(["reserve_transaction"]),
 })
 
 export const s_rule = z.object({
-  action: z.string(),
-  id: z.string(),
-  predicate: z.string(),
+  action: z.string().max(5000),
+  id: z.string().max(5000),
+  predicate: z.string().max(5000),
 })
 
 export const s_secret_service_resource_scope = z.object({
   type: z.enum(["account", "user"]),
-  user: z.string().optional(),
+  user: z.string().max(5000).optional(),
 })
 
 export const s_setup_attempt_payment_method_details_acss_debit = z.object({})
@@ -4171,9 +4182,9 @@ export const s_setup_attempt_payment_method_details_bacs_debit = z.object({})
 export const s_setup_attempt_payment_method_details_boleto = z.object({})
 
 export const s_setup_attempt_payment_method_details_card_checks = z.object({
-  address_line1_check: z.string().nullable().optional(),
-  address_postal_code_check: z.string().nullable().optional(),
-  cvc_check: z.string().nullable().optional(),
+  address_line1_check: z.string().max(5000).nullable().optional(),
+  address_postal_code_check: z.string().max(5000).nullable().optional(),
+  cvc_check: z.string().max(5000).nullable().optional(),
 })
 
 export const s_setup_attempt_payment_method_details_cashapp = z.object({})
@@ -4191,13 +4202,13 @@ export const s_setup_attempt_payment_method_details_us_bank_account = z.object(
 )
 
 export const s_setup_intent_next_action_redirect_to_url = z.object({
-  return_url: z.string().nullable().optional(),
-  url: z.string().nullable().optional(),
+  return_url: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_setup_intent_next_action_verify_with_microdeposits = z.object({
   arrival_date: z.coerce.number(),
-  hosted_verification_url: z.string(),
+  hosted_verification_url: z.string().max(5000),
   microdeposit_type: z
     .enum(["amounts", "descriptor_code"])
     .nullable()
@@ -4209,11 +4220,11 @@ export const s_setup_intent_payment_method_options_card_mandate_options =
     amount: z.coerce.number(),
     amount_type: z.enum(["fixed", "maximum"]),
     currency: z.string(),
-    description: z.string().nullable().optional(),
+    description: z.string().max(200).nullable().optional(),
     end_date: z.coerce.number().nullable().optional(),
     interval: z.enum(["day", "month", "sporadic", "week", "year"]),
     interval_count: z.coerce.number().nullable().optional(),
-    reference: z.string(),
+    reference: z.string().max(80),
     start_date: z.coerce.number(),
     supported_types: z
       .array(z.enum(["india"]))
@@ -4227,9 +4238,9 @@ export const s_setup_intent_payment_method_options_link = z.object({})
 
 export const s_setup_intent_payment_method_options_mandate_options_acss_debit =
   z.object({
-    custom_mandate_url: z.string().optional(),
+    custom_mandate_url: z.string().max(5000).optional(),
     default_for: z.array(z.enum(["invoice", "subscription"])).optional(),
-    interval_description: z.string().nullable().optional(),
+    interval_description: z.string().max(5000).nullable().optional(),
     payment_schedule: z
       .enum(["combined", "interval", "sporadic"])
       .nullable()
@@ -4241,7 +4252,7 @@ export const s_setup_intent_payment_method_options_mandate_options_sepa_debit =
   z.object({})
 
 export const s_setup_intent_payment_method_options_paypal = z.object({
-  billing_agreement_id: z.string().nullable().optional(),
+  billing_agreement_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_setup_intent_type_specific_payment_method_options_client =
@@ -4262,87 +4273,87 @@ export const s_shipping_rate_delivery_estimate_bound = z.object({
 })
 
 export const s_sigma_scheduled_query_run_error = z.object({
-  message: z.string(),
+  message: z.string().max(5000),
 })
 
 export const s_source_code_verification_flow = z.object({
   attempts_remaining: z.coerce.number(),
-  status: z.string(),
+  status: z.string().max(5000),
 })
 
 export const s_source_mandate_notification_acss_debit_data = z.object({
-  statement_descriptor: z.string().optional(),
+  statement_descriptor: z.string().max(5000).optional(),
 })
 
 export const s_source_mandate_notification_bacs_debit_data = z.object({
-  last4: z.string().optional(),
+  last4: z.string().max(5000).optional(),
 })
 
 export const s_source_mandate_notification_sepa_debit_data = z.object({
-  creditor_identifier: z.string().optional(),
-  last4: z.string().optional(),
-  mandate_reference: z.string().optional(),
+  creditor_identifier: z.string().max(5000).optional(),
+  last4: z.string().max(5000).optional(),
+  mandate_reference: z.string().max(5000).optional(),
 })
 
 export const s_source_order_item = z.object({
   amount: z.coerce.number().nullable().optional(),
-  currency: z.string().nullable().optional(),
-  description: z.string().nullable().optional(),
-  parent: z.string().nullable().optional(),
+  currency: z.string().max(5000).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  parent: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number().optional(),
-  type: z.string().nullable().optional(),
+  type: z.string().max(5000).nullable().optional(),
 })
 
 export const s_source_receiver_flow = z.object({
-  address: z.string().nullable().optional(),
+  address: z.string().max(5000).nullable().optional(),
   amount_charged: z.coerce.number(),
   amount_received: z.coerce.number(),
   amount_returned: z.coerce.number(),
-  refund_attributes_method: z.string(),
-  refund_attributes_status: z.string(),
+  refund_attributes_method: z.string().max(5000),
+  refund_attributes_status: z.string().max(5000),
 })
 
 export const s_source_redirect_flow = z.object({
-  failure_reason: z.string().nullable().optional(),
-  return_url: z.string(),
-  status: z.string(),
-  url: z.string(),
+  failure_reason: z.string().max(5000).nullable().optional(),
+  return_url: z.string().max(5000),
+  status: z.string().max(5000),
+  url: z.string().max(2048),
 })
 
 export const s_source_transaction_ach_credit_transfer_data = z.object({
-  customer_data: z.string().optional(),
-  fingerprint: z.string().optional(),
-  last4: z.string().optional(),
-  routing_number: z.string().optional(),
+  customer_data: z.string().max(5000).optional(),
+  fingerprint: z.string().max(5000).optional(),
+  last4: z.string().max(5000).optional(),
+  routing_number: z.string().max(5000).optional(),
 })
 
 export const s_source_transaction_chf_credit_transfer_data = z.object({
-  reference: z.string().optional(),
-  sender_address_country: z.string().optional(),
-  sender_address_line1: z.string().optional(),
-  sender_iban: z.string().optional(),
-  sender_name: z.string().optional(),
+  reference: z.string().max(5000).optional(),
+  sender_address_country: z.string().max(5000).optional(),
+  sender_address_line1: z.string().max(5000).optional(),
+  sender_iban: z.string().max(5000).optional(),
+  sender_name: z.string().max(5000).optional(),
 })
 
 export const s_source_transaction_gbp_credit_transfer_data = z.object({
-  fingerprint: z.string().optional(),
-  funding_method: z.string().optional(),
-  last4: z.string().optional(),
-  reference: z.string().optional(),
-  sender_account_number: z.string().optional(),
-  sender_name: z.string().optional(),
-  sender_sort_code: z.string().optional(),
+  fingerprint: z.string().max(5000).optional(),
+  funding_method: z.string().max(5000).optional(),
+  last4: z.string().max(5000).optional(),
+  reference: z.string().max(5000).optional(),
+  sender_account_number: z.string().max(5000).optional(),
+  sender_name: z.string().max(5000).optional(),
+  sender_sort_code: z.string().max(5000).optional(),
 })
 
 export const s_source_transaction_paper_check_data = z.object({
-  available_at: z.string().optional(),
-  invoices: z.string().optional(),
+  available_at: z.string().max(5000).optional(),
+  invoices: z.string().max(5000).optional(),
 })
 
 export const s_source_transaction_sepa_credit_transfer_data = z.object({
-  reference: z.string().optional(),
-  sender_iban: z.string().optional(),
-  sender_name: z.string().optional(),
+  reference: z.string().max(5000).optional(),
+  sender_iban: z.string().max(5000).optional(),
+  sender_name: z.string().max(5000).optional(),
 })
 
 export const s_source_type_ach_credit_transfer = z.object({
@@ -4559,7 +4570,7 @@ export const s_subscription_billing_thresholds = z.object({
 })
 
 export const s_subscription_details_data = z.object({
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
 })
 
 export const s_subscription_item_billing_thresholds = z.object({
@@ -4594,28 +4605,28 @@ export const s_subscriptions_trials_resource_end_behavior = z.object({
 })
 
 export const s_tax_code = z.object({
-  description: z.string(),
-  id: z.string(),
-  name: z.string(),
+  description: z.string().max(5000),
+  id: z.string().max(5000),
+  name: z.string().max(5000),
   object: z.enum(["tax_code"]),
 })
 
 export const s_tax_deducted_at_source = z.object({
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["tax_deducted_at_source"]),
   period_end: z.coerce.number(),
   period_start: z.coerce.number(),
-  tax_deduction_account_number: z.string(),
+  tax_deduction_account_number: z.string().max(5000),
 })
 
 export const s_tax_id_verification = z.object({
   status: z.enum(["pending", "unavailable", "unverified", "verified"]),
-  verified_address: z.string().nullable().optional(),
-  verified_name: z.string().nullable().optional(),
+  verified_address: z.string().max(5000).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
 })
 
 export const s_tax_product_registrations_resource_country_options_ca_province_standard =
-  z.object({ province: z.string() })
+  z.object({ province: z.string().max(5000) })
 
 export const s_tax_product_registrations_resource_country_options_default =
   z.object({ type: z.enum(["standard"]) })
@@ -4627,10 +4638,10 @@ export const s_tax_product_registrations_resource_country_options_simplified =
   z.object({ type: z.enum(["simplified"]) })
 
 export const s_tax_product_registrations_resource_country_options_us_local_amusement_tax =
-  z.object({ jurisdiction: z.string() })
+  z.object({ jurisdiction: z.string().max(5000) })
 
 export const s_tax_product_registrations_resource_country_options_us_local_lease_tax =
-  z.object({ jurisdiction: z.string() })
+  z.object({ jurisdiction: z.string().max(5000) })
 
 export const s_tax_product_resource_customer_details_resource_tax_id = z.object(
   {
@@ -4704,20 +4715,20 @@ export const s_tax_product_resource_customer_details_resource_tax_id = z.object(
       "vn_tin",
       "za_vat",
     ]),
-    value: z.string(),
+    value: z.string().max(5000),
   },
 )
 
 export const s_tax_product_resource_jurisdiction = z.object({
-  country: z.string(),
-  display_name: z.string(),
+  country: z.string().max(5000),
+  display_name: z.string().max(5000),
   level: z.enum(["city", "country", "county", "district", "state"]),
-  state: z.string().nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
 })
 
 export const s_tax_product_resource_line_item_tax_rate_details = z.object({
-  display_name: z.string(),
-  percentage_decimal: z.string(),
+  display_name: z.string().max(5000),
+  percentage_decimal: z.string().max(5000),
   tax_type: z.enum([
     "amusement_tax",
     "communications_tax",
@@ -4735,18 +4746,18 @@ export const s_tax_product_resource_line_item_tax_rate_details = z.object({
 })
 
 export const s_tax_product_resource_postal_address = z.object({
-  city: z.string().nullable().optional(),
-  country: z.string(),
-  line1: z.string().nullable().optional(),
-  line2: z.string().nullable().optional(),
-  postal_code: z.string().nullable().optional(),
-  state: z.string().nullable().optional(),
+  city: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000),
+  line1: z.string().max(5000).nullable().optional(),
+  line2: z.string().max(5000).nullable().optional(),
+  postal_code: z.string().max(5000).nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
 })
 
 export const s_tax_product_resource_tax_rate_details = z.object({
-  country: z.string().nullable().optional(),
-  percentage_decimal: z.string(),
-  state: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  percentage_decimal: z.string().max(5000),
+  state: z.string().max(5000).nullable().optional(),
   tax_type: z
     .enum([
       "amusement_tax",
@@ -4771,48 +4782,50 @@ export const s_tax_product_resource_tax_settings_defaults = z.object({
     .enum(["exclusive", "inclusive", "inferred_by_currency"])
     .nullable()
     .optional(),
-  tax_code: z.string().nullable().optional(),
+  tax_code: z.string().max(5000).nullable().optional(),
 })
 
 export const s_tax_product_resource_tax_settings_status_details_resource_active =
   z.object({})
 
 export const s_tax_product_resource_tax_settings_status_details_resource_pending =
-  z.object({ missing_fields: z.array(z.string()).nullable().optional() })
+  z.object({
+    missing_fields: z.array(z.string().max(5000)).nullable().optional(),
+  })
 
 export const s_tax_product_resource_tax_transaction_line_item_resource_reversal =
-  z.object({ original_line_item: z.string() })
+  z.object({ original_line_item: z.string().max(5000) })
 
 export const s_tax_product_resource_tax_transaction_resource_reversal =
-  z.object({ original_transaction: z.string().nullable().optional() })
+  z.object({ original_transaction: z.string().max(5000).nullable().optional() })
 
 export const s_tax_product_resource_tax_transaction_shipping_cost = z.object({
   amount: z.coerce.number(),
   amount_tax: z.coerce.number(),
-  shipping_rate: z.string().optional(),
+  shipping_rate: z.string().max(5000).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive"]),
-  tax_code: z.string(),
+  tax_code: z.string().max(5000),
 })
 
 export const s_tax_rate = z.object({
   active: z.coerce.boolean(),
-  country: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
-  description: z.string().nullable().optional(),
-  display_name: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  display_name: z.string().max(5000),
   effective_percentage: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   inclusive: z.coerce.boolean(),
-  jurisdiction: z.string().nullable().optional(),
+  jurisdiction: z.string().max(5000).nullable().optional(),
   jurisdiction_level: z
     .enum(["city", "country", "county", "district", "multiple", "state"])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["tax_rate"]),
   percentage: z.coerce.number(),
-  state: z.string().nullable().optional(),
+  state: z.string().max(5000).nullable().optional(),
   tax_type: z
     .enum([
       "amusement_tax",
@@ -4843,14 +4856,14 @@ export const s_terminal_configuration_configuration_resource_offline_config =
   z.object({ enabled: z.coerce.boolean().nullable().optional() })
 
 export const s_terminal_connection_token = z.object({
-  location: z.string().optional(),
+  location: z.string().max(5000).optional(),
   object: z.enum(["terminal.connection_token"]),
-  secret: z.string(),
+  secret: z.string().max(5000),
 })
 
 export const s_terminal_reader_reader_resource_line_item = z.object({
   amount: z.coerce.number(),
-  description: z.string(),
+  description: z.string().max(5000),
   quantity: z.coerce.number(),
 })
 
@@ -4870,9 +4883,9 @@ export const s_test_helpers_test_clock = z.object({
   created: z.coerce.number(),
   deletes_after: z.coerce.number(),
   frozen_time: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  name: z.string().nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   object: z.enum(["test_helpers.test_clock"]),
   status: z.enum(["advancing", "internal_failure", "ready"]),
 })
@@ -4909,7 +4922,7 @@ export const s_three_d_secure_details = z.object({
     ])
     .nullable()
     .optional(),
-  transaction_id: z.string().nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).nullable().optional(),
 })
 
@@ -4947,7 +4960,7 @@ export const s_three_d_secure_details_charge = z.object({
     ])
     .nullable()
     .optional(),
-  transaction_id: z.string().nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).nullable().optional(),
 })
 
@@ -4956,14 +4969,14 @@ export const s_three_d_secure_usage = z.object({
 })
 
 export const s_token_card_networks = z.object({
-  preferred: z.string().nullable().optional(),
+  preferred: z.string().max(5000).nullable().optional(),
 })
 
 export const s_transfer_schedule = z.object({
   delay_days: z.coerce.number(),
-  interval: z.string(),
+  interval: z.string().max(5000),
   monthly_anchor: z.coerce.number().optional(),
-  weekly_anchor: z.string().optional(),
+  weekly_anchor: z.string().max(5000).optional(),
 })
 
 export const s_transform_quantity = z.object({
@@ -4977,11 +4990,11 @@ export const s_transform_usage = z.object({
 })
 
 export const s_treasury_financial_accounts_resource_aba_record = z.object({
-  account_holder_name: z.string(),
-  account_number: z.string().nullable().optional(),
-  account_number_last4: z.string(),
-  bank_name: z.string(),
-  routing_number: z.string(),
+  account_holder_name: z.string().max(5000),
+  account_number: z.string().max(5000).nullable().optional(),
+  account_number_last4: z.string().max(5000),
+  bank_name: z.string().max(5000),
+  routing_number: z.string().max(5000),
 })
 
 export const s_treasury_financial_accounts_resource_balance = z.object({
@@ -5045,7 +5058,7 @@ export const s_treasury_inbound_transfers_resource_failure_details = z.object({
 })
 
 export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows =
-  z.object({ received_debit: z.string().nullable().optional() })
+  z.object({ received_debit: z.string().max(5000).nullable().optional() })
 
 export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions =
   z.object({
@@ -5056,7 +5069,7 @@ export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_sta
 
 export const s_treasury_outbound_payments_resource_outbound_payment_resource_end_user_details =
   z.object({
-    ip_address: z.string().nullable().optional(),
+    ip_address: z.string().max(5000).nullable().optional(),
     present: z.coerce.boolean(),
   })
 
@@ -5095,14 +5108,14 @@ export const s_treasury_received_credits_resource_status_transitions = z.object(
 )
 
 export const s_treasury_received_debits_resource_debit_reversal_linked_flows =
-  z.object({ issuing_dispute: z.string().nullable().optional() })
+  z.object({ issuing_dispute: z.string().max(5000).nullable().optional() })
 
 export const s_treasury_received_debits_resource_linked_flows = z.object({
-  debit_reversal: z.string().nullable().optional(),
-  inbound_transfer: z.string().nullable().optional(),
-  issuing_authorization: z.string().nullable().optional(),
-  issuing_transaction: z.string().nullable().optional(),
-  payout: z.string().nullable().optional(),
+  debit_reversal: z.string().max(5000).nullable().optional(),
+  inbound_transfer: z.string().max(5000).nullable().optional(),
+  issuing_authorization: z.string().max(5000).nullable().optional(),
+  issuing_transaction: z.string().max(5000).nullable().optional(),
+  payout: z.string().max(5000).nullable().optional(),
 })
 
 export const s_treasury_received_debits_resource_reversal_details = z.object({
@@ -5125,9 +5138,9 @@ export const s_treasury_received_debits_resource_status_transitions = z.object({
 
 export const s_treasury_shared_resource_initiating_payment_method_details_us_bank_account =
   z.object({
-    bank_name: z.string().nullable().optional(),
-    last4: z.string().nullable().optional(),
-    routing_number: z.string().nullable().optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    last4: z.string().max(5000).nullable().optional(),
+    routing_number: z.string().max(5000).nullable().optional(),
   })
 
 export const s_treasury_transactions_resource_abstract_transaction_resource_status_transitions =
@@ -5143,16 +5156,16 @@ export const s_treasury_transactions_resource_balance_impact = z.object({
 })
 
 export const s_us_bank_account_networks = z.object({
-  preferred: z.string().nullable().optional(),
+  preferred: z.string().max(5000).nullable().optional(),
   supported: z.array(z.enum(["ach", "us_domestic_wire"])),
 })
 
 export const s_usage_record = z.object({
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["usage_record"]),
   quantity: z.coerce.number(),
-  subscription_item: z.string(),
+  subscription_item: z.string().max(5000),
   timestamp: z.coerce.number(),
 })
 
@@ -5161,32 +5174,32 @@ export const s_verification_session_redaction = z.object({
 })
 
 export const s_webhook_endpoint = z.object({
-  api_version: z.string().nullable().optional(),
-  application: z.string().nullable().optional(),
+  api_version: z.string().max(5000).nullable().optional(),
+  application: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
-  description: z.string().nullable().optional(),
-  enabled_events: z.array(z.string()),
-  id: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  enabled_events: z.array(z.string().max(5000)),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["webhook_endpoint"]),
-  secret: z.string().optional(),
-  status: z.string(),
-  url: z.string(),
+  secret: z.string().max(5000).optional(),
+  status: z.string().max(5000),
+  url: z.string().max(5000),
 })
 
 export const s_account_business_profile = z.object({
   annual_revenue: s_account_annual_revenue.nullable().optional(),
   estimated_worker_count: z.coerce.number().nullable().optional(),
-  mcc: z.string().nullable().optional(),
+  mcc: z.string().max(5000).nullable().optional(),
   monthly_estimated_revenue: s_account_monthly_estimated_revenue.optional(),
-  name: z.string().nullable().optional(),
-  product_description: z.string().nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
+  product_description: z.string().max(40000).nullable().optional(),
   support_address: s_address.nullable().optional(),
-  support_email: z.string().nullable().optional(),
-  support_phone: z.string().nullable().optional(),
-  support_url: z.string().nullable().optional(),
-  url: z.string().nullable().optional(),
+  support_email: z.string().max(5000).nullable().optional(),
+  support_phone: z.string().max(5000).nullable().optional(),
+  support_url: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_capability_future_requirements = z.object({
@@ -5195,12 +5208,12 @@ export const s_account_capability_future_requirements = z.object({
     .nullable()
     .optional(),
   current_deadline: z.coerce.number().nullable().optional(),
-  currently_due: z.array(z.string()),
-  disabled_reason: z.string().nullable().optional(),
+  currently_due: z.array(z.string().max(5000)),
+  disabled_reason: z.string().max(5000).nullable().optional(),
   errors: z.array(s_account_requirements_error),
-  eventually_due: z.array(z.string()),
-  past_due: z.array(z.string()),
-  pending_verification: z.array(z.string()),
+  eventually_due: z.array(z.string().max(5000)),
+  past_due: z.array(z.string().max(5000)),
+  pending_verification: z.array(z.string().max(5000)),
 })
 
 export const s_account_capability_requirements = z.object({
@@ -5209,12 +5222,12 @@ export const s_account_capability_requirements = z.object({
     .nullable()
     .optional(),
   current_deadline: z.coerce.number().nullable().optional(),
-  currently_due: z.array(z.string()),
-  disabled_reason: z.string().nullable().optional(),
+  currently_due: z.array(z.string().max(5000)),
+  disabled_reason: z.string().max(5000).nullable().optional(),
   errors: z.array(s_account_requirements_error),
-  eventually_due: z.array(z.string()),
-  past_due: z.array(z.string()),
-  pending_verification: z.array(z.string()),
+  eventually_due: z.array(z.string().max(5000)),
+  past_due: z.array(z.string().max(5000)),
+  pending_verification: z.array(z.string().max(5000)),
 })
 
 export const s_account_card_issuing_settings = z.object({
@@ -5223,9 +5236,9 @@ export const s_account_card_issuing_settings = z.object({
 
 export const s_account_card_payments_settings = z.object({
   decline_on: s_account_decline_charge_on.optional(),
-  statement_descriptor_prefix: z.string().nullable().optional(),
-  statement_descriptor_prefix_kana: z.string().nullable().optional(),
-  statement_descriptor_prefix_kanji: z.string().nullable().optional(),
+  statement_descriptor_prefix: z.string().max(5000).nullable().optional(),
+  statement_descriptor_prefix_kana: z.string().max(5000).nullable().optional(),
+  statement_descriptor_prefix_kanji: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_future_requirements = z.object({
@@ -5234,18 +5247,18 @@ export const s_account_future_requirements = z.object({
     .nullable()
     .optional(),
   current_deadline: z.coerce.number().nullable().optional(),
-  currently_due: z.array(z.string()).nullable().optional(),
-  disabled_reason: z.string().nullable().optional(),
+  currently_due: z.array(z.string().max(5000)).nullable().optional(),
+  disabled_reason: z.string().max(5000).nullable().optional(),
   errors: z.array(s_account_requirements_error).nullable().optional(),
-  eventually_due: z.array(z.string()).nullable().optional(),
-  past_due: z.array(z.string()).nullable().optional(),
-  pending_verification: z.array(z.string()).nullable().optional(),
+  eventually_due: z.array(z.string().max(5000)).nullable().optional(),
+  past_due: z.array(z.string().max(5000)).nullable().optional(),
+  pending_verification: z.array(z.string().max(5000)).nullable().optional(),
 })
 
 export const s_account_payout_settings = z.object({
   debit_negative_balances: z.coerce.boolean(),
   schedule: s_transfer_schedule,
-  statement_descriptor: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
 })
 
 export const s_account_requirements = z.object({
@@ -5254,12 +5267,12 @@ export const s_account_requirements = z.object({
     .nullable()
     .optional(),
   current_deadline: z.coerce.number().nullable().optional(),
-  currently_due: z.array(z.string()).nullable().optional(),
-  disabled_reason: z.string().nullable().optional(),
+  currently_due: z.array(z.string().max(5000)).nullable().optional(),
+  disabled_reason: z.string().max(5000).nullable().optional(),
   errors: z.array(s_account_requirements_error).nullable().optional(),
-  eventually_due: z.array(z.string()).nullable().optional(),
-  past_due: z.array(z.string()).nullable().optional(),
-  pending_verification: z.array(z.string()).nullable().optional(),
+  eventually_due: z.array(z.string().max(5000)).nullable().optional(),
+  past_due: z.array(z.string().max(5000)).nullable().optional(),
+  pending_verification: z.array(z.string().max(5000)).nullable().optional(),
 })
 
 export const s_account_treasury_settings = z.object({
@@ -5270,11 +5283,11 @@ export const s_apps_secret = z.object({
   created: z.coerce.number(),
   deleted: z.coerce.boolean().optional(),
   expires_at: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  name: z.string(),
+  name: z.string().max(5000),
   object: z.enum(["apps.secret"]),
-  payload: z.string().nullable().optional(),
+  payload: z.string().max(5000).nullable().optional(),
   scope: s_secret_service_resource_scope,
 })
 
@@ -5301,19 +5314,19 @@ export const s_bank_connections_resource_balance = z.object({
 
 export const s_billing_details = z.object({
   address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
-  phone: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
 })
 
 export const s_billing_meter = z.object({
   created: z.coerce.number(),
   customer_mapping: s_billing_meter_resource_customer_mapping_settings,
   default_aggregation: s_billing_meter_resource_aggregation_settings,
-  display_name: z.string(),
-  event_name: z.string(),
+  display_name: z.string().max(5000),
+  event_name: z.string().max(5000),
   event_time_window: z.enum(["day", "hour"]).nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["billing.meter"]),
   status: z.enum(["active", "inactive"]),
@@ -5324,7 +5337,7 @@ export const s_billing_meter = z.object({
 
 export const s_billing_meter_event_adjustment = z.object({
   cancel: s_billing_meter_resource_billing_meter_event_adjustment_cancel,
-  event_name: z.string(),
+  event_name: z.string().max(100),
   livemode: z.coerce.boolean(),
   object: z.enum(["billing.meter_event_adjustment"]),
   status: z.enum(["complete", "pending"]),
@@ -5333,20 +5346,20 @@ export const s_billing_meter_event_adjustment = z.object({
 
 export const s_cash_balance = z.object({
   available: z.record(z.coerce.number()).nullable().optional(),
-  customer: z.string(),
+  customer: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["cash_balance"]),
   settings: s_customer_balance_customer_balance_settings,
 })
 
 export const s_charge_outcome = z.object({
-  network_status: z.string().nullable().optional(),
-  reason: z.string().nullable().optional(),
-  risk_level: z.string().optional(),
+  network_status: z.string().max(5000).nullable().optional(),
+  reason: z.string().max(5000).nullable().optional(),
+  risk_level: z.string().max(5000).optional(),
   risk_score: z.coerce.number().optional(),
-  rule: z.union([z.string(), s_rule]).optional(),
-  seller_message: z.string().nullable().optional(),
-  type: z.string(),
+  rule: z.union([z.string().max(5000), s_rule]).optional(),
+  seller_message: z.string().max(5000).nullable().optional(),
+  type: z.string().max(5000),
 })
 
 export const s_checkout_acss_debit_payment_method_options = z.object({
@@ -5362,8 +5375,8 @@ export const s_checkout_card_payment_method_options = z.object({
   installments: s_checkout_card_installments_options.optional(),
   request_three_d_secure: z.enum(["any", "automatic", "challenge"]),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
-  statement_descriptor_suffix_kana: z.string().optional(),
-  statement_descriptor_suffix_kanji: z.string().optional(),
+  statement_descriptor_suffix_kana: z.string().max(5000).optional(),
+  statement_descriptor_suffix_kanji: z.string().max(5000).optional(),
 })
 
 export const s_checkout_customer_balance_bank_transfer_payment_method_options =
@@ -5394,11 +5407,11 @@ export const s_checkout_us_bank_account_payment_method_options = z.object({
 })
 
 export const s_climate_supplier = z.object({
-  id: z.string(),
-  info_url: z.string(),
+  id: z.string().max(5000),
+  info_url: z.string().max(5000),
   livemode: z.coerce.boolean(),
   locations: z.array(s_climate_removals_location),
-  name: z.string(),
+  name: z.string().max(5000),
   object: z.enum(["climate.supplier"]),
   removal_pathway: z.enum([
     "biomass_carbon_removal_and_storage",
@@ -5413,13 +5426,13 @@ export const s_confirmation_tokens_resource_mandate_data_resource_customer_accep
       s_confirmation_tokens_resource_mandate_data_resource_customer_acceptance_resource_online
         .nullable()
         .optional(),
-    type: z.string(),
+    type: z.string().max(5000),
   })
 
 export const s_confirmation_tokens_resource_shipping = z.object({
   address: s_address,
-  name: z.string(),
-  phone: z.string().nullable().optional(),
+  name: z.string().max(5000),
+  phone: z.string().max(5000).nullable().optional(),
 })
 
 export const s_connect_embedded_account_config = z.object({
@@ -5455,11 +5468,11 @@ export const s_coupon = z.object({
   currency_options: z.record(s_coupon_currency_option).optional(),
   duration: z.enum(["forever", "once", "repeating"]),
   duration_in_months: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   max_redemptions: z.coerce.number().nullable().optional(),
-  metadata: z.record(z.string()).nullable().optional(),
-  name: z.string().nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   object: z.enum(["coupon"]),
   percent_off: z.coerce.number().nullable().optional(),
   redeem_by: z.coerce.number().nullable().optional(),
@@ -5470,7 +5483,7 @@ export const s_coupon = z.object({
 export const s_credit_note_tax_amount = z.object({
   amount: z.coerce.number(),
   inclusive: z.coerce.boolean(),
-  tax_rate: z.union([z.string(), s_tax_rate]),
+  tax_rate: z.union([z.string().max(5000), s_tax_rate]),
   taxability_reason: z
     .enum([
       "customer_exempt",
@@ -5520,7 +5533,7 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_funde
       s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_gb_bank_transfer.optional(),
     jp_bank_transfer:
       s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_jp_bank_transfer.optional(),
-    reference: z.string().nullable().optional(),
+    reference: z.string().max(5000).nullable().optional(),
     type: z.enum([
       "eu_bank_transfer",
       "gb_bank_transfer",
@@ -5544,7 +5557,7 @@ export const s_customer_tax = z.object({
     "supported",
     "unrecognized_location",
   ]),
-  ip_address: z.string().nullable().optional(),
+  ip_address: z.string().max(5000).nullable().optional(),
   location: s_customer_tax_location.nullable().optional(),
 })
 
@@ -5564,61 +5577,61 @@ export const s_dispute_payment_method_details = z.object({
 })
 
 export const s_event = z.object({
-  account: z.string().optional(),
-  api_version: z.string().nullable().optional(),
+  account: z.string().max(5000).optional(),
+  api_version: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   data: s_notification_event_data,
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["event"]),
   pending_webhooks: z.coerce.number(),
   request: s_notification_event_request.nullable().optional(),
-  type: z.string(),
+  type: z.string().max(5000),
 })
 
 export const s_external_account_requirements = z.object({
-  currently_due: z.array(z.string()).nullable().optional(),
+  currently_due: z.array(z.string().max(5000)).nullable().optional(),
   errors: z.array(s_account_requirements_error).nullable().optional(),
-  past_due: z.array(z.string()).nullable().optional(),
-  pending_verification: z.array(z.string()).nullable().optional(),
+  past_due: z.array(z.string().max(5000)).nullable().optional(),
+  pending_verification: z.array(z.string().max(5000)).nullable().optional(),
 })
 
 export const s_financial_connections_account_ownership = z.object({
   created: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["financial_connections.account_ownership"]),
   owners: z.object({
     data: z.array(s_financial_connections_account_owner),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
 })
 
 export const s_financial_connections_transaction = z.object({
-  account: z.string(),
+  account: z.string().max(5000),
   amount: z.coerce.number(),
-  currency: z.string(),
-  description: z.string(),
-  id: z.string(),
+  currency: z.string().max(5000),
+  description: z.string().max(5000),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["financial_connections.transaction"]),
   status: z.enum(["pending", "posted", "void"]),
   status_transitions:
     s_bank_connections_resource_transaction_resource_status_transitions,
   transacted_at: z.coerce.number(),
-  transaction_refresh: z.string(),
+  transaction_refresh: z.string().max(5000),
   updated: z.coerce.number(),
 })
 
 export const s_forwarded_request_details = z.object({
-  body: z.string(),
+  body: z.string().max(5000),
   headers: z.array(s_forwarded_request_header),
   http_method: z.enum(["POST"]),
 })
 
 export const s_forwarded_response_details = z.object({
-  body: z.string(),
+  body: z.string().max(5000),
   headers: z.array(s_forwarded_request_header),
   status: z.coerce.number(),
 })
@@ -5654,12 +5667,12 @@ export const s_gelato_document_report = z.object({
   expiration_date: s_gelato_data_document_report_expiration_date
     .nullable()
     .optional(),
-  files: z.array(z.string()).nullable().optional(),
-  first_name: z.string().nullable().optional(),
+  files: z.array(z.string().max(5000)).nullable().optional(),
+  first_name: z.string().max(5000).nullable().optional(),
   issued_date: s_gelato_data_document_report_issued_date.nullable().optional(),
-  issuing_country: z.string().nullable().optional(),
-  last_name: z.string().nullable().optional(),
-  number: z.string().nullable().optional(),
+  issuing_country: z.string().max(5000).nullable().optional(),
+  last_name: z.string().max(5000).nullable().optional(),
+  number: z.string().max(5000).nullable().optional(),
   status: z.enum(["unverified", "verified"]),
   type: z
     .enum(["driving_license", "id_card", "passport"])
@@ -5668,7 +5681,7 @@ export const s_gelato_document_report = z.object({
 })
 
 export const s_gelato_email_report = z.object({
-  email: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
   error: s_gelato_email_report_error.nullable().optional(),
   status: z.enum(["unverified", "verified"]),
 })
@@ -5676,23 +5689,23 @@ export const s_gelato_email_report = z.object({
 export const s_gelato_id_number_report = z.object({
   dob: s_gelato_data_id_number_report_date.nullable().optional(),
   error: s_gelato_id_number_report_error.nullable().optional(),
-  first_name: z.string().nullable().optional(),
-  id_number: z.string().nullable().optional(),
+  first_name: z.string().max(5000).nullable().optional(),
+  id_number: z.string().max(5000).nullable().optional(),
   id_number_type: z.enum(["br_cpf", "sg_nric", "us_ssn"]).nullable().optional(),
-  last_name: z.string().nullable().optional(),
+  last_name: z.string().max(5000).nullable().optional(),
   status: z.enum(["unverified", "verified"]),
 })
 
 export const s_gelato_phone_report = z.object({
   error: s_gelato_phone_report_error.nullable().optional(),
-  phone: z.string().nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
   status: z.enum(["unverified", "verified"]),
 })
 
 export const s_gelato_selfie_report = z.object({
-  document: z.string().nullable().optional(),
+  document: z.string().max(5000).nullable().optional(),
   error: s_gelato_selfie_report_error.nullable().optional(),
-  selfie: z.string().nullable().optional(),
+  selfie: z.string().max(5000).nullable().optional(),
   status: z.enum(["unverified", "verified"]),
 })
 
@@ -5711,12 +5724,12 @@ export const s_gelato_verification_session_options = z.object({
 export const s_gelato_verified_outputs = z.object({
   address: s_address.nullable().optional(),
   dob: s_gelato_data_verified_outputs_date.nullable().optional(),
-  email: z.string().nullable().optional(),
-  first_name: z.string().nullable().optional(),
-  id_number: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  first_name: z.string().max(5000).nullable().optional(),
+  id_number: z.string().max(5000).nullable().optional(),
   id_number_type: z.enum(["br_cpf", "sg_nric", "us_ssn"]).nullable().optional(),
-  last_name: z.string().nullable().optional(),
-  phone: z.string().nullable().optional(),
+  last_name: z.string().max(5000).nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
 })
 
 export const s_invoice_payment_method_options_acss_debit = z.object({
@@ -5753,7 +5766,7 @@ export const s_invoice_payment_method_options_us_bank_account = z.object({
 export const s_invoice_tax_amount = z.object({
   amount: z.coerce.number(),
   inclusive: z.coerce.boolean(),
-  tax_rate: z.union([z.string(), s_tax_rate]),
+  tax_rate: z.union([z.string().max(5000), s_tax_rate]),
   taxability_reason: z
     .enum([
       "customer_exempt",
@@ -5783,7 +5796,7 @@ export const s_invoice_threshold_reason = z.object({
 })
 
 export const s_invoices_resource_invoice_rendering = z.object({
-  amount_tax_display: z.string().nullable().optional(),
+  amount_tax_display: z.string().max(5000).nullable().optional(),
   pdf: s_invoice_rendering_pdf.nullable().optional(),
 })
 
@@ -5807,11 +5820,11 @@ export const s_issuing_authorization_request = z.object({
   amount: z.coerce.number(),
   amount_details: s_issuing_authorization_amount_details.nullable().optional(),
   approved: z.coerce.boolean(),
-  authorization_code: z.string().nullable().optional(),
+  authorization_code: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
-  currency: z.string(),
+  currency: z.string().max(5000),
   merchant_amount: z.coerce.number(),
-  merchant_currency: z.string(),
+  merchant_currency: z.string().max(5000),
   network_risk_score: z.coerce.number().nullable().optional(),
   reason: z.enum([
     "account_disabled",
@@ -5829,7 +5842,7 @@ export const s_issuing_authorization_request = z.object({
     "webhook_error",
     "webhook_timeout",
   ]),
-  reason_message: z.string().nullable().optional(),
+  reason_message: z.string().max(5000).nullable().optional(),
   requested_at: z.coerce.number().nullable().optional(),
 })
 
@@ -5841,7 +5854,7 @@ export const s_issuing_authorization_verification_data = z.object({
     .optional(),
   cvc_check: z.enum(["match", "mismatch", "not_provided"]),
   expiry_check: z.enum(["match", "mismatch", "not_provided"]),
-  postal_code: z.string().nullable().optional(),
+  postal_code: z.string().max(5000).nullable().optional(),
   three_d_secure: s_issuing_authorization_three_d_secure.nullable().optional(),
 })
 
@@ -6148,7 +6161,10 @@ export const s_issuing_card_authorization_controls = z.object({
     )
     .nullable()
     .optional(),
-  allowed_merchant_countries: z.array(z.string()).nullable().optional(),
+  allowed_merchant_countries: z
+    .array(z.string().max(5000))
+    .nullable()
+    .optional(),
   blocked_categories: z
     .array(
       z.enum([
@@ -6451,7 +6467,10 @@ export const s_issuing_card_authorization_controls = z.object({
     )
     .nullable()
     .optional(),
-  blocked_merchant_countries: z.array(z.string()).nullable().optional(),
+  blocked_merchant_countries: z
+    .array(z.string().max(5000))
+    .nullable()
+    .optional(),
   spending_limits: z.array(s_issuing_card_spending_limit).nullable().optional(),
   spending_limits_currency: z.string().nullable().optional(),
 })
@@ -6461,8 +6480,8 @@ export const s_issuing_card_shipping = z.object({
   carrier: z.enum(["dhl", "fedex", "royal_mail", "usps"]).nullable().optional(),
   customs: s_issuing_card_shipping_customs.nullable().optional(),
   eta: z.coerce.number().nullable().optional(),
-  name: z.string(),
-  phone_number: z.string().nullable().optional(),
+  name: z.string().max(5000),
+  phone_number: z.string().max(5000).nullable().optional(),
   require_signature: z.coerce.boolean().nullable().optional(),
   service: z.enum(["express", "priority", "standard"]),
   status: z
@@ -6476,15 +6495,15 @@ export const s_issuing_card_shipping = z.object({
     ])
     .nullable()
     .optional(),
-  tracking_number: z.string().nullable().optional(),
-  tracking_url: z.string().nullable().optional(),
+  tracking_number: z.string().max(5000).nullable().optional(),
+  tracking_url: z.string().max(5000).nullable().optional(),
   type: z.enum(["bulk", "individual"]),
 })
 
 export const s_issuing_card_wallets = z.object({
   apple_pay: s_issuing_card_apple_pay,
   google_pay: s_issuing_card_google_pay,
-  primary_account_identifier: z.string().nullable().optional(),
+  primary_account_identifier: z.string().max(5000).nullable().optional(),
 })
 
 export const s_issuing_cardholder_address = z.object({ address: s_address })
@@ -6792,7 +6811,10 @@ export const s_issuing_cardholder_authorization_controls = z.object({
     )
     .nullable()
     .optional(),
-  allowed_merchant_countries: z.array(z.string()).nullable().optional(),
+  allowed_merchant_countries: z
+    .array(z.string().max(5000))
+    .nullable()
+    .optional(),
   blocked_categories: z
     .array(
       z.enum([
@@ -7095,7 +7117,10 @@ export const s_issuing_cardholder_authorization_controls = z.object({
     )
     .nullable()
     .optional(),
-  blocked_merchant_countries: z.array(z.string()).nullable().optional(),
+  blocked_merchant_countries: z
+    .array(z.string().max(5000))
+    .nullable()
+    .optional(),
   spending_limits: z
     .array(s_issuing_cardholder_spending_limit)
     .nullable()
@@ -7110,13 +7135,13 @@ export const s_issuing_cardholder_card_issuing = z.object({
 })
 
 export const s_issuing_network_token_wallet_provider = z.object({
-  account_id: z.string().optional(),
+  account_id: z.string().max(5000).optional(),
   account_trust_score: z.coerce.number().optional(),
   card_number_source: z.enum(["app", "manual", "on_file", "other"]).optional(),
   cardholder_address: s_issuing_network_token_address.optional(),
-  cardholder_name: z.string().optional(),
+  cardholder_name: z.string().max(5000).optional(),
   device_trust_score: z.coerce.number().optional(),
-  hashed_account_email_address: z.string().optional(),
+  hashed_account_email_address: z.string().max(5000).optional(),
   reason_codes: z
     .array(
       z.enum([
@@ -7152,14 +7177,14 @@ export const s_issuing_network_token_wallet_provider = z.object({
     )
     .optional(),
   suggested_decision: z.enum(["approve", "decline", "require_auth"]).optional(),
-  suggested_decision_version: z.string().optional(),
+  suggested_decision_version: z.string().max(5000).optional(),
 })
 
 export const s_issuing_physical_bundle = z.object({
   features: s_issuing_physical_bundle_features.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  name: z.string(),
+  name: z.string().max(5000),
   object: z.enum(["issuing.physical_bundle"]),
   status: z.enum(["active", "inactive", "review"]),
   type: z.enum(["custom", "standard"]),
@@ -7167,13 +7192,13 @@ export const s_issuing_physical_bundle = z.object({
 
 export const s_issuing_transaction_flight_data = z.object({
   departure_at: z.coerce.number().nullable().optional(),
-  passenger_name: z.string().nullable().optional(),
+  passenger_name: z.string().max(5000).nullable().optional(),
   refundable: z.coerce.boolean().nullable().optional(),
   segments: z
     .array(s_issuing_transaction_flight_data_leg)
     .nullable()
     .optional(),
-  travel_agency: z.string().nullable().optional(),
+  travel_agency: z.string().max(5000).nullable().optional(),
 })
 
 export const s_line_items_tax_amount = z.object({
@@ -7211,7 +7236,7 @@ export const s_mandate_payment_method_details = z.object({
   link: s_mandate_link.optional(),
   paypal: s_mandate_paypal.optional(),
   sepa_debit: s_mandate_sepa_debit.optional(),
-  type: z.string(),
+  type: z.string().max(5000),
   us_bank_account: s_mandate_us_bank_account.optional(),
 })
 
@@ -7231,8 +7256,8 @@ export const s_payment_intent_card_processing = z.object({
 
 export const s_payment_intent_next_action_cashapp_handle_redirect_or_display_qr_code =
   z.object({
-    hosted_instructions_url: z.string(),
-    mobile_auth_url: z.string(),
+    hosted_instructions_url: z.string().max(5000),
+    mobile_auth_url: z.string().max(5000),
     qr_code: s_payment_intent_next_action_cashapp_qr_code,
   })
 
@@ -7249,7 +7274,7 @@ export const s_payment_intent_next_action_konbini_stores = z.object({
 
 export const s_payment_intent_next_action_swish_handle_redirect_or_display_qr_code =
   z.object({
-    hosted_instructions_url: z.string(),
+    hosted_instructions_url: z.string().max(5000),
     qr_code: s_payment_intent_next_action_swish_qr_code,
   })
 
@@ -7321,14 +7346,14 @@ export const s_payment_links_resource_restrictions = z.object({
 })
 
 export const s_payment_method_card_present = z.object({
-  brand: z.string().nullable().optional(),
-  cardholder_name: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
+  cardholder_name: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
   networks: s_payment_method_card_present_networks.nullable().optional(),
   read_method: z
     .enum([
@@ -7344,15 +7369,15 @@ export const s_payment_method_card_present = z.object({
 
 export const s_payment_method_card_wallet_masterpass = z.object({
   billing_address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   shipping_address: s_address.nullable().optional(),
 })
 
 export const s_payment_method_card_wallet_visa_checkout = z.object({
   billing_address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   shipping_address: s_address.nullable().optional(),
 })
 
@@ -7368,19 +7393,19 @@ export const s_payment_method_details_card_installments = z.object({
 
 export const s_payment_method_details_card_present = z.object({
   amount_authorized: z.coerce.number().nullable().optional(),
-  brand: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
   capture_before: z.coerce.number().optional(),
-  cardholder_name: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  emv_auth_data: z.string().nullable().optional(),
+  cardholder_name: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  emv_auth_data: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string().nullable().optional(),
-  generated_card: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000).nullable().optional(),
+  generated_card: z.string().max(5000).nullable().optional(),
   incremental_authorization_supported: z.coerce.boolean(),
-  last4: z.string().nullable().optional(),
-  network: z.string().nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  network: z.string().max(5000).nullable().optional(),
   offline: s_payment_method_details_card_present_offline.nullable().optional(),
   overcapture_supported: z.coerce.boolean(),
   read_method: z
@@ -7398,31 +7423,31 @@ export const s_payment_method_details_card_present = z.object({
 
 export const s_payment_method_details_card_wallet_masterpass = z.object({
   billing_address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   shipping_address: s_address.nullable().optional(),
 })
 
 export const s_payment_method_details_card_wallet_visa_checkout = z.object({
   billing_address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   shipping_address: s_address.nullable().optional(),
 })
 
 export const s_payment_method_details_interac_present = z.object({
-  brand: z.string().nullable().optional(),
-  cardholder_name: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
-  emv_auth_data: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
+  cardholder_name: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  emv_auth_data: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string().nullable().optional(),
-  generated_card: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  network: z.string().nullable().optional(),
-  preferred_locales: z.array(z.string()).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000).nullable().optional(),
+  generated_card: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  network: z.string().max(5000).nullable().optional(),
+  preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
   read_method: z
     .enum([
       "contact_emv",
@@ -7447,11 +7472,11 @@ export const s_payment_method_details_mobilepay = z.object({
 })
 
 export const s_payment_method_details_paypal = z.object({
-  payer_email: z.string().nullable().optional(),
-  payer_id: z.string().nullable().optional(),
-  payer_name: z.string().nullable().optional(),
+  payer_email: z.string().max(5000).nullable().optional(),
+  payer_id: z.string().max(5000).nullable().optional(),
+  payer_name: z.string().max(5000).nullable().optional(),
   seller_protection: s_paypal_seller_protection.nullable().optional(),
-  transaction_id: z.string().nullable().optional(),
+  transaction_id: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method_domain_resource_payment_method_status = z.object({
@@ -7461,16 +7486,16 @@ export const s_payment_method_domain_resource_payment_method_status = z.object({
 })
 
 export const s_payment_method_interac_present = z.object({
-  brand: z.string().nullable().optional(),
-  cardholder_name: z.string().nullable().optional(),
-  country: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
+  cardholder_name: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
   networks: s_payment_method_card_present_networks.nullable().optional(),
-  preferred_locales: z.array(z.string()).nullable().optional(),
+  preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
   read_method: z
     .enum([
       "contact_emv",
@@ -7540,7 +7565,7 @@ export const s_payment_pages_checkout_session_consent_collection = z.object({
 export const s_payment_pages_checkout_session_custom_fields_dropdown = z.object(
   {
     options: z.array(s_payment_pages_checkout_session_custom_fields_option),
-    value: z.string().nullable().optional(),
+    value: z.string().max(5000).nullable().optional(),
   },
 )
 
@@ -7560,9 +7585,9 @@ export const s_payment_pages_checkout_session_custom_text = z.object({
 
 export const s_payment_pages_checkout_session_customer_details = z.object({
   address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
-  phone: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
   tax_exempt: z.enum(["exempt", "none", "reverse"]).nullable().optional(),
   tax_ids: z
     .array(s_payment_pages_checkout_session_tax_id)
@@ -7579,11 +7604,11 @@ export const s_person_future_requirements = z.object({
     .array(s_account_requirements_alternative)
     .nullable()
     .optional(),
-  currently_due: z.array(z.string()),
+  currently_due: z.array(z.string().max(5000)),
   errors: z.array(s_account_requirements_error),
-  eventually_due: z.array(z.string()),
-  past_due: z.array(z.string()),
-  pending_verification: z.array(z.string()),
+  eventually_due: z.array(z.string().max(5000)),
+  past_due: z.array(z.string().max(5000)),
+  pending_verification: z.array(z.string().max(5000)),
 })
 
 export const s_person_requirements = z.object({
@@ -7591,11 +7616,11 @@ export const s_person_requirements = z.object({
     .array(s_account_requirements_alternative)
     .nullable()
     .optional(),
-  currently_due: z.array(z.string()),
+  currently_due: z.array(z.string().max(5000)),
   errors: z.array(s_account_requirements_error),
-  eventually_due: z.array(z.string()),
-  past_due: z.array(z.string()),
-  pending_verification: z.array(z.string()),
+  eventually_due: z.array(z.string().max(5000)),
+  past_due: z.array(z.string().max(5000)),
+  pending_verification: z.array(z.string().max(5000)),
 })
 
 export const s_portal_flows_flow_after_completion = z.object({
@@ -7612,7 +7637,7 @@ export const s_portal_flows_flow_subscription_update_confirm = z.object({
     .nullable()
     .optional(),
   items: z.array(s_portal_flows_subscription_update_confirm_item),
-  subscription: z.string(),
+  subscription: z.string().max(5000),
 })
 
 export const s_portal_flows_retention = z.object({
@@ -7640,14 +7665,14 @@ export const s_promotion_codes_resource_restrictions = z.object({
   currency_options: z.record(s_promotion_code_currency_option).optional(),
   first_time_transaction: z.coerce.boolean(),
   minimum_amount: z.coerce.number().nullable().optional(),
-  minimum_amount_currency: z.string().nullable().optional(),
+  minimum_amount_currency: z.string().max(5000).nullable().optional(),
 })
 
 export const s_radar_value_list = z.object({
-  alias: z.string(),
+  alias: z.string().max(5000),
   created: z.coerce.number(),
-  created_by: z.string(),
-  id: z.string(),
+  created_by: z.string().max(5000),
+  id: z.string().max(5000),
   item_type: z.enum([
     "card_bin",
     "card_fingerprint",
@@ -7664,11 +7689,11 @@ export const s_radar_value_list = z.object({
     data: z.array(s_radar_value_list_item),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
-  name: z.string(),
+  metadata: z.record(z.string().max(500)),
+  name: z.string().max(5000),
   object: z.enum(["radar.value_list"]),
 })
 
@@ -7698,7 +7723,7 @@ export const s_refund_destination_details = z.object({
   sofort: s_destination_details_unimplemented.optional(),
   swish: s_refund_destination_details_generic.optional(),
   th_bank_transfer: s_refund_destination_details_generic.optional(),
-  type: z.string(),
+  type: z.string().max(5000),
   us_bank_transfer: s_refund_destination_details_generic.optional(),
   wechat_pay: s_destination_details_unimplemented.optional(),
   zip: s_destination_details_unimplemented.optional(),
@@ -7766,10 +7791,10 @@ export const s_setup_intent_payment_method_options_us_bank_account = z.object({
 
 export const s_shipping = z.object({
   address: s_address.optional(),
-  carrier: z.string().nullable().optional(),
-  name: z.string().optional(),
-  phone: z.string().nullable().optional(),
-  tracking_number: z.string().nullable().optional(),
+  carrier: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).optional(),
+  phone: z.string().max(5000).nullable().optional(),
+  tracking_number: z.string().max(5000).nullable().optional(),
 })
 
 export const s_shipping_rate_delivery_estimate = z.object({
@@ -7785,13 +7810,13 @@ export const s_shipping_rate_fixed_amount = z.object({
 
 export const s_source_owner = z.object({
   address: s_address.nullable().optional(),
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
-  phone: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
   verified_address: s_address.nullable().optional(),
-  verified_email: z.string().nullable().optional(),
-  verified_name: z.string().nullable().optional(),
-  verified_phone: z.string().nullable().optional(),
+  verified_email: z.string().max(5000).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+  verified_phone: z.string().max(5000).nullable().optional(),
 })
 
 export const s_source_transaction = z.object({
@@ -7801,14 +7826,14 @@ export const s_source_transaction = z.object({
   created: z.coerce.number(),
   currency: z.string(),
   gbp_credit_transfer: s_source_transaction_gbp_credit_transfer_data.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["source_transaction"]),
   paper_check: s_source_transaction_paper_check_data.optional(),
   sepa_credit_transfer:
     s_source_transaction_sepa_credit_transfer_data.optional(),
-  source: z.string(),
-  status: z.string(),
+  source: z.string().max(5000),
+  status: z.string().max(5000),
   type: z.enum([
     "ach_credit_transfer",
     "ach_debit",
@@ -7877,7 +7902,7 @@ export const s_tax_product_registrations_resource_country_options_united_states 
       s_tax_product_registrations_resource_country_options_us_local_amusement_tax.optional(),
     local_lease_tax:
       s_tax_product_registrations_resource_country_options_us_local_lease_tax.optional(),
-    state: z.string(),
+    state: z.string().max(5000),
     type: z.enum([
       "local_amusement_tax",
       "local_lease_tax",
@@ -7889,7 +7914,7 @@ export const s_tax_product_registrations_resource_country_options_united_states 
 export const s_tax_product_resource_customer_details = z.object({
   address: s_tax_product_resource_postal_address.nullable().optional(),
   address_source: z.enum(["billing", "shipping"]).nullable().optional(),
-  ip_address: z.string().nullable().optional(),
+  ip_address: z.string().max(5000).nullable().optional(),
   tax_ids: z.array(s_tax_product_resource_customer_details_resource_tax_id),
   taxability_override: z.enum(["customer_exempt", "none", "reverse_charge"]),
 })
@@ -7959,18 +7984,18 @@ export const s_tax_product_resource_tax_settings_status_details = z.object({
 export const s_tax_transaction_line_item = z.object({
   amount: z.coerce.number(),
   amount_tax: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["tax.transaction_line_item"]),
-  product: z.string().nullable().optional(),
+  product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
-  reference: z.string(),
+  reference: z.string().max(5000),
   reversal: s_tax_product_resource_tax_transaction_line_item_resource_reversal
     .nullable()
     .optional(),
   tax_behavior: z.enum(["exclusive", "inclusive"]),
-  tax_code: z.string(),
+  tax_code: z.string().max(5000),
   type: z.enum(["reversal", "transaction"]),
 })
 
@@ -7995,11 +8020,11 @@ export const s_terminal_configuration_configuration_resource_tipping = z.object(
 
 export const s_terminal_location = z.object({
   address: s_address,
-  configuration_overrides: z.string().optional(),
-  display_name: z.string(),
-  id: z.string(),
+  configuration_overrides: z.string().max(5000).optional(),
+  display_name: z.string().max(5000),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["terminal.location"]),
 })
 
@@ -8057,17 +8082,17 @@ export const s_treasury_financial_accounts_resource_toggle_settings = z.object({
 
 export const s_treasury_shared_resource_billing_details = z.object({
   address: s_address,
-  email: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
 })
 
 export const s_usage_record_summary = z.object({
-  id: z.string(),
-  invoice: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  invoice: z.string().max(5000).nullable().optional(),
   livemode: z.coerce.boolean(),
   object: z.enum(["usage_record_summary"]),
   period: s_period,
-  subscription_item: z.string(),
+  subscription_item: z.string().max(5000),
   total_usage: z.coerce.number(),
 })
 
@@ -8077,7 +8102,7 @@ export const s_balance_detail = z.object({
 
 export const s_card_generated_from_payment_method_details = z.object({
   card_present: s_payment_method_details_card_present.optional(),
-  type: z.string(),
+  type: z.string().max(5000),
 })
 
 export const s_checkout_customer_balance_payment_method_options = z.object({
@@ -8091,10 +8116,10 @@ export const s_climate_product = z.object({
   created: z.coerce.number(),
   current_prices_per_metric_ton: z.record(s_climate_removals_products_price),
   delivery_year: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   metric_tons_available: z.string(),
-  name: z.string(),
+  name: z.string().max(5000),
   object: z.enum(["climate.product"]),
   suppliers: z.array(s_climate_supplier),
 })
@@ -8102,8 +8127,8 @@ export const s_climate_product = z.object({
 export const s_climate_removals_order_deliveries = z.object({
   delivered_at: z.coerce.number(),
   location: s_climate_removals_location.nullable().optional(),
-  metric_tons: z.string(),
-  registry_url: z.string().nullable().optional(),
+  metric_tons: z.string().max(5000),
+  registry_url: z.string().max(5000).nullable().optional(),
   supplier: s_climate_supplier,
 })
 
@@ -8121,13 +8146,13 @@ export const s_connect_embedded_account_session_create_components = z.object({
 })
 
 export const s_country_spec = z.object({
-  default_currency: z.string(),
-  id: z.string(),
+  default_currency: z.string().max(5000),
+  id: z.string().max(5000),
   object: z.enum(["country_spec"]),
-  supported_bank_account_currencies: z.record(z.array(z.string())),
-  supported_payment_currencies: z.array(z.string()),
-  supported_payment_methods: z.array(z.string()),
-  supported_transfer_countries: z.array(z.string()),
+  supported_bank_account_currencies: z.record(z.array(z.string().max(5000))),
+  supported_payment_currencies: z.array(z.string().max(5000)),
+  supported_payment_methods: z.array(z.string().max(5000)),
+  supported_transfer_countries: z.array(z.string().max(5000)),
   verification_fields: s_country_spec_verification_fields,
 })
 
@@ -8138,23 +8163,23 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_funde
   })
 
 export const s_forwarding_request = z.object({
-  config: z.string(),
+  config: z.string().max(5000),
   created: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["forwarding.request"]),
-  payment_method: z.string(),
+  payment_method: z.string().max(5000),
   replacements: z.array(
     z.enum(["card_cvc", "card_expiry", "card_number", "cardholder_name"]),
   ),
   request_context: s_forwarded_request_context.nullable().optional(),
   request_details: s_forwarded_request_details.nullable().optional(),
   response_details: s_forwarded_response_details.nullable().optional(),
-  url: z.string().nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_funding_instructions_bank_transfer = z.object({
-  country: z.string(),
+  country: z.string().max(5000),
   financial_addresses: z.array(
     s_funding_instructions_bank_transfer_financial_address,
   ),
@@ -8162,11 +8187,11 @@ export const s_funding_instructions_bank_transfer = z.object({
 })
 
 export const s_identity_verification_report = z.object({
-  client_reference_id: z.string().nullable().optional(),
+  client_reference_id: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   document: s_gelato_document_report.optional(),
   email: s_gelato_email_report.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   id_number: s_gelato_id_number_report.optional(),
   livemode: z.coerce.boolean(),
   object: z.enum(["identity.verification_report"]),
@@ -8174,8 +8199,8 @@ export const s_identity_verification_report = z.object({
   phone: s_gelato_phone_report.optional(),
   selfie: s_gelato_selfie_report.optional(),
   type: z.enum(["document", "id_number", "verification_flow"]),
-  verification_flow: z.string().optional(),
-  verification_session: z.string().nullable().optional(),
+  verification_flow: z.string().max(5000).optional(),
+  verification_session: z.string().max(5000).nullable().optional(),
 })
 
 export const s_invoice_payment_method_options_customer_balance = z.object({
@@ -8197,7 +8222,7 @@ export const s_issuing_transaction_purchase_details = z.object({
   fuel: s_issuing_transaction_fuel_data.nullable().optional(),
   lodging: s_issuing_transaction_lodging_data.nullable().optional(),
   receipt: z.array(s_issuing_transaction_receipt_data).nullable().optional(),
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_intent_next_action_display_bank_transfer_instructions =
@@ -8207,8 +8232,8 @@ export const s_payment_intent_next_action_display_bank_transfer_instructions =
     financial_addresses: z
       .array(s_funding_instructions_bank_transfer_financial_address)
       .optional(),
-    hosted_instructions_url: z.string().nullable().optional(),
-    reference: z.string().nullable().optional(),
+    hosted_instructions_url: z.string().max(5000).nullable().optional(),
+    reference: z.string().max(5000).nullable().optional(),
     type: z.enum([
       "eu_bank_transfer",
       "gb_bank_transfer",
@@ -8220,7 +8245,7 @@ export const s_payment_intent_next_action_display_bank_transfer_instructions =
 
 export const s_payment_intent_next_action_konbini = z.object({
   expires_at: z.coerce.number(),
-  hosted_voucher_url: z.string().nullable().optional(),
+  hosted_voucher_url: z.string().max(5000).nullable().optional(),
   stores: s_payment_intent_next_action_konbini_stores,
 })
 
@@ -8260,8 +8285,8 @@ export const s_payment_intent_payment_method_options_card = z.object({
     .optional(),
   require_cvc_recollection: z.coerce.boolean().optional(),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
-  statement_descriptor_suffix_kana: z.string().optional(),
-  statement_descriptor_suffix_kanji: z.string().optional(),
+  statement_descriptor_suffix_kana: z.string().max(5000).optional(),
+  statement_descriptor_suffix_kanji: z.string().max(5000).optional(),
 })
 
 export const s_payment_intent_processing = z.object({
@@ -8284,7 +8309,7 @@ export const s_payment_intent_type_specific_payment_method_options_client =
 
 export const s_payment_links_resource_custom_fields = z.object({
   dropdown: s_payment_links_resource_custom_fields_dropdown.optional(),
-  key: z.string(),
+  key: z.string().max(5000),
   label: s_payment_links_resource_custom_fields_label,
   numeric: s_payment_links_resource_custom_fields_numeric.optional(),
   optional: z.coerce.boolean(),
@@ -8296,7 +8321,7 @@ export const s_payment_method_card_wallet = z.object({
   amex_express_checkout:
     s_payment_method_card_wallet_amex_express_checkout.optional(),
   apple_pay: s_payment_method_card_wallet_apple_pay.optional(),
-  dynamic_last4: z.string().nullable().optional(),
+  dynamic_last4: z.string().max(5000).nullable().optional(),
   google_pay: s_payment_method_card_wallet_google_pay.optional(),
   link: s_payment_method_card_wallet_link.optional(),
   masterpass: s_payment_method_card_wallet_masterpass.optional(),
@@ -8323,7 +8348,7 @@ export const s_payment_method_configuration = z.object({
   alipay: s_payment_method_config_resource_payment_method_properties.optional(),
   apple_pay:
     s_payment_method_config_resource_payment_method_properties.optional(),
-  application: z.string().nullable().optional(),
+  application: z.string().max(5000).nullable().optional(),
   au_becs_debit:
     s_payment_method_config_resource_payment_method_properties.optional(),
   bacs_debit:
@@ -8347,7 +8372,7 @@ export const s_payment_method_configuration = z.object({
     s_payment_method_config_resource_payment_method_properties.optional(),
   grabpay:
     s_payment_method_config_resource_payment_method_properties.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   ideal: s_payment_method_config_resource_payment_method_properties.optional(),
   is_default: z.coerce.boolean(),
   jcb: s_payment_method_config_resource_payment_method_properties.optional(),
@@ -8356,11 +8381,11 @@ export const s_payment_method_configuration = z.object({
     s_payment_method_config_resource_payment_method_properties.optional(),
   link: s_payment_method_config_resource_payment_method_properties.optional(),
   livemode: z.coerce.boolean(),
-  name: z.string(),
+  name: z.string().max(5000),
   object: z.enum(["payment_method_configuration"]),
   oxxo: s_payment_method_config_resource_payment_method_properties.optional(),
   p24: s_payment_method_config_resource_payment_method_properties.optional(),
-  parent: z.string().nullable().optional(),
+  parent: z.string().max(5000).nullable().optional(),
   paynow: s_payment_method_config_resource_payment_method_properties.optional(),
   paypal: s_payment_method_config_resource_payment_method_properties.optional(),
   promptpay:
@@ -8381,7 +8406,7 @@ export const s_payment_method_details_card_wallet = z.object({
   amex_express_checkout:
     s_payment_method_details_card_wallet_amex_express_checkout.optional(),
   apple_pay: s_payment_method_details_card_wallet_apple_pay.optional(),
-  dynamic_last4: z.string().nullable().optional(),
+  dynamic_last4: z.string().max(5000).nullable().optional(),
   google_pay: s_payment_method_details_card_wallet_google_pay.optional(),
   link: s_payment_method_details_card_wallet_link.optional(),
   masterpass: s_payment_method_details_card_wallet_masterpass.optional(),
@@ -8401,10 +8426,10 @@ export const s_payment_method_details_card_wallet = z.object({
 export const s_payment_method_domain = z.object({
   apple_pay: s_payment_method_domain_resource_payment_method_status,
   created: z.coerce.number(),
-  domain_name: z.string(),
+  domain_name: z.string().max(5000),
   enabled: z.coerce.boolean(),
   google_pay: s_payment_method_domain_resource_payment_method_status,
-  id: z.string(),
+  id: z.string().max(5000),
   link: s_payment_method_domain_resource_payment_method_status,
   livemode: z.coerce.boolean(),
   object: z.enum(["payment_method_domain"]),
@@ -8421,12 +8446,12 @@ export const s_payment_method_options_customer_balance = z.object({
 export const s_payment_method_us_bank_account = z.object({
   account_holder_type: z.enum(["company", "individual"]).nullable().optional(),
   account_type: z.enum(["checking", "savings"]).nullable().optional(),
-  bank_name: z.string().nullable().optional(),
-  financial_connections_account: z.string().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  financial_connections_account: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
   networks: s_us_bank_account_networks.nullable().optional(),
-  routing_number: z.string().nullable().optional(),
+  routing_number: z.string().max(5000).nullable().optional(),
   status_details: s_payment_method_us_bank_account_status_details
     .nullable()
     .optional(),
@@ -8434,7 +8459,7 @@ export const s_payment_method_us_bank_account = z.object({
 
 export const s_payment_pages_checkout_session_custom_fields = z.object({
   dropdown: s_payment_pages_checkout_session_custom_fields_dropdown.optional(),
-  key: z.string(),
+  key: z.string().max(5000),
   label: s_payment_pages_checkout_session_custom_fields_label,
   numeric: s_payment_pages_checkout_session_custom_fields_numeric.optional(),
   optional: z.coerce.boolean(),
@@ -8452,26 +8477,26 @@ export const s_portal_features = z.object({
 
 export const s_portal_flows_flow_subscription_cancel = z.object({
   retention: s_portal_flows_retention.nullable().optional(),
-  subscription: z.string(),
+  subscription: z.string().max(5000),
 })
 
 export const s_refund_next_action = z.object({
   display_details: s_refund_next_action_display_details.nullable().optional(),
-  type: z.string(),
+  type: z.string().max(5000),
 })
 
 export const s_setup_attempt_payment_method_details_card = z.object({
-  brand: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
   checks: s_setup_attempt_payment_method_details_card_checks
     .nullable()
     .optional(),
-  country: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number().nullable().optional(),
   exp_year: z.coerce.number().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string().nullable().optional(),
-  last4: z.string().nullable().optional(),
-  network: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  network: z.string().max(5000).nullable().optional(),
   three_d_secure: s_three_d_secure_details.nullable().optional(),
   wallet: s_setup_attempt_payment_method_details_card_wallet
     .nullable()
@@ -8482,7 +8507,7 @@ export const s_setup_intent_next_action = z.object({
   cashapp_handle_redirect_or_display_qr_code:
     s_payment_intent_next_action_cashapp_handle_redirect_or_display_qr_code.optional(),
   redirect_to_url: s_setup_intent_next_action_redirect_to_url.optional(),
-  type: z.string(),
+  type: z.string().max(5000),
   use_stripe_sdk: z.object({}).optional(),
   verify_with_microdeposits:
     s_setup_intent_next_action_verify_with_microdeposits.optional(),
@@ -8532,24 +8557,27 @@ export const s_shipping_rate = z.object({
   active: z.coerce.boolean(),
   created: z.coerce.number(),
   delivery_estimate: s_shipping_rate_delivery_estimate.nullable().optional(),
-  display_name: z.string().nullable().optional(),
+  display_name: z.string().max(5000).nullable().optional(),
   fixed_amount: s_shipping_rate_fixed_amount.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["shipping_rate"]),
   tax_behavior: z
     .enum(["exclusive", "inclusive", "unspecified"])
     .nullable()
     .optional(),
-  tax_code: z.union([z.string(), s_tax_code]).nullable().optional(),
+  tax_code: z
+    .union([z.string().max(5000), s_tax_code])
+    .nullable()
+    .optional(),
   type: z.enum(["fixed_amount"]),
 })
 
 export const s_source_order = z.object({
   amount: z.coerce.number(),
   currency: z.string(),
-  email: z.string().optional(),
+  email: z.string().max(5000).optional(),
   items: z.array(s_source_order_item).nullable().optional(),
   shipping: s_shipping.optional(),
 })
@@ -8557,18 +8585,18 @@ export const s_source_order = z.object({
 export const s_tax_calculation_line_item = z.object({
   amount: z.coerce.number(),
   amount_tax: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["tax.calculation_line_item"]),
-  product: z.string().nullable().optional(),
+  product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
-  reference: z.string().nullable().optional(),
+  reference: z.string().max(5000).nullable().optional(),
   tax_behavior: z.enum(["exclusive", "inclusive"]),
   tax_breakdown: z
     .array(s_tax_product_resource_line_item_tax_breakdown)
     .nullable()
     .optional(),
-  tax_code: z.string(),
+  tax_code: z.string().max(5000),
 })
 
 export const s_tax_product_registrations_resource_country_options = z.object({
@@ -8626,12 +8654,12 @@ export const s_tax_product_registrations_resource_country_options = z.object({
 export const s_tax_product_resource_tax_calculation_shipping_cost = z.object({
   amount: z.coerce.number(),
   amount_tax: z.coerce.number(),
-  shipping_rate: z.string().optional(),
+  shipping_rate: z.string().max(5000).optional(),
   tax_behavior: z.enum(["exclusive", "inclusive"]),
   tax_breakdown: z
     .array(s_tax_product_resource_line_item_tax_breakdown)
     .optional(),
-  tax_code: z.string(),
+  tax_code: z.string().max(5000),
 })
 
 export const s_tax_settings = z.object({
@@ -8647,23 +8675,26 @@ export const s_tax_settings = z.object({
 
 export const s_tax_transaction = z.object({
   created: z.coerce.number(),
-  currency: z.string(),
-  customer: z.string().nullable().optional(),
+  currency: z.string().max(5000),
+  customer: z.string().max(5000).nullable().optional(),
   customer_details: s_tax_product_resource_customer_details,
-  id: z.string(),
+  id: z.string().max(5000),
   line_items: z
     .object({
       data: z.array(s_tax_transaction_line_item),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z
+        .string()
+        .max(5000)
+        .regex(new RegExp("^/v1/tax/transactions/[^/]+/line_items")),
     })
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["tax.transaction"]),
-  reference: z.string(),
+  reference: z.string().max(5000),
   reversal: s_tax_product_resource_tax_transaction_resource_reversal
     .nullable()
     .optional(),
@@ -8710,7 +8741,7 @@ export const s_treasury_shared_resource_initiating_payment_method_details_initia
     billing_details: s_treasury_shared_resource_billing_details,
     financial_account:
       s_received_payment_method_details_financial_account.optional(),
-    issuing_card: z.string().optional(),
+    issuing_card: z.string().max(5000).optional(),
     type: z.enum([
       "balance",
       "financial_account",
@@ -8723,8 +8754,8 @@ export const s_treasury_shared_resource_initiating_payment_method_details_initia
   })
 
 export const s_account_session = z.object({
-  account: z.string(),
-  client_secret: z.string(),
+  account: z.string().max(5000),
+  client_secret: z.string().max(5000),
   components: s_connect_embedded_account_session_create_components,
   expires_at: z.coerce.number(),
   livemode: z.coerce.boolean(),
@@ -8744,18 +8775,18 @@ export const s_balance = z.object({
 export const s_billing_portal_configuration = z.object({
   active: z.coerce.boolean(),
   application: z
-    .union([z.string(), s_application, s_deleted_application])
+    .union([z.string().max(5000), s_application, s_deleted_application])
     .nullable()
     .optional(),
   business_profile: s_portal_business_profile,
   created: z.coerce.number(),
-  default_return_url: z.string().nullable().optional(),
+  default_return_url: z.string().max(5000).nullable().optional(),
   features: s_portal_features,
-  id: z.string(),
+  id: z.string().max(5000),
   is_default: z.coerce.boolean(),
   livemode: z.coerce.boolean(),
   login_page: s_portal_login_page,
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["billing_portal.configuration"]),
   updated: z.coerce.number(),
 })
@@ -8804,20 +8835,20 @@ export const s_climate_order = z.object({
     .enum(["expired", "product_unavailable", "requested"])
     .nullable()
     .optional(),
-  certificate: z.string().nullable().optional(),
+  certificate: z.string().max(5000).nullable().optional(),
   confirmed_at: z.coerce.number().nullable().optional(),
   created: z.coerce.number(),
-  currency: z.string(),
+  currency: z.string().max(5000),
   delayed_at: z.coerce.number().nullable().optional(),
   delivered_at: z.coerce.number().nullable().optional(),
   delivery_details: z.array(s_climate_removals_order_deliveries),
   expected_delivery_year: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   metric_tons: z.string(),
   object: z.enum(["climate.order"]),
-  product: z.union([z.string(), s_climate_product]),
+  product: z.union([z.string().max(5000), s_climate_product]),
   product_substituted_at: z.coerce.number().nullable().optional(),
   status: z.enum([
     "awaiting_funds",
@@ -8830,32 +8861,32 @@ export const s_climate_order = z.object({
 
 export const s_funding_instructions = z.object({
   bank_transfer: s_funding_instructions_bank_transfer,
-  currency: z.string(),
+  currency: z.string().max(5000),
   funding_type: z.enum(["bank_transfer"]),
   livemode: z.coerce.boolean(),
   object: z.enum(["funding_instructions"]),
 })
 
 export const s_identity_verification_session = z.object({
-  client_reference_id: z.string().nullable().optional(),
-  client_secret: z.string().nullable().optional(),
+  client_reference_id: z.string().max(5000).nullable().optional(),
+  client_secret: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   last_error: s_gelato_session_last_error.nullable().optional(),
   last_verification_report: z
-    .union([z.string(), s_identity_verification_report])
+    .union([z.string().max(5000), s_identity_verification_report])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["identity.verification_session"]),
   options: s_gelato_verification_session_options.nullable().optional(),
   provided_details: s_gelato_provided_details.nullable().optional(),
   redaction: s_verification_session_redaction.nullable().optional(),
   status: z.enum(["canceled", "processing", "requires_input", "verified"]),
   type: z.enum(["document", "id_number", "verification_flow"]),
-  url: z.string().nullable().optional(),
-  verification_flow: z.string().optional(),
+  url: z.string().max(5000).nullable().optional(),
+  verification_flow: z.string().max(5000).optional(),
   verified_outputs: s_gelato_verified_outputs.nullable().optional(),
 })
 
@@ -8877,7 +8908,10 @@ export const s_invoices_resource_shipping_cost = z.object({
   amount_subtotal: z.coerce.number(),
   amount_tax: z.coerce.number(),
   amount_total: z.coerce.number(),
-  shipping_rate: z.union([z.string(), s_shipping_rate]).nullable().optional(),
+  shipping_rate: z
+    .union([z.string().max(5000), s_shipping_rate])
+    .nullable()
+    .optional(),
   taxes: z.array(s_line_items_tax_amount).optional(),
 })
 
@@ -8903,7 +8937,7 @@ export const s_payment_intent_next_action = z.object({
   redirect_to_url: s_payment_intent_next_action_redirect_to_url.optional(),
   swish_handle_redirect_or_display_qr_code:
     s_payment_intent_next_action_swish_handle_redirect_or_display_qr_code.optional(),
-  type: z.string(),
+  type: z.string().max(5000),
   use_stripe_sdk: z.object({}).optional(),
   verify_with_microdeposits:
     s_payment_intent_next_action_verify_with_microdeposits.optional(),
@@ -9136,31 +9170,31 @@ export const s_payment_intent_payment_method_options = z.object({
 
 export const s_payment_links_resource_shipping_option = z.object({
   shipping_amount: z.coerce.number(),
-  shipping_rate: z.union([z.string(), s_shipping_rate]),
+  shipping_rate: z.union([z.string().max(5000), s_shipping_rate]),
 })
 
 export const s_payment_method_details_card = z.object({
   amount_authorized: z.coerce.number().nullable().optional(),
-  brand: z.string().nullable().optional(),
+  brand: z.string().max(5000).nullable().optional(),
   capture_before: z.coerce.number().optional(),
   checks: s_payment_method_details_card_checks.nullable().optional(),
-  country: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
   extended_authorization:
     s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_extended_authorization_extended_authorization.optional(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000).nullable().optional(),
   incremental_authorization:
     s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_incremental_authorization_incremental_authorization.optional(),
   installments: s_payment_method_details_card_installments
     .nullable()
     .optional(),
-  last4: z.string().nullable().optional(),
-  mandate: z.string().nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.string().max(5000).nullable().optional(),
   multicapture:
     s_payment_flows_private_payment_methods_card_details_api_resource_multicapture.optional(),
-  network: z.string().nullable().optional(),
+  network: z.string().max(5000).nullable().optional(),
   network_token: s_payment_method_details_card_network_token
     .nullable()
     .optional(),
@@ -9174,13 +9208,16 @@ export const s_payment_pages_checkout_session_shipping_cost = z.object({
   amount_subtotal: z.coerce.number(),
   amount_tax: z.coerce.number(),
   amount_total: z.coerce.number(),
-  shipping_rate: z.union([z.string(), s_shipping_rate]).nullable().optional(),
+  shipping_rate: z
+    .union([z.string().max(5000), s_shipping_rate])
+    .nullable()
+    .optional(),
   taxes: z.array(s_line_items_tax_amount).optional(),
 })
 
 export const s_payment_pages_checkout_session_shipping_option = z.object({
   shipping_amount: z.coerce.number(),
-  shipping_rate: z.union([z.string(), s_shipping_rate]),
+  shipping_rate: z.union([z.string().max(5000), s_shipping_rate]),
 })
 
 export const s_portal_flows_flow = z.object({
@@ -9212,19 +9249,19 @@ export const s_source = z.object({
   bancontact: s_source_type_bancontact.optional(),
   card: s_source_type_card.optional(),
   card_present: s_source_type_card_present.optional(),
-  client_secret: z.string(),
+  client_secret: z.string().max(5000),
   code_verification: s_source_code_verification_flow.optional(),
   created: z.coerce.number(),
   currency: z.string().nullable().optional(),
-  customer: z.string().optional(),
+  customer: z.string().max(5000).optional(),
   eps: s_source_type_eps.optional(),
-  flow: z.string(),
+  flow: z.string().max(5000),
   giropay: s_source_type_giropay.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   ideal: s_source_type_ideal.optional(),
   klarna: s_source_type_klarna.optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   multibanco: s_source_type_multibanco.optional(),
   object: z.enum(["source"]),
   owner: s_source_owner.nullable().optional(),
@@ -9234,8 +9271,8 @@ export const s_source = z.object({
   sepa_debit: s_source_type_sepa_debit.optional(),
   sofort: s_source_type_sofort.optional(),
   source_order: s_source_order.optional(),
-  statement_descriptor: z.string().nullable().optional(),
-  status: z.string(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  status: z.string().max(5000),
   three_d_secure: s_source_type_three_d_secure.optional(),
   type: z.enum([
     "ach_credit_transfer",
@@ -9257,7 +9294,7 @@ export const s_source = z.object({
     "three_d_secure",
     "wechat",
   ]),
-  usage: z.string().nullable().optional(),
+  usage: z.string().max(5000).nullable().optional(),
   wechat: s_source_type_wechat.optional(),
 })
 
@@ -9277,17 +9314,20 @@ export const s_subscriptions_resource_payment_method_options = z.object({
 
 export const s_tax_calculation = z.object({
   amount_total: z.coerce.number(),
-  currency: z.string(),
-  customer: z.string().nullable().optional(),
+  currency: z.string().max(5000),
+  customer: z.string().max(5000).nullable().optional(),
   customer_details: s_tax_product_resource_customer_details,
   expires_at: z.coerce.number().nullable().optional(),
-  id: z.string().nullable().optional(),
+  id: z.string().max(5000).nullable().optional(),
   line_items: z
     .object({
       data: z.array(s_tax_calculation_line_item),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z
+        .string()
+        .max(5000)
+        .regex(new RegExp("^/v1/tax/calculations/[^/]+/line_items")),
     })
     .nullable()
     .optional(),
@@ -9304,11 +9344,11 @@ export const s_tax_calculation = z.object({
 
 export const s_tax_registration = z.object({
   active_from: z.coerce.number(),
-  country: z.string(),
+  country: z.string().max(5000),
   country_options: s_tax_product_registrations_resource_country_options,
   created: z.coerce.number(),
   expires_at: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["tax.registration"]),
   status: z.enum(["active", "expired", "scheduled"]),
@@ -9333,11 +9373,14 @@ export const s_treasury_financial_account_features = z.object({
 })
 
 export const s_billing_portal_session = z.object({
-  configuration: z.union([z.string(), s_billing_portal_configuration]),
+  configuration: z.union([
+    z.string().max(5000),
+    s_billing_portal_configuration,
+  ]),
   created: z.coerce.number(),
-  customer: z.string(),
+  customer: z.string().max(5000),
   flow: s_portal_flows_flow.nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   locale: z
     .enum([
@@ -9392,13 +9435,13 @@ export const s_billing_portal_session = z.object({
     .nullable()
     .optional(),
   object: z.enum(["billing_portal.session"]),
-  on_behalf_of: z.string().nullable().optional(),
-  return_url: z.string().nullable().optional(),
-  url: z.string(),
+  on_behalf_of: z.string().max(5000).nullable().optional(),
+  return_url: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000),
 })
 
 export const s_invoices_payment_settings = z.object({
-  default_mandate: z.string().nullable().optional(),
+  default_mandate: z.string().max(5000).nullable().optional(),
   payment_method_options: s_invoices_payment_method_options
     .nullable()
     .optional(),
@@ -9441,14 +9484,14 @@ export const s_source_mandate_notification = z.object({
   amount: z.coerce.number().nullable().optional(),
   bacs_debit: s_source_mandate_notification_bacs_debit_data.optional(),
   created: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["source_mandate_notification"]),
-  reason: z.string(),
+  reason: z.string().max(5000),
   sepa_debit: s_source_mandate_notification_sepa_debit_data.optional(),
   source: s_source,
-  status: z.string(),
-  type: z.string(),
+  status: z.string().max(5000),
+  type: z.string().max(5000),
 })
 
 export const s_subscriptions_resource_payment_settings = z.object({
@@ -9511,15 +9554,15 @@ export const s_treasury_financial_account = z.object({
     )
     .optional(),
   balance: s_treasury_financial_accounts_resource_balance,
-  country: z.string(),
+  country: z.string().max(5000),
   created: z.coerce.number(),
   features: s_treasury_financial_account_features.optional(),
   financial_addresses: z.array(
     s_treasury_financial_accounts_resource_financial_address,
   ),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["treasury.financial_account"]),
   pending_features: z
     .array(
@@ -9572,11 +9615,11 @@ export const s_account: z.ZodType<t_account> = z.object({
   charges_enabled: z.coerce.boolean().optional(),
   company: z.lazy(() => s_legal_entity_company.optional()),
   controller: s_account_unification_account_controller.optional(),
-  country: z.string().optional(),
+  country: z.string().max(5000).optional(),
   created: z.coerce.number().optional(),
-  default_currency: z.string().optional(),
+  default_currency: z.string().max(5000).optional(),
   details_submitted: z.coerce.boolean().optional(),
-  email: z.string().nullable().optional(),
+  email: z.string().max(5000).nullable().optional(),
   external_accounts: z
     .object({
       data: z.array(
@@ -9584,13 +9627,13 @@ export const s_account: z.ZodType<t_account> = z.object({
       ),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   future_requirements: s_account_future_requirements.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   individual: z.lazy(() => s_person.optional()),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string().max(500)).optional(),
   object: z.enum(["account"]),
   payouts_enabled: z.coerce.boolean().optional(),
   requirements: s_account_requirements.optional(),
@@ -9609,9 +9652,9 @@ export const s_external_account: z.ZodType<t_external_account> = z.union([
 ])
 
 export const s_capability: z.ZodType<t_capability> = z.object({
-  account: z.union([z.string(), z.lazy(() => s_account)]),
+  account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   future_requirements: s_account_capability_future_requirements.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["capability"]),
   requested: z.coerce.boolean(),
   requested_at: z.coerce.number().nullable().optional(),
@@ -9621,102 +9664,102 @@ export const s_capability: z.ZodType<t_capability> = z.object({
 
 export const s_bank_account: z.ZodType<t_bank_account> = z.object({
   account: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
-  account_holder_name: z.string().nullable().optional(),
-  account_holder_type: z.string().nullable().optional(),
-  account_type: z.string().nullable().optional(),
+  account_holder_name: z.string().max(5000).nullable().optional(),
+  account_holder_type: z.string().max(5000).nullable().optional(),
+  account_type: z.string().max(5000).nullable().optional(),
   available_payout_methods: z
     .array(z.enum(["instant", "standard"]))
     .nullable()
     .optional(),
-  bank_name: z.string().nullable().optional(),
-  country: z.string(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000),
   currency: z.string(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   default_for_currency: z.coerce.boolean().nullable().optional(),
-  fingerprint: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
   future_requirements: s_external_account_requirements.nullable().optional(),
-  id: z.string(),
-  last4: z.string(),
-  metadata: z.record(z.string()).nullable().optional(),
+  id: z.string().max(5000),
+  last4: z.string().max(5000),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["bank_account"]),
   requirements: s_external_account_requirements.nullable().optional(),
-  routing_number: z.string().nullable().optional(),
-  status: z.string(),
+  routing_number: z.string().max(5000).nullable().optional(),
+  status: z.string().max(5000),
 })
 
 export const s_card: z.ZodType<t_card> = z.object({
   account: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
-  address_city: z.string().nullable().optional(),
-  address_country: z.string().nullable().optional(),
-  address_line1: z.string().nullable().optional(),
-  address_line1_check: z.string().nullable().optional(),
-  address_line2: z.string().nullable().optional(),
-  address_state: z.string().nullable().optional(),
-  address_zip: z.string().nullable().optional(),
-  address_zip_check: z.string().nullable().optional(),
+  address_city: z.string().max(5000).nullable().optional(),
+  address_country: z.string().max(5000).nullable().optional(),
+  address_line1: z.string().max(5000).nullable().optional(),
+  address_line1_check: z.string().max(5000).nullable().optional(),
+  address_line2: z.string().max(5000).nullable().optional(),
+  address_state: z.string().max(5000).nullable().optional(),
+  address_zip: z.string().max(5000).nullable().optional(),
+  address_zip_check: z.string().max(5000).nullable().optional(),
   available_payout_methods: z
     .array(z.enum(["instant", "standard"]))
     .nullable()
     .optional(),
-  brand: z.string(),
-  country: z.string().nullable().optional(),
+  brand: z.string().max(5000),
+  country: z.string().max(5000).nullable().optional(),
   currency: z.string().nullable().optional(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  cvc_check: z.string().nullable().optional(),
+  cvc_check: z.string().max(5000).nullable().optional(),
   default_for_currency: z.coerce.boolean().nullable().optional(),
-  dynamic_last4: z.string().nullable().optional(),
+  dynamic_last4: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
-  fingerprint: z.string().nullable().optional(),
-  funding: z.string(),
-  id: z.string(),
-  last4: z.string(),
-  metadata: z.record(z.string()).nullable().optional(),
-  name: z.string().nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000),
+  id: z.string().max(5000),
+  last4: z.string().max(5000),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  name: z.string().max(5000).nullable().optional(),
   networks: s_token_card_networks.optional(),
   object: z.enum(["card"]),
-  status: z.string().nullable().optional(),
-  tokenization_method: z.string().nullable().optional(),
+  status: z.string().max(5000).nullable().optional(),
+  tokenization_method: z.string().max(5000).nullable().optional(),
 })
 
 export const s_person: z.ZodType<t_person> = z.object({
-  account: z.string(),
+  account: z.string().max(5000),
   additional_tos_acceptances: s_person_additional_tos_acceptances.optional(),
   address: s_address.optional(),
   address_kana: s_legal_entity_japan_address.nullable().optional(),
   address_kanji: s_legal_entity_japan_address.nullable().optional(),
   created: z.coerce.number(),
   dob: s_legal_entity_dob.optional(),
-  email: z.string().nullable().optional(),
-  first_name: z.string().nullable().optional(),
-  first_name_kana: z.string().nullable().optional(),
-  first_name_kanji: z.string().nullable().optional(),
-  full_name_aliases: z.array(z.string()).optional(),
+  email: z.string().max(5000).nullable().optional(),
+  first_name: z.string().max(5000).nullable().optional(),
+  first_name_kana: z.string().max(5000).nullable().optional(),
+  first_name_kanji: z.string().max(5000).nullable().optional(),
+  full_name_aliases: z.array(z.string().max(5000)).optional(),
   future_requirements: s_person_future_requirements.nullable().optional(),
   gender: z.string().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   id_number_provided: z.coerce.boolean().optional(),
   id_number_secondary_provided: z.coerce.boolean().optional(),
-  last_name: z.string().nullable().optional(),
-  last_name_kana: z.string().nullable().optional(),
-  last_name_kanji: z.string().nullable().optional(),
-  maiden_name: z.string().nullable().optional(),
-  metadata: z.record(z.string()).optional(),
-  nationality: z.string().nullable().optional(),
+  last_name: z.string().max(5000).nullable().optional(),
+  last_name_kana: z.string().max(5000).nullable().optional(),
+  last_name_kanji: z.string().max(5000).nullable().optional(),
+  maiden_name: z.string().max(5000).nullable().optional(),
+  metadata: z.record(z.string().max(500)).optional(),
+  nationality: z.string().max(5000).nullable().optional(),
   object: z.enum(["person"]),
-  phone: z.string().nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
   political_exposure: z.enum(["existing", "none"]).optional(),
   registered_address: s_address.optional(),
   relationship: s_person_relationship.optional(),
@@ -9726,22 +9769,22 @@ export const s_person: z.ZodType<t_person> = z.object({
 })
 
 export const s_application_fee: z.ZodType<t_application_fee> = z.object({
-  account: z.union([z.string(), z.lazy(() => s_account)]),
+  account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   amount: z.coerce.number(),
   amount_refunded: z.coerce.number(),
-  application: z.union([z.string(), s_application]),
+  application: z.union([z.string().max(5000), s_application]),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
-  charge: z.union([z.string(), z.lazy(() => s_charge)]),
+  charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]),
   created: z.coerce.number(),
   currency: z.string(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["application_fee"]),
   originating_transaction: z
-    .union([z.string(), z.lazy(() => s_charge)])
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
   refunded: z.coerce.boolean(),
@@ -9749,21 +9792,21 @@ export const s_application_fee: z.ZodType<t_application_fee> = z.object({
     data: z.array(z.lazy(() => s_fee_refund)),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
 })
 
 export const s_fee_refund: z.ZodType<t_fee_refund> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   created: z.coerce.number(),
   currency: z.string(),
-  fee: z.union([z.string(), z.lazy(() => s_application_fee)]),
-  id: z.string(),
-  metadata: z.record(z.string()).nullable().optional(),
+  fee: z.union([z.string().max(5000), z.lazy(() => s_application_fee)]),
+  id: z.string().max(5000),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["fee_refund"]),
 })
 
@@ -9773,17 +9816,17 @@ export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
     available_on: z.coerce.number(),
     created: z.coerce.number(),
     currency: z.string(),
-    description: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
     exchange_rate: z.coerce.number().nullable().optional(),
     fee: z.coerce.number(),
     fee_details: z.array(s_fee),
-    id: z.string(),
+    id: z.string().max(5000),
     net: z.coerce.number(),
     object: z.enum(["balance_transaction"]),
-    reporting_category: z.string(),
+    reporting_category: z.string().max(5000),
     source: z
       .union([
-        z.string(),
+        z.string().max(5000),
         z.lazy(() => s_application_fee),
         z.lazy(() => s_charge),
         z.lazy(() => s_connect_collection_transfer),
@@ -9804,7 +9847,7 @@ export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
       ])
       .nullable()
       .optional(),
-    status: z.string(),
+    status: z.string().max(5000),
     type: z.enum([
       "adjustment",
       "advance",
@@ -9854,106 +9897,111 @@ export const s_charge: z.ZodType<t_charge> = z.object({
   amount: z.coerce.number(),
   amount_captured: z.coerce.number(),
   amount_refunded: z.coerce.number(),
-  application: z.union([z.string(), s_application]).nullable().optional(),
+  application: z
+    .union([z.string().max(5000), s_application])
+    .nullable()
+    .optional(),
   application_fee: z
-    .union([z.string(), z.lazy(() => s_application_fee)])
+    .union([z.string().max(5000), z.lazy(() => s_application_fee)])
     .nullable()
     .optional(),
   application_fee_amount: z.coerce.number().nullable().optional(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   billing_details: s_billing_details,
-  calculated_statement_descriptor: z.string().nullable().optional(),
+  calculated_statement_descriptor: z.string().max(5000).nullable().optional(),
   captured: z.coerce.boolean(),
   created: z.coerce.number(),
   currency: z.string(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(40000).nullable().optional(),
   disputed: z.coerce.boolean(),
   failure_balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
-  failure_code: z.string().nullable().optional(),
-  failure_message: z.string().nullable().optional(),
+  failure_code: z.string().max(5000).nullable().optional(),
+  failure_message: z.string().max(5000).nullable().optional(),
   fraud_details: s_charge_fraud_details.nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   invoice: z
-    .union([z.string(), z.lazy(() => s_invoice)])
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["charge"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   outcome: s_charge_outcome.nullable().optional(),
   paid: z.coerce.boolean(),
   payment_intent: z
-    .union([z.string(), z.lazy(() => s_payment_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
     .optional(),
-  payment_method: z.string().nullable().optional(),
+  payment_method: z.string().max(5000).nullable().optional(),
   payment_method_details: z.lazy(() =>
     s_payment_method_details.nullable().optional(),
   ),
   radar_options: s_radar_radar_options.optional(),
-  receipt_email: z.string().nullable().optional(),
-  receipt_number: z.string().nullable().optional(),
-  receipt_url: z.string().nullable().optional(),
+  receipt_email: z.string().max(5000).nullable().optional(),
+  receipt_number: z.string().max(5000).nullable().optional(),
+  receipt_url: z.string().max(5000).nullable().optional(),
   refunded: z.coerce.boolean(),
   refunds: z
     .object({
       data: z.array(z.lazy(() => s_refund)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .nullable()
     .optional(),
   review: z
-    .union([z.string(), z.lazy(() => s_review)])
+    .union([z.string().max(5000), z.lazy(() => s_review)])
     .nullable()
     .optional(),
   shipping: s_shipping.nullable().optional(),
   source_transfer: z
-    .union([z.string(), z.lazy(() => s_transfer)])
+    .union([z.string().max(5000), z.lazy(() => s_transfer)])
     .nullable()
     .optional(),
-  statement_descriptor: z.string().nullable().optional(),
-  statement_descriptor_suffix: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  statement_descriptor_suffix: z.string().max(5000).nullable().optional(),
   status: z.enum(["failed", "pending", "succeeded"]),
-  transfer: z.union([z.string(), z.lazy(() => s_transfer)]).optional(),
+  transfer: z
+    .union([z.string().max(5000), z.lazy(() => s_transfer)])
+    .optional(),
   transfer_data: z.lazy(() => s_charge_transfer_data.nullable().optional()),
-  transfer_group: z.string().nullable().optional(),
+  transfer_group: z.string().max(5000).nullable().optional(),
 })
 
 export const s_dispute: z.ZodType<t_dispute> = z.object({
   amount: z.coerce.number(),
   balance_transactions: z.array(z.lazy(() => s_balance_transaction)),
-  charge: z.union([z.string(), z.lazy(() => s_charge)]),
+  charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]),
   created: z.coerce.number(),
   currency: z.string(),
   evidence: z.lazy(() => s_dispute_evidence),
   evidence_details: s_dispute_evidence_details,
-  id: z.string(),
+  id: z.string().max(5000),
   is_charge_refundable: z.coerce.boolean(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["dispute"]),
   payment_intent: z
-    .union([z.string(), z.lazy(() => s_payment_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
     .optional(),
   payment_method_details: s_dispute_payment_method_details.optional(),
-  reason: z.string(),
+  reason: z.string().max(5000),
   status: z.enum([
     "lost",
     "needs_response",
@@ -9968,28 +10016,28 @@ export const s_dispute: z.ZodType<t_dispute> = z.object({
 export const s_refund: z.ZodType<t_refund> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   charge: z
-    .union([z.string(), z.lazy(() => s_charge)])
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
   created: z.coerce.number(),
   currency: z.string(),
-  description: z.string().optional(),
+  description: z.string().max(5000).optional(),
   destination_details: s_refund_destination_details.optional(),
   failure_balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .optional(),
-  failure_reason: z.string().optional(),
-  id: z.string(),
-  instructions_email: z.string().optional(),
-  metadata: z.record(z.string()).nullable().optional(),
+  failure_reason: z.string().max(5000).optional(),
+  id: z.string().max(5000),
+  instructions_email: z.string().max(5000).optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   next_action: s_refund_next_action.optional(),
   object: z.enum(["refund"]),
   payment_intent: z
-    .union([z.string(), z.lazy(() => s_payment_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
     .optional(),
   reason: z
@@ -10001,14 +10049,14 @@ export const s_refund: z.ZodType<t_refund> = z.object({
     ])
     .nullable()
     .optional(),
-  receipt_number: z.string().nullable().optional(),
+  receipt_number: z.string().max(5000).nullable().optional(),
   source_transfer_reversal: z
-    .union([z.string(), z.lazy(() => s_transfer_reversal)])
+    .union([z.string().max(5000), z.lazy(() => s_transfer_reversal)])
     .nullable()
     .optional(),
-  status: z.string().nullable().optional(),
+  status: z.string().max(5000).nullable().optional(),
   transfer_reversal: z
-    .union([z.string(), z.lazy(() => s_transfer_reversal)])
+    .union([z.string().max(5000), z.lazy(() => s_transfer_reversal)])
     .nullable()
     .optional(),
 })
@@ -10025,9 +10073,9 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
     .enum(["auto", "required"])
     .nullable()
     .optional(),
-  cancel_url: z.string().nullable().optional(),
-  client_reference_id: z.string().nullable().optional(),
-  client_secret: z.string().nullable().optional(),
+  cancel_url: z.string().max(5000).nullable().optional(),
+  client_reference_id: z.string().max(5000).nullable().optional(),
+  client_secret: z.string().max(5000).nullable().optional(),
   consent: s_payment_pages_checkout_session_consent.nullable().optional(),
   consent_collection: s_payment_pages_checkout_session_consent_collection
     .nullable()
@@ -10040,18 +10088,18 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
   custom_fields: z.array(s_payment_pages_checkout_session_custom_fields),
   custom_text: s_payment_pages_checkout_session_custom_text,
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   customer_creation: z.enum(["always", "if_required"]).nullable().optional(),
   customer_details: s_payment_pages_checkout_session_customer_details
     .nullable()
     .optional(),
-  customer_email: z.string().nullable().optional(),
+  customer_email: z.string().max(5000).nullable().optional(),
   expires_at: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   invoice: z
-    .union([z.string(), z.lazy(() => s_invoice)])
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
   invoice_creation: z.lazy(() =>
@@ -10062,7 +10110,7 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
       data: z.array(z.lazy(() => s_item)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   livemode: z.coerce.boolean(),
@@ -10112,15 +10160,15 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
     ])
     .nullable()
     .optional(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   mode: z.enum(["payment", "setup", "subscription"]),
   object: z.enum(["checkout.session"]),
   payment_intent: z
-    .union([z.string(), z.lazy(() => s_payment_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
     .optional(),
   payment_link: z
-    .union([z.string(), z.lazy(() => s_payment_link)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_link)])
     .nullable()
     .optional(),
   payment_method_collection: z
@@ -10134,15 +10182,15 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
   payment_method_options: s_checkout_session_payment_method_options
     .nullable()
     .optional(),
-  payment_method_types: z.array(z.string()),
+  payment_method_types: z.array(z.string().max(5000)),
   payment_status: z.enum(["no_payment_required", "paid", "unpaid"]),
   phone_number_collection:
     s_payment_pages_checkout_session_phone_number_collection.optional(),
-  recovered_from: z.string().nullable().optional(),
+  recovered_from: z.string().max(5000).nullable().optional(),
   redirect_on_completion: z.enum(["always", "if_required", "never"]).optional(),
-  return_url: z.string().optional(),
+  return_url: z.string().max(5000).optional(),
   setup_intent: z
-    .union([z.string(), z.lazy(() => s_setup_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_setup_intent)])
     .nullable()
     .optional(),
   shipping_address_collection:
@@ -10157,17 +10205,17 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
   status: z.enum(["complete", "expired", "open"]).nullable().optional(),
   submit_type: z.enum(["auto", "book", "donate", "pay"]).nullable().optional(),
   subscription: z
-    .union([z.string(), z.lazy(() => s_subscription)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription)])
     .nullable()
     .optional(),
-  success_url: z.string().nullable().optional(),
+  success_url: z.string().max(5000).nullable().optional(),
   tax_id_collection:
     s_payment_pages_checkout_session_tax_id_collection.optional(),
   total_details: z.lazy(() =>
     s_payment_pages_checkout_session_total_details.nullable().optional(),
   ),
   ui_mode: z.enum(["embedded", "hosted"]).nullable().optional(),
-  url: z.string().nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_item: z.ZodType<t_item> = z.object({
@@ -10176,9 +10224,9 @@ export const s_item: z.ZodType<t_item> = z.object({
   amount_tax: z.coerce.number(),
   amount_total: z.coerce.number(),
   currency: z.string(),
-  description: z.string(),
+  description: z.string().max(5000),
   discounts: z.array(z.lazy(() => s_line_items_discount_amount)).optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   object: z.enum(["item"]),
   price: z.lazy(() => s_price.nullable().optional()),
   quantity: z.coerce.number().nullable().optional(),
@@ -10188,22 +10236,22 @@ export const s_item: z.ZodType<t_item> = z.object({
 export const s_confirmation_token: z.ZodType<t_confirmation_token> = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   mandate_data: s_confirmation_tokens_resource_mandate_data
     .nullable()
     .optional(),
   object: z.enum(["confirmation_token"]),
-  payment_intent: z.string().nullable().optional(),
+  payment_intent: z.string().max(5000).nullable().optional(),
   payment_method_preview: z.lazy(() =>
     s_confirmation_tokens_resource_payment_method_preview.nullable().optional(),
   ),
-  return_url: z.string().nullable().optional(),
+  return_url: z.string().max(5000).nullable().optional(),
   setup_future_usage: z
     .enum(["off_session", "on_session"])
     .nullable()
     .optional(),
-  setup_intent: z.string().nullable().optional(),
+  setup_intent: z.string().max(5000).nullable().optional(),
   shipping: s_confirmation_tokens_resource_shipping.nullable().optional(),
   use_stripe_sdk: z.coerce.boolean(),
 })
@@ -10213,35 +10261,39 @@ export const s_credit_note: z.ZodType<t_credit_note> = z.object({
   amount_shipping: z.coerce.number(),
   created: z.coerce.number(),
   currency: z.string(),
-  customer: z.union([z.string(), z.lazy(() => s_customer), s_deleted_customer]),
+  customer: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_customer),
+    s_deleted_customer,
+  ]),
   customer_balance_transaction: z
-    .union([z.string(), z.lazy(() => s_customer_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_customer_balance_transaction)])
     .nullable()
     .optional(),
   discount_amount: z.coerce.number(),
   discount_amounts: z.array(z.lazy(() => s_discounts_resource_discount_amount)),
   effective_at: z.coerce.number().nullable().optional(),
-  id: z.string(),
-  invoice: z.union([z.string(), z.lazy(() => s_invoice)]),
+  id: z.string().max(5000),
+  invoice: z.union([z.string().max(5000), z.lazy(() => s_invoice)]),
   lines: z.object({
     data: z.array(z.lazy(() => s_credit_note_line_item)),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
   livemode: z.coerce.boolean(),
-  memo: z.string().nullable().optional(),
-  metadata: z.record(z.string()).nullable().optional(),
-  number: z.string(),
+  memo: z.string().max(5000).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  number: z.string().max(5000),
   object: z.enum(["credit_note"]),
   out_of_band_amount: z.coerce.number().nullable().optional(),
-  pdf: z.string(),
+  pdf: z.string().max(5000),
   reason: z
     .enum(["duplicate", "fraudulent", "order_change", "product_unsatisfactory"])
     .nullable()
     .optional(),
   refund: z
-    .union([z.string(), z.lazy(() => s_refund)])
+    .union([z.string().max(5000), z.lazy(() => s_refund)])
     .nullable()
     .optional(),
   shipping_cost: s_invoices_resource_shipping_cost.nullable().optional(),
@@ -10259,13 +10311,13 @@ export const s_credit_note_line_item: z.ZodType<t_credit_note_line_item> =
   z.object({
     amount: z.coerce.number(),
     amount_excluding_tax: z.coerce.number().nullable().optional(),
-    description: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
     discount_amount: z.coerce.number(),
     discount_amounts: z.array(
       z.lazy(() => s_discounts_resource_discount_amount),
     ),
-    id: z.string(),
-    invoice_line_item: z.string().optional(),
+    id: z.string().max(5000),
+    invoice_line_item: z.string().max(5000).optional(),
     livemode: z.coerce.boolean(),
     object: z.enum(["credit_note_line_item"]),
     quantity: z.coerce.number().nullable().optional(),
@@ -10278,10 +10330,10 @@ export const s_credit_note_line_item: z.ZodType<t_credit_note_line_item> =
   })
 
 export const s_customer_session: z.ZodType<t_customer_session> = z.object({
-  client_secret: z.string(),
+  client_secret: z.string().max(5000),
   components: s_customer_session_resource_components.optional(),
   created: z.coerce.number(),
-  customer: z.union([z.string(), z.lazy(() => s_customer)]),
+  customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
   expires_at: z.coerce.number(),
   livemode: z.coerce.boolean(),
   object: z.enum(["customer_session"]),
@@ -10292,10 +10344,10 @@ export const s_customer: z.ZodType<t_customer> = z.object({
   balance: z.coerce.number().optional(),
   cash_balance: s_cash_balance.nullable().optional(),
   created: z.coerce.number(),
-  currency: z.string().nullable().optional(),
+  currency: z.string().max(5000).nullable().optional(),
   default_source: z
     .union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_bank_account),
       z.lazy(() => s_card),
       s_source,
@@ -10303,20 +10355,20 @@ export const s_customer: z.ZodType<t_customer> = z.object({
     .nullable()
     .optional(),
   delinquent: z.coerce.boolean().nullable().optional(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   discount: z.lazy(() => s_discount.nullable().optional()),
-  email: z.string().nullable().optional(),
-  id: z.string(),
+  email: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   invoice_credit_balance: z.record(z.coerce.number()).optional(),
-  invoice_prefix: z.string().nullable().optional(),
+  invoice_prefix: z.string().max(5000).nullable().optional(),
   invoice_settings: z.lazy(() => s_invoice_setting_customer_setting.optional()),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).optional(),
-  name: z.string().nullable().optional(),
+  metadata: z.record(z.string().max(500)).optional(),
+  name: z.string().max(5000).nullable().optional(),
   next_invoice_sequence: z.coerce.number().optional(),
   object: z.enum(["customer"]),
-  phone: z.string().nullable().optional(),
-  preferred_locales: z.array(z.string()).nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
+  preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
   shipping: s_shipping.nullable().optional(),
   sources: z
     .object({
@@ -10325,7 +10377,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
       ),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   subscriptions: z
@@ -10333,7 +10385,7 @@ export const s_customer: z.ZodType<t_customer> = z.object({
       data: z.array(z.lazy(() => s_subscription)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   tax: s_customer_tax.optional(),
@@ -10343,11 +10395,11 @@ export const s_customer: z.ZodType<t_customer> = z.object({
       data: z.array(z.lazy(() => s_tax_id)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   test_clock: z
-    .union([z.string(), s_test_helpers_test_clock])
+    .union([z.string().max(5000), s_test_helpers_test_clock])
     .nullable()
     .optional(),
 })
@@ -10357,20 +10409,20 @@ export const s_customer_balance_transaction: z.ZodType<t_customer_balance_transa
     amount: z.coerce.number(),
     created: z.coerce.number(),
     credit_note: z
-      .union([z.string(), z.lazy(() => s_credit_note)])
+      .union([z.string().max(5000), z.lazy(() => s_credit_note)])
       .nullable()
       .optional(),
     currency: z.string(),
-    customer: z.union([z.string(), z.lazy(() => s_customer)]),
-    description: z.string().nullable().optional(),
+    customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
+    description: z.string().max(5000).nullable().optional(),
     ending_balance: z.coerce.number(),
-    id: z.string(),
+    id: z.string().max(5000),
     invoice: z
-      .union([z.string(), z.lazy(() => s_invoice)])
+      .union([z.string().max(5000), z.lazy(() => s_invoice)])
       .nullable()
       .optional(),
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()).nullable().optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
     object: z.enum(["customer_balance_transaction"]),
     type: z.enum([
       "adjustment",
@@ -10402,12 +10454,12 @@ export const s_customer_cash_balance_transaction: z.ZodType<t_customer_cash_bala
       s_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction.optional(),
     ),
     created: z.coerce.number(),
-    currency: z.string(),
-    customer: z.union([z.string(), z.lazy(() => s_customer)]),
+    currency: z.string().max(5000),
+    customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
     ending_balance: z.coerce.number(),
     funded:
       s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction.optional(),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     net_amount: z.coerce.number(),
     object: z.enum(["customer_cash_balance_transaction"]),
@@ -10434,45 +10486,45 @@ export const s_customer_cash_balance_transaction: z.ZodType<t_customer_cash_bala
   })
 
 export const s_deleted_discount: z.ZodType<t_deleted_discount> = z.object({
-  checkout_session: z.string().nullable().optional(),
+  checkout_session: z.string().max(5000).nullable().optional(),
   coupon: s_coupon,
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   deleted: z.coerce.boolean(),
-  id: z.string(),
-  invoice: z.string().nullable().optional(),
-  invoice_item: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  invoice: z.string().max(5000).nullable().optional(),
+  invoice_item: z.string().max(5000).nullable().optional(),
   object: z.enum(["discount"]),
   promotion_code: z
-    .union([z.string(), z.lazy(() => s_promotion_code)])
+    .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
     .nullable()
     .optional(),
   start: z.coerce.number(),
-  subscription: z.string().nullable().optional(),
-  subscription_item: z.string().nullable().optional(),
+  subscription: z.string().max(5000).nullable().optional(),
+  subscription_item: z.string().max(5000).nullable().optional(),
 })
 
 export const s_discount: z.ZodType<t_discount> = z.object({
-  checkout_session: z.string().nullable().optional(),
+  checkout_session: z.string().max(5000).nullable().optional(),
   coupon: s_coupon,
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   end: z.coerce.number().nullable().optional(),
-  id: z.string(),
-  invoice: z.string().nullable().optional(),
-  invoice_item: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  invoice: z.string().max(5000).nullable().optional(),
+  invoice_item: z.string().max(5000).nullable().optional(),
   object: z.enum(["discount"]),
   promotion_code: z
-    .union([z.string(), z.lazy(() => s_promotion_code)])
+    .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
     .nullable()
     .optional(),
   start: z.coerce.number(),
-  subscription: z.string().nullable().optional(),
-  subscription_item: z.string().nullable().optional(),
+  subscription: z.string().max(5000).nullable().optional(),
+  subscription_item: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_method: z.ZodType<t_payment_method> = z.object({
@@ -10491,7 +10543,7 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
   cashapp: s_payment_method_cashapp.optional(),
   created: z.coerce.number(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer)])
+    .union([z.string().max(5000), z.lazy(() => s_customer)])
     .nullable()
     .optional(),
   customer_balance: s_payment_method_customer_balance.optional(),
@@ -10499,14 +10551,14 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
   fpx: s_payment_method_fpx.optional(),
   giropay: s_payment_method_giropay.optional(),
   grabpay: s_payment_method_grabpay.optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   ideal: s_payment_method_ideal.optional(),
   interac_present: s_payment_method_interac_present.optional(),
   klarna: s_payment_method_klarna.optional(),
   konbini: s_payment_method_konbini.optional(),
   link: s_payment_method_link.optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   mobilepay: s_payment_method_mobilepay.optional(),
   object: z.enum(["payment_method"]),
   oxxo: s_payment_method_oxxo.optional(),
@@ -10565,7 +10617,7 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
 
 export const s_subscription: z.ZodType<t_subscription> = z.object({
   application: z
-    .union([z.string(), s_application, s_deleted_application])
+    .union([z.string().max(5000), s_application, s_deleted_application])
     .nullable()
     .optional(),
   application_fee_percent: z.coerce.number().nullable().optional(),
@@ -10583,15 +10635,19 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
   currency: z.string(),
   current_period_end: z.coerce.number(),
   current_period_start: z.coerce.number(),
-  customer: z.union([z.string(), z.lazy(() => s_customer), s_deleted_customer]),
+  customer: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_customer),
+    s_deleted_customer,
+  ]),
   days_until_due: z.coerce.number().nullable().optional(),
   default_payment_method: z
-    .union([z.string(), z.lazy(() => s_payment_method)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
     .nullable()
     .optional(),
   default_source: z
     .union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_bank_account),
       z.lazy(() => s_card),
       s_source,
@@ -10599,27 +10655,27 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
     .nullable()
     .optional(),
   default_tax_rates: z.array(s_tax_rate).nullable().optional(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(500).nullable().optional(),
   discount: z.lazy(() => s_discount.nullable().optional()),
-  discounts: z.array(z.union([z.string(), z.lazy(() => s_discount)])),
+  discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
   ended_at: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   items: z.object({
     data: z.array(z.lazy(() => s_subscription_item)),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
   latest_invoice: z
-    .union([z.string(), z.lazy(() => s_invoice)])
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   next_pending_invoice_item_invoice: z.coerce.number().nullable().optional(),
   object: z.enum(["subscription"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   pause_collection: s_subscriptions_resource_pause_collection
@@ -10632,14 +10688,14 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
     .nullable()
     .optional(),
   pending_setup_intent: z
-    .union([z.string(), z.lazy(() => s_setup_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_setup_intent)])
     .nullable()
     .optional(),
   pending_update: z.lazy(() =>
     s_subscriptions_resource_pending_update.nullable().optional(),
   ),
   schedule: z
-    .union([z.string(), z.lazy(() => s_subscription_schedule)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription_schedule)])
     .nullable()
     .optional(),
   start_date: z.coerce.number(),
@@ -10654,7 +10710,7 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
     "unpaid",
   ]),
   test_clock: z
-    .union([z.string(), s_test_helpers_test_clock])
+    .union([z.string().max(5000), s_test_helpers_test_clock])
     .nullable()
     .optional(),
   transfer_data: z.lazy(() =>
@@ -10668,13 +10724,13 @@ export const s_subscription: z.ZodType<t_subscription> = z.object({
 })
 
 export const s_tax_id: z.ZodType<t_tax_id> = z.object({
-  country: z.string().nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer)])
+    .union([z.string().max(5000), z.lazy(() => s_customer)])
     .nullable()
     .optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["tax_id"]),
   owner: z.lazy(() => s_tax_i_ds_owner.nullable().optional()),
@@ -10748,7 +10804,7 @@ export const s_tax_id: z.ZodType<t_tax_id> = z.object({
     "vn_tin",
     "za_vat",
   ]),
-  value: z.string(),
+  value: z.string().max(5000),
   verification: s_tax_id_verification.nullable().optional(),
 })
 
@@ -10756,25 +10812,25 @@ export const s_file_link: z.ZodType<t_file_link> = z.object({
   created: z.coerce.number(),
   expired: z.coerce.boolean(),
   expires_at: z.coerce.number().nullable().optional(),
-  file: z.union([z.string(), z.lazy(() => s_file)]),
-  id: z.string(),
+  file: z.union([z.string().max(5000), z.lazy(() => s_file)]),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["file_link"]),
-  url: z.string().nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_file: z.ZodType<t_file> = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number().nullable().optional(),
-  filename: z.string().nullable().optional(),
-  id: z.string(),
+  filename: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   links: z
     .object({
       data: z.array(z.lazy(() => s_file_link)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
     })
     .nullable()
     .optional(),
@@ -10797,9 +10853,9 @@ export const s_file: z.ZodType<t_file> = z.object({
     "terminal_reader_splashscreen",
   ]),
   size: z.coerce.number(),
-  title: z.string().nullable().optional(),
-  type: z.string().nullable().optional(),
-  url: z.string().nullable().optional(),
+  title: z.string().max(5000).nullable().optional(),
+  type: z.string().max(5000).nullable().optional(),
+  url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_financial_connections_account: z.ZodType<t_financial_connections_account> =
@@ -10813,14 +10869,14 @@ export const s_financial_connections_account: z.ZodType<t_financial_connections_
       .optional(),
     category: z.enum(["cash", "credit", "investment", "other"]),
     created: z.coerce.number(),
-    display_name: z.string().nullable().optional(),
-    id: z.string(),
-    institution_name: z.string(),
-    last4: z.string().nullable().optional(),
+    display_name: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
+    institution_name: z.string().max(5000),
+    last4: z.string().max(5000).nullable().optional(),
     livemode: z.coerce.boolean(),
     object: z.enum(["financial_connections.account"]),
     ownership: z
-      .union([z.string(), s_financial_connections_account_ownership])
+      .union([z.string().max(5000), s_financial_connections_account_ownership])
       .nullable()
       .optional(),
     ownership_refresh: s_bank_connections_resource_ownership_refresh
@@ -10862,12 +10918,15 @@ export const s_financial_connections_session: z.ZodType<t_financial_connections_
       data: z.array(z.lazy(() => s_financial_connections_account)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z
+        .string()
+        .max(5000)
+        .regex(new RegExp("^/v1/financial_connections/accounts")),
     }),
-    client_secret: z.string(),
+    client_secret: z.string().max(5000),
     filters:
       s_bank_connections_resource_link_account_session_filters.optional(),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["financial_connections.session"]),
     permissions: z.array(
@@ -10877,40 +10936,44 @@ export const s_financial_connections_session: z.ZodType<t_financial_connections_
       .array(z.enum(["balances", "ownership", "transactions"]))
       .nullable()
       .optional(),
-    return_url: z.string().optional(),
+    return_url: z.string().max(5000).optional(),
   })
 
 export const s_invoiceitem: z.ZodType<t_invoiceitem> = z.object({
   amount: z.coerce.number(),
   currency: z.string(),
-  customer: z.union([z.string(), z.lazy(() => s_customer), s_deleted_customer]),
+  customer: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_customer),
+    s_deleted_customer,
+  ]),
   date: z.coerce.number(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   discountable: z.coerce.boolean(),
   discounts: z
-    .array(z.union([z.string(), z.lazy(() => s_discount)]))
+    .array(z.union([z.string().max(5000), z.lazy(() => s_discount)]))
     .nullable()
     .optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   invoice: z
-    .union([z.string(), z.lazy(() => s_invoice)])
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["invoiceitem"]),
   period: s_invoice_line_item_period,
   price: z.lazy(() => s_price.nullable().optional()),
   proration: z.coerce.boolean(),
   quantity: z.coerce.number(),
   subscription: z
-    .union([z.string(), z.lazy(() => s_subscription)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription)])
     .nullable()
     .optional(),
-  subscription_item: z.string().optional(),
+  subscription_item: z.string().max(5000).optional(),
   tax_rates: z.array(s_tax_rate).nullable().optional(),
   test_clock: z
-    .union([z.string(), s_test_helpers_test_clock])
+    .union([z.string().max(5000), s_test_helpers_test_clock])
     .nullable()
     .optional(),
   unit_amount: z.coerce.number().nullable().optional(),
@@ -10918,10 +10981,12 @@ export const s_invoiceitem: z.ZodType<t_invoiceitem> = z.object({
 })
 
 export const s_invoice: z.ZodType<t_invoice> = z.object({
-  account_country: z.string().nullable().optional(),
-  account_name: z.string().nullable().optional(),
+  account_country: z.string().max(5000).nullable().optional(),
+  account_name: z.string().max(5000).nullable().optional(),
   account_tax_ids: z
-    .array(z.union([z.string(), z.lazy(() => s_tax_id), s_deleted_tax_id]))
+    .array(
+      z.union([z.string().max(5000), z.lazy(() => s_tax_id), s_deleted_tax_id]),
+    )
     .nullable()
     .optional(),
   amount_due: z.coerce.number(),
@@ -10929,7 +10994,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   amount_remaining: z.coerce.number(),
   amount_shipping: z.coerce.number(),
   application: z
-    .union([z.string(), s_application, s_deleted_application])
+    .union([z.string().max(5000), s_application, s_deleted_application])
     .nullable()
     .optional(),
   application_fee_amount: z.coerce.number().nullable().optional(),
@@ -10952,7 +11017,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .nullable()
     .optional(),
   charge: z
-    .union([z.string(), z.lazy(() => s_charge)])
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
   collection_method: z.enum(["charge_automatically", "send_invoice"]),
@@ -10960,13 +11025,13 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   currency: z.string(),
   custom_fields: z.array(s_invoice_setting_custom_field).nullable().optional(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   customer_address: s_address.nullable().optional(),
-  customer_email: z.string().nullable().optional(),
-  customer_name: z.string().nullable().optional(),
-  customer_phone: z.string().nullable().optional(),
+  customer_email: z.string().max(5000).nullable().optional(),
+  customer_name: z.string().max(5000).nullable().optional(),
+  customer_phone: z.string().max(5000).nullable().optional(),
   customer_shipping: s_shipping.nullable().optional(),
   customer_tax_exempt: z
     .enum(["exempt", "none", "reverse"])
@@ -10977,12 +11042,12 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .nullable()
     .optional(),
   default_payment_method: z
-    .union([z.string(), z.lazy(() => s_payment_method)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
     .nullable()
     .optional(),
   default_source: z
     .union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_bank_account),
       z.lazy(() => s_card),
       s_source,
@@ -10990,11 +11055,11 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .nullable()
     .optional(),
   default_tax_rates: z.array(s_tax_rate),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   discount: z.lazy(() => s_discount.nullable().optional()),
   discounts: z.array(
     z.union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_discount),
       z.lazy(() => s_deleted_discount),
     ]),
@@ -11002,38 +11067,38 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   due_date: z.coerce.number().nullable().optional(),
   effective_at: z.coerce.number().nullable().optional(),
   ending_balance: z.coerce.number().nullable().optional(),
-  footer: z.string().nullable().optional(),
+  footer: z.string().max(5000).nullable().optional(),
   from_invoice: z.lazy(() =>
     s_invoices_resource_from_invoice.nullable().optional(),
   ),
-  hosted_invoice_url: z.string().nullable().optional(),
-  id: z.string().optional(),
-  invoice_pdf: z.string().nullable().optional(),
+  hosted_invoice_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000).optional(),
+  invoice_pdf: z.string().max(5000).nullable().optional(),
   issuer: z.lazy(() => s_connect_account_reference),
   last_finalization_error: z.lazy(() => s_api_errors.nullable().optional()),
   latest_revision: z
-    .union([z.string(), z.lazy(() => s_invoice)])
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
   lines: z.object({
     data: z.array(z.lazy(() => s_line_item)),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   next_payment_attempt: z.coerce.number().nullable().optional(),
-  number: z.string().nullable().optional(),
+  number: z.string().max(5000).nullable().optional(),
   object: z.enum(["invoice"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   paid: z.coerce.boolean(),
   paid_out_of_band: z.coerce.boolean(),
   payment_intent: z
-    .union([z.string(), z.lazy(() => s_payment_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
     .optional(),
   payment_settings: s_invoices_payment_settings,
@@ -11042,22 +11107,22 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   post_payment_credit_notes_amount: z.coerce.number(),
   pre_payment_credit_notes_amount: z.coerce.number(),
   quote: z
-    .union([z.string(), z.lazy(() => s_quote)])
+    .union([z.string().max(5000), z.lazy(() => s_quote)])
     .nullable()
     .optional(),
-  receipt_number: z.string().nullable().optional(),
+  receipt_number: z.string().max(5000).nullable().optional(),
   rendering: s_invoices_resource_invoice_rendering.nullable().optional(),
   shipping_cost: s_invoices_resource_shipping_cost.nullable().optional(),
   shipping_details: s_shipping.nullable().optional(),
   starting_balance: z.coerce.number(),
-  statement_descriptor: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
   status: z
     .enum(["draft", "open", "paid", "uncollectible", "void"])
     .nullable()
     .optional(),
   status_transitions: s_invoices_resource_status_transitions,
   subscription: z
-    .union([z.string(), z.lazy(() => s_subscription)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription)])
     .nullable()
     .optional(),
   subscription_details: s_subscription_details_data.nullable().optional(),
@@ -11066,7 +11131,7 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   subtotal_excluding_tax: z.coerce.number().nullable().optional(),
   tax: z.coerce.number().nullable().optional(),
   test_clock: z
-    .union([z.string(), s_test_helpers_test_clock])
+    .union([z.string().max(5000), s_test_helpers_test_clock])
     .nullable()
     .optional(),
   threshold_reason: s_invoice_threshold_reason.optional(),
@@ -11085,18 +11150,20 @@ export const s_line_item: z.ZodType<t_line_item> = z.object({
   amount: z.coerce.number(),
   amount_excluding_tax: z.coerce.number().nullable().optional(),
   currency: z.string(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   discount_amounts: z
     .array(z.lazy(() => s_discounts_resource_discount_amount))
     .nullable()
     .optional(),
   discountable: z.coerce.boolean(),
-  discounts: z.array(z.union([z.string(), z.lazy(() => s_discount)])),
-  id: z.string(),
-  invoice: z.string().nullable().optional(),
-  invoice_item: z.union([z.string(), z.lazy(() => s_invoiceitem)]).optional(),
+  discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
+  id: z.string().max(5000),
+  invoice: z.string().max(5000).nullable().optional(),
+  invoice_item: z
+    .union([z.string().max(5000), z.lazy(() => s_invoiceitem)])
+    .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["line_item"]),
   period: s_invoice_line_item_period,
   price: z.lazy(() => s_price.nullable().optional()),
@@ -11106,11 +11173,11 @@ export const s_line_item: z.ZodType<t_line_item> = z.object({
     .optional(),
   quantity: z.coerce.number().nullable().optional(),
   subscription: z
-    .union([z.string(), z.lazy(() => s_subscription)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription)])
     .nullable()
     .optional(),
   subscription_item: z
-    .union([z.string(), z.lazy(() => s_subscription_item)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription_item)])
     .optional(),
   tax_amounts: z.array(s_invoice_tax_amount).optional(),
   tax_rates: z.array(s_tax_rate).optional(),
@@ -11135,17 +11202,17 @@ export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
     balance_transactions: z.array(z.lazy(() => s_balance_transaction)),
     card: z.lazy(() => s_issuing_card),
     cardholder: z
-      .union([z.string(), z.lazy(() => s_issuing_cardholder)])
+      .union([z.string().max(5000), z.lazy(() => s_issuing_cardholder)])
       .nullable()
       .optional(),
     created: z.coerce.number(),
     currency: z.string(),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     merchant_amount: z.coerce.number(),
     merchant_currency: z.string(),
     merchant_data: s_issuing_authorization_merchant_data,
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     network_data: s_issuing_authorization_network_data.nullable().optional(),
     object: z.enum(["issuing.authorization"]),
     pending_request: s_issuing_authorization_pending_request
@@ -11154,29 +11221,29 @@ export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
     request_history: z.array(s_issuing_authorization_request),
     status: z.enum(["closed", "pending", "reversed"]),
     token: z
-      .union([z.string(), z.lazy(() => s_issuing_token)])
+      .union([z.string().max(5000), z.lazy(() => s_issuing_token)])
       .nullable()
       .optional(),
     transactions: z.array(z.lazy(() => s_issuing_transaction)),
     treasury: s_issuing_authorization_treasury.nullable().optional(),
     verification_data: s_issuing_authorization_verification_data,
-    wallet: z.string().nullable().optional(),
+    wallet: z.string().max(5000).nullable().optional(),
   })
 
 export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
   billing: s_issuing_cardholder_address,
   company: s_issuing_cardholder_company.nullable().optional(),
   created: z.coerce.number(),
-  email: z.string().nullable().optional(),
-  id: z.string(),
+  email: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   individual: z.lazy(() =>
     s_issuing_cardholder_individual.nullable().optional(),
   ),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
-  name: z.string(),
+  metadata: z.record(z.string().max(500)),
+  name: z.string().max(5000),
   object: z.enum(["issuing.cardholder"]),
-  phone_number: z.string().nullable().optional(),
+  phone_number: z.string().max(5000).nullable().optional(),
   preferred_locales: z
     .array(z.enum(["de", "en", "es", "fr", "it"]))
     .nullable()
@@ -11190,7 +11257,7 @@ export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
 })
 
 export const s_issuing_card: z.ZodType<t_issuing_card> = z.object({
-  brand: z.string(),
+  brand: z.string().max(5000),
   cancellation_reason: z
     .enum(["design_rejected", "lost", "stolen"])
     .nullable()
@@ -11198,26 +11265,29 @@ export const s_issuing_card: z.ZodType<t_issuing_card> = z.object({
   cardholder: z.lazy(() => s_issuing_cardholder),
   created: z.coerce.number(),
   currency: z.string(),
-  cvc: z.string().optional(),
+  cvc: z.string().max(5000).optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
-  financial_account: z.string().nullable().optional(),
-  id: z.string(),
-  last4: z.string(),
+  financial_account: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  last4: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
-  number: z.string().optional(),
+  metadata: z.record(z.string().max(500)),
+  number: z.string().max(5000).optional(),
   object: z.enum(["issuing.card"]),
   personalization_design: z
-    .union([z.string(), z.lazy(() => s_issuing_personalization_design)])
+    .union([
+      z.string().max(5000),
+      z.lazy(() => s_issuing_personalization_design),
+    ])
     .nullable()
     .optional(),
   replaced_by: z
-    .union([z.string(), z.lazy(() => s_issuing_card)])
+    .union([z.string().max(5000), z.lazy(() => s_issuing_card)])
     .nullable()
     .optional(),
   replacement_for: z
-    .union([z.string(), z.lazy(() => s_issuing_card)])
+    .union([z.string().max(5000), z.lazy(() => s_issuing_card)])
     .nullable()
     .optional(),
   replacement_reason: z
@@ -11240,43 +11310,46 @@ export const s_issuing_dispute: z.ZodType<t_issuing_dispute> = z.object({
   created: z.coerce.number(),
   currency: z.string(),
   evidence: z.lazy(() => s_issuing_dispute_evidence),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["issuing.dispute"]),
   status: z.enum(["expired", "lost", "submitted", "unsubmitted", "won"]),
-  transaction: z.union([z.string(), z.lazy(() => s_issuing_transaction)]),
+  transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_issuing_transaction),
+  ]),
   treasury: s_issuing_dispute_treasury.nullable().optional(),
 })
 
 export const s_issuing_personalization_design: z.ZodType<t_issuing_personalization_design> =
   z.object({
     card_logo: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     carrier_text: s_issuing_personalization_design_carrier_text
       .nullable()
       .optional(),
     created: z.coerce.number(),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
-    lookup_key: z.string().nullable().optional(),
-    metadata: z.record(z.string()),
-    name: z.string().nullable().optional(),
+    lookup_key: z.string().max(5000).nullable().optional(),
+    metadata: z.record(z.string().max(500)),
+    name: z.string().max(5000).nullable().optional(),
     object: z.enum(["issuing.personalization_design"]),
-    physical_bundle: z.union([z.string(), s_issuing_physical_bundle]),
+    physical_bundle: z.union([z.string().max(5000), s_issuing_physical_bundle]),
     preferences: s_issuing_personalization_design_preferences,
     rejection_reasons: s_issuing_personalization_design_rejection_reasons,
     status: z.enum(["active", "inactive", "rejected", "review"]),
   })
 
 export const s_issuing_token: z.ZodType<t_issuing_token> = z.object({
-  card: z.union([z.string(), z.lazy(() => s_issuing_card)]),
+  card: z.union([z.string().max(5000), z.lazy(() => s_issuing_card)]),
   created: z.coerce.number(),
-  device_fingerprint: z.string().nullable().optional(),
-  id: z.string(),
-  last4: z.string().optional(),
+  device_fingerprint: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  last4: z.string().max(5000).optional(),
   livemode: z.coerce.boolean(),
   network: z.enum(["mastercard", "visa"]),
   network_data: s_issuing_network_token_network_data.optional(),
@@ -11293,37 +11366,37 @@ export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
     amount: z.coerce.number(),
     amount_details: s_issuing_transaction_amount_details.nullable().optional(),
     authorization: z
-      .union([z.string(), z.lazy(() => s_issuing_authorization)])
+      .union([z.string().max(5000), z.lazy(() => s_issuing_authorization)])
       .nullable()
       .optional(),
     balance_transaction: z
-      .union([z.string(), z.lazy(() => s_balance_transaction)])
+      .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
       .nullable()
       .optional(),
-    card: z.union([z.string(), z.lazy(() => s_issuing_card)]),
+    card: z.union([z.string().max(5000), z.lazy(() => s_issuing_card)]),
     cardholder: z
-      .union([z.string(), z.lazy(() => s_issuing_cardholder)])
+      .union([z.string().max(5000), z.lazy(() => s_issuing_cardholder)])
       .nullable()
       .optional(),
     created: z.coerce.number(),
     currency: z.string(),
     dispute: z
-      .union([z.string(), z.lazy(() => s_issuing_dispute)])
+      .union([z.string().max(5000), z.lazy(() => s_issuing_dispute)])
       .nullable()
       .optional(),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     merchant_amount: z.coerce.number(),
     merchant_currency: z.string(),
     merchant_data: s_issuing_authorization_merchant_data,
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     network_data: s_issuing_transaction_network_data.nullable().optional(),
     object: z.enum(["issuing.transaction"]),
     purchase_details: s_issuing_transaction_purchase_details
       .nullable()
       .optional(),
     token: z
-      .union([z.string(), z.lazy(() => s_issuing_token)])
+      .union([z.string().max(5000), z.lazy(() => s_issuing_token)])
       .nullable()
       .optional(),
     treasury: s_issuing_transaction_treasury.nullable().optional(),
@@ -11337,12 +11410,15 @@ export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
 
 export const s_mandate: z.ZodType<t_mandate> = z.object({
   customer_acceptance: s_customer_acceptance,
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   multi_use: s_mandate_multi_use.optional(),
   object: z.enum(["mandate"]),
-  on_behalf_of: z.string().optional(),
-  payment_method: z.union([z.string(), z.lazy(() => s_payment_method)]),
+  on_behalf_of: z.string().max(5000).optional(),
+  payment_method: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_payment_method),
+  ]),
   payment_method_details: s_mandate_payment_method_details,
   single_use: s_mandate_single_use.optional(),
   status: z.enum(["active", "inactive", "pending"]),
@@ -11354,7 +11430,10 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
   amount_capturable: z.coerce.number().optional(),
   amount_details: s_payment_flows_amount_details.optional(),
   amount_received: z.coerce.number().optional(),
-  application: z.union([z.string(), s_application]).nullable().optional(),
+  application: z
+    .union([z.string().max(5000), s_application])
+    .nullable()
+    .optional(),
   application_fee_amount: z.coerce.number().nullable().optional(),
   automatic_payment_methods:
     s_payment_flows_automatic_payment_methods_payment_intent
@@ -11374,35 +11453,35 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
     .nullable()
     .optional(),
   capture_method: z.enum(["automatic", "automatic_async", "manual"]),
-  client_secret: z.string().nullable().optional(),
+  client_secret: z.string().max(5000).nullable().optional(),
   confirmation_method: z.enum(["automatic", "manual"]),
   created: z.coerce.number(),
   currency: z.string(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  description: z.string().nullable().optional(),
-  id: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   invoice: z
-    .union([z.string(), z.lazy(() => s_invoice)])
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
   last_payment_error: z.lazy(() => s_api_errors.nullable().optional()),
   latest_charge: z
-    .union([z.string(), z.lazy(() => s_charge)])
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string().max(500)).optional(),
   next_action: s_payment_intent_next_action.nullable().optional(),
   object: z.enum(["payment_intent"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   payment_method: z
-    .union([z.string(), z.lazy(() => s_payment_method)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
     .nullable()
     .optional(),
   payment_method_configuration_details:
@@ -11412,11 +11491,11 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
   payment_method_options: s_payment_intent_payment_method_options
     .nullable()
     .optional(),
-  payment_method_types: z.array(z.string()),
+  payment_method_types: z.array(z.string().max(5000)),
   processing: s_payment_intent_processing.nullable().optional(),
-  receipt_email: z.string().nullable().optional(),
+  receipt_email: z.string().max(5000).nullable().optional(),
   review: z
-    .union([z.string(), z.lazy(() => s_review)])
+    .union([z.string().max(5000), z.lazy(() => s_review)])
     .nullable()
     .optional(),
   setup_future_usage: z
@@ -11424,8 +11503,8 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
     .nullable()
     .optional(),
   shipping: s_shipping.nullable().optional(),
-  statement_descriptor: z.string().nullable().optional(),
-  statement_descriptor_suffix: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  statement_descriptor_suffix: z.string().max(5000).nullable().optional(),
   status: z.enum([
     "canceled",
     "processing",
@@ -11436,7 +11515,7 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
     "succeeded",
   ]),
   transfer_data: z.lazy(() => s_transfer_data.nullable().optional()),
-  transfer_group: z.string().nullable().optional(),
+  transfer_group: z.string().max(5000).nullable().optional(),
 })
 
 export const s_payment_link: z.ZodType<t_payment_link> = z.object({
@@ -11444,7 +11523,7 @@ export const s_payment_link: z.ZodType<t_payment_link> = z.object({
   after_completion: s_payment_links_resource_after_completion,
   allow_promotion_codes: z.coerce.boolean(),
   application: z
-    .union([z.string(), s_application, s_deleted_application])
+    .union([z.string().max(5000), s_application, s_deleted_application])
     .nullable()
     .optional(),
   application_fee_amount: z.coerce.number().nullable().optional(),
@@ -11458,8 +11537,8 @@ export const s_payment_link: z.ZodType<t_payment_link> = z.object({
   custom_fields: z.array(s_payment_links_resource_custom_fields),
   custom_text: s_payment_links_resource_custom_text,
   customer_creation: z.enum(["always", "if_required"]),
-  id: z.string(),
-  inactive_message: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  inactive_message: z.string().max(5000).nullable().optional(),
   invoice_creation: z.lazy(() =>
     s_payment_links_resource_invoice_creation.nullable().optional(),
   ),
@@ -11468,14 +11547,14 @@ export const s_payment_link: z.ZodType<t_payment_link> = z.object({
       data: z.array(z.lazy(() => s_item)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["payment_link"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   payment_intent_data: s_payment_links_resource_payment_intent_data
@@ -11531,7 +11610,7 @@ export const s_payment_link: z.ZodType<t_payment_link> = z.object({
   transfer_data: z.lazy(() =>
     s_payment_links_resource_transfer_data.nullable().optional(),
   ),
-  url: z.string(),
+  url: z.string().max(5000),
 })
 
 export const s_payout: z.ZodType<t_payout> = z.object({
@@ -11539,15 +11618,15 @@ export const s_payout: z.ZodType<t_payout> = z.object({
   arrival_date: z.coerce.number(),
   automatic: z.coerce.boolean(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   created: z.coerce.number(),
   currency: z.string(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   destination: z
     .union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_bank_account),
       z.lazy(() => s_card),
       s_deleted_bank_account,
@@ -11556,28 +11635,28 @@ export const s_payout: z.ZodType<t_payout> = z.object({
     .nullable()
     .optional(),
   failure_balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
-  failure_code: z.string().nullable().optional(),
-  failure_message: z.string().nullable().optional(),
-  id: z.string(),
+  failure_code: z.string().max(5000).nullable().optional(),
+  failure_message: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
-  method: z.string(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  method: z.string().max(5000),
   object: z.enum(["payout"]),
   original_payout: z
-    .union([z.string(), z.lazy(() => s_payout)])
+    .union([z.string().max(5000), z.lazy(() => s_payout)])
     .nullable()
     .optional(),
   reconciliation_status: z.enum(["completed", "in_progress", "not_applicable"]),
   reversed_by: z
-    .union([z.string(), z.lazy(() => s_payout)])
+    .union([z.string().max(5000), z.lazy(() => s_payout)])
     .nullable()
     .optional(),
-  source_type: z.string(),
-  statement_descriptor: z.string().nullable().optional(),
-  status: z.string(),
+  source_type: z.string().max(5000),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  status: z.string().max(5000),
   type: z.enum(["bank_account", "card"]),
 })
 
@@ -11592,16 +11671,16 @@ export const s_plan: z.ZodType<t_plan> = z.object({
   billing_scheme: z.enum(["per_unit", "tiered"]),
   created: z.coerce.number(),
   currency: z.string(),
-  id: z.string(),
+  id: z.string().max(5000),
   interval: z.enum(["day", "month", "week", "year"]),
   interval_count: z.coerce.number(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()).nullable().optional(),
-  meter: z.string().nullable().optional(),
-  nickname: z.string().nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  meter: z.string().max(5000).nullable().optional(),
+  nickname: z.string().max(5000).nullable().optional(),
   object: z.enum(["plan"]),
   product: z
-    .union([z.string(), z.lazy(() => s_product), s_deleted_product])
+    .union([z.string().max(5000), z.lazy(() => s_product), s_deleted_product])
     .nullable()
     .optional(),
   tiers: z.array(s_plan_tier).optional(),
@@ -11618,13 +11697,17 @@ export const s_price: z.ZodType<t_price> = z.object({
   currency: z.string(),
   currency_options: z.record(s_currency_option).optional(),
   custom_unit_amount: s_custom_unit_amount.nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  lookup_key: z.string().nullable().optional(),
-  metadata: z.record(z.string()),
-  nickname: z.string().nullable().optional(),
+  lookup_key: z.string().max(5000).nullable().optional(),
+  metadata: z.record(z.string().max(500)),
+  nickname: z.string().max(5000).nullable().optional(),
   object: z.enum(["price"]),
-  product: z.union([z.string(), z.lazy(() => s_product), s_deleted_product]),
+  product: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_product),
+    s_deleted_product,
+  ]),
   recurring: s_recurring.nullable().optional(),
   tax_behavior: z
     .enum(["exclusive", "inclusive", "unspecified"])
@@ -11642,40 +11725,43 @@ export const s_product: z.ZodType<t_product> = z.object({
   active: z.coerce.boolean(),
   created: z.coerce.number(),
   default_price: z
-    .union([z.string(), z.lazy(() => s_price)])
+    .union([z.string().max(5000), z.lazy(() => s_price)])
     .nullable()
     .optional(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   features: z.array(s_product_marketing_feature),
-  id: z.string(),
-  images: z.array(z.string()),
+  id: z.string().max(5000),
+  images: z.array(z.string().max(5000)),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
-  name: z.string(),
+  metadata: z.record(z.string().max(500)),
+  name: z.string().max(5000),
   object: z.enum(["product"]),
   package_dimensions: s_package_dimensions.nullable().optional(),
   shippable: z.coerce.boolean().nullable().optional(),
-  statement_descriptor: z.string().nullable().optional(),
-  tax_code: z.union([z.string(), s_tax_code]).nullable().optional(),
-  unit_label: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
+  tax_code: z
+    .union([z.string().max(5000), s_tax_code])
+    .nullable()
+    .optional(),
+  unit_label: z.string().max(5000).nullable().optional(),
   updated: z.coerce.number(),
-  url: z.string().nullable().optional(),
+  url: z.string().max(2048).nullable().optional(),
 })
 
 export const s_promotion_code: z.ZodType<t_promotion_code> = z.object({
   active: z.coerce.boolean(),
-  code: z.string(),
+  code: z.string().max(5000),
   coupon: s_coupon,
   created: z.coerce.number(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   expires_at: z.coerce.number().nullable().optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   max_redemptions: z.coerce.number().nullable().optional(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["promotion_code"]),
   restrictions: s_promotion_codes_resource_restrictions,
   times_redeemed: z.coerce.number(),
@@ -11685,7 +11771,7 @@ export const s_quote: z.ZodType<t_quote> = z.object({
   amount_subtotal: z.coerce.number(),
   amount_total: z.coerce.number(),
   application: z
-    .union([z.string(), s_application, s_deleted_application])
+    .union([z.string().max(5000), s_application, s_deleted_application])
     .nullable()
     .optional(),
   application_fee_amount: z.coerce.number().nullable().optional(),
@@ -11694,21 +11780,23 @@ export const s_quote: z.ZodType<t_quote> = z.object({
   collection_method: z.enum(["charge_automatically", "send_invoice"]),
   computed: z.lazy(() => s_quotes_resource_computed),
   created: z.coerce.number(),
-  currency: z.string().nullable().optional(),
+  currency: z.string().max(5000).nullable().optional(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  default_tax_rates: z.array(z.union([z.string(), s_tax_rate])).optional(),
-  description: z.string().nullable().optional(),
-  discounts: z.array(z.union([z.string(), z.lazy(() => s_discount)])),
+  default_tax_rates: z
+    .array(z.union([z.string().max(5000), s_tax_rate]))
+    .optional(),
+  description: z.string().max(5000).nullable().optional(),
+  discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
   expires_at: z.coerce.number(),
-  footer: z.string().nullable().optional(),
+  footer: z.string().max(5000).nullable().optional(),
   from_quote: z.lazy(() => s_quotes_resource_from_quote.nullable().optional()),
-  header: z.string().nullable().optional(),
-  id: z.string(),
+  header: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   invoice: z
-    .union([z.string(), z.lazy(() => s_invoice), s_deleted_invoice])
+    .union([z.string().max(5000), z.lazy(() => s_invoice), s_deleted_invoice])
     .nullable()
     .optional(),
   invoice_settings: z.lazy(() => s_invoice_setting_quote_setting),
@@ -11717,30 +11805,30 @@ export const s_quote: z.ZodType<t_quote> = z.object({
       data: z.array(z.lazy(() => s_item)),
       has_more: z.coerce.boolean(),
       object: z.enum(["list"]),
-      url: z.string(),
+      url: z.string().max(5000),
     })
     .optional(),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
-  number: z.string().nullable().optional(),
+  metadata: z.record(z.string().max(500)),
+  number: z.string().max(5000).nullable().optional(),
   object: z.enum(["quote"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   status: z.enum(["accepted", "canceled", "draft", "open"]),
   status_transitions: s_quotes_resource_status_transitions,
   subscription: z
-    .union([z.string(), z.lazy(() => s_subscription)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription)])
     .nullable()
     .optional(),
   subscription_data: s_quotes_resource_subscription_data_subscription_data,
   subscription_schedule: z
-    .union([z.string(), z.lazy(() => s_subscription_schedule)])
+    .union([z.string().max(5000), z.lazy(() => s_subscription_schedule)])
     .nullable()
     .optional(),
   test_clock: z
-    .union([z.string(), s_test_helpers_test_clock])
+    .union([z.string().max(5000), s_test_helpers_test_clock])
     .nullable()
     .optional(),
   total_details: z.lazy(() => s_quotes_resource_total_details),
@@ -11752,35 +11840,35 @@ export const s_quote: z.ZodType<t_quote> = z.object({
 export const s_radar_early_fraud_warning: z.ZodType<t_radar_early_fraud_warning> =
   z.object({
     actionable: z.coerce.boolean(),
-    charge: z.union([z.string(), z.lazy(() => s_charge)]),
+    charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]),
     created: z.coerce.number(),
-    fraud_type: z.string(),
-    id: z.string(),
+    fraud_type: z.string().max(5000),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["radar.early_fraud_warning"]),
     payment_intent: z
-      .union([z.string(), z.lazy(() => s_payment_intent)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
       .optional(),
   })
 
 export const s_reporting_report_run: z.ZodType<t_reporting_report_run> =
   z.object({
     created: z.coerce.number(),
-    error: z.string().nullable().optional(),
-    id: z.string(),
+    error: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["reporting.report_run"]),
     parameters: s_financial_reporting_finance_report_run_run_parameters,
-    report_type: z.string(),
+    report_type: z.string().max(5000),
     result: z.lazy(() => s_file.nullable().optional()),
-    status: z.string(),
+    status: z.string().max(5000),
     succeeded_at: z.coerce.number().nullable().optional(),
   })
 
 export const s_review: z.ZodType<t_review> = z.object({
-  billing_zip: z.string().nullable().optional(),
+  billing_zip: z.string().max(5000).nullable().optional(),
   charge: z
-    .union([z.string(), z.lazy(() => s_charge)])
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
   closed_reason: z
@@ -11788,49 +11876,58 @@ export const s_review: z.ZodType<t_review> = z.object({
     .nullable()
     .optional(),
   created: z.coerce.number(),
-  id: z.string(),
-  ip_address: z.string().nullable().optional(),
+  id: z.string().max(5000),
+  ip_address: z.string().max(5000).nullable().optional(),
   ip_address_location: s_radar_review_resource_location.nullable().optional(),
   livemode: z.coerce.boolean(),
   object: z.enum(["review"]),
   open: z.coerce.boolean(),
   opened_reason: z.enum(["manual", "rule"]),
   payment_intent: z
-    .union([z.string(), z.lazy(() => s_payment_intent)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .optional(),
-  reason: z.string(),
+  reason: z.string().max(5000),
   session: s_radar_review_resource_session.nullable().optional(),
 })
 
 export const s_setup_attempt: z.ZodType<t_setup_attempt> = z.object({
-  application: z.union([z.string(), s_application]).nullable().optional(),
+  application: z
+    .union([z.string().max(5000), s_application])
+    .nullable()
+    .optional(),
   attach_to_self: z.coerce.boolean().optional(),
   created: z.coerce.number(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
   flow_directions: z
     .array(z.enum(["inbound", "outbound"]))
     .nullable()
     .optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["setup_attempt"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
-  payment_method: z.union([z.string(), z.lazy(() => s_payment_method)]),
+  payment_method: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_payment_method),
+  ]),
   payment_method_details: z.lazy(() => s_setup_attempt_payment_method_details),
   setup_error: z.lazy(() => s_api_errors.nullable().optional()),
-  setup_intent: z.union([z.string(), z.lazy(() => s_setup_intent)]),
-  status: z.string(),
-  usage: z.string(),
+  setup_intent: z.union([z.string().max(5000), z.lazy(() => s_setup_intent)]),
+  status: z.string().max(5000),
+  usage: z.string().max(5000),
 })
 
 export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
-  application: z.union([z.string(), s_application]).nullable().optional(),
+  application: z
+    .union([z.string().max(5000), s_application])
+    .nullable()
+    .optional(),
   attach_to_self: z.coerce.boolean().optional(),
   automatic_payment_methods:
     s_payment_flows_automatic_payment_methods_setup_intent
@@ -11840,37 +11937,37 @@ export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
     .enum(["abandoned", "duplicate", "requested_by_customer"])
     .nullable()
     .optional(),
-  client_secret: z.string().nullable().optional(),
+  client_secret: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   customer: z
-    .union([z.string(), z.lazy(() => s_customer), s_deleted_customer])
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
     .nullable()
     .optional(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   flow_directions: z
     .array(z.enum(["inbound", "outbound"]))
     .nullable()
     .optional(),
-  id: z.string(),
+  id: z.string().max(5000),
   last_setup_error: z.lazy(() => s_api_errors.nullable().optional()),
   latest_attempt: z
-    .union([z.string(), z.lazy(() => s_setup_attempt)])
+    .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
     .nullable()
     .optional(),
   livemode: z.coerce.boolean(),
   mandate: z
-    .union([z.string(), z.lazy(() => s_mandate)])
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
     .nullable()
     .optional(),
-  metadata: z.record(z.string()).nullable().optional(),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   next_action: s_setup_intent_next_action.nullable().optional(),
   object: z.enum(["setup_intent"]),
   on_behalf_of: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
   payment_method: z
-    .union([z.string(), z.lazy(() => s_payment_method)])
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
     .nullable()
     .optional(),
   payment_method_configuration_details:
@@ -11880,9 +11977,9 @@ export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
   payment_method_options: s_setup_intent_payment_method_options
     .nullable()
     .optional(),
-  payment_method_types: z.array(z.string()),
+  payment_method_types: z.array(z.string().max(5000)),
   single_use_mandate: z
-    .union([z.string(), z.lazy(() => s_mandate)])
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
     .nullable()
     .optional(),
   status: z.enum([
@@ -11893,7 +11990,7 @@ export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
     "requires_payment_method",
     "succeeded",
   ]),
-  usage: z.string(),
+  usage: z.string().max(5000),
 })
 
 export const s_scheduled_query_run: z.ZodType<t_scheduled_query_run> = z.object(
@@ -11902,13 +11999,13 @@ export const s_scheduled_query_run: z.ZodType<t_scheduled_query_run> = z.object(
     data_load_time: z.coerce.number(),
     error: s_sigma_scheduled_query_run_error.optional(),
     file: z.lazy(() => s_file.nullable().optional()),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["scheduled_query_run"]),
     result_available_until: z.coerce.number(),
-    sql: z.string(),
-    status: z.string(),
-    title: z.string(),
+    sql: z.string().max(100000),
+    status: z.string().max(5000),
+    title: z.string().max(5000),
   },
 )
 
@@ -11917,20 +12014,20 @@ export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
     .nullable()
     .optional(),
   created: z.coerce.number(),
-  discounts: z.array(z.union([z.string(), z.lazy(() => s_discount)])),
-  id: z.string(),
-  metadata: z.record(z.string()),
+  discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
+  id: z.string().max(5000),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["subscription_item"]),
   price: z.lazy(() => s_price),
   quantity: z.coerce.number().optional(),
-  subscription: z.string(),
+  subscription: z.string().max(5000),
   tax_rates: z.array(s_tax_rate).nullable().optional(),
 })
 
 export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
   z.object({
     application: z
-      .union([z.string(), s_application, s_deleted_application])
+      .union([z.string().max(5000), s_application, s_deleted_application])
       .nullable()
       .optional(),
     canceled_at: z.coerce.number().nullable().optional(),
@@ -11938,7 +12035,7 @@ export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
     created: z.coerce.number(),
     current_phase: s_subscription_schedule_current_phase.nullable().optional(),
     customer: z.union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_customer),
       s_deleted_customer,
     ]),
@@ -11946,13 +12043,13 @@ export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
       () => s_subscription_schedules_resource_default_settings,
     ),
     end_behavior: z.enum(["cancel", "none", "release", "renew"]),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()).nullable().optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
     object: z.enum(["subscription_schedule"]),
     phases: z.array(z.lazy(() => s_subscription_schedule_phase_configuration)),
     released_at: z.coerce.number().nullable().optional(),
-    released_subscription: z.string().nullable().optional(),
+    released_subscription: z.string().max(5000).nullable().optional(),
     status: z.enum([
       "active",
       "canceled",
@@ -11961,11 +12058,11 @@ export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
       "released",
     ]),
     subscription: z
-      .union([z.string(), z.lazy(() => s_subscription)])
+      .union([z.string().max(5000), z.lazy(() => s_subscription)])
       .nullable()
       .optional(),
     test_clock: z
-      .union([z.string(), s_test_helpers_test_clock])
+      .union([z.string().max(5000), s_test_helpers_test_clock])
       .nullable()
       .optional(),
   })
@@ -11975,10 +12072,10 @@ export const s_terminal_configuration: z.ZodType<t_terminal_configuration> =
     bbpos_wisepos_e: z.lazy(() =>
       s_terminal_configuration_configuration_resource_device_type_specific_config.optional(),
     ),
-    id: z.string(),
+    id: z.string().max(5000),
     is_account_default: z.coerce.boolean().nullable().optional(),
     livemode: z.coerce.boolean(),
-    name: z.string().nullable().optional(),
+    name: z.string().max(5000).nullable().optional(),
     object: z.enum(["terminal.configuration"]),
     offline:
       s_terminal_configuration_configuration_resource_offline_config.optional(),
@@ -11992,7 +12089,7 @@ export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
   action: z.lazy(() =>
     s_terminal_reader_reader_resource_reader_action.nullable().optional(),
   ),
-  device_sw_version: z.string().nullable().optional(),
+  device_sw_version: z.string().max(5000).nullable().optional(),
   device_type: z.enum([
     "bbpos_chipper2x",
     "bbpos_wisepad3",
@@ -12002,14 +12099,17 @@ export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
     "stripe_m2",
     "verifone_P400",
   ]),
-  id: z.string(),
-  ip_address: z.string().nullable().optional(),
-  label: z.string(),
+  id: z.string().max(5000),
+  ip_address: z.string().max(5000).nullable().optional(),
+  label: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  location: z.union([z.string(), s_terminal_location]).nullable().optional(),
-  metadata: z.record(z.string()),
+  location: z
+    .union([z.string().max(5000), s_terminal_location])
+    .nullable()
+    .optional(),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["terminal.reader"]),
-  serial_number: z.string(),
+  serial_number: z.string().max(5000),
   status: z.enum(["offline", "online"]).nullable().optional(),
 })
 
@@ -12019,29 +12119,29 @@ export const s_treasury_inbound_transfer: z.ZodType<t_treasury_inbound_transfer>
     cancelable: z.coerce.boolean(),
     created: z.coerce.number(),
     currency: z.string(),
-    description: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
     failure_details: s_treasury_inbound_transfers_resource_failure_details
       .nullable()
       .optional(),
-    financial_account: z.string(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     linked_flows:
       s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows,
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     object: z.enum(["treasury.inbound_transfer"]),
-    origin_payment_method: z.string(),
+    origin_payment_method: z.string().max(5000),
     origin_payment_method_details: z.lazy(() =>
       s_inbound_transfers.nullable().optional(),
     ),
     returned: z.coerce.boolean().nullable().optional(),
-    statement_descriptor: z.string(),
+    statement_descriptor: z.string().max(5000),
     status: z.enum(["canceled", "failed", "processing", "succeeded"]),
     status_transitions:
       s_treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions,
     transaction: z
-      .union([z.string(), z.lazy(() => s_treasury_transaction)])
+      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
       .nullable()
       .optional(),
   })
@@ -12052,9 +12152,9 @@ export const s_treasury_outbound_payment: z.ZodType<t_treasury_outbound_payment>
     cancelable: z.coerce.boolean(),
     created: z.coerce.number(),
     currency: z.string(),
-    customer: z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    destination_payment_method: z.string().nullable().optional(),
+    customer: z.string().max(5000).nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
+    destination_payment_method: z.string().max(5000).nullable().optional(),
     destination_payment_method_details: z.lazy(() =>
       s_outbound_payments_payment_method_details.nullable().optional(),
     ),
@@ -12063,22 +12163,25 @@ export const s_treasury_outbound_payment: z.ZodType<t_treasury_outbound_payment>
         .nullable()
         .optional(),
     expected_arrival_date: z.coerce.number(),
-    financial_account: z.string(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     object: z.enum(["treasury.outbound_payment"]),
     returned_details: z.lazy(() =>
       s_treasury_outbound_payments_resource_returned_status
         .nullable()
         .optional(),
     ),
-    statement_descriptor: z.string(),
+    statement_descriptor: z.string().max(5000),
     status: z.enum(["canceled", "failed", "posted", "processing", "returned"]),
     status_transitions:
       s_treasury_outbound_payments_resource_outbound_payment_resource_status_transitions,
-    transaction: z.union([z.string(), z.lazy(() => s_treasury_transaction)]),
+    transaction: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_treasury_transaction),
+    ]),
   })
 
 export const s_treasury_outbound_transfer: z.ZodType<t_treasury_outbound_transfer> =
@@ -12087,28 +12190,31 @@ export const s_treasury_outbound_transfer: z.ZodType<t_treasury_outbound_transfe
     cancelable: z.coerce.boolean(),
     created: z.coerce.number(),
     currency: z.string(),
-    description: z.string().nullable().optional(),
-    destination_payment_method: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
+    destination_payment_method: z.string().max(5000).nullable().optional(),
     destination_payment_method_details: z.lazy(
       () => s_outbound_transfers_payment_method_details,
     ),
     expected_arrival_date: z.coerce.number(),
-    financial_account: z.string(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     object: z.enum(["treasury.outbound_transfer"]),
     returned_details: z.lazy(() =>
       s_treasury_outbound_transfers_resource_returned_details
         .nullable()
         .optional(),
     ),
-    statement_descriptor: z.string(),
+    statement_descriptor: z.string().max(5000),
     status: z.enum(["canceled", "failed", "posted", "processing", "returned"]),
     status_transitions:
       s_treasury_outbound_transfers_resource_status_transitions,
-    transaction: z.union([z.string(), z.lazy(() => s_treasury_transaction)]),
+    transaction: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_treasury_transaction),
+    ]),
   })
 
 export const s_treasury_received_credit: z.ZodType<t_treasury_received_credit> =
@@ -12116,14 +12222,14 @@ export const s_treasury_received_credit: z.ZodType<t_treasury_received_credit> =
     amount: z.coerce.number(),
     created: z.coerce.number(),
     currency: z.string(),
-    description: z.string(),
+    description: z.string().max(5000),
     failure_code: z
       .enum(["account_closed", "account_frozen", "other"])
       .nullable()
       .optional(),
-    financial_account: z.string().nullable().optional(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000).nullable().optional(),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     initiating_payment_method_details:
       s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details,
     linked_flows: z.lazy(
@@ -12137,7 +12243,7 @@ export const s_treasury_received_credit: z.ZodType<t_treasury_received_credit> =
       .optional(),
     status: z.enum(["failed", "succeeded"]),
     transaction: z
-      .union([z.string(), z.lazy(() => s_treasury_transaction)])
+      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
       .nullable()
       .optional(),
   })
@@ -12147,14 +12253,14 @@ export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
     amount: z.coerce.number(),
     created: z.coerce.number(),
     currency: z.string(),
-    description: z.string(),
+    description: z.string().max(5000),
     failure_code: z
       .enum(["account_closed", "account_frozen", "insufficient_funds", "other"])
       .nullable()
       .optional(),
-    financial_account: z.string().nullable().optional(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000).nullable().optional(),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     initiating_payment_method_details:
       s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details.optional(),
     linked_flows: s_treasury_received_debits_resource_linked_flows,
@@ -12166,7 +12272,7 @@ export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
       .optional(),
     status: z.enum(["failed", "succeeded"]),
     transaction: z
-      .union([z.string(), z.lazy(() => s_treasury_transaction)])
+      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
       .nullable()
       .optional(),
   })
@@ -12174,91 +12280,93 @@ export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
 export const s_token: z.ZodType<t_token> = z.object({
   bank_account: z.lazy(() => s_bank_account.optional()),
   card: z.lazy(() => s_card.optional()),
-  client_ip: z.string().nullable().optional(),
+  client_ip: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
-  id: z.string(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
   object: z.enum(["token"]),
-  type: z.string(),
+  type: z.string().max(5000),
   used: z.coerce.boolean(),
 })
 
 export const s_topup: z.ZodType<t_topup> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   created: z.coerce.number(),
-  currency: z.string(),
-  description: z.string().nullable().optional(),
+  currency: z.string().max(5000),
+  description: z.string().max(5000).nullable().optional(),
   expected_availability_date: z.coerce.number().nullable().optional(),
-  failure_code: z.string().nullable().optional(),
-  failure_message: z.string().nullable().optional(),
-  id: z.string(),
+  failure_code: z.string().max(5000).nullable().optional(),
+  failure_message: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["topup"]),
   source: s_source.nullable().optional(),
-  statement_descriptor: z.string().nullable().optional(),
+  statement_descriptor: z.string().max(5000).nullable().optional(),
   status: z.enum(["canceled", "failed", "pending", "reversed", "succeeded"]),
-  transfer_group: z.string().nullable().optional(),
+  transfer_group: z.string().max(5000).nullable().optional(),
 })
 
 export const s_transfer: z.ZodType<t_transfer> = z.object({
   amount: z.coerce.number(),
   amount_reversed: z.coerce.number(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   created: z.coerce.number(),
   currency: z.string(),
-  description: z.string().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   destination: z
-    .union([z.string(), z.lazy(() => s_account)])
+    .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
-  destination_payment: z.union([z.string(), z.lazy(() => s_charge)]).optional(),
-  id: z.string(),
+  destination_payment: z
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
+    .optional(),
+  id: z.string().max(5000),
   livemode: z.coerce.boolean(),
-  metadata: z.record(z.string()),
+  metadata: z.record(z.string().max(500)),
   object: z.enum(["transfer"]),
   reversals: z.object({
     data: z.array(z.lazy(() => s_transfer_reversal)),
     has_more: z.coerce.boolean(),
     object: z.enum(["list"]),
-    url: z.string(),
+    url: z.string().max(5000),
   }),
   reversed: z.coerce.boolean(),
   source_transaction: z
-    .union([z.string(), z.lazy(() => s_charge)])
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
-  source_type: z.string().optional(),
-  transfer_group: z.string().nullable().optional(),
+  source_type: z.string().max(5000).optional(),
+  transfer_group: z.string().max(5000).nullable().optional(),
 })
 
 export const s_transfer_reversal: z.ZodType<t_transfer_reversal> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
-    .union([z.string(), z.lazy(() => s_balance_transaction)])
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
     .optional(),
   created: z.coerce.number(),
   currency: z.string(),
   destination_payment_refund: z
-    .union([z.string(), z.lazy(() => s_refund)])
+    .union([z.string().max(5000), z.lazy(() => s_refund)])
     .nullable()
     .optional(),
-  id: z.string(),
-  metadata: z.record(z.string()).nullable().optional(),
+  id: z.string().max(5000),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["transfer_reversal"]),
   source_refund: z
-    .union([z.string(), z.lazy(() => s_refund)])
+    .union([z.string().max(5000), z.lazy(() => s_refund)])
     .nullable()
     .optional(),
-  transfer: z.union([z.string(), z.lazy(() => s_transfer)]),
+  transfer: z.union([z.string().max(5000), z.lazy(() => s_transfer)]),
 })
 
 export const s_treasury_credit_reversal: z.ZodType<t_treasury_credit_reversal> =
@@ -12266,18 +12374,18 @@ export const s_treasury_credit_reversal: z.ZodType<t_treasury_credit_reversal> =
     amount: z.coerce.number(),
     created: z.coerce.number(),
     currency: z.string(),
-    financial_account: z.string(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     network: z.enum(["ach", "stripe"]),
     object: z.enum(["treasury.credit_reversal"]),
-    received_credit: z.string(),
+    received_credit: z.string().max(5000),
     status: z.enum(["canceled", "posted", "processing"]),
     status_transitions: s_treasury_received_credits_resource_status_transitions,
     transaction: z
-      .union([z.string(), z.lazy(() => s_treasury_transaction)])
+      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
       .nullable()
       .optional(),
   })
@@ -12287,22 +12395,22 @@ export const s_treasury_debit_reversal: z.ZodType<t_treasury_debit_reversal> =
     amount: z.coerce.number(),
     created: z.coerce.number(),
     currency: z.string(),
-    financial_account: z.string().nullable().optional(),
-    hosted_regulatory_receipt_url: z.string().nullable().optional(),
-    id: z.string(),
+    financial_account: z.string().max(5000).nullable().optional(),
+    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
     linked_flows:
       s_treasury_received_debits_resource_debit_reversal_linked_flows
         .nullable()
         .optional(),
     livemode: z.coerce.boolean(),
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     network: z.enum(["ach", "card"]),
     object: z.enum(["treasury.debit_reversal"]),
-    received_debit: z.string(),
+    received_debit: z.string().max(5000),
     status: z.enum(["failed", "processing", "succeeded"]),
     status_transitions: s_treasury_received_debits_resource_status_transitions,
     transaction: z
-      .union([z.string(), z.lazy(() => s_treasury_transaction)])
+      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
       .nullable()
       .optional(),
   })
@@ -12313,8 +12421,8 @@ export const s_treasury_transaction_entry: z.ZodType<t_treasury_transaction_entr
     created: z.coerce.number(),
     currency: z.string(),
     effective_at: z.coerce.number(),
-    financial_account: z.string(),
-    flow: z.string().nullable().optional(),
+    financial_account: z.string().max(5000),
+    flow: z.string().max(5000).nullable().optional(),
     flow_details: z.lazy(() =>
       s_treasury_transactions_resource_flow_details.nullable().optional(),
     ),
@@ -12329,10 +12437,13 @@ export const s_treasury_transaction_entry: z.ZodType<t_treasury_transaction_entr
       "received_credit",
       "received_debit",
     ]),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["treasury.transaction_entry"]),
-    transaction: z.union([z.string(), z.lazy(() => s_treasury_transaction)]),
+    transaction: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_treasury_transaction),
+    ]),
     type: z.enum([
       "credit_reversal",
       "credit_reversal_posting",
@@ -12363,18 +12474,21 @@ export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
     balance_impact: s_treasury_transactions_resource_balance_impact,
     created: z.coerce.number(),
     currency: z.string(),
-    description: z.string(),
+    description: z.string().max(5000),
     entries: z
       .object({
         data: z.array(z.lazy(() => s_treasury_transaction_entry)),
         has_more: z.coerce.boolean(),
         object: z.enum(["list"]),
-        url: z.string(),
+        url: z
+          .string()
+          .max(5000)
+          .regex(new RegExp("^/v1/treasury/transaction_entries")),
       })
       .nullable()
       .optional(),
-    financial_account: z.string(),
-    flow: z.string().nullable().optional(),
+    financial_account: z.string().max(5000),
+    flow: z.string().max(5000).nullable().optional(),
     flow_details: z.lazy(() =>
       s_treasury_transactions_resource_flow_details.nullable().optional(),
     ),
@@ -12389,7 +12503,7 @@ export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
       "received_credit",
       "received_debit",
     ]),
-    id: z.string(),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["treasury.transaction"]),
     status: z.enum(["open", "posted", "void"]),
@@ -12404,14 +12518,14 @@ export const s_legal_entity_company: z.ZodType<t_legal_entity_company> =
     address_kanji: s_legal_entity_japan_address.nullable().optional(),
     directors_provided: z.coerce.boolean().optional(),
     executives_provided: z.coerce.boolean().optional(),
-    export_license_id: z.string().optional(),
-    export_purpose_code: z.string().optional(),
-    name: z.string().nullable().optional(),
-    name_kana: z.string().nullable().optional(),
-    name_kanji: z.string().nullable().optional(),
+    export_license_id: z.string().max(5000).optional(),
+    export_purpose_code: z.string().max(5000).optional(),
+    name: z.string().max(5000).nullable().optional(),
+    name_kana: z.string().max(5000).nullable().optional(),
+    name_kanji: z.string().max(5000).nullable().optional(),
     owners_provided: z.coerce.boolean().optional(),
     ownership_declaration: s_legal_entity_ubo_declaration.nullable().optional(),
-    phone: z.string().nullable().optional(),
+    phone: z.string().max(5000).nullable().optional(),
     structure: z
       .enum([
         "free_zone_establishment",
@@ -12440,7 +12554,7 @@ export const s_legal_entity_company: z.ZodType<t_legal_entity_company> =
       ])
       .optional(),
     tax_id_provided: z.coerce.boolean().optional(),
-    tax_id_registrar: z.string().optional(),
+    tax_id_registrar: z.string().max(5000).optional(),
     vat_id_provided: z.coerce.boolean().optional(),
     verification: z.lazy(() =>
       s_legal_entity_company_verification.nullable().optional(),
@@ -12461,16 +12575,16 @@ export const s_account_settings: z.ZodType<t_account_settings> = z.object({
 })
 
 export const s_api_errors: z.ZodType<t_api_errors> = z.object({
-  charge: z.string().optional(),
-  code: z.string().optional(),
-  decline_code: z.string().optional(),
-  doc_url: z.string().optional(),
-  message: z.string().optional(),
-  param: z.string().optional(),
+  charge: z.string().max(5000).optional(),
+  code: z.string().max(5000).optional(),
+  decline_code: z.string().max(5000).optional(),
+  doc_url: z.string().max(5000).optional(),
+  message: z.string().max(40000).optional(),
+  param: z.string().max(5000).optional(),
   payment_intent: z.lazy(() => s_payment_intent.optional()),
   payment_method: z.lazy(() => s_payment_method.optional()),
-  payment_method_type: z.string().optional(),
-  request_log_url: z.string().optional(),
+  payment_method_type: z.string().max(5000).optional(),
+  request_log_url: z.string().max(5000).optional(),
   setup_intent: z.lazy(() => s_setup_intent.optional()),
   source: z
     .union([z.lazy(() => s_bank_account), z.lazy(() => s_card), s_source])
@@ -12488,20 +12602,20 @@ export const s_legal_entity_person_verification: z.ZodType<t_legal_entity_person
     additional_document: z.lazy(() =>
       s_legal_entity_person_verification_document.nullable().optional(),
     ),
-    details: z.string().nullable().optional(),
-    details_code: z.string().nullable().optional(),
+    details: z.string().max(5000).nullable().optional(),
+    details_code: z.string().max(5000).nullable().optional(),
     document: z.lazy(() =>
       s_legal_entity_person_verification_document.optional(),
     ),
-    status: z.string(),
+    status: z.string().max(5000),
   })
 
 export const s_connect_collection_transfer: z.ZodType<t_connect_collection_transfer> =
   z.object({
     amount: z.coerce.number(),
     currency: z.string(),
-    destination: z.union([z.string(), z.lazy(() => s_account)]),
-    id: z.string(),
+    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+    id: z.string().max(5000),
     livemode: z.coerce.boolean(),
     object: z.enum(["connect_collection_transfer"]),
   })
@@ -12546,7 +12660,7 @@ export const s_payment_method_details: z.ZodType<t_payment_method_details> =
     sofort: z.lazy(() => s_payment_method_details_sofort.optional()),
     stripe_account: s_payment_method_details_stripe_account.optional(),
     swish: s_payment_method_details_swish.optional(),
-    type: z.string(),
+    type: z.string().max(5000),
     us_bank_account: z.lazy(() =>
       s_payment_method_details_us_bank_account.optional(),
     ),
@@ -12558,64 +12672,64 @@ export const s_payment_method_details: z.ZodType<t_payment_method_details> =
 export const s_charge_transfer_data: z.ZodType<t_charge_transfer_data> =
   z.object({
     amount: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string(), z.lazy(() => s_account)]),
+    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   })
 
 export const s_dispute_evidence: z.ZodType<t_dispute_evidence> = z.object({
-  access_activity_log: z.string().nullable().optional(),
-  billing_address: z.string().nullable().optional(),
+  access_activity_log: z.string().max(150000).nullable().optional(),
+  billing_address: z.string().max(5000).nullable().optional(),
   cancellation_policy: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  cancellation_policy_disclosure: z.string().nullable().optional(),
-  cancellation_rebuttal: z.string().nullable().optional(),
+  cancellation_policy_disclosure: z.string().max(150000).nullable().optional(),
+  cancellation_rebuttal: z.string().max(150000).nullable().optional(),
   customer_communication: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  customer_email_address: z.string().nullable().optional(),
-  customer_name: z.string().nullable().optional(),
-  customer_purchase_ip: z.string().nullable().optional(),
+  customer_email_address: z.string().max(5000).nullable().optional(),
+  customer_name: z.string().max(5000).nullable().optional(),
+  customer_purchase_ip: z.string().max(5000).nullable().optional(),
   customer_signature: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
   duplicate_charge_documentation: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  duplicate_charge_explanation: z.string().nullable().optional(),
-  duplicate_charge_id: z.string().nullable().optional(),
-  product_description: z.string().nullable().optional(),
+  duplicate_charge_explanation: z.string().max(150000).nullable().optional(),
+  duplicate_charge_id: z.string().max(5000).nullable().optional(),
+  product_description: z.string().max(150000).nullable().optional(),
   receipt: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
   refund_policy: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  refund_policy_disclosure: z.string().nullable().optional(),
-  refund_refusal_explanation: z.string().nullable().optional(),
-  service_date: z.string().nullable().optional(),
+  refund_policy_disclosure: z.string().max(150000).nullable().optional(),
+  refund_refusal_explanation: z.string().max(150000).nullable().optional(),
+  service_date: z.string().max(5000).nullable().optional(),
   service_documentation: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  shipping_address: z.string().nullable().optional(),
-  shipping_carrier: z.string().nullable().optional(),
-  shipping_date: z.string().nullable().optional(),
+  shipping_address: z.string().max(5000).nullable().optional(),
+  shipping_carrier: z.string().max(5000).nullable().optional(),
+  shipping_date: z.string().max(5000).nullable().optional(),
   shipping_documentation: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  shipping_tracking_number: z.string().nullable().optional(),
+  shipping_tracking_number: z.string().max(5000).nullable().optional(),
   uncategorized_file: z
-    .union([z.string(), z.lazy(() => s_file)])
+    .union([z.string().max(5000), z.lazy(() => s_file)])
     .nullable()
     .optional(),
-  uncategorized_text: z.string().nullable().optional(),
+  uncategorized_text: z.string().max(150000).nullable().optional(),
 })
 
 export const s_payment_pages_checkout_session_automatic_tax: z.ZodType<t_payment_pages_checkout_session_automatic_tax> =
@@ -12732,7 +12846,7 @@ export const s_discounts_resource_discount_amount: z.ZodType<t_discounts_resourc
   z.object({
     amount: z.coerce.number(),
     discount: z.union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_discount),
       z.lazy(() => s_deleted_discount),
     ]),
@@ -12745,10 +12859,10 @@ export const s_invoice_setting_customer_setting: z.ZodType<t_invoice_setting_cus
       .nullable()
       .optional(),
     default_payment_method: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
-    footer: z.string().nullable().optional(),
+    footer: z.string().max(5000).nullable().optional(),
     rendering_options: s_invoice_setting_rendering_options
       .nullable()
       .optional(),
@@ -12757,50 +12871,56 @@ export const s_invoice_setting_customer_setting: z.ZodType<t_invoice_setting_cus
 export const s_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft> =
   z.object({
     balance_transaction: z.union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_balance_transaction),
     ]),
     linked_transaction: z.union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_customer_cash_balance_transaction),
     ]),
   })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction> =
   z.object({
-    payment_intent: z.union([z.string(), z.lazy(() => s_payment_intent)]),
+    payment_intent: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_payment_intent),
+    ]),
   })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction> =
-  z.object({ refund: z.union([z.string(), z.lazy(() => s_refund)]) })
+  z.object({ refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]) })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance> =
   z.object({
     balance_transaction: z.union([
-      z.string(),
+      z.string().max(5000),
       z.lazy(() => s_balance_transaction),
     ]),
   })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction> =
   z.object({
-    payment_intent: z.union([z.string(), z.lazy(() => s_payment_intent)]),
+    payment_intent: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_payment_intent),
+    ]),
   })
 
 export const s_payment_method_card: z.ZodType<t_payment_method_card> = z.object(
   {
-    brand: z.string(),
+    brand: z.string().max(5000),
     checks: s_payment_method_card_checks.nullable().optional(),
-    country: z.string().nullable().optional(),
-    display_brand: z.string().nullable().optional(),
+    country: z.string().max(5000).nullable().optional(),
+    display_brand: z.string().max(5000).nullable().optional(),
     exp_month: z.coerce.number(),
     exp_year: z.coerce.number(),
-    fingerprint: z.string().nullable().optional(),
-    funding: z.string(),
+    fingerprint: z.string().max(5000).nullable().optional(),
+    funding: z.string().max(5000),
     generated_from: z.lazy(() =>
       s_payment_method_card_generated_card.nullable().optional(),
     ),
-    last4: z.string(),
+    last4: z.string().max(5000),
     networks: s_networks.nullable().optional(),
     three_d_secure_usage: s_three_d_secure_usage.nullable().optional(),
     wallet: s_payment_method_card_wallet.nullable().optional(),
@@ -12809,14 +12929,14 @@ export const s_payment_method_card: z.ZodType<t_payment_method_card> = z.object(
 
 export const s_payment_method_sepa_debit: z.ZodType<t_payment_method_sepa_debit> =
   z.object({
-    bank_code: z.string().nullable().optional(),
-    branch_code: z.string().nullable().optional(),
-    country: z.string().nullable().optional(),
-    fingerprint: z.string().nullable().optional(),
+    bank_code: z.string().max(5000).nullable().optional(),
+    branch_code: z.string().max(5000).nullable().optional(),
+    country: z.string().max(5000).nullable().optional(),
+    fingerprint: z.string().max(5000).nullable().optional(),
     generated_from: z.lazy(() =>
       s_sepa_debit_generated_from.nullable().optional(),
     ),
-    last4: z.string().nullable().optional(),
+    last4: z.string().max(5000).nullable().optional(),
   })
 
 export const s_subscription_automatic_tax: z.ZodType<t_subscription_automatic_tax> =
@@ -12840,20 +12960,26 @@ export const s_subscriptions_resource_pending_update: z.ZodType<t_subscriptions_
 export const s_subscription_transfer_data: z.ZodType<t_subscription_transfer_data> =
   z.object({
     amount_percent: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string(), z.lazy(() => s_account)]),
+    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   })
 
 export const s_tax_i_ds_owner: z.ZodType<t_tax_i_ds_owner> = z.object({
-  account: z.union([z.string(), z.lazy(() => s_account)]).optional(),
-  application: z.union([z.string(), s_application]).optional(),
-  customer: z.union([z.string(), z.lazy(() => s_customer)]).optional(),
+  account: z.union([z.string().max(5000), z.lazy(() => s_account)]).optional(),
+  application: z.union([z.string().max(5000), s_application]).optional(),
+  customer: z
+    .union([z.string().max(5000), z.lazy(() => s_customer)])
+    .optional(),
   type: z.enum(["account", "application", "customer", "self"]),
 })
 
 export const s_bank_connections_resource_accountholder: z.ZodType<t_bank_connections_resource_accountholder> =
   z.object({
-    account: z.union([z.string(), z.lazy(() => s_account)]).optional(),
-    customer: z.union([z.string(), z.lazy(() => s_customer)]).optional(),
+    account: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .optional(),
+    customer: z
+      .union([z.string().max(5000), z.lazy(() => s_customer)])
+      .optional(),
     type: z.enum(["account", "customer"]),
   })
 
@@ -12868,28 +12994,30 @@ export const s_automatic_tax: z.ZodType<t_automatic_tax> = z.object({
 
 export const s_invoices_resource_from_invoice: z.ZodType<t_invoices_resource_from_invoice> =
   z.object({
-    action: z.string(),
-    invoice: z.union([z.string(), z.lazy(() => s_invoice)]),
+    action: z.string().max(5000),
+    invoice: z.union([z.string().max(5000), z.lazy(() => s_invoice)]),
   })
 
 export const s_connect_account_reference: z.ZodType<t_connect_account_reference> =
   z.object({
-    account: z.union([z.string(), z.lazy(() => s_account)]).optional(),
+    account: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .optional(),
     type: z.enum(["account", "self"]),
   })
 
 export const s_invoice_transfer_data: z.ZodType<t_invoice_transfer_data> =
   z.object({
     amount: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string(), z.lazy(() => s_account)]),
+    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   })
 
 export const s_issuing_cardholder_individual: z.ZodType<t_issuing_cardholder_individual> =
   z.object({
     card_issuing: s_issuing_cardholder_card_issuing.nullable().optional(),
     dob: s_issuing_cardholder_individual_dob.nullable().optional(),
-    first_name: z.string().nullable().optional(),
-    last_name: z.string().nullable().optional(),
+    first_name: z.string().max(5000).nullable().optional(),
+    last_name: z.string().max(5000).nullable().optional(),
     verification: z.lazy(() =>
       s_issuing_cardholder_verification.nullable().optional(),
     ),
@@ -12923,7 +13051,7 @@ export const s_issuing_dispute_evidence: z.ZodType<t_issuing_dispute_evidence> =
 
 export const s_transfer_data: z.ZodType<t_transfer_data> = z.object({
   amount: z.coerce.number().optional(),
-  destination: z.union([z.string(), z.lazy(() => s_account)]),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
 })
 
 export const s_payment_links_resource_automatic_tax: z.ZodType<t_payment_links_resource_automatic_tax> =
@@ -12942,11 +13070,11 @@ export const s_payment_links_resource_invoice_creation: z.ZodType<t_payment_link
 
 export const s_payment_links_resource_subscription_data: z.ZodType<t_payment_links_resource_subscription_data> =
   z.object({
-    description: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
     invoice_settings: z.lazy(
       () => s_payment_links_resource_subscription_data_invoice_settings,
     ),
-    metadata: z.record(z.string()),
+    metadata: z.record(z.string().max(500)),
     trial_period_days: z.coerce.number().nullable().optional(),
     trial_settings: s_subscriptions_trials_resource_trial_settings
       .nullable()
@@ -12956,7 +13084,7 @@ export const s_payment_links_resource_subscription_data: z.ZodType<t_payment_lin
 export const s_payment_links_resource_transfer_data: z.ZodType<t_payment_links_resource_transfer_data> =
   z.object({
     amount: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string(), z.lazy(() => s_account)]),
+    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   })
 
 export const s_quotes_resource_automatic_tax: z.ZodType<t_quotes_resource_automatic_tax> =
@@ -12978,7 +13106,7 @@ export const s_quotes_resource_computed: z.ZodType<t_quotes_resource_computed> =
 export const s_quotes_resource_from_quote: z.ZodType<t_quotes_resource_from_quote> =
   z.object({
     is_revision: z.coerce.boolean(),
-    quote: z.union([z.string(), z.lazy(() => s_quote)]),
+    quote: z.union([z.string().max(5000), z.lazy(() => s_quote)]),
   })
 
 export const s_invoice_setting_quote_setting: z.ZodType<t_invoice_setting_quote_setting> =
@@ -13001,7 +13129,7 @@ export const s_quotes_resource_transfer_data: z.ZodType<t_quotes_resource_transf
   z.object({
     amount: z.coerce.number().nullable().optional(),
     amount_percent: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string(), z.lazy(() => s_account)]),
+    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   })
 
 export const s_setup_attempt_payment_method_details: z.ZodType<t_setup_attempt_payment_method_details> =
@@ -13029,7 +13157,7 @@ export const s_setup_attempt_payment_method_details: z.ZodType<t_setup_attempt_p
     sofort: z.lazy(() =>
       s_setup_attempt_payment_method_details_sofort.optional(),
     ),
-    type: z.string(),
+    type: z.string().max(5000),
     us_bank_account:
       s_setup_attempt_payment_method_details_us_bank_account.optional(),
   })
@@ -13047,15 +13175,15 @@ export const s_subscription_schedules_resource_default_settings: z.ZodType<t_sub
       .nullable()
       .optional(),
     default_payment_method: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
-    description: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
     invoice_settings: z.lazy(
       () => s_invoice_setting_subscription_schedule_setting,
     ),
     on_behalf_of: z
-      .union([z.string(), z.lazy(() => s_account)])
+      .union([z.string().max(5000), z.lazy(() => s_account)])
       .nullable()
       .optional(),
     transfer_data: z.lazy(() =>
@@ -13080,16 +13208,16 @@ export const s_subscription_schedule_phase_configuration: z.ZodType<t_subscripti
       .nullable()
       .optional(),
     coupon: z
-      .union([z.string(), s_coupon, s_deleted_coupon])
+      .union([z.string().max(5000), s_coupon, s_deleted_coupon])
       .nullable()
       .optional(),
     currency: z.string(),
     default_payment_method: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     default_tax_rates: z.array(s_tax_rate).nullable().optional(),
-    description: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
     discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
     end_date: z.coerce.number(),
     invoice_settings: z.lazy(() =>
@@ -13098,9 +13226,9 @@ export const s_subscription_schedule_phase_configuration: z.ZodType<t_subscripti
         .optional(),
     ),
     items: z.array(z.lazy(() => s_subscription_schedule_configuration_item)),
-    metadata: z.record(z.string()).nullable().optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
     on_behalf_of: z
-      .union([z.string(), z.lazy(() => s_account)])
+      .union([z.string().max(5000), z.lazy(() => s_account)])
       .nullable()
       .optional(),
     proration_behavior: z.enum(["always_invoice", "create_prorations", "none"]),
@@ -13113,13 +13241,15 @@ export const s_subscription_schedule_phase_configuration: z.ZodType<t_subscripti
 
 export const s_terminal_configuration_configuration_resource_device_type_specific_config: z.ZodType<t_terminal_configuration_configuration_resource_device_type_specific_config> =
   z.object({
-    splashscreen: z.union([z.string(), z.lazy(() => s_file)]).optional(),
+    splashscreen: z
+      .union([z.string().max(5000), z.lazy(() => s_file)])
+      .optional(),
   })
 
 export const s_terminal_reader_reader_resource_reader_action: z.ZodType<t_terminal_reader_reader_resource_reader_action> =
   z.object({
-    failure_code: z.string().nullable().optional(),
-    failure_message: z.string().nullable().optional(),
+    failure_code: z.string().max(5000).nullable().optional(),
+    failure_message: z.string().max(5000).nullable().optional(),
     process_payment_intent: z.lazy(() =>
       s_terminal_reader_reader_resource_process_payment_intent_action.optional(),
     ),
@@ -13173,7 +13303,10 @@ export const s_treasury_outbound_payments_resource_returned_status: z.ZodType<t_
       "no_account",
       "other",
     ]),
-    transaction: z.union([z.string(), z.lazy(() => s_treasury_transaction)]),
+    transaction: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_treasury_transaction),
+    ]),
   })
 
 export const s_outbound_transfers_payment_method_details: z.ZodType<t_outbound_transfers_payment_method_details> =
@@ -13199,21 +13332,24 @@ export const s_treasury_outbound_transfers_resource_returned_details: z.ZodType<
       "no_account",
       "other",
     ]),
-    transaction: z.union([z.string(), z.lazy(() => s_treasury_transaction)]),
+    transaction: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_treasury_transaction),
+    ]),
   })
 
 export const s_treasury_received_credits_resource_linked_flows: z.ZodType<t_treasury_received_credits_resource_linked_flows> =
   z.object({
-    credit_reversal: z.string().nullable().optional(),
-    issuing_authorization: z.string().nullable().optional(),
-    issuing_transaction: z.string().nullable().optional(),
-    source_flow: z.string().nullable().optional(),
+    credit_reversal: z.string().max(5000).nullable().optional(),
+    issuing_authorization: z.string().max(5000).nullable().optional(),
+    issuing_transaction: z.string().max(5000).nullable().optional(),
+    source_flow: z.string().max(5000).nullable().optional(),
     source_flow_details: z.lazy(() =>
       s_treasury_received_credits_resource_source_flows_details
         .nullable()
         .optional(),
     ),
-    source_flow_type: z.string().nullable().optional(),
+    source_flow_type: z.string().max(5000).nullable().optional(),
   })
 
 export const s_treasury_transactions_resource_flow_details: z.ZodType<t_treasury_transactions_resource_flow_details> =
@@ -13247,21 +13383,21 @@ export const s_legal_entity_company_verification: z.ZodType<t_legal_entity_compa
 export const s_account_branding_settings: z.ZodType<t_account_branding_settings> =
   z.object({
     icon: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     logo: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    primary_color: z.string().nullable().optional(),
-    secondary_color: z.string().nullable().optional(),
+    primary_color: z.string().max(5000).nullable().optional(),
+    secondary_color: z.string().max(5000).nullable().optional(),
   })
 
 export const s_account_invoices_settings: z.ZodType<t_account_invoices_settings> =
   z.object({
     default_account_tax_ids: z
-      .array(z.union([z.string(), z.lazy(() => s_tax_id)]))
+      .array(z.union([z.string().max(5000), z.lazy(() => s_tax_id)]))
       .nullable()
       .optional(),
   })
@@ -13269,33 +13405,33 @@ export const s_account_invoices_settings: z.ZodType<t_account_invoices_settings>
 export const s_legal_entity_person_verification_document: z.ZodType<t_legal_entity_person_verification_document> =
   z.object({
     back: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    details: z.string().nullable().optional(),
-    details_code: z.string().nullable().optional(),
+    details: z.string().max(5000).nullable().optional(),
+    details_code: z.string().max(5000).nullable().optional(),
     front: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
   })
 
 export const s_payment_method_details_bancontact: z.ZodType<t_payment_method_details_bancontact> =
   z.object({
-    bank_code: z.string().nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    bic: z.string().nullable().optional(),
+    bank_code: z.string().max(5000).nullable().optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    bic: z.string().max(5000).nullable().optional(),
     generated_sepa_debit: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     generated_sepa_debit_mandate: z
-      .union([z.string(), z.lazy(() => s_mandate)])
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .nullable()
       .optional(),
-    iban_last4: z.string().nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
     preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
-    verified_name: z.string().nullable().optional(),
+    verified_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_payment_method_details_ideal: z.ZodType<t_payment_method_details_ideal> =
@@ -13344,37 +13480,37 @@ export const s_payment_method_details_ideal: z.ZodType<t_payment_method_details_
       .nullable()
       .optional(),
     generated_sepa_debit: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     generated_sepa_debit_mandate: z
-      .union([z.string(), z.lazy(() => s_mandate)])
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .nullable()
       .optional(),
-    iban_last4: z.string().nullable().optional(),
-    verified_name: z.string().nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
+    verified_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_payment_method_details_sofort: z.ZodType<t_payment_method_details_sofort> =
   z.object({
-    bank_code: z.string().nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    bic: z.string().nullable().optional(),
-    country: z.string().nullable().optional(),
+    bank_code: z.string().max(5000).nullable().optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    bic: z.string().max(5000).nullable().optional(),
+    country: z.string().max(5000).nullable().optional(),
     generated_sepa_debit: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     generated_sepa_debit_mandate: z
-      .union([z.string(), z.lazy(() => s_mandate)])
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .nullable()
       .optional(),
-    iban_last4: z.string().nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
     preferred_language: z
       .enum(["de", "en", "es", "fr", "it", "nl", "pl"])
       .nullable()
       .optional(),
-    verified_name: z.string().nullable().optional(),
+    verified_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_payment_method_details_us_bank_account: z.ZodType<t_payment_method_details_us_bank_account> =
@@ -13384,28 +13520,36 @@ export const s_payment_method_details_us_bank_account: z.ZodType<t_payment_metho
       .nullable()
       .optional(),
     account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    fingerprint: z.string().nullable().optional(),
-    last4: z.string().nullable().optional(),
-    mandate: z.union([z.string(), z.lazy(() => s_mandate)]).optional(),
-    payment_reference: z.string().nullable().optional(),
-    routing_number: z.string().nullable().optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    fingerprint: z.string().max(5000).nullable().optional(),
+    last4: z.string().max(5000).nullable().optional(),
+    mandate: z
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
+      .optional(),
+    payment_reference: z.string().max(5000).nullable().optional(),
+    routing_number: z.string().max(5000).nullable().optional(),
   })
 
 export const s_payment_pages_checkout_session_invoice_settings: z.ZodType<t_payment_pages_checkout_session_invoice_settings> =
   z.object({
     account_tax_ids: z
-      .array(z.union([z.string(), z.lazy(() => s_tax_id), s_deleted_tax_id]))
+      .array(
+        z.union([
+          z.string().max(5000),
+          z.lazy(() => s_tax_id),
+          s_deleted_tax_id,
+        ]),
+      )
       .nullable()
       .optional(),
     custom_fields: z
       .array(s_invoice_setting_custom_field)
       .nullable()
       .optional(),
-    description: z.string().nullable().optional(),
-    footer: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
+    footer: z.string().max(5000).nullable().optional(),
     issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
-    metadata: z.record(z.string()).nullable().optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
     rendering_options: s_invoice_setting_rendering_options
       .nullable()
       .optional(),
@@ -13419,12 +13563,12 @@ export const s_payment_pages_checkout_session_total_details_resource_breakdown: 
 
 export const s_payment_method_card_generated_card: z.ZodType<t_payment_method_card_generated_card> =
   z.object({
-    charge: z.string().nullable().optional(),
+    charge: z.string().max(5000).nullable().optional(),
     payment_method_details: s_card_generated_from_payment_method_details
       .nullable()
       .optional(),
     setup_attempt: z
-      .union([z.string(), z.lazy(() => s_setup_attempt)])
+      .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
       .nullable()
       .optional(),
   })
@@ -13432,11 +13576,11 @@ export const s_payment_method_card_generated_card: z.ZodType<t_payment_method_ca
 export const s_sepa_debit_generated_from: z.ZodType<t_sepa_debit_generated_from> =
   z.object({
     charge: z
-      .union([z.string(), z.lazy(() => s_charge)])
+      .union([z.string().max(5000), z.lazy(() => s_charge)])
       .nullable()
       .optional(),
     setup_attempt: z
-      .union([z.string(), z.lazy(() => s_setup_attempt)])
+      .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
       .nullable()
       .optional(),
   })
@@ -13451,15 +13595,15 @@ export const s_issuing_cardholder_verification: z.ZodType<t_issuing_cardholder_v
 export const s_issuing_dispute_canceled_evidence: z.ZodType<t_issuing_dispute_canceled_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     canceled_at: z.coerce.number().nullable().optional(),
     cancellation_policy_provided: z.coerce.boolean().nullable().optional(),
-    cancellation_reason: z.string().nullable().optional(),
+    cancellation_reason: z.string().max(5000).nullable().optional(),
     expected_at: z.coerce.number().nullable().optional(),
-    explanation: z.string().nullable().optional(),
-    product_description: z.string().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
+    product_description: z.string().max(5000).nullable().optional(),
     product_type: z.enum(["merchandise", "service"]).nullable().optional(),
     return_status: z
       .enum(["merchant_rejected", "successful"])
@@ -13471,43 +13615,43 @@ export const s_issuing_dispute_canceled_evidence: z.ZodType<t_issuing_dispute_ca
 export const s_issuing_dispute_duplicate_evidence: z.ZodType<t_issuing_dispute_duplicate_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     card_statement: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     cash_receipt: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     check_image: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    explanation: z.string().nullable().optional(),
-    original_transaction: z.string().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
+    original_transaction: z.string().max(5000).nullable().optional(),
   })
 
 export const s_issuing_dispute_fraudulent_evidence: z.ZodType<t_issuing_dispute_fraudulent_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    explanation: z.string().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
   })
 
 export const s_issuing_dispute_merchandise_not_as_described_evidence: z.ZodType<t_issuing_dispute_merchandise_not_as_described_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    explanation: z.string().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
     received_at: z.coerce.number().nullable().optional(),
-    return_description: z.string().nullable().optional(),
+    return_description: z.string().max(5000).nullable().optional(),
     return_status: z
       .enum(["merchant_rejected", "successful"])
       .nullable()
@@ -13518,52 +13662,58 @@ export const s_issuing_dispute_merchandise_not_as_described_evidence: z.ZodType<
 export const s_issuing_dispute_not_received_evidence: z.ZodType<t_issuing_dispute_not_received_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     expected_at: z.coerce.number().nullable().optional(),
-    explanation: z.string().nullable().optional(),
-    product_description: z.string().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
+    product_description: z.string().max(5000).nullable().optional(),
     product_type: z.enum(["merchandise", "service"]).nullable().optional(),
   })
 
 export const s_issuing_dispute_other_evidence: z.ZodType<t_issuing_dispute_other_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    explanation: z.string().nullable().optional(),
-    product_description: z.string().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
+    product_description: z.string().max(5000).nullable().optional(),
     product_type: z.enum(["merchandise", "service"]).nullable().optional(),
   })
 
 export const s_issuing_dispute_service_not_as_described_evidence: z.ZodType<t_issuing_dispute_service_not_as_described_evidence> =
   z.object({
     additional_documentation: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     canceled_at: z.coerce.number().nullable().optional(),
-    cancellation_reason: z.string().nullable().optional(),
-    explanation: z.string().nullable().optional(),
+    cancellation_reason: z.string().max(5000).nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
     received_at: z.coerce.number().nullable().optional(),
   })
 
 export const s_payment_links_resource_invoice_settings: z.ZodType<t_payment_links_resource_invoice_settings> =
   z.object({
     account_tax_ids: z
-      .array(z.union([z.string(), z.lazy(() => s_tax_id), s_deleted_tax_id]))
+      .array(
+        z.union([
+          z.string().max(5000),
+          z.lazy(() => s_tax_id),
+          s_deleted_tax_id,
+        ]),
+      )
       .nullable()
       .optional(),
     custom_fields: z
       .array(s_invoice_setting_custom_field)
       .nullable()
       .optional(),
-    description: z.string().nullable().optional(),
-    footer: z.string().nullable().optional(),
+    description: z.string().max(5000).nullable().optional(),
+    footer: z.string().max(5000).nullable().optional(),
     issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
-    metadata: z.record(z.string()).nullable().optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
     rendering_options: s_invoice_setting_rendering_options
       .nullable()
       .optional(),
@@ -13590,7 +13740,7 @@ export const s_quotes_resource_upfront: z.ZodType<t_quotes_resource_upfront> =
         data: z.array(z.lazy(() => s_item)),
         has_more: z.coerce.boolean(),
         object: z.enum(["list"]),
-        url: z.string(),
+        url: z.string().max(5000),
       })
       .optional(),
     total_details: z.lazy(() => s_quotes_resource_total_details),
@@ -13604,26 +13754,26 @@ export const s_quotes_resource_total_details_resource_breakdown: z.ZodType<t_quo
 
 export const s_setup_attempt_payment_method_details_bancontact: z.ZodType<t_setup_attempt_payment_method_details_bancontact> =
   z.object({
-    bank_code: z.string().nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    bic: z.string().nullable().optional(),
+    bank_code: z.string().max(5000).nullable().optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    bic: z.string().max(5000).nullable().optional(),
     generated_sepa_debit: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     generated_sepa_debit_mandate: z
-      .union([z.string(), z.lazy(() => s_mandate)])
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .nullable()
       .optional(),
-    iban_last4: z.string().nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
     preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
-    verified_name: z.string().nullable().optional(),
+    verified_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_setup_attempt_payment_method_details_card_present: z.ZodType<t_setup_attempt_payment_method_details_card_present> =
   z.object({
     generated_card: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     offline: s_payment_method_details_card_present_offline
@@ -13677,33 +13827,33 @@ export const s_setup_attempt_payment_method_details_ideal: z.ZodType<t_setup_att
       .nullable()
       .optional(),
     generated_sepa_debit: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     generated_sepa_debit_mandate: z
-      .union([z.string(), z.lazy(() => s_mandate)])
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .nullable()
       .optional(),
-    iban_last4: z.string().nullable().optional(),
-    verified_name: z.string().nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
+    verified_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_setup_attempt_payment_method_details_sofort: z.ZodType<t_setup_attempt_payment_method_details_sofort> =
   z.object({
-    bank_code: z.string().nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    bic: z.string().nullable().optional(),
+    bank_code: z.string().max(5000).nullable().optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    bic: z.string().max(5000).nullable().optional(),
     generated_sepa_debit: z
-      .union([z.string(), z.lazy(() => s_payment_method)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
       .nullable()
       .optional(),
     generated_sepa_debit_mandate: z
-      .union([z.string(), z.lazy(() => s_mandate)])
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
       .nullable()
       .optional(),
-    iban_last4: z.string().nullable().optional(),
+    iban_last4: z.string().max(5000).nullable().optional(),
     preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
-    verified_name: z.string().nullable().optional(),
+    verified_name: z.string().max(5000).nullable().optional(),
   })
 
 export const s_subscription_schedules_resource_default_settings_automatic_tax: z.ZodType<t_subscription_schedules_resource_default_settings_automatic_tax> =
@@ -13715,7 +13865,13 @@ export const s_subscription_schedules_resource_default_settings_automatic_tax: z
 export const s_invoice_setting_subscription_schedule_setting: z.ZodType<t_invoice_setting_subscription_schedule_setting> =
   z.object({
     account_tax_ids: z
-      .array(z.union([z.string(), z.lazy(() => s_tax_id), s_deleted_tax_id]))
+      .array(
+        z.union([
+          z.string().max(5000),
+          z.lazy(() => s_tax_id),
+          s_deleted_tax_id,
+        ]),
+      )
       .nullable()
       .optional(),
     days_until_due: z.coerce.number().nullable().optional(),
@@ -13725,7 +13881,11 @@ export const s_invoice_setting_subscription_schedule_setting: z.ZodType<t_invoic
 export const s_subscription_schedule_add_invoice_item: z.ZodType<t_subscription_schedule_add_invoice_item> =
   z.object({
     discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
-    price: z.union([z.string(), z.lazy(() => s_price), s_deleted_price]),
+    price: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_price),
+      s_deleted_price,
+    ]),
     quantity: z.coerce.number().nullable().optional(),
     tax_rates: z.array(s_tax_rate).nullable().optional(),
   })
@@ -13738,13 +13898,16 @@ export const s_schedules_phase_automatic_tax: z.ZodType<t_schedules_phase_automa
 
 export const s_discounts_resource_stackable_discount: z.ZodType<t_discounts_resource_stackable_discount> =
   z.object({
-    coupon: z.union([z.string(), s_coupon]).nullable().optional(),
+    coupon: z
+      .union([z.string().max(5000), s_coupon])
+      .nullable()
+      .optional(),
     discount: z
-      .union([z.string(), z.lazy(() => s_discount)])
+      .union([z.string().max(5000), z.lazy(() => s_discount)])
       .nullable()
       .optional(),
     promotion_code: z
-      .union([z.string(), z.lazy(() => s_promotion_code)])
+      .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
       .nullable()
       .optional(),
   })
@@ -13752,7 +13915,13 @@ export const s_discounts_resource_stackable_discount: z.ZodType<t_discounts_reso
 export const s_invoice_setting_subscription_schedule_phase_setting: z.ZodType<t_invoice_setting_subscription_schedule_phase_setting> =
   z.object({
     account_tax_ids: z
-      .array(z.union([z.string(), z.lazy(() => s_tax_id), s_deleted_tax_id]))
+      .array(
+        z.union([
+          z.string().max(5000),
+          z.lazy(() => s_tax_id),
+          s_deleted_tax_id,
+        ]),
+      )
       .nullable()
       .optional(),
     days_until_due: z.coerce.number().nullable().optional(),
@@ -13765,38 +13934,45 @@ export const s_subscription_schedule_configuration_item: z.ZodType<t_subscriptio
       .nullable()
       .optional(),
     discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
-    metadata: z.record(z.string()).nullable().optional(),
-    price: z.union([z.string(), z.lazy(() => s_price), s_deleted_price]),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
+    price: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_price),
+      s_deleted_price,
+    ]),
     quantity: z.coerce.number().optional(),
     tax_rates: z.array(s_tax_rate).nullable().optional(),
   })
 
 export const s_terminal_reader_reader_resource_process_payment_intent_action: z.ZodType<t_terminal_reader_reader_resource_process_payment_intent_action> =
   z.object({
-    payment_intent: z.union([z.string(), z.lazy(() => s_payment_intent)]),
+    payment_intent: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_payment_intent),
+    ]),
     process_config: s_terminal_reader_reader_resource_process_config.optional(),
   })
 
 export const s_terminal_reader_reader_resource_process_setup_intent_action: z.ZodType<t_terminal_reader_reader_resource_process_setup_intent_action> =
   z.object({
-    generated_card: z.string().optional(),
+    generated_card: z.string().max(5000).optional(),
     process_config:
       s_terminal_reader_reader_resource_process_setup_config.optional(),
-    setup_intent: z.union([z.string(), z.lazy(() => s_setup_intent)]),
+    setup_intent: z.union([z.string().max(5000), z.lazy(() => s_setup_intent)]),
   })
 
 export const s_terminal_reader_reader_resource_refund_payment_action: z.ZodType<t_terminal_reader_reader_resource_refund_payment_action> =
   z.object({
     amount: z.coerce.number().optional(),
-    charge: z.union([z.string(), z.lazy(() => s_charge)]).optional(),
-    metadata: z.record(z.string()).optional(),
+    charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]).optional(),
+    metadata: z.record(z.string().max(500)).optional(),
     payment_intent: z
-      .union([z.string(), z.lazy(() => s_payment_intent)])
+      .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
       .optional(),
     reason: z
       .enum(["duplicate", "fraudulent", "requested_by_customer"])
       .optional(),
-    refund: z.union([z.string(), z.lazy(() => s_refund)]).optional(),
+    refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]).optional(),
     refund_application_fee: z.coerce.boolean().optional(),
     refund_payment_config:
       s_terminal_reader_reader_resource_refund_payment_config.optional(),
@@ -13810,12 +13986,14 @@ export const s_inbound_transfers_payment_method_details_us_bank_account: z.ZodTy
       .nullable()
       .optional(),
     account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    fingerprint: z.string().nullable().optional(),
-    last4: z.string().nullable().optional(),
-    mandate: z.union([z.string(), z.lazy(() => s_mandate)]).optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    fingerprint: z.string().max(5000).nullable().optional(),
+    last4: z.string().max(5000).nullable().optional(),
+    mandate: z
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
+      .optional(),
     network: z.enum(["ach"]),
-    routing_number: z.string().nullable().optional(),
+    routing_number: z.string().max(5000).nullable().optional(),
   })
 
 export const s_outbound_payments_payment_method_details_us_bank_account: z.ZodType<t_outbound_payments_payment_method_details_us_bank_account> =
@@ -13825,12 +14003,14 @@ export const s_outbound_payments_payment_method_details_us_bank_account: z.ZodTy
       .nullable()
       .optional(),
     account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    fingerprint: z.string().nullable().optional(),
-    last4: z.string().nullable().optional(),
-    mandate: z.union([z.string(), z.lazy(() => s_mandate)]).optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    fingerprint: z.string().max(5000).nullable().optional(),
+    last4: z.string().max(5000).nullable().optional(),
+    mandate: z
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
+      .optional(),
     network: z.enum(["ach", "us_domestic_wire"]),
-    routing_number: z.string().nullable().optional(),
+    routing_number: z.string().max(5000).nullable().optional(),
   })
 
 export const s_outbound_transfers_payment_method_details_us_bank_account: z.ZodType<t_outbound_transfers_payment_method_details_us_bank_account> =
@@ -13840,12 +14020,14 @@ export const s_outbound_transfers_payment_method_details_us_bank_account: z.ZodT
       .nullable()
       .optional(),
     account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().nullable().optional(),
-    fingerprint: z.string().nullable().optional(),
-    last4: z.string().nullable().optional(),
-    mandate: z.union([z.string(), z.lazy(() => s_mandate)]).optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    fingerprint: z.string().max(5000).nullable().optional(),
+    last4: z.string().max(5000).nullable().optional(),
+    mandate: z
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
+      .optional(),
     network: z.enum(["ach", "us_domestic_wire"]),
-    routing_number: z.string().nullable().optional(),
+    routing_number: z.string().max(5000).nullable().optional(),
   })
 
 export const s_treasury_received_credits_resource_source_flows_details: z.ZodType<t_treasury_received_credits_resource_source_flows_details> =
@@ -13859,13 +14041,13 @@ export const s_treasury_received_credits_resource_source_flows_details: z.ZodTyp
 export const s_legal_entity_company_verification_document: z.ZodType<t_legal_entity_company_verification_document> =
   z.object({
     back: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
-    details: z.string().nullable().optional(),
-    details_code: z.string().nullable().optional(),
+    details: z.string().max(5000).nullable().optional(),
+    details_code: z.string().max(5000).nullable().optional(),
     front: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
   })
@@ -13873,11 +14055,11 @@ export const s_legal_entity_company_verification_document: z.ZodType<t_legal_ent
 export const s_issuing_cardholder_id_document: z.ZodType<t_issuing_cardholder_id_document> =
   z.object({
     back: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
     front: z
-      .union([z.string(), z.lazy(() => s_file)])
+      .union([z.string().max(5000), z.lazy(() => s_file)])
       .nullable()
       .optional(),
   })

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -456,6 +456,9 @@ function normalizeSchemaObject(
         type: schemaObject.type,
         format: schemaObject.format,
         enum: enumValues.length ? enumValues : undefined,
+        maxLength: schemaObject.maxLength,
+        minLength: schemaObject.minLength,
+        pattern: schemaObject.pattern,
       } satisfies IRModelString
     }
     case "boolean":

--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -33,6 +33,9 @@ export interface IRModelString extends IRModelBase {
   type: "string"
   format?: IRModelStringFormat | string | undefined
   enum?: string[] | undefined
+  maxLength?: number | undefined
+  minLength?: number | undefined
+  pattern?: string | undefined
 }
 
 export interface IRModelBoolean extends IRModelBase {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -167,7 +167,14 @@ export class JoiBuilder extends AbstractSchemaBuilder<JoiBuilder> {
         .join(".")
     }
 
-    return result
+    return [
+      result,
+      Number.isFinite(model.minLength) ? `min(${model.minLength})` : undefined,
+      Number.isFinite(model.maxLength) ? `max(${model.maxLength})` : undefined,
+      model.pattern ? `pattern(/${model.pattern}/)` : undefined,
+    ]
+      .filter(isDefined)
+      .join(".")
   }
 
   protected boolean() {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -171,7 +171,11 @@ export class JoiBuilder extends AbstractSchemaBuilder<JoiBuilder> {
       result,
       Number.isFinite(model.minLength) ? `min(${model.minLength})` : undefined,
       Number.isFinite(model.maxLength) ? `max(${model.maxLength})` : undefined,
-      model.pattern ? `pattern(/${model.pattern}/)` : undefined,
+      model.pattern
+        ? `pattern(new RegExp("${model.pattern
+            .replaceAll("\\", "\\\\")
+            .replaceAll('"', '\\"')}"))`
+        : undefined,
     ]
       .filter(isDefined)
       .join(".")

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -176,7 +176,11 @@ export class ZodBuilder extends AbstractSchemaBuilder<ZodBuilder> {
       "string()",
       Number.isFinite(model.minLength) ? `min(${model.minLength})` : undefined,
       Number.isFinite(model.maxLength) ? `max(${model.maxLength})` : undefined,
-      model.pattern ? `regex(/${model.pattern}/)` : undefined,
+      model.pattern
+        ? `regex(new RegExp("${model.pattern
+            .replaceAll("\\", "\\\\")
+            .replaceAll('"', '\\"')}"))`
+        : undefined,
       model.format === "date-time" ? "datetime({offset:true})" : undefined,
       model.format === "email" ? "email()" : undefined,
     ]

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -174,6 +174,9 @@ export class ZodBuilder extends AbstractSchemaBuilder<ZodBuilder> {
     return [
       zod,
       "string()",
+      Number.isFinite(model.minLength) ? `min(${model.minLength})` : undefined,
+      Number.isFinite(model.maxLength) ? `max(${model.maxLength})` : undefined,
+      model.pattern ? `regex(/${model.pattern}/)` : undefined,
       model.format === "date-time" ? "datetime({offset:true})" : undefined,
       model.format === "email" ? "email()" : undefined,
     ]


### PR DESCRIPTION
adds support for the validation keywords defined for strings in https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.3

originally I tried to create `/RegExp literals/` but this didn't work for the test harness with `joi` due to https://github.com/nodejs/node/issues/2503#issuecomment-133842814 and a reliance on `pattern instanceof RegExp` check that `joi` makes.