### PR TITLE
fix!: stricter booleans

### DIFF
--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -1604,6 +1604,7 @@ import {
   t_workflow_usage,
 } from "./models"
 import {
+  PermissiveBoolean,
   s_actions_billing_usage,
   s_actions_cache_list,
   s_actions_cache_usage_by_repository,
@@ -20832,7 +20833,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .enum(["unknown", "low", "medium", "high", "critical"])
       .optional(),
     cwes: z.union([z.string(), z.array(z.string())]).optional(),
-    is_withdrawn: z.coerce.boolean().optional(),
+    is_withdrawn: PermissiveBoolean.optional(),
     affects: z.union([z.string(), z.array(z.string())]).optional(),
     published: z.string().optional(),
     updated: z.string().optional(),
@@ -21160,7 +21161,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const appsListWebhookDeliveriesQuerySchema = z.object({
     per_page: z.coerce.number().optional(),
     cursor: z.string().optional(),
-    redelivery: z.coerce.boolean().optional(),
+    redelivery: PermissiveBoolean.optional(),
   })
 
   const appsListWebhookDeliveriesResponseValidator = responseValidationFactory(
@@ -22917,7 +22918,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const gistsCreateBodySchema = z.object({
     description: z.string().optional(),
     files: z.record(z.object({ content: z.string() })),
-    public: z.union([z.coerce.boolean(), z.enum(["true", "false"])]).optional(),
+    public: z.union([PermissiveBoolean, z.enum(["true", "false"])]).optional(),
   })
 
   const gistsCreateResponseValidator = responseValidationFactory(
@@ -24275,10 +24276,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     sort: z.enum(["created", "updated", "comments"]).optional(),
     direction: z.enum(["asc", "desc"]).optional(),
     since: z.string().datetime({ offset: true }).optional(),
-    collab: z.coerce.boolean().optional(),
-    orgs: z.coerce.boolean().optional(),
-    owned: z.coerce.boolean().optional(),
-    pulls: z.coerce.boolean().optional(),
+    collab: PermissiveBoolean.optional(),
+    orgs: PermissiveBoolean.optional(),
+    owned: PermissiveBoolean.optional(),
+    pulls: PermissiveBoolean.optional(),
     per_page: z.coerce.number().optional(),
     page: z.coerce.number().optional(),
   })
@@ -24337,7 +24338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const licensesGetAllCommonlyUsedQuerySchema = z.object({
-    featured: z.coerce.boolean().optional(),
+    featured: PermissiveBoolean.optional(),
     per_page: z.coerce.number().optional(),
     page: z.coerce.number().optional(),
   })
@@ -25032,8 +25033,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const activityListNotificationsForAuthenticatedUserQuerySchema = z.object({
-    all: z.coerce.boolean().optional(),
-    participating: z.coerce.boolean().optional(),
+    all: PermissiveBoolean.optional(),
+    participating: PermissiveBoolean.optional(),
     since: z.string().datetime({ offset: true }).optional(),
     before: z.string().datetime({ offset: true }).optional(),
     page: z.coerce.number().optional(),
@@ -25108,7 +25109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const activityMarkNotificationsAsReadBodySchema = z
     .object({
       last_read_at: z.string().datetime({ offset: true }).optional(),
-      read: z.coerce.boolean().optional(),
+      read: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -25416,7 +25417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const activitySetThreadSubscriptionBodySchema = z
-    .object({ ignored: z.coerce.boolean().optional() })
+    .object({ ignored: PermissiveBoolean.optional() })
     .optional()
 
   const activitySetThreadSubscriptionResponseValidator =
@@ -25692,45 +25693,38 @@ export function createRouter(implementation: Implementation): KoaRouter {
       location: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
-      has_organization_projects: z.coerce.boolean().optional(),
-      has_repository_projects: z.coerce.boolean().optional(),
+      has_organization_projects: PermissiveBoolean.optional(),
+      has_repository_projects: PermissiveBoolean.optional(),
       default_repository_permission: z
         .enum(["read", "write", "admin", "none"])
         .optional(),
-      members_can_create_repositories: z.coerce.boolean().optional(),
-      members_can_create_internal_repositories: z.coerce.boolean().optional(),
-      members_can_create_private_repositories: z.coerce.boolean().optional(),
-      members_can_create_public_repositories: z.coerce.boolean().optional(),
+      members_can_create_repositories: PermissiveBoolean.optional(),
+      members_can_create_internal_repositories: PermissiveBoolean.optional(),
+      members_can_create_private_repositories: PermissiveBoolean.optional(),
+      members_can_create_public_repositories: PermissiveBoolean.optional(),
       members_allowed_repository_creation_type: z
         .enum(["all", "private", "none"])
         .optional(),
-      members_can_create_pages: z.coerce.boolean().optional(),
-      members_can_create_public_pages: z.coerce.boolean().optional(),
-      members_can_create_private_pages: z.coerce.boolean().optional(),
-      members_can_fork_private_repositories: z.coerce.boolean().optional(),
-      web_commit_signoff_required: z.coerce.boolean().optional(),
+      members_can_create_pages: PermissiveBoolean.optional(),
+      members_can_create_public_pages: PermissiveBoolean.optional(),
+      members_can_create_private_pages: PermissiveBoolean.optional(),
+      members_can_fork_private_repositories: PermissiveBoolean.optional(),
+      web_commit_signoff_required: PermissiveBoolean.optional(),
       blog: z.string().optional(),
-      advanced_security_enabled_for_new_repositories: z.coerce
-        .boolean()
-        .optional(),
-      dependabot_alerts_enabled_for_new_repositories: z.coerce
-        .boolean()
-        .optional(),
-      dependabot_security_updates_enabled_for_new_repositories: z.coerce
-        .boolean()
-        .optional(),
-      dependency_graph_enabled_for_new_repositories: z.coerce
-        .boolean()
-        .optional(),
-      secret_scanning_enabled_for_new_repositories: z.coerce
-        .boolean()
-        .optional(),
-      secret_scanning_push_protection_enabled_for_new_repositories: z.coerce
-        .boolean()
-        .optional(),
-      secret_scanning_push_protection_custom_link_enabled: z.coerce
-        .boolean()
-        .optional(),
+      advanced_security_enabled_for_new_repositories:
+        PermissiveBoolean.optional(),
+      dependabot_alerts_enabled_for_new_repositories:
+        PermissiveBoolean.optional(),
+      dependabot_security_updates_enabled_for_new_repositories:
+        PermissiveBoolean.optional(),
+      dependency_graph_enabled_for_new_repositories:
+        PermissiveBoolean.optional(),
+      secret_scanning_enabled_for_new_repositories:
+        PermissiveBoolean.optional(),
+      secret_scanning_push_protection_enabled_for_new_repositories:
+        PermissiveBoolean.optional(),
+      secret_scanning_push_protection_custom_link_enabled:
+        PermissiveBoolean.optional(),
       secret_scanning_push_protection_custom_link: z.string().optional(),
     })
     .optional()
@@ -31016,7 +31010,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       password: z.string().optional(),
     }),
     events: z.array(z.string()).optional(),
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
   })
 
   const orgsCreateWebhookResponseValidator = responseValidationFactory(
@@ -31142,7 +31136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       events: z.array(z.string()).optional(),
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       name: z.string().optional(),
     })
     .optional()
@@ -31373,7 +31367,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const orgsListWebhookDeliveriesQuerySchema = z.object({
     per_page: z.coerce.number().optional(),
     cursor: z.string().optional(),
-    redelivery: z.coerce.boolean().optional(),
+    redelivery: PermissiveBoolean.optional(),
   })
 
   const orgsListWebhookDeliveriesResponseValidator = responseValidationFactory(
@@ -32931,13 +32925,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const migrationsStartForOrgBodySchema = z.object({
     repositories: z.array(z.string()),
-    lock_repositories: z.coerce.boolean().optional(),
-    exclude_metadata: z.coerce.boolean().optional(),
-    exclude_git_data: z.coerce.boolean().optional(),
-    exclude_attachments: z.coerce.boolean().optional(),
-    exclude_releases: z.coerce.boolean().optional(),
-    exclude_owner_projects: z.coerce.boolean().optional(),
-    org_metadata_only: z.coerce.boolean().optional(),
+    lock_repositories: PermissiveBoolean.optional(),
+    exclude_metadata: PermissiveBoolean.optional(),
+    exclude_git_data: PermissiveBoolean.optional(),
+    exclude_attachments: PermissiveBoolean.optional(),
+    exclude_releases: PermissiveBoolean.optional(),
+    exclude_owner_projects: PermissiveBoolean.optional(),
+    org_metadata_only: PermissiveBoolean.optional(),
     exclude: z.array(z.enum(["repositories"])).optional(),
   })
 
@@ -34169,7 +34163,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const orgsConvertMemberToOutsideCollaboratorBodySchema = z
-    .object({ async: z.coerce.boolean().optional() })
+    .object({ async: PermissiveBoolean.optional() })
     .optional()
 
   const orgsConvertMemberToOutsideCollaboratorResponseValidator =
@@ -35822,7 +35816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const orgsCreateOrUpdateCustomPropertyBodySchema = z.object({
     value_type: z.enum(["string", "single_select"]),
-    required: z.coerce.boolean().optional(),
+    required: PermissiveBoolean.optional(),
     default_value: z
       .union([z.string(), z.array(z.string())])
       .nullable()
@@ -36373,23 +36367,23 @@ export function createRouter(implementation: Implementation): KoaRouter {
     name: z.string(),
     description: z.string().optional(),
     homepage: z.string().optional(),
-    private: z.coerce.boolean().optional(),
+    private: PermissiveBoolean.optional(),
     visibility: z.enum(["public", "private"]).optional(),
-    has_issues: z.coerce.boolean().optional(),
-    has_projects: z.coerce.boolean().optional(),
-    has_wiki: z.coerce.boolean().optional(),
-    has_downloads: z.coerce.boolean().optional(),
-    is_template: z.coerce.boolean().optional(),
+    has_issues: PermissiveBoolean.optional(),
+    has_projects: PermissiveBoolean.optional(),
+    has_wiki: PermissiveBoolean.optional(),
+    has_downloads: PermissiveBoolean.optional(),
+    is_template: PermissiveBoolean.optional(),
     team_id: z.coerce.number().optional(),
-    auto_init: z.coerce.boolean().optional(),
+    auto_init: PermissiveBoolean.optional(),
     gitignore_template: z.string().optional(),
     license_template: z.string().optional(),
-    allow_squash_merge: z.coerce.boolean().optional(),
-    allow_merge_commit: z.coerce.boolean().optional(),
-    allow_rebase_merge: z.coerce.boolean().optional(),
-    allow_auto_merge: z.coerce.boolean().optional(),
-    delete_branch_on_merge: z.coerce.boolean().optional(),
-    use_squash_pr_title_as_default: z.coerce.boolean().optional(),
+    allow_squash_merge: PermissiveBoolean.optional(),
+    allow_merge_commit: PermissiveBoolean.optional(),
+    allow_rebase_merge: PermissiveBoolean.optional(),
+    allow_auto_merge: PermissiveBoolean.optional(),
+    delete_branch_on_merge: PermissiveBoolean.optional(),
+    use_squash_pr_title_as_default: PermissiveBoolean.optional(),
     squash_merge_commit_title: z
       .enum(["PR_TITLE", "COMMIT_OR_PR_TITLE"])
       .optional(),
@@ -37726,7 +37720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const teamsCreateDiscussionInOrgBodySchema = z.object({
     title: z.string(),
     body: z.string(),
-    private: z.coerce.boolean().optional(),
+    private: PermissiveBoolean.optional(),
   })
 
   const teamsCreateDiscussionInOrgResponseValidator = responseValidationFactory(
@@ -39578,7 +39572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const projectsUpdateCardBodySchema = z
     .object({
       note: z.string().nullable().optional(),
-      archived: z.coerce.boolean().optional(),
+      archived: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -40354,7 +40348,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       organization_permission: z
         .enum(["read", "write", "admin", "none"])
         .optional(),
-      private: z.coerce.boolean().optional(),
+      private: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -41066,7 +41060,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       name: z.string().optional(),
       description: z.string().optional(),
       homepage: z.string().optional(),
-      private: z.coerce.boolean().optional(),
+      private: PermissiveBoolean.optional(),
       visibility: z.enum(["public", "private"]).optional(),
       security_and_analysis: z
         .object({
@@ -41082,18 +41076,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .nullable()
         .optional(),
-      has_issues: z.coerce.boolean().optional(),
-      has_projects: z.coerce.boolean().optional(),
-      has_wiki: z.coerce.boolean().optional(),
-      is_template: z.coerce.boolean().optional(),
+      has_issues: PermissiveBoolean.optional(),
+      has_projects: PermissiveBoolean.optional(),
+      has_wiki: PermissiveBoolean.optional(),
+      is_template: PermissiveBoolean.optional(),
       default_branch: z.string().optional(),
-      allow_squash_merge: z.coerce.boolean().optional(),
-      allow_merge_commit: z.coerce.boolean().optional(),
-      allow_rebase_merge: z.coerce.boolean().optional(),
-      allow_auto_merge: z.coerce.boolean().optional(),
-      delete_branch_on_merge: z.coerce.boolean().optional(),
-      allow_update_branch: z.coerce.boolean().optional(),
-      use_squash_pr_title_as_default: z.coerce.boolean().optional(),
+      allow_squash_merge: PermissiveBoolean.optional(),
+      allow_merge_commit: PermissiveBoolean.optional(),
+      allow_rebase_merge: PermissiveBoolean.optional(),
+      allow_auto_merge: PermissiveBoolean.optional(),
+      delete_branch_on_merge: PermissiveBoolean.optional(),
+      allow_update_branch: PermissiveBoolean.optional(),
+      use_squash_pr_title_as_default: PermissiveBoolean.optional(),
       squash_merge_commit_title: z
         .enum(["PR_TITLE", "COMMIT_OR_PR_TITLE"])
         .optional(),
@@ -41102,9 +41096,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       merge_commit_title: z.enum(["PR_TITLE", "MERGE_MESSAGE"]).optional(),
       merge_commit_message: z.enum(["PR_BODY", "PR_TITLE", "BLANK"]).optional(),
-      archived: z.coerce.boolean().optional(),
-      allow_forking: z.coerce.boolean().optional(),
-      web_commit_signoff_required: z.coerce.boolean().optional(),
+      archived: PermissiveBoolean.optional(),
+      allow_forking: PermissiveBoolean.optional(),
+      web_commit_signoff_required: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -41780,7 +41774,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsReRunJobForWorkflowRunBodySchema = z
-    .object({ enable_debug_logging: z.coerce.boolean().optional() })
+    .object({ enable_debug_logging: PermissiveBoolean.optional() })
     .nullable()
     .optional()
 
@@ -41906,7 +41900,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsSetCustomOidcSubClaimForRepoBodySchema = z.object({
-    use_default: z.coerce.boolean(),
+    use_default: PermissiveBoolean,
     include_claim_keys: z.array(z.string()).optional(),
   })
 
@@ -43378,7 +43372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     per_page: z.coerce.number().optional(),
     page: z.coerce.number().optional(),
     created: z.string().datetime({ offset: true }).optional(),
-    exclude_pull_requests: z.coerce.boolean().optional(),
+    exclude_pull_requests: PermissiveBoolean.optional(),
     check_suite_id: z.coerce.number().optional(),
     head_sha: z.string().optional(),
   })
@@ -43449,7 +43443,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsGetWorkflowRunQuerySchema = z.object({
-    exclude_pull_requests: z.coerce.boolean().optional(),
+    exclude_pull_requests: PermissiveBoolean.optional(),
   })
 
   const actionsGetWorkflowRunResponseValidator = responseValidationFactory(
@@ -43735,7 +43729,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsGetWorkflowRunAttemptQuerySchema = z.object({
-    exclude_pull_requests: z.coerce.boolean().optional(),
+    exclude_pull_requests: PermissiveBoolean.optional(),
   })
 
   const actionsGetWorkflowRunAttemptResponseValidator =
@@ -44371,7 +44365,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsReRunWorkflowBodySchema = z
-    .object({ enable_debug_logging: z.coerce.boolean().optional() })
+    .object({ enable_debug_logging: PermissiveBoolean.optional() })
     .nullable()
     .optional()
 
@@ -44429,7 +44423,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsReRunWorkflowFailedJobsBodySchema = z
-    .object({ enable_debug_logging: z.coerce.boolean().optional() })
+    .object({ enable_debug_logging: PermissiveBoolean.optional() })
     .nullable()
     .optional()
 
@@ -45396,7 +45390,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     per_page: z.coerce.number().optional(),
     page: z.coerce.number().optional(),
     created: z.string().datetime({ offset: true }).optional(),
-    exclude_pull_requests: z.coerce.boolean().optional(),
+    exclude_pull_requests: PermissiveBoolean.optional(),
     check_suite_id: z.coerce.number().optional(),
     head_sha: z.string().optional(),
   })
@@ -45761,7 +45755,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposCreateAutolinkBodySchema = z.object({
     key_prefix: z.string(),
     url_template: z.string(),
-    is_alphanumeric: z.coerce.boolean().optional(),
+    is_alphanumeric: PermissiveBoolean.optional(),
   })
 
   const reposCreateAutolinkResponseValidator = responseValidationFactory(
@@ -46086,7 +46080,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposListBranchesQuerySchema = z.object({
-    protected: z.coerce.boolean().optional(),
+    protected: PermissiveBoolean.optional(),
     per_page: z.coerce.number().optional(),
     page: z.coerce.number().optional(),
   })
@@ -46267,7 +46261,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposUpdateBranchProtectionBodySchema = z.object({
     required_status_checks: z
       .object({
-        strict: z.coerce.boolean(),
+        strict: PermissiveBoolean,
         contexts: z.array(z.string()),
         checks: z
           .array(
@@ -46279,7 +46273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .nullable(),
-    enforce_admins: z.coerce.boolean().nullable(),
+    enforce_admins: PermissiveBoolean.nullable(),
     required_pull_request_reviews: z
       .object({
         dismissal_restrictions: z
@@ -46289,10 +46283,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             apps: z.array(z.string()).optional(),
           })
           .optional(),
-        dismiss_stale_reviews: z.coerce.boolean().optional(),
-        require_code_owner_reviews: z.coerce.boolean().optional(),
+        dismiss_stale_reviews: PermissiveBoolean.optional(),
+        require_code_owner_reviews: PermissiveBoolean.optional(),
         required_approving_review_count: z.coerce.number().optional(),
-        require_last_push_approval: z.coerce.boolean().optional(),
+        require_last_push_approval: PermissiveBoolean.optional(),
         bypass_pull_request_allowances: z
           .object({
             users: z.array(z.string()).optional(),
@@ -46309,13 +46303,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         apps: z.array(z.string()).optional(),
       })
       .nullable(),
-    required_linear_history: z.coerce.boolean().optional(),
-    allow_force_pushes: z.coerce.boolean().nullable().optional(),
-    allow_deletions: z.coerce.boolean().optional(),
-    block_creations: z.coerce.boolean().optional(),
-    required_conversation_resolution: z.coerce.boolean().optional(),
-    lock_branch: z.coerce.boolean().optional(),
-    allow_fork_syncing: z.coerce.boolean().optional(),
+    required_linear_history: PermissiveBoolean.optional(),
+    allow_force_pushes: PermissiveBoolean.nullable().optional(),
+    allow_deletions: PermissiveBoolean.optional(),
+    block_creations: PermissiveBoolean.optional(),
+    required_conversation_resolution: PermissiveBoolean.optional(),
+    lock_branch: PermissiveBoolean.optional(),
+    allow_fork_syncing: PermissiveBoolean.optional(),
   })
 
   const reposUpdateBranchProtectionResponseValidator =
@@ -46662,10 +46656,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           apps: z.array(z.string()).optional(),
         })
         .optional(),
-      dismiss_stale_reviews: z.coerce.boolean().optional(),
-      require_code_owner_reviews: z.coerce.boolean().optional(),
+      dismiss_stale_reviews: PermissiveBoolean.optional(),
+      require_code_owner_reviews: PermissiveBoolean.optional(),
       required_approving_review_count: z.coerce.number().optional(),
-      require_last_push_approval: z.coerce.boolean().optional(),
+      require_last_push_approval: PermissiveBoolean.optional(),
       bypass_pull_request_allowances: z
         .object({
           users: z.array(z.string()).optional(),
@@ -47035,7 +47029,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const reposUpdateStatusCheckProtectionBodySchema = z
     .object({
-      strict: z.coerce.boolean().optional(),
+      strict: PermissiveBoolean.optional(),
       contexts: z.array(z.string()).optional(),
       checks: z
         .array(
@@ -48772,7 +48766,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const checksSetSuitesPreferencesBodySchema = z.object({
     auto_trigger_checks: z
       .array(
-        z.object({ app_id: z.coerce.number(), setting: z.coerce.boolean() }),
+        z.object({ app_id: z.coerce.number(), setting: PermissiveBoolean }),
       )
       .optional(),
   })
@@ -49916,7 +49910,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     checkout_uri: z.string().optional(),
     started_at: z.string().datetime({ offset: true }).optional(),
     tool_name: z.string().optional(),
-    validate: z.coerce.boolean().optional(),
+    validate: PermissiveBoolean.optional(),
   })
 
   const codeScanningUploadSarifResponseValidator = responseValidationFactory(
@@ -50239,7 +50233,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       client_ip: z.string().optional(),
       machine: z.string().optional(),
       devcontainer_path: z.string().optional(),
-      multi_repo_permissions_opt_out: z.coerce.boolean().optional(),
+      multi_repo_permissions_opt_out: PermissiveBoolean.optional(),
       working_directory: z.string().optional(),
       idle_timeout_minutes: z.coerce.number().optional(),
       display_name: z.string().optional(),
@@ -53725,13 +53719,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposCreateDeploymentBodySchema = z.object({
     ref: z.string(),
     task: z.string().optional(),
-    auto_merge: z.coerce.boolean().optional(),
+    auto_merge: PermissiveBoolean.optional(),
     required_contexts: z.array(z.string()).optional(),
     payload: z.union([z.record(z.any()), z.string()]).optional(),
     environment: z.string().optional(),
     description: z.string().nullable().optional(),
-    transient_environment: z.coerce.boolean().optional(),
-    production_environment: z.coerce.boolean().optional(),
+    transient_environment: PermissiveBoolean.optional(),
+    production_environment: PermissiveBoolean.optional(),
   })
 
   const reposCreateDeploymentResponseValidator = responseValidationFactory(
@@ -53997,7 +53991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     description: z.string().optional(),
     environment: z.string().optional(),
     environment_url: z.string().optional(),
-    auto_inactive: z.coerce.boolean().optional(),
+    auto_inactive: PermissiveBoolean.optional(),
   })
 
   const reposCreateDeploymentStatusResponseValidator =
@@ -55725,7 +55719,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       organization: z.string().optional(),
       name: z.string().optional(),
-      default_branch_only: z.coerce.boolean().optional(),
+      default_branch_only: PermissiveBoolean.optional(),
     })
     .nullable()
     .optional()
@@ -56269,7 +56263,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const gitUpdateRefBodySchema = z.object({
     sha: z.string(),
-    force: z.coerce.boolean().optional(),
+    force: PermissiveBoolean.optional(),
   })
 
   const gitUpdateRefResponseValidator = responseValidationFactory(
@@ -56757,7 +56751,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       events: z.array(z.string()).optional(),
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
     })
     .nullable()
     .optional()
@@ -56889,7 +56883,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     events: z.array(z.string()).optional(),
     add_events: z.array(z.string()).optional(),
     remove_events: z.array(z.string()).optional(),
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
   })
 
   const reposUpdateWebhookResponseValidator = responseValidationFactory(
@@ -57120,7 +57114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposListWebhookDeliveriesQuerySchema = z.object({
     per_page: z.coerce.number().optional(),
     cursor: z.string().optional(),
-    redelivery: z.coerce.boolean().optional(),
+    redelivery: PermissiveBoolean.optional(),
   })
 
   const reposListWebhookDeliveriesResponseValidator = responseValidationFactory(
@@ -60483,7 +60477,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposCreateDeployKeyBodySchema = z.object({
     title: z.string().optional(),
     key: z.string(),
-    read_only: z.coerce.boolean().optional(),
+    read_only: PermissiveBoolean.optional(),
   })
 
   const reposCreateDeployKeyResponseValidator = responseValidationFactory(
@@ -61558,8 +61552,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const activityListRepoNotificationsForAuthenticatedUserQuerySchema = z.object(
     {
-      all: z.coerce.boolean().optional(),
-      participating: z.coerce.boolean().optional(),
+      all: PermissiveBoolean.optional(),
+      participating: PermissiveBoolean.optional(),
       since: z.string().datetime({ offset: true }).optional(),
       before: z.string().datetime({ offset: true }).optional(),
       per_page: z.coerce.number().optional(),
@@ -61827,7 +61821,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const reposUpdateInformationAboutPagesSiteBodySchema = z.object({
     cname: z.string().nullable().optional(),
-    https_enforced: z.coerce.boolean().optional(),
+    https_enforced: PermissiveBoolean.optional(),
     build_type: z.enum(["legacy", "workflow"]).optional(),
     source: z
       .union([
@@ -62424,7 +62418,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposCheckPrivateVulnerabilityReportingResponseValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ enabled: z.coerce.boolean() })],
+        ["200", z.object({ enabled: PermissiveBoolean })],
         ["422", s_scim_error],
       ],
       undefined,
@@ -62962,8 +62956,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     head_repo: z.string().optional(),
     base: z.string(),
     body: z.string().optional(),
-    maintainer_can_modify: z.coerce.boolean().optional(),
-    draft: z.coerce.boolean().optional(),
+    maintainer_can_modify: PermissiveBoolean.optional(),
+    draft: PermissiveBoolean.optional(),
     issue: z.coerce.number().optional(),
   })
 
@@ -63551,7 +63545,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       body: z.string().optional(),
       state: z.enum(["open", "closed"]).optional(),
       base: z.string().optional(),
-      maintainer_can_modify: z.coerce.boolean().optional(),
+      maintainer_can_modify: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -63627,7 +63621,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       client_ip: z.string().optional(),
       machine: z.string().optional(),
       devcontainer_path: z.string().optional(),
-      multi_repo_permissions_opt_out: z.coerce.boolean().optional(),
+      multi_repo_permissions_opt_out: PermissiveBoolean.optional(),
       working_directory: z.string().optional(),
       idle_timeout_minutes: z.coerce.number().optional(),
       display_name: z.string().optional(),
@@ -65213,10 +65207,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     target_commitish: z.string().optional(),
     name: z.string().optional(),
     body: z.string().optional(),
-    draft: z.coerce.boolean().optional(),
-    prerelease: z.coerce.boolean().optional(),
+    draft: PermissiveBoolean.optional(),
+    prerelease: PermissiveBoolean.optional(),
     discussion_category_name: z.string().optional(),
-    generate_release_notes: z.coerce.boolean().optional(),
+    generate_release_notes: PermissiveBoolean.optional(),
     make_latest: z.enum(["true", "false", "legacy"]).optional(),
   })
 
@@ -65681,8 +65675,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       target_commitish: z.string().optional(),
       name: z.string().optional(),
       body: z.string().optional(),
-      draft: z.coerce.boolean().optional(),
-      prerelease: z.coerce.boolean().optional(),
+      draft: PermissiveBoolean.optional(),
+      prerelease: PermissiveBoolean.optional(),
       make_latest: z.enum(["true", "false", "legacy"]).optional(),
       discussion_category_name: z.string().optional(),
     })
@@ -66168,7 +66162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposGetRepoRulesetsQuerySchema = z.object({
     per_page: z.coerce.number().optional(),
     page: z.coerce.number().optional(),
-    includes_parents: z.coerce.boolean().optional(),
+    includes_parents: PermissiveBoolean.optional(),
   })
 
   const reposGetRepoRulesetsResponseValidator = responseValidationFactory(
@@ -66436,7 +66430,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposGetRepoRulesetQuerySchema = z.object({
-    includes_parents: z.coerce.boolean().optional(),
+    includes_parents: PermissiveBoolean.optional(),
   })
 
   const reposGetRepoRulesetResponseValidator = responseValidationFactory(
@@ -68003,8 +67997,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const activitySetRepoSubscriptionBodySchema = z
     .object({
-      subscribed: z.coerce.boolean().optional(),
-      ignored: z.coerce.boolean().optional(),
+      subscribed: PermissiveBoolean.optional(),
+      ignored: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -69065,8 +69059,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     owner: z.string().optional(),
     name: z.string(),
     description: z.string().optional(),
-    include_all_branches: z.coerce.boolean().optional(),
-    private: z.coerce.boolean().optional(),
+    include_all_branches: PermissiveBoolean.optional(),
+    private: PermissiveBoolean.optional(),
   })
 
   const reposCreateUsingTemplateResponseValidator = responseValidationFactory(
@@ -69183,7 +69177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           total_count: z.coerce.number(),
-          incomplete_results: z.coerce.boolean(),
+          incomplete_results: PermissiveBoolean,
           items: z.array(s_code_search_result_item),
         }),
       ],
@@ -69270,7 +69264,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           total_count: z.coerce.number(),
-          incomplete_results: z.coerce.boolean(),
+          incomplete_results: PermissiveBoolean,
           items: z.array(s_commit_search_result_item),
         }),
       ],
@@ -69349,7 +69343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             total_count: z.coerce.number(),
-            incomplete_results: z.coerce.boolean(),
+            incomplete_results: PermissiveBoolean,
             items: z.array(s_issue_search_result_item),
           }),
         ],
@@ -69441,7 +69435,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           total_count: z.coerce.number(),
-          incomplete_results: z.coerce.boolean(),
+          incomplete_results: PermissiveBoolean,
           items: z.array(s_label_search_result_item),
         }),
       ],
@@ -69519,7 +69513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           total_count: z.coerce.number(),
-          incomplete_results: z.coerce.boolean(),
+          incomplete_results: PermissiveBoolean,
           items: z.array(s_repo_search_result_item),
         }),
       ],
@@ -69600,7 +69594,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           total_count: z.coerce.number(),
-          incomplete_results: z.coerce.boolean(),
+          incomplete_results: PermissiveBoolean,
           items: z.array(s_topic_search_result_item),
         }),
       ],
@@ -69664,7 +69658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           total_count: z.coerce.number(),
-          incomplete_results: z.coerce.boolean(),
+          incomplete_results: PermissiveBoolean,
           items: z.array(s_user_search_result_item),
         }),
       ],
@@ -69969,7 +69963,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const teamsCreateDiscussionLegacyBodySchema = z.object({
     title: z.string(),
     body: z.string(),
-    private: z.coerce.boolean().optional(),
+    private: PermissiveBoolean.optional(),
   })
 
   const teamsCreateDiscussionLegacyResponseValidator =
@@ -71826,7 +71820,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       twitter_username: z.string().nullable().optional(),
       company: z.string().optional(),
       location: z.string().optional(),
-      hireable: z.coerce.boolean().optional(),
+      hireable: PermissiveBoolean.optional(),
       bio: z.string().optional(),
     })
     .optional()
@@ -72242,7 +72236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       client_ip: z.string().optional(),
       machine: z.string().optional(),
       devcontainer_path: z.string().optional(),
-      multi_repo_permissions_opt_out: z.coerce.boolean().optional(),
+      multi_repo_permissions_opt_out: PermissiveBoolean.optional(),
       working_directory: z.string().optional(),
       idle_timeout_minutes: z.coerce.number().optional(),
       display_name: z.string().optional(),
@@ -73390,7 +73384,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const codespacesPublishForAuthenticatedUserBodySchema = z.object({
     name: z.string().optional(),
-    private: z.coerce.boolean().optional(),
+    private: PermissiveBoolean.optional(),
   })
 
   const codespacesPublishForAuthenticatedUserResponseValidator =
@@ -75780,13 +75774,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const migrationsStartForAuthenticatedUserBodySchema = z.object({
-    lock_repositories: z.coerce.boolean().optional(),
-    exclude_metadata: z.coerce.boolean().optional(),
-    exclude_git_data: z.coerce.boolean().optional(),
-    exclude_attachments: z.coerce.boolean().optional(),
-    exclude_releases: z.coerce.boolean().optional(),
-    exclude_owner_projects: z.coerce.boolean().optional(),
-    org_metadata_only: z.coerce.boolean().optional(),
+    lock_repositories: PermissiveBoolean.optional(),
+    exclude_metadata: PermissiveBoolean.optional(),
+    exclude_git_data: PermissiveBoolean.optional(),
+    exclude_attachments: PermissiveBoolean.optional(),
+    exclude_releases: PermissiveBoolean.optional(),
+    exclude_owner_projects: PermissiveBoolean.optional(),
+    org_metadata_only: PermissiveBoolean.optional(),
     exclude: z.array(z.enum(["repositories"])).optional(),
     repositories: z.array(z.string()),
   })
@@ -77064,20 +77058,20 @@ export function createRouter(implementation: Implementation): KoaRouter {
     name: z.string(),
     description: z.string().optional(),
     homepage: z.string().optional(),
-    private: z.coerce.boolean().optional(),
-    has_issues: z.coerce.boolean().optional(),
-    has_projects: z.coerce.boolean().optional(),
-    has_wiki: z.coerce.boolean().optional(),
-    has_discussions: z.coerce.boolean().optional(),
+    private: PermissiveBoolean.optional(),
+    has_issues: PermissiveBoolean.optional(),
+    has_projects: PermissiveBoolean.optional(),
+    has_wiki: PermissiveBoolean.optional(),
+    has_discussions: PermissiveBoolean.optional(),
     team_id: z.coerce.number().optional(),
-    auto_init: z.coerce.boolean().optional(),
+    auto_init: PermissiveBoolean.optional(),
     gitignore_template: z.string().optional(),
     license_template: z.string().optional(),
-    allow_squash_merge: z.coerce.boolean().optional(),
-    allow_merge_commit: z.coerce.boolean().optional(),
-    allow_rebase_merge: z.coerce.boolean().optional(),
-    allow_auto_merge: z.coerce.boolean().optional(),
-    delete_branch_on_merge: z.coerce.boolean().optional(),
+    allow_squash_merge: PermissiveBoolean.optional(),
+    allow_merge_commit: PermissiveBoolean.optional(),
+    allow_rebase_merge: PermissiveBoolean.optional(),
+    allow_auto_merge: PermissiveBoolean.optional(),
+    delete_branch_on_merge: PermissiveBoolean.optional(),
     squash_merge_commit_title: z
       .enum(["PR_TITLE", "COMMIT_OR_PR_TITLE"])
       .optional(),
@@ -77086,8 +77080,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     merge_commit_title: z.enum(["PR_TITLE", "MERGE_MESSAGE"]).optional(),
     merge_commit_message: z.enum(["PR_BODY", "PR_TITLE", "BLANK"]).optional(),
-    has_downloads: z.coerce.boolean().optional(),
-    is_template: z.coerce.boolean().optional(),
+    has_downloads: PermissiveBoolean.optional(),
+    is_template: PermissiveBoolean.optional(),
   })
 
   const reposCreateForAuthenticatedUserResponseValidator =

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -4,6 +4,15 @@
 
 import { z } from "zod"
 
+export const PermissiveBoolean = z.preprocess((value) => {
+  if (typeof value === "string" && (value === "true" || value === "false")) {
+    return value === "true"
+  } else if (typeof value === "number" && (value === 1 || value === 0)) {
+    return value === 1
+  }
+  return value
+}, z.boolean())
+
 export const s_actions_billing_usage = z.object({
   total_minutes_used: z.coerce.number(),
   total_paid_minutes_used: z.coerce.number(),
@@ -53,11 +62,11 @@ export const s_actions_cache_usage_org_enterprise = z.object({
   total_active_caches_size_in_bytes: z.coerce.number(),
 })
 
-export const s_actions_can_approve_pull_request_reviews = z.coerce.boolean()
+export const s_actions_can_approve_pull_request_reviews = PermissiveBoolean
 
 export const s_actions_default_workflow_permissions = z.enum(["read", "write"])
 
-export const s_actions_enabled = z.coerce.boolean()
+export const s_actions_enabled = PermissiveBoolean
 
 export const s_actions_public_key = z.object({
   key_id: z.string(),
@@ -121,7 +130,7 @@ export const s_alert_url = z.string()
 export const s_allowed_actions = z.enum(["all", "local_only", "selected"])
 
 export const s_api_overview = z.object({
-  verifiable_password_authentication: z.coerce.boolean(),
+  verifiable_password_authentication: PermissiveBoolean,
   ssh_key_fingerprints: z
     .object({
       SHA256_RSA: z.string().optional(),
@@ -212,7 +221,7 @@ export const s_artifact = z.object({
   size_in_bytes: z.coerce.number(),
   url: z.string(),
   archive_download_url: z.string(),
-  expired: z.coerce.boolean(),
+  expired: PermissiveBoolean,
   created_at: z.string().datetime({ offset: true }).nullable(),
   expires_at: z.string().datetime({ offset: true }).nullable(),
   updated_at: z.string().datetime({ offset: true }).nullable(),
@@ -243,7 +252,7 @@ export const s_autolink = z.object({
   id: z.coerce.number(),
   key_prefix: z.string(),
   url_template: z.string(),
-  is_alphanumeric: z.coerce.boolean(),
+  is_alphanumeric: PermissiveBoolean,
 })
 
 export const s_basic_error = z.object({
@@ -287,7 +296,7 @@ export const s_branch_restriction_policy = z.object({
       events_url: z.string().optional(),
       received_events_url: z.string().optional(),
       type: z.string().optional(),
-      site_admin: z.coerce.boolean().optional(),
+      site_admin: PermissiveBoolean.optional(),
     }),
   ),
   teams: z.array(
@@ -336,7 +345,7 @@ export const s_branch_restriction_policy = z.object({
           organizations_url: z.string().optional(),
           received_events_url: z.string().optional(),
           type: z.string().optional(),
-          site_admin: z.coerce.boolean().optional(),
+          site_admin: PermissiveBoolean.optional(),
         })
         .optional(),
       name: z.string().optional(),
@@ -361,7 +370,7 @@ export const s_branch_restriction_policy = z.object({
 export const s_branch_short = z.object({
   name: z.string(),
   commit: z.object({ sha: z.string(), url: z.string() }),
-  protected: z.coerce.boolean(),
+  protected: PermissiveBoolean,
 })
 
 export const s_check_annotation = z.object({
@@ -378,8 +387,8 @@ export const s_check_annotation = z.object({
 })
 
 export const s_check_automated_security_fixes = z.object({
-  enabled: z.coerce.boolean(),
-  paused: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
+  paused: PermissiveBoolean,
 })
 
 export const s_classroom_assignment_grade = z.object({
@@ -623,7 +632,7 @@ export const s_codespaces_org_secret = z.object({
 })
 
 export const s_codespaces_permissions_check_for_devcontainer = z.object({
-  accepted: z.coerce.boolean(),
+  accepted: PermissiveBoolean,
 })
 
 export const s_codespaces_public_key = z.object({
@@ -668,14 +677,14 @@ export const s_collaborator = z.object({
   events_url: z.string(),
   received_events_url: z.string(),
   type: z.string(),
-  site_admin: z.coerce.boolean(),
+  site_admin: PermissiveBoolean,
   permissions: z
     .object({
-      pull: z.coerce.boolean(),
-      triage: z.coerce.boolean().optional(),
-      push: z.coerce.boolean(),
-      maintain: z.coerce.boolean().optional(),
-      admin: z.coerce.boolean(),
+      pull: PermissiveBoolean,
+      triage: PermissiveBoolean.optional(),
+      push: PermissiveBoolean,
+      maintain: PermissiveBoolean.optional(),
+      admin: PermissiveBoolean,
     })
     .optional(),
   role_name: z.string(),
@@ -795,7 +804,7 @@ export const s_contributor = z.object({
   events_url: z.string().optional(),
   received_events_url: z.string().optional(),
   type: z.string(),
-  site_admin: z.coerce.boolean().optional(),
+  site_admin: PermissiveBoolean.optional(),
   contributions: z.coerce.number(),
   email: z.string().optional(),
   name: z.string().optional(),
@@ -878,7 +887,7 @@ export const s_dependency_graph_spdx_sbom = z.object({
         name: z.string().optional(),
         versionInfo: z.string().optional(),
         downloadLocation: z.string().optional(),
-        filesAnalyzed: z.coerce.boolean().optional(),
+        filesAnalyzed: PermissiveBoolean.optional(),
         licenseConcluded: z.string().optional(),
         licenseDeclared: z.string().optional(),
         supplier: z.string().optional(),
@@ -901,9 +910,9 @@ export const s_deploy_key = z.object({
   key: z.string(),
   url: z.string(),
   title: z.string(),
-  verified: z.coerce.boolean(),
+  verified: PermissiveBoolean,
   created_at: z.string(),
-  read_only: z.coerce.boolean(),
+  read_only: PermissiveBoolean,
   added_by: z.string().nullable().optional(),
   last_used: z.string().nullable().optional(),
 })
@@ -926,8 +935,8 @@ export const s_deployment_branch_policy_name_pattern_with_type = z.object({
 
 export const s_deployment_branch_policy_settings = z
   .object({
-    protected_branches: z.coerce.boolean(),
-    custom_branch_policies: z.coerce.boolean(),
+    protected_branches: PermissiveBoolean,
+    custom_branch_policies: PermissiveBoolean,
   })
   .nullable()
 
@@ -957,8 +966,8 @@ export const s_diff_entry = z.object({
 
 export const s_email = z.object({
   email: z.string().email(),
-  primary: z.coerce.boolean(),
-  verified: z.coerce.boolean(),
+  primary: PermissiveBoolean,
+  verified: PermissiveBoolean,
   visibility: z.string().nullable(),
 })
 
@@ -1034,7 +1043,7 @@ export const s_file_commit = z.object({
       .optional(),
     verification: z
       .object({
-        verified: z.coerce.boolean().optional(),
+        verified: PermissiveBoolean.optional(),
         reason: z.string().optional(),
         signature: z.string().nullable().optional(),
         payload: z.string().nullable().optional(),
@@ -1063,7 +1072,7 @@ export const s_git_commit = z.object({
     z.object({ sha: z.string(), url: z.string(), html_url: z.string() }),
   ),
   verification: z.object({
-    verified: z.coerce.boolean(),
+    verified: PermissiveBoolean,
     reason: z.string(),
     signature: z.string().nullable(),
     payload: z.string().nullable(),
@@ -1085,7 +1094,7 @@ export const s_git_ref = z.object({
 export const s_git_tree = z.object({
   sha: z.string(),
   url: z.string(),
-  truncated: z.coerce.boolean(),
+  truncated: PermissiveBoolean,
   tree: z.array(
     z.object({
       path: z.string().optional(),
@@ -1112,7 +1121,7 @@ export const s_gpg_key = z.object({
   emails: z.array(
     z.object({
       email: z.string().optional(),
-      verified: z.coerce.boolean().optional(),
+      verified: PermissiveBoolean.optional(),
     }),
   ),
   subkeys: z.array(
@@ -1125,28 +1134,28 @@ export const s_gpg_key = z.object({
         .array(
           z.object({
             email: z.string().optional(),
-            verified: z.coerce.boolean().optional(),
+            verified: PermissiveBoolean.optional(),
           }),
         )
         .optional(),
       subkeys: z.array(z.object({})).optional(),
-      can_sign: z.coerce.boolean().optional(),
-      can_encrypt_comms: z.coerce.boolean().optional(),
-      can_encrypt_storage: z.coerce.boolean().optional(),
-      can_certify: z.coerce.boolean().optional(),
+      can_sign: PermissiveBoolean.optional(),
+      can_encrypt_comms: PermissiveBoolean.optional(),
+      can_encrypt_storage: PermissiveBoolean.optional(),
+      can_certify: PermissiveBoolean.optional(),
       created_at: z.string().optional(),
       expires_at: z.string().nullable().optional(),
       raw_key: z.string().nullable().optional(),
-      revoked: z.coerce.boolean().optional(),
+      revoked: PermissiveBoolean.optional(),
     }),
   ),
-  can_sign: z.coerce.boolean(),
-  can_encrypt_comms: z.coerce.boolean(),
-  can_encrypt_storage: z.coerce.boolean(),
-  can_certify: z.coerce.boolean(),
+  can_sign: PermissiveBoolean,
+  can_encrypt_comms: PermissiveBoolean,
+  can_encrypt_storage: PermissiveBoolean,
+  can_certify: PermissiveBoolean,
   created_at: z.string().datetime({ offset: true }),
   expires_at: z.string().datetime({ offset: true }).nullable(),
-  revoked: z.coerce.boolean(),
+  revoked: PermissiveBoolean,
   raw_key: z.string().nullable(),
 })
 
@@ -1154,7 +1163,7 @@ export const s_hook_delivery = z.object({
   id: z.coerce.number(),
   guid: z.string(),
   delivered_at: z.string().datetime({ offset: true }),
-  redelivery: z.coerce.boolean(),
+  redelivery: PermissiveBoolean,
   duration: z.coerce.number(),
   status: z.string(),
   status_code: z.coerce.number(),
@@ -1177,7 +1186,7 @@ export const s_hook_delivery_item = z.object({
   id: z.coerce.number(),
   guid: z.string(),
   delivered_at: z.string().datetime({ offset: true }),
-  redelivery: z.coerce.boolean(),
+  redelivery: PermissiveBoolean,
   duration: z.coerce.number(),
   status: z.string(),
   status_code: z.coerce.number(),
@@ -1199,7 +1208,7 @@ export const s_hovercard = z.object({
 
 export const s_import = z.object({
   vcs: z.string().nullable(),
-  use_lfs: z.coerce.boolean().optional(),
+  use_lfs: PermissiveBoolean.optional(),
   vcs_url: z.string(),
   svc_root: z.string().optional(),
   tfvc_project: z.string().optional(),
@@ -1227,7 +1236,7 @@ export const s_import = z.object({
   import_percent: z.coerce.number().nullable().optional(),
   commit_count: z.coerce.number().nullable().optional(),
   push_percent: z.coerce.number().nullable().optional(),
-  has_large_files: z.coerce.boolean().optional(),
+  has_large_files: PermissiveBoolean.optional(),
   large_files_size: z.coerce.number().optional(),
   large_files_count: z.coerce.number().optional(),
   project_choices: z
@@ -1354,8 +1363,8 @@ export const s_key = z.object({
   url: z.string(),
   title: z.string(),
   created_at: z.string().datetime({ offset: true }),
-  verified: z.coerce.boolean(),
-  read_only: z.coerce.boolean(),
+  verified: PermissiveBoolean,
+  read_only: PermissiveBoolean,
 })
 
 export const s_key_simple = z.object({ id: z.coerce.number(), key: z.string() })
@@ -1367,7 +1376,7 @@ export const s_label = z.object({
   name: z.string(),
   description: z.string().nullable(),
   color: z.string(),
-  default: z.coerce.boolean(),
+  default: PermissiveBoolean,
 })
 
 export const s_language = z.record(z.coerce.number())
@@ -1385,7 +1394,7 @@ export const s_license = z.object({
   conditions: z.array(z.string()),
   limitations: z.array(z.string()),
   body: z.string(),
-  featured: z.coerce.boolean(),
+  featured: PermissiveBoolean,
 })
 
 export const s_license_simple = z.object({
@@ -1421,7 +1430,7 @@ export const s_marketplace_listing_plan = z.object({
   monthly_price_in_cents: z.coerce.number(),
   yearly_price_in_cents: z.coerce.number(),
   price_model: z.enum(["FREE", "FLAT_RATE", "PER_UNIT"]),
-  has_free_trial: z.coerce.boolean(),
+  has_free_trial: PermissiveBoolean,
   unit_name: z.string().nullable(),
   state: z.string(),
   bullets: z.array(z.string()),
@@ -1434,7 +1443,7 @@ export const s_merged_upstream = z.object({
 })
 
 export const s_metadata = z.record(
-  z.union([z.string(), z.coerce.number(), z.coerce.boolean()]).nullable(),
+  z.union([z.string(), z.coerce.number(), PermissiveBoolean]).nullable(),
 )
 
 export const s_nullable_alert_updated_at = z
@@ -1484,14 +1493,14 @@ export const s_nullable_collaborator = z
     events_url: z.string(),
     received_events_url: z.string(),
     type: z.string(),
-    site_admin: z.coerce.boolean(),
+    site_admin: PermissiveBoolean,
     permissions: z
       .object({
-        pull: z.coerce.boolean(),
-        triage: z.coerce.boolean().optional(),
-        push: z.coerce.boolean(),
-        maintain: z.coerce.boolean().optional(),
-        admin: z.coerce.boolean(),
+        pull: PermissiveBoolean,
+        triage: PermissiveBoolean.optional(),
+        push: PermissiveBoolean,
+        maintain: PermissiveBoolean.optional(),
+        admin: PermissiveBoolean,
       })
       .optional(),
     role_name: z.string(),
@@ -1557,7 +1566,7 @@ export const s_nullable_simple_user = z
     events_url: z.string(),
     received_events_url: z.string(),
     type: z.string(),
-    site_admin: z.coerce.boolean(),
+    site_admin: PermissiveBoolean,
     starred_at: z.string().optional(),
   })
   .nullable()
@@ -1585,14 +1594,14 @@ export const s_oidc_custom_sub = z.object({
 })
 
 export const s_oidc_custom_sub_repo = z.object({
-  use_default: z.coerce.boolean(),
+  use_default: PermissiveBoolean,
   include_claim_keys: z.array(z.string()).optional(),
 })
 
 export const s_org_custom_property = z.object({
   property_name: z.string(),
   value_type: z.enum(["string", "single_select"]),
-  required: z.coerce.boolean().optional(),
+  required: PermissiveBoolean.optional(),
   default_value: z
     .union([z.string(), z.array(z.string())])
     .nullable()
@@ -1612,7 +1621,7 @@ export const s_org_hook = z.object({
   deliveries_url: z.string().optional(),
   name: z.string(),
   events: z.array(z.string()),
-  active: z.coerce.boolean(),
+  active: PermissiveBoolean,
   config: z.object({
     url: z.string().optional(),
     insecure_ssl: z.string().optional(),
@@ -1643,9 +1652,9 @@ export const s_organization = z.object({
   company: z.string().optional(),
   location: z.string().optional(),
   email: z.string().email().optional(),
-  has_organization_projects: z.coerce.boolean(),
-  has_repository_projects: z.coerce.boolean(),
-  is_verified: z.coerce.boolean().optional(),
+  has_organization_projects: PermissiveBoolean,
+  has_repository_projects: PermissiveBoolean,
+  is_verified: PermissiveBoolean.optional(),
   public_repos: z.coerce.number(),
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
@@ -1713,9 +1722,9 @@ export const s_organization_full = z.object({
   location: z.string().optional(),
   email: z.string().email().optional(),
   twitter_username: z.string().nullable().optional(),
-  is_verified: z.coerce.boolean().optional(),
-  has_organization_projects: z.coerce.boolean(),
-  has_repository_projects: z.coerce.boolean(),
+  is_verified: PermissiveBoolean.optional(),
+  has_organization_projects: PermissiveBoolean,
+  has_repository_projects: PermissiveBoolean,
   public_repos: z.coerce.number(),
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
@@ -1738,33 +1747,28 @@ export const s_organization_full = z.object({
     })
     .optional(),
   default_repository_permission: z.string().nullable().optional(),
-  members_can_create_repositories: z.coerce.boolean().nullable().optional(),
-  two_factor_requirement_enabled: z.coerce.boolean().nullable().optional(),
+  members_can_create_repositories: PermissiveBoolean.nullable().optional(),
+  two_factor_requirement_enabled: PermissiveBoolean.nullable().optional(),
   members_allowed_repository_creation_type: z.string().optional(),
-  members_can_create_public_repositories: z.coerce.boolean().optional(),
-  members_can_create_private_repositories: z.coerce.boolean().optional(),
-  members_can_create_internal_repositories: z.coerce.boolean().optional(),
-  members_can_create_pages: z.coerce.boolean().optional(),
-  members_can_create_public_pages: z.coerce.boolean().optional(),
-  members_can_create_private_pages: z.coerce.boolean().optional(),
-  members_can_fork_private_repositories: z.coerce
-    .boolean()
-    .nullable()
-    .optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
-  advanced_security_enabled_for_new_repositories: z.coerce.boolean().optional(),
-  dependabot_alerts_enabled_for_new_repositories: z.coerce.boolean().optional(),
-  dependabot_security_updates_enabled_for_new_repositories: z.coerce
-    .boolean()
-    .optional(),
-  dependency_graph_enabled_for_new_repositories: z.coerce.boolean().optional(),
-  secret_scanning_enabled_for_new_repositories: z.coerce.boolean().optional(),
-  secret_scanning_push_protection_enabled_for_new_repositories: z.coerce
-    .boolean()
-    .optional(),
-  secret_scanning_push_protection_custom_link_enabled: z.coerce
-    .boolean()
-    .optional(),
+  members_can_create_public_repositories: PermissiveBoolean.optional(),
+  members_can_create_private_repositories: PermissiveBoolean.optional(),
+  members_can_create_internal_repositories: PermissiveBoolean.optional(),
+  members_can_create_pages: PermissiveBoolean.optional(),
+  members_can_create_public_pages: PermissiveBoolean.optional(),
+  members_can_create_private_pages: PermissiveBoolean.optional(),
+  members_can_fork_private_repositories:
+    PermissiveBoolean.nullable().optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
+  advanced_security_enabled_for_new_repositories: PermissiveBoolean.optional(),
+  dependabot_alerts_enabled_for_new_repositories: PermissiveBoolean.optional(),
+  dependabot_security_updates_enabled_for_new_repositories:
+    PermissiveBoolean.optional(),
+  dependency_graph_enabled_for_new_repositories: PermissiveBoolean.optional(),
+  secret_scanning_enabled_for_new_repositories: PermissiveBoolean.optional(),
+  secret_scanning_push_protection_enabled_for_new_repositories:
+    PermissiveBoolean.optional(),
+  secret_scanning_push_protection_custom_link_enabled:
+    PermissiveBoolean.optional(),
   secret_scanning_push_protection_custom_link: z.string().nullable().optional(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
@@ -1855,33 +1859,31 @@ export const s_pages_health_check = z.object({
       host: z.string().optional(),
       uri: z.string().optional(),
       nameservers: z.string().optional(),
-      dns_resolves: z.coerce.boolean().optional(),
-      is_proxied: z.coerce.boolean().nullable().optional(),
-      is_cloudflare_ip: z.coerce.boolean().nullable().optional(),
-      is_fastly_ip: z.coerce.boolean().nullable().optional(),
-      is_old_ip_address: z.coerce.boolean().nullable().optional(),
-      is_a_record: z.coerce.boolean().nullable().optional(),
-      has_cname_record: z.coerce.boolean().nullable().optional(),
-      has_mx_records_present: z.coerce.boolean().nullable().optional(),
-      is_valid_domain: z.coerce.boolean().optional(),
-      is_apex_domain: z.coerce.boolean().optional(),
-      should_be_a_record: z.coerce.boolean().nullable().optional(),
-      is_cname_to_github_user_domain: z.coerce.boolean().nullable().optional(),
-      is_cname_to_pages_dot_github_dot_com: z.coerce
-        .boolean()
-        .nullable()
-        .optional(),
-      is_cname_to_fastly: z.coerce.boolean().nullable().optional(),
-      is_pointed_to_github_pages_ip: z.coerce.boolean().nullable().optional(),
-      is_non_github_pages_ip_present: z.coerce.boolean().nullable().optional(),
-      is_pages_domain: z.coerce.boolean().optional(),
-      is_served_by_pages: z.coerce.boolean().nullable().optional(),
-      is_valid: z.coerce.boolean().optional(),
+      dns_resolves: PermissiveBoolean.optional(),
+      is_proxied: PermissiveBoolean.nullable().optional(),
+      is_cloudflare_ip: PermissiveBoolean.nullable().optional(),
+      is_fastly_ip: PermissiveBoolean.nullable().optional(),
+      is_old_ip_address: PermissiveBoolean.nullable().optional(),
+      is_a_record: PermissiveBoolean.nullable().optional(),
+      has_cname_record: PermissiveBoolean.nullable().optional(),
+      has_mx_records_present: PermissiveBoolean.nullable().optional(),
+      is_valid_domain: PermissiveBoolean.optional(),
+      is_apex_domain: PermissiveBoolean.optional(),
+      should_be_a_record: PermissiveBoolean.nullable().optional(),
+      is_cname_to_github_user_domain: PermissiveBoolean.nullable().optional(),
+      is_cname_to_pages_dot_github_dot_com:
+        PermissiveBoolean.nullable().optional(),
+      is_cname_to_fastly: PermissiveBoolean.nullable().optional(),
+      is_pointed_to_github_pages_ip: PermissiveBoolean.nullable().optional(),
+      is_non_github_pages_ip_present: PermissiveBoolean.nullable().optional(),
+      is_pages_domain: PermissiveBoolean.optional(),
+      is_served_by_pages: PermissiveBoolean.nullable().optional(),
+      is_valid: PermissiveBoolean.optional(),
       reason: z.string().nullable().optional(),
-      responds_to_https: z.coerce.boolean().optional(),
-      enforces_https: z.coerce.boolean().optional(),
+      responds_to_https: PermissiveBoolean.optional(),
+      enforces_https: PermissiveBoolean.optional(),
       https_error: z.string().nullable().optional(),
-      is_https_eligible: z.coerce.boolean().nullable().optional(),
+      is_https_eligible: PermissiveBoolean.nullable().optional(),
       caa_error: z.string().nullable().optional(),
     })
     .optional(),
@@ -1890,33 +1892,31 @@ export const s_pages_health_check = z.object({
       host: z.string().optional(),
       uri: z.string().optional(),
       nameservers: z.string().optional(),
-      dns_resolves: z.coerce.boolean().optional(),
-      is_proxied: z.coerce.boolean().nullable().optional(),
-      is_cloudflare_ip: z.coerce.boolean().nullable().optional(),
-      is_fastly_ip: z.coerce.boolean().nullable().optional(),
-      is_old_ip_address: z.coerce.boolean().nullable().optional(),
-      is_a_record: z.coerce.boolean().nullable().optional(),
-      has_cname_record: z.coerce.boolean().nullable().optional(),
-      has_mx_records_present: z.coerce.boolean().nullable().optional(),
-      is_valid_domain: z.coerce.boolean().optional(),
-      is_apex_domain: z.coerce.boolean().optional(),
-      should_be_a_record: z.coerce.boolean().nullable().optional(),
-      is_cname_to_github_user_domain: z.coerce.boolean().nullable().optional(),
-      is_cname_to_pages_dot_github_dot_com: z.coerce
-        .boolean()
-        .nullable()
-        .optional(),
-      is_cname_to_fastly: z.coerce.boolean().nullable().optional(),
-      is_pointed_to_github_pages_ip: z.coerce.boolean().nullable().optional(),
-      is_non_github_pages_ip_present: z.coerce.boolean().nullable().optional(),
-      is_pages_domain: z.coerce.boolean().optional(),
-      is_served_by_pages: z.coerce.boolean().nullable().optional(),
-      is_valid: z.coerce.boolean().optional(),
+      dns_resolves: PermissiveBoolean.optional(),
+      is_proxied: PermissiveBoolean.nullable().optional(),
+      is_cloudflare_ip: PermissiveBoolean.nullable().optional(),
+      is_fastly_ip: PermissiveBoolean.nullable().optional(),
+      is_old_ip_address: PermissiveBoolean.nullable().optional(),
+      is_a_record: PermissiveBoolean.nullable().optional(),
+      has_cname_record: PermissiveBoolean.nullable().optional(),
+      has_mx_records_present: PermissiveBoolean.nullable().optional(),
+      is_valid_domain: PermissiveBoolean.optional(),
+      is_apex_domain: PermissiveBoolean.optional(),
+      should_be_a_record: PermissiveBoolean.nullable().optional(),
+      is_cname_to_github_user_domain: PermissiveBoolean.nullable().optional(),
+      is_cname_to_pages_dot_github_dot_com:
+        PermissiveBoolean.nullable().optional(),
+      is_cname_to_fastly: PermissiveBoolean.nullable().optional(),
+      is_pointed_to_github_pages_ip: PermissiveBoolean.nullable().optional(),
+      is_non_github_pages_ip_present: PermissiveBoolean.nullable().optional(),
+      is_pages_domain: PermissiveBoolean.optional(),
+      is_served_by_pages: PermissiveBoolean.nullable().optional(),
+      is_valid: PermissiveBoolean.optional(),
       reason: z.string().nullable().optional(),
-      responds_to_https: z.coerce.boolean().optional(),
-      enforces_https: z.coerce.boolean().optional(),
+      responds_to_https: PermissiveBoolean.optional(),
+      enforces_https: PermissiveBoolean.optional(),
       https_error: z.string().nullable().optional(),
-      is_https_eligible: z.coerce.boolean().nullable().optional(),
+      is_https_eligible: PermissiveBoolean.nullable().optional(),
       caa_error: z.string().nullable().optional(),
     })
     .nullable()
@@ -1970,7 +1970,7 @@ export const s_porter_large_file = z.object({
   size: z.coerce.number(),
 })
 
-export const s_prevent_self_review = z.coerce.boolean()
+export const s_prevent_self_review = PermissiveBoolean
 
 export const s_private_user = z.object({
   login: z.string(),
@@ -1990,13 +1990,13 @@ export const s_private_user = z.object({
   events_url: z.string(),
   received_events_url: z.string(),
   type: z.string(),
-  site_admin: z.coerce.boolean(),
+  site_admin: PermissiveBoolean,
   name: z.string().nullable(),
   company: z.string().nullable(),
   blog: z.string().nullable(),
   location: z.string().nullable(),
   email: z.string().email().nullable(),
-  hireable: z.coerce.boolean().nullable(),
+  hireable: PermissiveBoolean.nullable(),
   bio: z.string().nullable(),
   twitter_username: z.string().nullable().optional(),
   public_repos: z.coerce.number(),
@@ -2010,7 +2010,7 @@ export const s_private_user = z.object({
   owned_private_repos: z.coerce.number(),
   disk_usage: z.coerce.number(),
   collaborators: z.coerce.number(),
-  two_factor_authentication: z.coerce.boolean(),
+  two_factor_authentication: PermissiveBoolean,
   plan: z
     .object({
       collaborators: z.coerce.number(),
@@ -2020,7 +2020,7 @@ export const s_private_user = z.object({
     })
     .optional(),
   suspended_at: z.string().datetime({ offset: true }).nullable().optional(),
-  business_plus: z.coerce.boolean().optional(),
+  business_plus: PermissiveBoolean.optional(),
   ldap_dn: z.string().optional(),
 })
 
@@ -2037,7 +2037,7 @@ export const s_project_column = z.object({
 
 export const s_protected_branch_admin_enforced = z.object({
   url: z.string(),
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
 })
 
 export const s_protected_branch_required_status_check = z.object({
@@ -2048,7 +2048,7 @@ export const s_protected_branch_required_status_check = z.object({
     z.object({ context: z.string(), app_id: z.coerce.number().nullable() }),
   ),
   contexts_url: z.string().optional(),
-  strict: z.coerce.boolean().optional(),
+  strict: PermissiveBoolean.optional(),
 })
 
 export const s_public_user = z.object({
@@ -2069,13 +2069,13 @@ export const s_public_user = z.object({
   events_url: z.string(),
   received_events_url: z.string(),
   type: z.string(),
-  site_admin: z.coerce.boolean(),
+  site_admin: PermissiveBoolean,
   name: z.string().nullable(),
   company: z.string().nullable(),
   blog: z.string().nullable(),
   location: z.string().nullable(),
   email: z.string().email().nullable(),
-  hireable: z.coerce.boolean().nullable(),
+  hireable: PermissiveBoolean.nullable(),
   bio: z.string().nullable(),
   twitter_username: z.string().nullable().optional(),
   public_repos: z.coerce.number(),
@@ -2102,7 +2102,7 @@ export const s_public_user = z.object({
 
 export const s_pull_request_merge_result = z.object({
   sha: z.string(),
-  merged: z.coerce.boolean(),
+  merged: PermissiveBoolean,
   message: z.string(),
 })
 
@@ -2178,7 +2178,7 @@ export const s_repository_rule_branch_name_pattern = z.object({
   parameters: z
     .object({
       name: z.string().optional(),
-      negate: z.coerce.boolean().optional(),
+      negate: PermissiveBoolean.optional(),
       operator: z.enum(["starts_with", "ends_with", "contains", "regex"]),
       pattern: z.string(),
     })
@@ -2190,7 +2190,7 @@ export const s_repository_rule_commit_author_email_pattern = z.object({
   parameters: z
     .object({
       name: z.string().optional(),
-      negate: z.coerce.boolean().optional(),
+      negate: PermissiveBoolean.optional(),
       operator: z.enum(["starts_with", "ends_with", "contains", "regex"]),
       pattern: z.string(),
     })
@@ -2202,7 +2202,7 @@ export const s_repository_rule_commit_message_pattern = z.object({
   parameters: z
     .object({
       name: z.string().optional(),
-      negate: z.coerce.boolean().optional(),
+      negate: PermissiveBoolean.optional(),
       operator: z.enum(["starts_with", "ends_with", "contains", "regex"]),
       pattern: z.string(),
     })
@@ -2214,7 +2214,7 @@ export const s_repository_rule_committer_email_pattern = z.object({
   parameters: z
     .object({
       name: z.string().optional(),
-      negate: z.coerce.boolean().optional(),
+      negate: PermissiveBoolean.optional(),
       operator: z.enum(["starts_with", "ends_with", "contains", "regex"]),
       pattern: z.string(),
     })
@@ -2255,11 +2255,11 @@ export const s_repository_rule_pull_request = z.object({
   type: z.enum(["pull_request"]),
   parameters: z
     .object({
-      dismiss_stale_reviews_on_push: z.coerce.boolean(),
-      require_code_owner_review: z.coerce.boolean(),
-      require_last_push_approval: z.coerce.boolean(),
+      dismiss_stale_reviews_on_push: PermissiveBoolean,
+      require_code_owner_review: PermissiveBoolean,
+      require_last_push_approval: PermissiveBoolean,
       required_approving_review_count: z.coerce.number().min(0).max(10),
-      required_review_thread_resolution: z.coerce.boolean(),
+      required_review_thread_resolution: PermissiveBoolean,
     })
     .optional(),
 })
@@ -2290,7 +2290,7 @@ export const s_repository_rule_tag_name_pattern = z.object({
   parameters: z
     .object({
       name: z.string().optional(),
-      negate: z.coerce.boolean().optional(),
+      negate: PermissiveBoolean.optional(),
       operator: z.enum(["starts_with", "ends_with", "contains", "regex"]),
       pattern: z.string(),
     })
@@ -2300,7 +2300,7 @@ export const s_repository_rule_tag_name_pattern = z.object({
 export const s_repository_rule_update = z.object({
   type: z.enum(["update"]),
   parameters: z
-    .object({ update_allows_fetch_and_merge: z.coerce.boolean() })
+    .object({ update_allows_fetch_and_merge: PermissiveBoolean })
     .optional(),
 })
 
@@ -2334,7 +2334,7 @@ export const s_repository_ruleset_conditions_repository_name_target = z.object({
   repository_name: z.object({
     include: z.array(z.string()).optional(),
     exclude: z.array(z.string()).optional(),
-    protected: z.coerce.boolean().optional(),
+    protected: PermissiveBoolean.optional(),
   }),
 })
 
@@ -2342,8 +2342,8 @@ export const s_repository_ruleset_conditions_repository_property_spec =
   z.object({ name: z.string(), property_values: z.array(z.string()) })
 
 export const s_repository_subscription = z.object({
-  subscribed: z.coerce.boolean(),
-  ignored: z.coerce.boolean(),
+  subscribed: PermissiveBoolean,
+  ignored: PermissiveBoolean,
   reason: z.string().nullable(),
   created_at: z.string().datetime({ offset: true }),
   url: z.string(),
@@ -2610,8 +2610,8 @@ export const s_security_and_analysis = z
   .nullable()
 
 export const s_selected_actions = z.object({
-  github_owned_allowed: z.coerce.boolean().optional(),
-  verified_allowed: z.coerce.boolean().optional(),
+  github_owned_allowed: PermissiveBoolean.optional(),
+  verified_allowed: PermissiveBoolean.optional(),
   patterns_allowed: z.array(z.string()).optional(),
 })
 
@@ -2622,7 +2622,7 @@ export const s_short_blob = z.object({ url: z.string(), sha: z.string() })
 export const s_simple_classroom = z.object({
   id: z.coerce.number(),
   name: z.string(),
-  archived: z.coerce.boolean(),
+  archived: PermissiveBoolean,
   url: z.string(),
 })
 
@@ -2640,7 +2640,7 @@ export const s_simple_classroom_repository = z.object({
   full_name: z.string(),
   html_url: z.string(),
   node_id: z.string(),
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   default_branch: z.string(),
 })
 
@@ -2669,7 +2669,7 @@ export const s_simple_commit_status = z.object({
   state: z.string(),
   context: z.string(),
   target_url: z.string().nullable(),
-  required: z.coerce.boolean().nullable().optional(),
+  required: PermissiveBoolean.nullable().optional(),
   avatar_url: z.string().nullable(),
   url: z.string(),
   created_at: z.string().datetime({ offset: true }),
@@ -2696,7 +2696,7 @@ export const s_simple_user = z.object({
   events_url: z.string(),
   received_events_url: z.string(),
   type: z.string(),
-  site_admin: z.coerce.boolean(),
+  site_admin: PermissiveBoolean,
   starred_at: z.string().optional(),
 })
 
@@ -2714,7 +2714,7 @@ export const s_ssh_signing_key = z.object({
 
 export const s_status_check_policy = z.object({
   url: z.string(),
-  strict: z.coerce.boolean(),
+  strict: PermissiveBoolean,
   contexts: z.array(z.string()),
   checks: z.array(
     z.object({ context: z.string(), app_id: z.coerce.number().nullable() }),
@@ -2734,7 +2734,7 @@ export const s_tag_protection = z.object({
   id: z.coerce.number().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
-  enabled: z.coerce.boolean().optional(),
+  enabled: PermissiveBoolean.optional(),
   pattern: z.string(),
 })
 
@@ -2763,9 +2763,9 @@ export const s_team_organization = z.object({
   location: z.string().optional(),
   email: z.string().email().optional(),
   twitter_username: z.string().nullable().optional(),
-  is_verified: z.coerce.boolean().optional(),
-  has_organization_projects: z.coerce.boolean(),
-  has_repository_projects: z.coerce.boolean(),
+  is_verified: PermissiveBoolean.optional(),
+  has_organization_projects: PermissiveBoolean,
+  has_repository_projects: PermissiveBoolean,
   public_repos: z.coerce.number(),
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
@@ -2789,20 +2789,18 @@ export const s_team_organization = z.object({
     })
     .optional(),
   default_repository_permission: z.string().nullable().optional(),
-  members_can_create_repositories: z.coerce.boolean().nullable().optional(),
-  two_factor_requirement_enabled: z.coerce.boolean().nullable().optional(),
+  members_can_create_repositories: PermissiveBoolean.nullable().optional(),
+  two_factor_requirement_enabled: PermissiveBoolean.nullable().optional(),
   members_allowed_repository_creation_type: z.string().optional(),
-  members_can_create_public_repositories: z.coerce.boolean().optional(),
-  members_can_create_private_repositories: z.coerce.boolean().optional(),
-  members_can_create_internal_repositories: z.coerce.boolean().optional(),
-  members_can_create_pages: z.coerce.boolean().optional(),
-  members_can_create_public_pages: z.coerce.boolean().optional(),
-  members_can_create_private_pages: z.coerce.boolean().optional(),
-  members_can_fork_private_repositories: z.coerce
-    .boolean()
-    .nullable()
-    .optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
+  members_can_create_public_repositories: PermissiveBoolean.optional(),
+  members_can_create_private_repositories: PermissiveBoolean.optional(),
+  members_can_create_internal_repositories: PermissiveBoolean.optional(),
+  members_can_create_pages: PermissiveBoolean.optional(),
+  members_can_create_public_pages: PermissiveBoolean.optional(),
+  members_can_create_private_pages: PermissiveBoolean.optional(),
+  members_can_fork_private_repositories:
+    PermissiveBoolean.nullable().optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
   updated_at: z.string().datetime({ offset: true }),
   archived_at: z.string().datetime({ offset: true }).nullable(),
 })
@@ -2824,8 +2822,8 @@ export const s_team_simple = z.object({
 })
 
 export const s_thread_subscription = z.object({
-  subscribed: z.coerce.boolean(),
-  ignored: z.coerce.boolean(),
+  subscribed: PermissiveBoolean,
+  ignored: PermissiveBoolean,
   reason: z.string().nullable(),
   created_at: z.string().datetime({ offset: true }).nullable(),
   url: z.string(),
@@ -2854,7 +2852,7 @@ export const s_timeline_committed_event = z.object({
     z.object({ sha: z.string(), url: z.string(), html_url: z.string() }),
   ),
   verification: z.object({
-    verified: z.coerce.boolean(),
+    verified: PermissiveBoolean,
     reason: z.string(),
     signature: z.string().nullable(),
     payload: z.string().nullable(),
@@ -2900,7 +2898,7 @@ export const s_validation_error_simple = z.object({
 })
 
 export const s_verification = z.object({
-  verified: z.coerce.boolean(),
+  verified: PermissiveBoolean,
   reason: z.string(),
   payload: z.string().nullable(),
   signature: z.string().nullable(),
@@ -3065,7 +3063,7 @@ export const s_base_gist = z.object({
       size: z.coerce.number().optional(),
     }),
   ),
-  public: z.coerce.boolean(),
+  public: PermissiveBoolean,
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
   description: z.string().nullable(),
@@ -3073,7 +3071,7 @@ export const s_base_gist = z.object({
   user: s_nullable_simple_user,
   comments_url: z.string(),
   owner: s_simple_user.optional(),
-  truncated: z.coerce.boolean().optional(),
+  truncated: PermissiveBoolean.optional(),
   forks: z.array(z.object({})).optional(),
   history: z.array(z.object({})).optional(),
 })
@@ -3081,7 +3079,7 @@ export const s_base_gist = z.object({
 export const s_classroom = z.object({
   id: z.coerce.number(),
   name: z.string(),
-  archived: z.coerce.boolean(),
+  archived: PermissiveBoolean,
   organization: s_simple_classroom_organization,
   url: z.string(),
 })
@@ -3194,7 +3192,7 @@ export const s_community_profile = z.object({
     pull_request_template: s_nullable_community_health_file,
   }),
   updated_at: z.string().datetime({ offset: true }).nullable(),
-  content_reports_enabled: z.coerce.boolean().optional(),
+  content_reports_enabled: PermissiveBoolean.optional(),
 })
 
 export const s_contributor_activity = z.object({
@@ -3250,7 +3248,7 @@ export const s_dependency = z.object({
 export const s_deployment_protection_rule = z.object({
   id: z.coerce.number(),
   node_id: z.string(),
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   app: s_custom_deployment_rule_app,
 })
 
@@ -3408,7 +3406,7 @@ export const s_installation = z.object({
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
   single_file_name: z.string().nullable(),
-  has_multiple_single_files: z.coerce.boolean().optional(),
+  has_multiple_single_files: PermissiveBoolean.optional(),
   single_file_paths: z.array(z.string()).optional(),
   app_slug: z.string(),
   suspended_by: s_nullable_simple_user,
@@ -3470,7 +3468,7 @@ export const s_label_search_result_item = z.object({
   url: z.string(),
   name: z.string(),
   color: z.string(),
-  default: z.coerce.boolean(),
+  default: PermissiveBoolean,
   description: z.string().nullable(),
   score: z.coerce.number(),
   text_matches: s_search_result_text_matches.optional(),
@@ -3505,7 +3503,7 @@ export const s_marketplace_purchase = z.object({
   email: z.string().nullable().optional(),
   marketplace_pending_change: z
     .object({
-      is_installed: z.coerce.boolean().optional(),
+      is_installed: PermissiveBoolean.optional(),
       effective_date: z.string().optional(),
       unit_count: z.coerce.number().nullable().optional(),
       id: z.coerce.number().optional(),
@@ -3516,9 +3514,9 @@ export const s_marketplace_purchase = z.object({
   marketplace_purchase: z.object({
     billing_cycle: z.string().optional(),
     next_billing_date: z.string().nullable().optional(),
-    is_installed: z.coerce.boolean().optional(),
+    is_installed: PermissiveBoolean.optional(),
     unit_count: z.coerce.number().nullable().optional(),
-    on_free_trial: z.coerce.boolean().optional(),
+    on_free_trial: PermissiveBoolean.optional(),
     free_trial_ends_on: z.string().nullable().optional(),
     updated_at: z.string().optional(),
     plan: s_marketplace_listing_plan.optional(),
@@ -3550,10 +3548,10 @@ export const s_minimal_repository = z.object({
   name: z.string(),
   full_name: z.string(),
   owner: s_simple_user,
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   html_url: z.string(),
   description: z.string().nullable(),
-  fork: z.coerce.boolean(),
+  fork: PermissiveBoolean,
   url: z.string(),
   archive_url: z.string(),
   assignees_url: z.string(),
@@ -3604,32 +3602,32 @@ export const s_minimal_repository = z.object({
   size: z.coerce.number().optional(),
   default_branch: z.string().optional(),
   open_issues_count: z.coerce.number().optional(),
-  is_template: z.coerce.boolean().optional(),
+  is_template: PermissiveBoolean.optional(),
   topics: z.array(z.string()).optional(),
-  has_issues: z.coerce.boolean().optional(),
-  has_projects: z.coerce.boolean().optional(),
-  has_wiki: z.coerce.boolean().optional(),
-  has_pages: z.coerce.boolean().optional(),
-  has_downloads: z.coerce.boolean().optional(),
-  has_discussions: z.coerce.boolean().optional(),
-  archived: z.coerce.boolean().optional(),
-  disabled: z.coerce.boolean().optional(),
+  has_issues: PermissiveBoolean.optional(),
+  has_projects: PermissiveBoolean.optional(),
+  has_wiki: PermissiveBoolean.optional(),
+  has_pages: PermissiveBoolean.optional(),
+  has_downloads: PermissiveBoolean.optional(),
+  has_discussions: PermissiveBoolean.optional(),
+  archived: PermissiveBoolean.optional(),
+  disabled: PermissiveBoolean.optional(),
   visibility: z.string().optional(),
   pushed_at: z.string().datetime({ offset: true }).nullable().optional(),
   created_at: z.string().datetime({ offset: true }).nullable().optional(),
   updated_at: z.string().datetime({ offset: true }).nullable().optional(),
   permissions: z
     .object({
-      admin: z.coerce.boolean().optional(),
-      maintain: z.coerce.boolean().optional(),
-      push: z.coerce.boolean().optional(),
-      triage: z.coerce.boolean().optional(),
-      pull: z.coerce.boolean().optional(),
+      admin: PermissiveBoolean.optional(),
+      maintain: PermissiveBoolean.optional(),
+      push: PermissiveBoolean.optional(),
+      triage: PermissiveBoolean.optional(),
+      pull: PermissiveBoolean.optional(),
     })
     .optional(),
   role_name: z.string().optional(),
   temp_clone_token: z.string().optional(),
-  delete_branch_on_merge: z.coerce.boolean().optional(),
+  delete_branch_on_merge: PermissiveBoolean.optional(),
   subscribers_count: z.coerce.number().optional(),
   network_count: z.coerce.number().optional(),
   code_of_conduct: s_code_of_conduct.optional(),
@@ -3646,8 +3644,8 @@ export const s_minimal_repository = z.object({
   forks: z.coerce.number().optional(),
   open_issues: z.coerce.number().optional(),
   watchers: z.coerce.number().optional(),
-  allow_forking: z.coerce.boolean().optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
+  allow_forking: PermissiveBoolean.optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
   security_and_analysis: s_security_and_analysis.optional(),
 })
 
@@ -3710,10 +3708,10 @@ export const s_nullable_minimal_repository = z
     name: z.string(),
     full_name: z.string(),
     owner: s_simple_user,
-    private: z.coerce.boolean(),
+    private: PermissiveBoolean,
     html_url: z.string(),
     description: z.string().nullable(),
-    fork: z.coerce.boolean(),
+    fork: PermissiveBoolean,
     url: z.string(),
     archive_url: z.string(),
     assignees_url: z.string(),
@@ -3764,32 +3762,32 @@ export const s_nullable_minimal_repository = z
     size: z.coerce.number().optional(),
     default_branch: z.string().optional(),
     open_issues_count: z.coerce.number().optional(),
-    is_template: z.coerce.boolean().optional(),
+    is_template: PermissiveBoolean.optional(),
     topics: z.array(z.string()).optional(),
-    has_issues: z.coerce.boolean().optional(),
-    has_projects: z.coerce.boolean().optional(),
-    has_wiki: z.coerce.boolean().optional(),
-    has_pages: z.coerce.boolean().optional(),
-    has_downloads: z.coerce.boolean().optional(),
-    has_discussions: z.coerce.boolean().optional(),
-    archived: z.coerce.boolean().optional(),
-    disabled: z.coerce.boolean().optional(),
+    has_issues: PermissiveBoolean.optional(),
+    has_projects: PermissiveBoolean.optional(),
+    has_wiki: PermissiveBoolean.optional(),
+    has_pages: PermissiveBoolean.optional(),
+    has_downloads: PermissiveBoolean.optional(),
+    has_discussions: PermissiveBoolean.optional(),
+    archived: PermissiveBoolean.optional(),
+    disabled: PermissiveBoolean.optional(),
     visibility: z.string().optional(),
     pushed_at: z.string().datetime({ offset: true }).nullable().optional(),
     created_at: z.string().datetime({ offset: true }).nullable().optional(),
     updated_at: z.string().datetime({ offset: true }).nullable().optional(),
     permissions: z
       .object({
-        admin: z.coerce.boolean().optional(),
-        maintain: z.coerce.boolean().optional(),
-        push: z.coerce.boolean().optional(),
-        triage: z.coerce.boolean().optional(),
-        pull: z.coerce.boolean().optional(),
+        admin: PermissiveBoolean.optional(),
+        maintain: PermissiveBoolean.optional(),
+        push: PermissiveBoolean.optional(),
+        triage: PermissiveBoolean.optional(),
+        pull: PermissiveBoolean.optional(),
       })
       .optional(),
     role_name: z.string().optional(),
     temp_clone_token: z.string().optional(),
-    delete_branch_on_merge: z.coerce.boolean().optional(),
+    delete_branch_on_merge: PermissiveBoolean.optional(),
     subscribers_count: z.coerce.number().optional(),
     network_count: z.coerce.number().optional(),
     code_of_conduct: s_code_of_conduct.optional(),
@@ -3806,8 +3804,8 @@ export const s_nullable_minimal_repository = z
     forks: z.coerce.number().optional(),
     open_issues: z.coerce.number().optional(),
     watchers: z.coerce.number().optional(),
-    allow_forking: z.coerce.boolean().optional(),
-    web_commit_signoff_required: z.coerce.boolean().optional(),
+    allow_forking: PermissiveBoolean.optional(),
+    web_commit_signoff_required: PermissiveBoolean.optional(),
     security_and_analysis: s_security_and_analysis.optional(),
   })
   .nullable()
@@ -3822,18 +3820,18 @@ export const s_nullable_repository = z
     forks: z.coerce.number(),
     permissions: z
       .object({
-        admin: z.coerce.boolean(),
-        pull: z.coerce.boolean(),
-        triage: z.coerce.boolean().optional(),
-        push: z.coerce.boolean(),
-        maintain: z.coerce.boolean().optional(),
+        admin: PermissiveBoolean,
+        pull: PermissiveBoolean,
+        triage: PermissiveBoolean.optional(),
+        push: PermissiveBoolean,
+        maintain: PermissiveBoolean.optional(),
       })
       .optional(),
     owner: s_simple_user,
-    private: z.coerce.boolean(),
+    private: PermissiveBoolean,
     html_url: z.string(),
     description: z.string().nullable(),
-    fork: z.coerce.boolean(),
+    fork: PermissiveBoolean,
     url: z.string(),
     archive_url: z.string(),
     assignees_url: z.string(),
@@ -3884,27 +3882,27 @@ export const s_nullable_repository = z
     size: z.coerce.number(),
     default_branch: z.string(),
     open_issues_count: z.coerce.number(),
-    is_template: z.coerce.boolean().optional(),
+    is_template: PermissiveBoolean.optional(),
     topics: z.array(z.string()).optional(),
-    has_issues: z.coerce.boolean(),
-    has_projects: z.coerce.boolean(),
-    has_wiki: z.coerce.boolean(),
-    has_pages: z.coerce.boolean(),
-    has_downloads: z.coerce.boolean(),
-    has_discussions: z.coerce.boolean().optional(),
-    archived: z.coerce.boolean(),
-    disabled: z.coerce.boolean(),
+    has_issues: PermissiveBoolean,
+    has_projects: PermissiveBoolean,
+    has_wiki: PermissiveBoolean,
+    has_pages: PermissiveBoolean,
+    has_downloads: PermissiveBoolean,
+    has_discussions: PermissiveBoolean.optional(),
+    archived: PermissiveBoolean,
+    disabled: PermissiveBoolean,
     visibility: z.string().optional(),
     pushed_at: z.string().datetime({ offset: true }).nullable(),
     created_at: z.string().datetime({ offset: true }).nullable(),
     updated_at: z.string().datetime({ offset: true }).nullable(),
-    allow_rebase_merge: z.coerce.boolean().optional(),
+    allow_rebase_merge: PermissiveBoolean.optional(),
     temp_clone_token: z.string().optional(),
-    allow_squash_merge: z.coerce.boolean().optional(),
-    allow_auto_merge: z.coerce.boolean().optional(),
-    delete_branch_on_merge: z.coerce.boolean().optional(),
-    allow_update_branch: z.coerce.boolean().optional(),
-    use_squash_pr_title_as_default: z.coerce.boolean().optional(),
+    allow_squash_merge: PermissiveBoolean.optional(),
+    allow_auto_merge: PermissiveBoolean.optional(),
+    delete_branch_on_merge: PermissiveBoolean.optional(),
+    allow_update_branch: PermissiveBoolean.optional(),
+    use_squash_pr_title_as_default: PermissiveBoolean.optional(),
     squash_merge_commit_title: z
       .enum(["PR_TITLE", "COMMIT_OR_PR_TITLE"])
       .optional(),
@@ -3913,14 +3911,14 @@ export const s_nullable_repository = z
       .optional(),
     merge_commit_title: z.enum(["PR_TITLE", "MERGE_MESSAGE"]).optional(),
     merge_commit_message: z.enum(["PR_BODY", "PR_TITLE", "BLANK"]).optional(),
-    allow_merge_commit: z.coerce.boolean().optional(),
-    allow_forking: z.coerce.boolean().optional(),
-    web_commit_signoff_required: z.coerce.boolean().optional(),
+    allow_merge_commit: PermissiveBoolean.optional(),
+    allow_forking: PermissiveBoolean.optional(),
+    web_commit_signoff_required: PermissiveBoolean.optional(),
     open_issues: z.coerce.number(),
     watchers: z.coerce.number(),
     master_branch: z.string().optional(),
     starred_at: z.string().optional(),
-    anonymous_access_enabled: z.coerce.boolean().optional(),
+    anonymous_access_enabled: PermissiveBoolean.optional(),
   })
   .nullable()
 
@@ -3929,7 +3927,7 @@ export const s_nullable_scoped_installation = z
     permissions: s_app_permissions,
     repository_selection: z.enum(["all", "selected"]),
     single_file_name: z.string().nullable(),
-    has_multiple_single_files: z.coerce.boolean().optional(),
+    has_multiple_single_files: PermissiveBoolean.optional(),
     single_file_paths: z.array(z.string()).optional(),
     repositories_url: z.string(),
     account: s_simple_user,
@@ -3944,7 +3942,7 @@ export const s_org_membership = z.object({
   organization: s_organization_simple,
   user: s_nullable_simple_user,
   permissions: z
-    .object({ can_create_repository: z.coerce.boolean() })
+    .object({ can_create_repository: PermissiveBoolean })
     .optional(),
 })
 
@@ -3981,7 +3979,7 @@ export const s_organization_programmatic_access_grant = z.object({
     other: z.record(z.string()).optional(),
   }),
   access_granted_at: z.string(),
-  token_expired: z.coerce.boolean(),
+  token_expired: PermissiveBoolean,
   token_expires_at: z.string().nullable(),
   token_last_used_at: z.string().nullable(),
 })
@@ -3998,7 +3996,7 @@ export const s_organization_programmatic_access_grant_request = z.object({
     other: z.record(z.string()).optional(),
   }),
   created_at: z.string(),
-  token_expired: z.coerce.boolean(),
+  token_expired: PermissiveBoolean,
   token_expires_at: z.string().nullable(),
   token_last_used_at: z.string().nullable(),
 })
@@ -4026,13 +4024,13 @@ export const s_page = z.object({
     .datetime({ offset: true })
     .nullable()
     .optional(),
-  custom_404: z.coerce.boolean(),
+  custom_404: PermissiveBoolean,
   html_url: z.string().optional(),
   build_type: z.enum(["legacy", "workflow"]).nullable().optional(),
   source: s_pages_source_hash.optional(),
-  public: z.coerce.boolean(),
+  public: PermissiveBoolean,
   https_certificate: s_pages_https_certificate.optional(),
-  https_enforced: z.coerce.boolean().optional(),
+  https_enforced: PermissiveBoolean.optional(),
 })
 
 export const s_page_build = z.object({
@@ -4066,7 +4064,7 @@ export const s_private_vulnerability_report_create = z.object({
   cwe_ids: z.array(z.string()).nullable().optional(),
   severity: z.enum(["critical", "high", "medium", "low"]).nullable().optional(),
   cvss_vector_string: z.string().nullable().optional(),
-  start_private_fork: z.coerce.boolean().optional(),
+  start_private_fork: PermissiveBoolean.optional(),
 })
 
 export const s_project = z.object({
@@ -4086,7 +4084,7 @@ export const s_project = z.object({
   organization_permission: z
     .enum(["read", "write", "admin", "none"])
     .optional(),
-  private: z.coerce.boolean().optional(),
+  private: PermissiveBoolean.optional(),
 })
 
 export const s_project_card = z.object({
@@ -4097,7 +4095,7 @@ export const s_project_card = z.object({
   creator: s_nullable_simple_user,
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
-  archived: z.coerce.boolean().optional(),
+  archived: PermissiveBoolean.optional(),
   column_name: z.string().optional(),
   project_id: z.string().optional(),
   column_url: z.string(),
@@ -4220,10 +4218,10 @@ export const s_repo_search_result_item = z.object({
   name: z.string(),
   full_name: z.string(),
   owner: s_nullable_simple_user,
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   html_url: z.string(),
   description: z.string().nullable(),
-  fork: z.coerce.boolean(),
+  fork: PermissiveBoolean,
   url: z.string(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
@@ -4283,35 +4281,35 @@ export const s_repo_search_result_item = z.object({
   watchers: z.coerce.number(),
   topics: z.array(z.string()).optional(),
   mirror_url: z.string().nullable(),
-  has_issues: z.coerce.boolean(),
-  has_projects: z.coerce.boolean(),
-  has_pages: z.coerce.boolean(),
-  has_wiki: z.coerce.boolean(),
-  has_downloads: z.coerce.boolean(),
-  has_discussions: z.coerce.boolean().optional(),
-  archived: z.coerce.boolean(),
-  disabled: z.coerce.boolean(),
+  has_issues: PermissiveBoolean,
+  has_projects: PermissiveBoolean,
+  has_pages: PermissiveBoolean,
+  has_wiki: PermissiveBoolean,
+  has_downloads: PermissiveBoolean,
+  has_discussions: PermissiveBoolean.optional(),
+  archived: PermissiveBoolean,
+  disabled: PermissiveBoolean,
   visibility: z.string().optional(),
   license: s_nullable_license_simple,
   permissions: z
     .object({
-      admin: z.coerce.boolean(),
-      maintain: z.coerce.boolean().optional(),
-      push: z.coerce.boolean(),
-      triage: z.coerce.boolean().optional(),
-      pull: z.coerce.boolean(),
+      admin: PermissiveBoolean,
+      maintain: PermissiveBoolean.optional(),
+      push: PermissiveBoolean,
+      triage: PermissiveBoolean.optional(),
+      pull: PermissiveBoolean,
     })
     .optional(),
   text_matches: s_search_result_text_matches.optional(),
   temp_clone_token: z.string().optional(),
-  allow_merge_commit: z.coerce.boolean().optional(),
-  allow_squash_merge: z.coerce.boolean().optional(),
-  allow_rebase_merge: z.coerce.boolean().optional(),
-  allow_auto_merge: z.coerce.boolean().optional(),
-  delete_branch_on_merge: z.coerce.boolean().optional(),
-  allow_forking: z.coerce.boolean().optional(),
-  is_template: z.coerce.boolean().optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
+  allow_merge_commit: PermissiveBoolean.optional(),
+  allow_squash_merge: PermissiveBoolean.optional(),
+  allow_rebase_merge: PermissiveBoolean.optional(),
+  allow_auto_merge: PermissiveBoolean.optional(),
+  delete_branch_on_merge: PermissiveBoolean.optional(),
+  allow_forking: PermissiveBoolean.optional(),
+  is_template: PermissiveBoolean.optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
 })
 
 export const s_repository = z.object({
@@ -4323,18 +4321,18 @@ export const s_repository = z.object({
   forks: z.coerce.number(),
   permissions: z
     .object({
-      admin: z.coerce.boolean(),
-      pull: z.coerce.boolean(),
-      triage: z.coerce.boolean().optional(),
-      push: z.coerce.boolean(),
-      maintain: z.coerce.boolean().optional(),
+      admin: PermissiveBoolean,
+      pull: PermissiveBoolean,
+      triage: PermissiveBoolean.optional(),
+      push: PermissiveBoolean,
+      maintain: PermissiveBoolean.optional(),
     })
     .optional(),
   owner: s_simple_user,
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   html_url: z.string(),
   description: z.string().nullable(),
-  fork: z.coerce.boolean(),
+  fork: PermissiveBoolean,
   url: z.string(),
   archive_url: z.string(),
   assignees_url: z.string(),
@@ -4385,27 +4383,27 @@ export const s_repository = z.object({
   size: z.coerce.number(),
   default_branch: z.string(),
   open_issues_count: z.coerce.number(),
-  is_template: z.coerce.boolean().optional(),
+  is_template: PermissiveBoolean.optional(),
   topics: z.array(z.string()).optional(),
-  has_issues: z.coerce.boolean(),
-  has_projects: z.coerce.boolean(),
-  has_wiki: z.coerce.boolean(),
-  has_pages: z.coerce.boolean(),
-  has_downloads: z.coerce.boolean(),
-  has_discussions: z.coerce.boolean().optional(),
-  archived: z.coerce.boolean(),
-  disabled: z.coerce.boolean(),
+  has_issues: PermissiveBoolean,
+  has_projects: PermissiveBoolean,
+  has_wiki: PermissiveBoolean,
+  has_pages: PermissiveBoolean,
+  has_downloads: PermissiveBoolean,
+  has_discussions: PermissiveBoolean.optional(),
+  archived: PermissiveBoolean,
+  disabled: PermissiveBoolean,
   visibility: z.string().optional(),
   pushed_at: z.string().datetime({ offset: true }).nullable(),
   created_at: z.string().datetime({ offset: true }).nullable(),
   updated_at: z.string().datetime({ offset: true }).nullable(),
-  allow_rebase_merge: z.coerce.boolean().optional(),
+  allow_rebase_merge: PermissiveBoolean.optional(),
   temp_clone_token: z.string().optional(),
-  allow_squash_merge: z.coerce.boolean().optional(),
-  allow_auto_merge: z.coerce.boolean().optional(),
-  delete_branch_on_merge: z.coerce.boolean().optional(),
-  allow_update_branch: z.coerce.boolean().optional(),
-  use_squash_pr_title_as_default: z.coerce.boolean().optional(),
+  allow_squash_merge: PermissiveBoolean.optional(),
+  allow_auto_merge: PermissiveBoolean.optional(),
+  delete_branch_on_merge: PermissiveBoolean.optional(),
+  allow_update_branch: PermissiveBoolean.optional(),
+  use_squash_pr_title_as_default: PermissiveBoolean.optional(),
   squash_merge_commit_title: z
     .enum(["PR_TITLE", "COMMIT_OR_PR_TITLE"])
     .optional(),
@@ -4414,14 +4412,14 @@ export const s_repository = z.object({
     .optional(),
   merge_commit_title: z.enum(["PR_TITLE", "MERGE_MESSAGE"]).optional(),
   merge_commit_message: z.enum(["PR_BODY", "PR_TITLE", "BLANK"]).optional(),
-  allow_merge_commit: z.coerce.boolean().optional(),
-  allow_forking: z.coerce.boolean().optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
+  allow_merge_commit: PermissiveBoolean.optional(),
+  allow_forking: PermissiveBoolean.optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
   open_issues: z.coerce.number(),
   watchers: z.coerce.number(),
   master_branch: z.string().optional(),
   starred_at: z.string().optional(),
-  anonymous_access_enabled: z.coerce.boolean().optional(),
+  anonymous_access_enabled: PermissiveBoolean.optional(),
 })
 
 export const s_repository_advisory_create = z.object({
@@ -4448,7 +4446,7 @@ export const s_repository_advisory_create = z.object({
     .optional(),
   severity: z.enum(["critical", "high", "medium", "low"]).nullable().optional(),
   cvss_vector_string: z.string().nullable().optional(),
-  start_private_fork: z.coerce.boolean().optional(),
+  start_private_fork: PermissiveBoolean.optional(),
 })
 
 export const s_repository_advisory_credit = z.object({
@@ -4513,7 +4511,7 @@ export const s_repository_rule_required_status_checks = z.object({
       required_status_checks: z.array(
         s_repository_rule_params_status_check_configuration,
       ),
-      strict_required_status_checks_policy: z.coerce.boolean(),
+      strict_required_status_checks_policy: PermissiveBoolean,
     })
     .optional(),
 })
@@ -4576,7 +4574,7 @@ export const s_runner = z.object({
   name: z.string(),
   os: z.string(),
   status: z.string(),
-  busy: z.coerce.boolean(),
+  busy: PermissiveBoolean,
   labels: z.array(s_runner_label),
 })
 
@@ -4595,7 +4593,7 @@ export const s_secret_scanning_alert = z.object({
   secret_type: z.string().optional(),
   secret_type_display_name: z.string().optional(),
   secret: z.string().optional(),
-  push_protection_bypassed: z.coerce.boolean().nullable().optional(),
+  push_protection_bypassed: PermissiveBoolean.nullable().optional(),
   push_protection_bypassed_by: s_nullable_simple_user.optional(),
   push_protection_bypassed_at: z
     .string()
@@ -4644,14 +4642,14 @@ export const s_secret_scanning_location = z.object({
 
 export const s_simple_classroom_assignment = z.object({
   id: z.coerce.number(),
-  public_repo: z.coerce.boolean(),
+  public_repo: PermissiveBoolean,
   title: z.string(),
   type: z.enum(["individual", "group"]),
   invite_link: z.string(),
-  invitations_enabled: z.coerce.boolean(),
+  invitations_enabled: PermissiveBoolean,
   slug: z.string(),
-  students_are_repo_admins: z.coerce.boolean(),
-  feedback_pull_requests_enabled: z.coerce.boolean(),
+  students_are_repo_admins: PermissiveBoolean,
+  feedback_pull_requests_enabled: PermissiveBoolean,
   max_teams: z.coerce.number().nullable().optional(),
   max_members: z.coerce.number().nullable().optional(),
   editor: z.string(),
@@ -4669,10 +4667,10 @@ export const s_simple_repository = z.object({
   name: z.string(),
   full_name: z.string(),
   owner: s_simple_user,
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   html_url: z.string(),
   description: z.string().nullable(),
-  fork: z.coerce.boolean(),
+  fork: PermissiveBoolean,
   url: z.string(),
   archive_url: z.string(),
   assignees_url: z.string(),
@@ -4742,11 +4740,11 @@ export const s_team = z.object({
   permission: z.string(),
   permissions: z
     .object({
-      pull: z.coerce.boolean(),
-      triage: z.coerce.boolean(),
-      push: z.coerce.boolean(),
-      maintain: z.coerce.boolean(),
-      admin: z.coerce.boolean(),
+      pull: PermissiveBoolean,
+      triage: PermissiveBoolean,
+      push: PermissiveBoolean,
+      maintain: PermissiveBoolean,
+      admin: PermissiveBoolean,
     })
     .optional(),
   url: z.string(),
@@ -4768,8 +4766,8 @@ export const s_team_discussion = z.object({
   html_url: z.string(),
   node_id: z.string(),
   number: z.coerce.number(),
-  pinned: z.coerce.boolean(),
-  private: z.coerce.boolean(),
+  pinned: PermissiveBoolean,
+  private: PermissiveBoolean,
   team_url: z.string(),
   title: z.string(),
   updated_at: z.string().datetime({ offset: true }),
@@ -4832,11 +4830,11 @@ export const s_team_project = z.object({
   created_at: z.string(),
   updated_at: z.string(),
   organization_permission: z.string().optional(),
-  private: z.coerce.boolean().optional(),
+  private: PermissiveBoolean.optional(),
   permissions: z.object({
-    read: z.coerce.boolean(),
-    write: z.coerce.boolean(),
-    admin: z.coerce.boolean(),
+    read: PermissiveBoolean,
+    write: PermissiveBoolean,
+    admin: PermissiveBoolean,
   }),
 })
 
@@ -4849,19 +4847,19 @@ export const s_team_repository = z.object({
   forks: z.coerce.number(),
   permissions: z
     .object({
-      admin: z.coerce.boolean(),
-      pull: z.coerce.boolean(),
-      triage: z.coerce.boolean().optional(),
-      push: z.coerce.boolean(),
-      maintain: z.coerce.boolean().optional(),
+      admin: PermissiveBoolean,
+      pull: PermissiveBoolean,
+      triage: PermissiveBoolean.optional(),
+      push: PermissiveBoolean,
+      maintain: PermissiveBoolean.optional(),
     })
     .optional(),
   role_name: z.string().optional(),
   owner: s_nullable_simple_user,
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   html_url: z.string(),
   description: z.string().nullable(),
-  fork: z.coerce.boolean(),
+  fork: PermissiveBoolean,
   url: z.string(),
   archive_url: z.string(),
   assignees_url: z.string(),
@@ -4912,27 +4910,27 @@ export const s_team_repository = z.object({
   size: z.coerce.number(),
   default_branch: z.string(),
   open_issues_count: z.coerce.number(),
-  is_template: z.coerce.boolean().optional(),
+  is_template: PermissiveBoolean.optional(),
   topics: z.array(z.string()).optional(),
-  has_issues: z.coerce.boolean(),
-  has_projects: z.coerce.boolean(),
-  has_wiki: z.coerce.boolean(),
-  has_pages: z.coerce.boolean(),
-  has_downloads: z.coerce.boolean(),
-  archived: z.coerce.boolean(),
-  disabled: z.coerce.boolean(),
+  has_issues: PermissiveBoolean,
+  has_projects: PermissiveBoolean,
+  has_wiki: PermissiveBoolean,
+  has_pages: PermissiveBoolean,
+  has_downloads: PermissiveBoolean,
+  archived: PermissiveBoolean,
+  disabled: PermissiveBoolean,
   visibility: z.string().optional(),
   pushed_at: z.string().datetime({ offset: true }).nullable(),
   created_at: z.string().datetime({ offset: true }).nullable(),
   updated_at: z.string().datetime({ offset: true }).nullable(),
-  allow_rebase_merge: z.coerce.boolean().optional(),
+  allow_rebase_merge: PermissiveBoolean.optional(),
   temp_clone_token: z.string().optional(),
-  allow_squash_merge: z.coerce.boolean().optional(),
-  allow_auto_merge: z.coerce.boolean().optional(),
-  delete_branch_on_merge: z.coerce.boolean().optional(),
-  allow_merge_commit: z.coerce.boolean().optional(),
-  allow_forking: z.coerce.boolean().optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
+  allow_squash_merge: PermissiveBoolean.optional(),
+  allow_auto_merge: PermissiveBoolean.optional(),
+  delete_branch_on_merge: PermissiveBoolean.optional(),
+  allow_merge_commit: PermissiveBoolean.optional(),
+  allow_forking: PermissiveBoolean.optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
   subscribers_count: z.coerce.number().optional(),
   network_count: z.coerce.number().optional(),
   open_issues: z.coerce.number(),
@@ -4969,8 +4967,8 @@ export const s_topic_search_result_item = z.object({
   released: z.string().nullable(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
-  featured: z.coerce.boolean(),
-  curated: z.coerce.boolean(),
+  featured: PermissiveBoolean,
+  curated: PermissiveBoolean,
   score: z.coerce.number(),
   repository_count: z.coerce.number().nullable().optional(),
   logo_url: z.string().nullable().optional(),
@@ -5011,7 +5009,7 @@ export const s_user_marketplace_purchase = z.object({
   billing_cycle: z.string(),
   next_billing_date: z.string().datetime({ offset: true }).nullable(),
   unit_count: z.coerce.number().nullable(),
-  on_free_trial: z.coerce.boolean(),
+  on_free_trial: PermissiveBoolean,
   free_trial_ends_on: z.string().datetime({ offset: true }).nullable(),
   updated_at: z.string().datetime({ offset: true }).nullable(),
   account: s_marketplace_account,
@@ -5047,8 +5045,8 @@ export const s_user_search_result_item = z.object({
   bio: z.string().nullable().optional(),
   email: z.string().email().nullable().optional(),
   location: z.string().nullable().optional(),
-  site_admin: z.coerce.boolean(),
-  hireable: z.coerce.boolean().nullable().optional(),
+  site_admin: PermissiveBoolean,
+  hireable: PermissiveBoolean.nullable().optional(),
   text_matches: s_search_result_text_matches.optional(),
   blog: z.string().nullable().optional(),
   company: z.string().nullable().optional(),
@@ -5170,15 +5168,15 @@ export const s_check_suite = z.object({
   head_commit: s_simple_commit,
   latest_check_runs_count: z.coerce.number(),
   check_runs_url: z.string(),
-  rerequestable: z.coerce.boolean().optional(),
-  runs_rerequestable: z.coerce.boolean().optional(),
+  rerequestable: PermissiveBoolean.optional(),
+  runs_rerequestable: PermissiveBoolean.optional(),
 })
 
 export const s_check_suite_preference = z.object({
   preferences: z.object({
     auto_trigger_checks: z
       .array(
-        z.object({ app_id: z.coerce.number(), setting: z.coerce.boolean() }),
+        z.object({ app_id: z.coerce.number(), setting: PermissiveBoolean }),
       )
       .optional(),
   }),
@@ -5187,8 +5185,8 @@ export const s_check_suite_preference = z.object({
 
 export const s_classroom_accepted_assignment = z.object({
   id: z.coerce.number(),
-  submitted: z.coerce.boolean(),
-  passing: z.coerce.boolean(),
+  submitted: PermissiveBoolean,
+  passing: PermissiveBoolean,
   commit_count: z.coerce.number(),
   grade: z.string(),
   students: z.array(s_simple_classroom_user),
@@ -5198,14 +5196,14 @@ export const s_classroom_accepted_assignment = z.object({
 
 export const s_classroom_assignment = z.object({
   id: z.coerce.number(),
-  public_repo: z.coerce.boolean(),
+  public_repo: PermissiveBoolean,
   title: z.string(),
   type: z.enum(["individual", "group"]),
   invite_link: z.string(),
-  invitations_enabled: z.coerce.boolean(),
+  invitations_enabled: PermissiveBoolean,
   slug: z.string(),
-  students_are_repo_admins: z.coerce.boolean(),
-  feedback_pull_requests_enabled: z.coerce.boolean(),
+  students_are_repo_admins: PermissiveBoolean,
+  feedback_pull_requests_enabled: PermissiveBoolean,
   max_teams: z.coerce.number().nullable(),
   max_members: z.coerce.number().nullable(),
   editor: z.string(),
@@ -5268,7 +5266,7 @@ export const s_code_scanning_analysis = z.object({
   url: s_code_scanning_analysis_url,
   sarif_id: s_code_scanning_analysis_sarif_id,
   tool: s_code_scanning_analysis_tool,
-  deletable: z.coerce.boolean(),
+  deletable: PermissiveBoolean,
   warning: z.string(),
 })
 
@@ -5317,7 +5315,7 @@ export const s_codespace = z.object({
   repository: s_minimal_repository,
   machine: s_nullable_codespace_machine,
   devcontainer_path: z.string().nullable().optional(),
-  prebuild: z.coerce.boolean().nullable(),
+  prebuild: PermissiveBoolean.nullable(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
   last_used_at: z.string().datetime({ offset: true }),
@@ -5344,8 +5342,8 @@ export const s_codespace = z.object({
   git_status: z.object({
     ahead: z.coerce.number().optional(),
     behind: z.coerce.number().optional(),
-    has_unpushed_changes: z.coerce.boolean().optional(),
-    has_uncommitted_changes: z.coerce.boolean().optional(),
+    has_unpushed_changes: PermissiveBoolean.optional(),
+    has_uncommitted_changes: PermissiveBoolean.optional(),
     ref: z.string().optional(),
   }),
   location: z.enum(["EastUs", "SouthEastAsia", "WestEurope", "WestUs2"]),
@@ -5362,7 +5360,7 @@ export const s_codespace = z.object({
       allowed_port_privacy_settings: z.array(z.string()).nullable().optional(),
     })
     .optional(),
-  pending_operation: z.coerce.boolean().nullable().optional(),
+  pending_operation: PermissiveBoolean.nullable().optional(),
   pending_operation_disabled_reason: z.string().nullable().optional(),
   idle_timeout_notice: z.string().nullable().optional(),
   retention_period_minutes: z.coerce.number().nullable().optional(),
@@ -5515,8 +5513,8 @@ export const s_deployment = z.object({
   updated_at: z.string().datetime({ offset: true }),
   statuses_url: z.string(),
   repository_url: z.string(),
-  transient_environment: z.coerce.boolean().optional(),
-  production_environment: z.coerce.boolean().optional(),
+  transient_environment: PermissiveBoolean.optional(),
+  production_environment: PermissiveBoolean.optional(),
   performed_via_github_app: s_nullable_integration.optional(),
 })
 
@@ -5532,8 +5530,8 @@ export const s_deployment_simple = z.object({
   updated_at: z.string().datetime({ offset: true }),
   statuses_url: z.string(),
   repository_url: z.string(),
-  transient_environment: z.coerce.boolean().optional(),
-  production_environment: z.coerce.boolean().optional(),
+  transient_environment: PermissiveBoolean.optional(),
+  production_environment: PermissiveBoolean.optional(),
   performed_via_github_app: s_nullable_integration.optional(),
 })
 
@@ -5583,7 +5581,7 @@ export const s_environment = z.object({
         z.object({
           id: z.coerce.number(),
           node_id: z.string(),
-          prevent_self_review: z.coerce.boolean().optional(),
+          prevent_self_review: PermissiveBoolean.optional(),
           type: z.string(),
           reviewers: z
             .array(
@@ -5611,10 +5609,10 @@ export const s_full_repository = z.object({
   name: z.string(),
   full_name: z.string(),
   owner: s_simple_user,
-  private: z.coerce.boolean(),
+  private: PermissiveBoolean,
   html_url: z.string(),
   description: z.string().nullable(),
-  fork: z.coerce.boolean(),
+  fork: PermissiveBoolean,
   url: z.string(),
   archive_url: z.string(),
   assignees_url: z.string(),
@@ -5665,38 +5663,38 @@ export const s_full_repository = z.object({
   size: z.coerce.number(),
   default_branch: z.string(),
   open_issues_count: z.coerce.number(),
-  is_template: z.coerce.boolean().optional(),
+  is_template: PermissiveBoolean.optional(),
   topics: z.array(z.string()).optional(),
-  has_issues: z.coerce.boolean(),
-  has_projects: z.coerce.boolean(),
-  has_wiki: z.coerce.boolean(),
-  has_pages: z.coerce.boolean(),
-  has_downloads: z.coerce.boolean().optional(),
-  has_discussions: z.coerce.boolean(),
-  archived: z.coerce.boolean(),
-  disabled: z.coerce.boolean(),
+  has_issues: PermissiveBoolean,
+  has_projects: PermissiveBoolean,
+  has_wiki: PermissiveBoolean,
+  has_pages: PermissiveBoolean,
+  has_downloads: PermissiveBoolean.optional(),
+  has_discussions: PermissiveBoolean,
+  archived: PermissiveBoolean,
+  disabled: PermissiveBoolean,
   visibility: z.string().optional(),
   pushed_at: z.string().datetime({ offset: true }),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
   permissions: z
     .object({
-      admin: z.coerce.boolean(),
-      maintain: z.coerce.boolean().optional(),
-      push: z.coerce.boolean(),
-      triage: z.coerce.boolean().optional(),
-      pull: z.coerce.boolean(),
+      admin: PermissiveBoolean,
+      maintain: PermissiveBoolean.optional(),
+      push: PermissiveBoolean,
+      triage: PermissiveBoolean.optional(),
+      pull: PermissiveBoolean,
     })
     .optional(),
-  allow_rebase_merge: z.coerce.boolean().optional(),
+  allow_rebase_merge: PermissiveBoolean.optional(),
   template_repository: s_nullable_repository.optional(),
   temp_clone_token: z.string().nullable().optional(),
-  allow_squash_merge: z.coerce.boolean().optional(),
-  allow_auto_merge: z.coerce.boolean().optional(),
-  delete_branch_on_merge: z.coerce.boolean().optional(),
-  allow_merge_commit: z.coerce.boolean().optional(),
-  allow_update_branch: z.coerce.boolean().optional(),
-  use_squash_pr_title_as_default: z.coerce.boolean().optional(),
+  allow_squash_merge: PermissiveBoolean.optional(),
+  allow_auto_merge: PermissiveBoolean.optional(),
+  delete_branch_on_merge: PermissiveBoolean.optional(),
+  allow_merge_commit: PermissiveBoolean.optional(),
+  allow_update_branch: PermissiveBoolean.optional(),
+  use_squash_pr_title_as_default: PermissiveBoolean.optional(),
   squash_merge_commit_title: z
     .enum(["PR_TITLE", "COMMIT_OR_PR_TITLE"])
     .optional(),
@@ -5705,8 +5703,8 @@ export const s_full_repository = z.object({
     .optional(),
   merge_commit_title: z.enum(["PR_TITLE", "MERGE_MESSAGE"]).optional(),
   merge_commit_message: z.enum(["PR_BODY", "PR_TITLE", "BLANK"]).optional(),
-  allow_forking: z.coerce.boolean().optional(),
-  web_commit_signoff_required: z.coerce.boolean().optional(),
+  allow_forking: PermissiveBoolean.optional(),
+  web_commit_signoff_required: PermissiveBoolean.optional(),
   subscribers_count: z.coerce.number(),
   network_count: z.coerce.number(),
   license: s_nullable_license_simple,
@@ -5717,7 +5715,7 @@ export const s_full_repository = z.object({
   master_branch: z.string().optional(),
   open_issues: z.coerce.number(),
   watchers: z.coerce.number(),
-  anonymous_access_enabled: z.coerce.boolean().optional(),
+  anonymous_access_enabled: PermissiveBoolean.optional(),
   code_of_conduct: s_code_of_conduct_simple.optional(),
   security_and_analysis: s_security_and_analysis.optional(),
   custom_properties: z.record(z.any()).optional(),
@@ -5756,7 +5754,7 @@ export const s_gist_simple = z.object({
           size: z.coerce.number().optional(),
         }),
       ),
-      public: z.coerce.boolean(),
+      public: PermissiveBoolean,
       created_at: z.string().datetime({ offset: true }),
       updated_at: z.string().datetime({ offset: true }),
       description: z.string().nullable(),
@@ -5764,7 +5762,7 @@ export const s_gist_simple = z.object({
       user: s_nullable_simple_user,
       comments_url: z.string(),
       owner: s_nullable_simple_user.optional(),
-      truncated: z.coerce.boolean().optional(),
+      truncated: PermissiveBoolean.optional(),
       forks: z.array(z.object({})).optional(),
       history: z.array(z.object({})).optional(),
     })
@@ -5787,13 +5785,13 @@ export const s_gist_simple = z.object({
           language: z.string().optional(),
           raw_url: z.string().optional(),
           size: z.coerce.number().optional(),
-          truncated: z.coerce.boolean().optional(),
+          truncated: PermissiveBoolean.optional(),
           content: z.string().optional(),
         })
         .nullable(),
     )
     .optional(),
-  public: z.coerce.boolean().optional(),
+  public: PermissiveBoolean.optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
   description: z.string().nullable().optional(),
@@ -5801,14 +5799,14 @@ export const s_gist_simple = z.object({
   user: z.string().nullable().optional(),
   comments_url: z.string().optional(),
   owner: s_simple_user.optional(),
-  truncated: z.coerce.boolean().optional(),
+  truncated: PermissiveBoolean.optional(),
 })
 
 export const s_hook = z.object({
   type: z.string(),
   id: z.coerce.number(),
   name: z.string(),
-  active: z.coerce.boolean(),
+  active: PermissiveBoolean,
   events: z.array(z.string()),
   config: s_webhook_config,
   updated_at: z.string().datetime({ offset: true }),
@@ -5827,7 +5825,7 @@ export const s_installation_token = z.object({
   repository_selection: z.enum(["all", "selected"]).optional(),
   repositories: z.array(s_repository).optional(),
   single_file: z.string().optional(),
-  has_multiple_single_files: z.coerce.boolean().optional(),
+  has_multiple_single_files: PermissiveBoolean.optional(),
   single_file_paths: z.array(z.string()).optional(),
 })
 
@@ -5859,14 +5857,14 @@ export const s_issue = z.object({
         name: z.string().optional(),
         description: z.string().nullable().optional(),
         color: z.string().nullable().optional(),
-        default: z.coerce.boolean().optional(),
+        default: PermissiveBoolean.optional(),
       }),
     ]),
   ),
   assignee: s_nullable_simple_user,
   assignees: z.array(s_simple_user).nullable().optional(),
   milestone: s_nullable_milestone,
-  locked: z.coerce.boolean(),
+  locked: PermissiveBoolean,
   active_lock_reason: z.string().nullable().optional(),
   comments: z.coerce.number(),
   pull_request: z
@@ -5881,7 +5879,7 @@ export const s_issue = z.object({
   closed_at: z.string().datetime({ offset: true }).nullable(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
-  draft: z.coerce.boolean().optional(),
+  draft: PermissiveBoolean.optional(),
   closed_by: s_nullable_simple_user.optional(),
   body_html: z.string().optional(),
   body_text: z.string().optional(),
@@ -5920,7 +5918,7 @@ export const s_issue_search_result_item = z.object({
   node_id: z.string(),
   number: z.coerce.number(),
   title: z.string(),
-  locked: z.coerce.boolean(),
+  locked: PermissiveBoolean,
   active_lock_reason: z.string().nullable().optional(),
   assignees: z.array(s_simple_user).nullable().optional(),
   user: s_nullable_simple_user,
@@ -5931,7 +5929,7 @@ export const s_issue_search_result_item = z.object({
       url: z.string().optional(),
       name: z.string().optional(),
       color: z.string().optional(),
-      default: z.coerce.boolean().optional(),
+      default: PermissiveBoolean.optional(),
       description: z.string().nullable().optional(),
     }),
   ),
@@ -5956,7 +5954,7 @@ export const s_issue_search_result_item = z.object({
   body: z.string().optional(),
   score: z.coerce.number(),
   author_association: s_author_association,
-  draft: z.coerce.boolean().optional(),
+  draft: PermissiveBoolean.optional(),
   repository: s_repository.optional(),
   body_html: z.string().optional(),
   body_text: z.string().optional(),
@@ -6003,13 +6001,13 @@ export const s_migration = z.object({
   owner: s_nullable_simple_user,
   guid: z.string(),
   state: z.string(),
-  lock_repositories: z.coerce.boolean(),
-  exclude_metadata: z.coerce.boolean(),
-  exclude_git_data: z.coerce.boolean(),
-  exclude_attachments: z.coerce.boolean(),
-  exclude_releases: z.coerce.boolean(),
-  exclude_owner_projects: z.coerce.boolean(),
-  org_metadata_only: z.coerce.boolean(),
+  lock_repositories: PermissiveBoolean,
+  exclude_metadata: PermissiveBoolean,
+  exclude_git_data: PermissiveBoolean,
+  exclude_attachments: PermissiveBoolean,
+  exclude_releases: PermissiveBoolean,
+  exclude_owner_projects: PermissiveBoolean,
+  org_metadata_only: PermissiveBoolean,
   repositories: z.array(s_repository),
   url: z.string(),
   created_at: z.string().datetime({ offset: true }),
@@ -6083,14 +6081,14 @@ export const s_nullable_issue = z
           name: z.string().optional(),
           description: z.string().nullable().optional(),
           color: z.string().nullable().optional(),
-          default: z.coerce.boolean().optional(),
+          default: PermissiveBoolean.optional(),
         }),
       ]),
     ),
     assignee: s_nullable_simple_user,
     assignees: z.array(s_simple_user).nullable().optional(),
     milestone: s_nullable_milestone,
-    locked: z.coerce.boolean(),
+    locked: PermissiveBoolean,
     active_lock_reason: z.string().nullable().optional(),
     comments: z.coerce.number(),
     pull_request: z
@@ -6105,7 +6103,7 @@ export const s_nullable_issue = z
     closed_at: z.string().datetime({ offset: true }).nullable(),
     created_at: z.string().datetime({ offset: true }),
     updated_at: z.string().datetime({ offset: true }),
-    draft: z.coerce.boolean().optional(),
+    draft: PermissiveBoolean.optional(),
     closed_by: s_nullable_simple_user.optional(),
     body_html: z.string().optional(),
     body_text: z.string().optional(),
@@ -6144,7 +6142,7 @@ export const s_organization_secret_scanning_alert = z.object({
   secret_type_display_name: z.string().optional(),
   secret: z.string().optional(),
   repository: s_simple_repository.optional(),
-  push_protection_bypassed: z.coerce.boolean().nullable().optional(),
+  push_protection_bypassed: PermissiveBoolean.nullable().optional(),
   push_protection_bypassed_by: s_nullable_simple_user.optional(),
   push_protection_bypassed_at: z
     .string()
@@ -6186,7 +6184,7 @@ export const s_pending_deployment = z.object({
   }),
   wait_timer: z.coerce.number(),
   wait_timer_started_at: z.string().datetime({ offset: true }).nullable(),
-  current_user_can_approve: z.coerce.boolean(),
+  current_user_can_approve: PermissiveBoolean,
   reviewers: z.array(
     z.object({
       type: s_deployment_reviewer_type.optional(),
@@ -6201,10 +6199,10 @@ export const s_protected_branch = z.object({
   required_pull_request_reviews: z
     .object({
       url: z.string(),
-      dismiss_stale_reviews: z.coerce.boolean().optional(),
-      require_code_owner_reviews: z.coerce.boolean().optional(),
+      dismiss_stale_reviews: PermissiveBoolean.optional(),
+      require_code_owner_reviews: PermissiveBoolean.optional(),
       required_approving_review_count: z.coerce.number().optional(),
-      require_last_push_approval: z.coerce.boolean().optional(),
+      require_last_push_approval: PermissiveBoolean.optional(),
       dismissal_restrictions: z
         .object({
           url: z.string(),
@@ -6225,22 +6223,22 @@ export const s_protected_branch = z.object({
     })
     .optional(),
   required_signatures: z
-    .object({ url: z.string(), enabled: z.coerce.boolean() })
+    .object({ url: z.string(), enabled: PermissiveBoolean })
     .optional(),
   enforce_admins: z
-    .object({ url: z.string(), enabled: z.coerce.boolean() })
+    .object({ url: z.string(), enabled: PermissiveBoolean })
     .optional(),
-  required_linear_history: z.object({ enabled: z.coerce.boolean() }).optional(),
-  allow_force_pushes: z.object({ enabled: z.coerce.boolean() }).optional(),
-  allow_deletions: z.object({ enabled: z.coerce.boolean() }).optional(),
+  required_linear_history: z.object({ enabled: PermissiveBoolean }).optional(),
+  allow_force_pushes: z.object({ enabled: PermissiveBoolean }).optional(),
+  allow_deletions: z.object({ enabled: PermissiveBoolean }).optional(),
   restrictions: s_branch_restriction_policy.optional(),
   required_conversation_resolution: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
-  block_creations: z.object({ enabled: z.coerce.boolean() }).optional(),
-  lock_branch: z.object({ enabled: z.coerce.boolean().optional() }).optional(),
+  block_creations: z.object({ enabled: PermissiveBoolean }).optional(),
+  lock_branch: z.object({ enabled: PermissiveBoolean.optional() }).optional(),
   allow_fork_syncing: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
 })
 
@@ -6263,10 +6261,10 @@ export const s_protected_branch_pull_request_review = z.object({
       apps: z.array(s_integration).optional(),
     })
     .optional(),
-  dismiss_stale_reviews: z.coerce.boolean(),
-  require_code_owner_reviews: z.coerce.boolean(),
+  dismiss_stale_reviews: PermissiveBoolean,
+  require_code_owner_reviews: PermissiveBoolean,
   required_approving_review_count: z.coerce.number().min(0).max(6).optional(),
-  require_last_push_approval: z.coerce.boolean().optional(),
+  require_last_push_approval: PermissiveBoolean.optional(),
 })
 
 export const s_pull_request = z.object({
@@ -6284,7 +6282,7 @@ export const s_pull_request = z.object({
   statuses_url: z.string(),
   number: z.coerce.number(),
   state: z.enum(["open", "closed"]),
-  locked: z.coerce.boolean(),
+  locked: PermissiveBoolean,
   title: z.string(),
   user: s_simple_user,
   body: z.string().nullable(),
@@ -6296,7 +6294,7 @@ export const s_pull_request = z.object({
       name: z.string(),
       description: z.string().nullable(),
       color: z.string(),
-      default: z.coerce.boolean(),
+      default: PermissiveBoolean,
     }),
   ),
   milestone: s_nullable_milestone,
@@ -6329,7 +6327,7 @@ export const s_pull_request = z.object({
         description: z.string().nullable(),
         downloads_url: z.string(),
         events_url: z.string(),
-        fork: z.coerce.boolean(),
+        fork: PermissiveBoolean,
         forks_url: z.string(),
         full_name: z.string(),
         git_commits_url: z.string(),
@@ -6363,13 +6361,13 @@ export const s_pull_request = z.object({
           organizations_url: z.string(),
           received_events_url: z.string(),
           repos_url: z.string(),
-          site_admin: z.coerce.boolean(),
+          site_admin: PermissiveBoolean,
           starred_url: z.string(),
           subscriptions_url: z.string(),
           type: z.string(),
           url: z.string(),
         }),
-        private: z.coerce.boolean(),
+        private: PermissiveBoolean,
         pulls_url: z.string(),
         releases_url: z.string(),
         stargazers_url: z.string(),
@@ -6385,34 +6383,34 @@ export const s_pull_request = z.object({
         forks: z.coerce.number(),
         forks_count: z.coerce.number(),
         git_url: z.string(),
-        has_downloads: z.coerce.boolean(),
-        has_issues: z.coerce.boolean(),
-        has_projects: z.coerce.boolean(),
-        has_wiki: z.coerce.boolean(),
-        has_pages: z.coerce.boolean(),
-        has_discussions: z.coerce.boolean(),
+        has_downloads: PermissiveBoolean,
+        has_issues: PermissiveBoolean,
+        has_projects: PermissiveBoolean,
+        has_wiki: PermissiveBoolean,
+        has_pages: PermissiveBoolean,
+        has_discussions: PermissiveBoolean,
         homepage: z.string().nullable(),
         language: z.string().nullable(),
         master_branch: z.string().optional(),
-        archived: z.coerce.boolean(),
-        disabled: z.coerce.boolean(),
+        archived: PermissiveBoolean,
+        disabled: PermissiveBoolean,
         visibility: z.string().optional(),
         mirror_url: z.string().nullable(),
         open_issues: z.coerce.number(),
         open_issues_count: z.coerce.number(),
         permissions: z
           .object({
-            admin: z.coerce.boolean(),
-            maintain: z.coerce.boolean().optional(),
-            push: z.coerce.boolean(),
-            triage: z.coerce.boolean().optional(),
-            pull: z.coerce.boolean(),
+            admin: PermissiveBoolean,
+            maintain: PermissiveBoolean.optional(),
+            push: PermissiveBoolean,
+            triage: PermissiveBoolean.optional(),
+            pull: PermissiveBoolean,
           })
           .optional(),
         temp_clone_token: z.string().optional(),
-        allow_merge_commit: z.coerce.boolean().optional(),
-        allow_squash_merge: z.coerce.boolean().optional(),
-        allow_rebase_merge: z.coerce.boolean().optional(),
+        allow_merge_commit: PermissiveBoolean.optional(),
+        allow_squash_merge: PermissiveBoolean.optional(),
+        allow_rebase_merge: PermissiveBoolean.optional(),
         license: z
           .object({
             key: z.string(),
@@ -6432,9 +6430,9 @@ export const s_pull_request = z.object({
         watchers_count: z.coerce.number(),
         created_at: z.string().datetime({ offset: true }),
         updated_at: z.string().datetime({ offset: true }),
-        allow_forking: z.coerce.boolean().optional(),
-        is_template: z.coerce.boolean().optional(),
-        web_commit_signoff_required: z.coerce.boolean().optional(),
+        allow_forking: PermissiveBoolean.optional(),
+        is_template: PermissiveBoolean.optional(),
+        web_commit_signoff_required: PermissiveBoolean.optional(),
       })
       .nullable(),
     sha: z.string(),
@@ -6452,7 +6450,7 @@ export const s_pull_request = z.object({
       organizations_url: z.string(),
       received_events_url: z.string(),
       repos_url: z.string(),
-      site_admin: z.coerce.boolean(),
+      site_admin: PermissiveBoolean,
       starred_url: z.string(),
       subscriptions_url: z.string(),
       type: z.string(),
@@ -6477,7 +6475,7 @@ export const s_pull_request = z.object({
       description: z.string().nullable(),
       downloads_url: z.string(),
       events_url: z.string(),
-      fork: z.coerce.boolean(),
+      fork: PermissiveBoolean,
       forks_url: z.string(),
       full_name: z.string(),
       git_commits_url: z.string(),
@@ -6486,7 +6484,7 @@ export const s_pull_request = z.object({
       hooks_url: z.string(),
       html_url: z.string(),
       id: z.coerce.number(),
-      is_template: z.coerce.boolean().optional(),
+      is_template: PermissiveBoolean.optional(),
       node_id: z.string(),
       issue_comment_url: z.string(),
       issue_events_url: z.string(),
@@ -6512,13 +6510,13 @@ export const s_pull_request = z.object({
         organizations_url: z.string(),
         received_events_url: z.string(),
         repos_url: z.string(),
-        site_admin: z.coerce.boolean(),
+        site_admin: PermissiveBoolean,
         starred_url: z.string(),
         subscriptions_url: z.string(),
         type: z.string(),
         url: z.string(),
       }),
-      private: z.coerce.boolean(),
+      private: PermissiveBoolean,
       pulls_url: z.string(),
       releases_url: z.string(),
       stargazers_url: z.string(),
@@ -6534,34 +6532,34 @@ export const s_pull_request = z.object({
       forks: z.coerce.number(),
       forks_count: z.coerce.number(),
       git_url: z.string(),
-      has_downloads: z.coerce.boolean(),
-      has_issues: z.coerce.boolean(),
-      has_projects: z.coerce.boolean(),
-      has_wiki: z.coerce.boolean(),
-      has_pages: z.coerce.boolean(),
-      has_discussions: z.coerce.boolean(),
+      has_downloads: PermissiveBoolean,
+      has_issues: PermissiveBoolean,
+      has_projects: PermissiveBoolean,
+      has_wiki: PermissiveBoolean,
+      has_pages: PermissiveBoolean,
+      has_discussions: PermissiveBoolean,
       homepage: z.string().nullable(),
       language: z.string().nullable(),
       master_branch: z.string().optional(),
-      archived: z.coerce.boolean(),
-      disabled: z.coerce.boolean(),
+      archived: PermissiveBoolean,
+      disabled: PermissiveBoolean,
       visibility: z.string().optional(),
       mirror_url: z.string().nullable(),
       open_issues: z.coerce.number(),
       open_issues_count: z.coerce.number(),
       permissions: z
         .object({
-          admin: z.coerce.boolean(),
-          maintain: z.coerce.boolean().optional(),
-          push: z.coerce.boolean(),
-          triage: z.coerce.boolean().optional(),
-          pull: z.coerce.boolean(),
+          admin: PermissiveBoolean,
+          maintain: PermissiveBoolean.optional(),
+          push: PermissiveBoolean,
+          triage: PermissiveBoolean.optional(),
+          pull: PermissiveBoolean,
         })
         .optional(),
       temp_clone_token: z.string().optional(),
-      allow_merge_commit: z.coerce.boolean().optional(),
-      allow_squash_merge: z.coerce.boolean().optional(),
-      allow_rebase_merge: z.coerce.boolean().optional(),
+      allow_merge_commit: PermissiveBoolean.optional(),
+      allow_squash_merge: PermissiveBoolean.optional(),
+      allow_rebase_merge: PermissiveBoolean.optional(),
       license: s_nullable_license_simple,
       pushed_at: z.string().datetime({ offset: true }),
       size: z.coerce.number(),
@@ -6573,8 +6571,8 @@ export const s_pull_request = z.object({
       watchers_count: z.coerce.number(),
       created_at: z.string().datetime({ offset: true }),
       updated_at: z.string().datetime({ offset: true }),
-      allow_forking: z.coerce.boolean().optional(),
-      web_commit_signoff_required: z.coerce.boolean().optional(),
+      allow_forking: PermissiveBoolean.optional(),
+      web_commit_signoff_required: PermissiveBoolean.optional(),
     }),
     sha: z.string(),
     user: z.object({
@@ -6591,7 +6589,7 @@ export const s_pull_request = z.object({
       organizations_url: z.string(),
       received_events_url: z.string(),
       repos_url: z.string(),
-      site_admin: z.coerce.boolean(),
+      site_admin: PermissiveBoolean,
       starred_url: z.string(),
       subscriptions_url: z.string(),
       type: z.string(),
@@ -6610,15 +6608,15 @@ export const s_pull_request = z.object({
   }),
   author_association: s_author_association,
   auto_merge: s_auto_merge,
-  draft: z.coerce.boolean().optional(),
-  merged: z.coerce.boolean(),
-  mergeable: z.coerce.boolean().nullable(),
-  rebaseable: z.coerce.boolean().nullable().optional(),
+  draft: PermissiveBoolean.optional(),
+  merged: PermissiveBoolean,
+  mergeable: PermissiveBoolean.nullable(),
+  rebaseable: PermissiveBoolean.nullable().optional(),
   mergeable_state: z.string(),
   merged_by: s_nullable_simple_user,
   comments: z.coerce.number(),
   review_comments: z.coerce.number(),
-  maintainer_can_modify: z.coerce.boolean(),
+  maintainer_can_modify: PermissiveBoolean,
   commits: z.coerce.number(),
   additions: z.coerce.number(),
   deletions: z.coerce.number(),
@@ -6645,7 +6643,7 @@ export const s_pull_request_simple = z.object({
   statuses_url: z.string(),
   number: z.coerce.number(),
   state: z.string(),
-  locked: z.coerce.boolean(),
+  locked: PermissiveBoolean,
   title: z.string(),
   user: s_nullable_simple_user,
   body: z.string().nullable(),
@@ -6657,7 +6655,7 @@ export const s_pull_request_simple = z.object({
       name: z.string(),
       description: z.string(),
       color: z.string(),
-      default: z.coerce.boolean(),
+      default: PermissiveBoolean,
     }),
   ),
   milestone: s_nullable_milestone,
@@ -6697,7 +6695,7 @@ export const s_pull_request_simple = z.object({
   }),
   author_association: s_author_association,
   auto_merge: s_auto_merge,
-  draft: z.coerce.boolean().optional(),
+  draft: PermissiveBoolean.optional(),
 })
 
 export const s_release = z.object({
@@ -6713,8 +6711,8 @@ export const s_release = z.object({
   target_commitish: z.string(),
   name: z.string().nullable(),
   body: z.string().nullable().optional(),
-  draft: z.coerce.boolean(),
-  prerelease: z.coerce.boolean(),
+  draft: PermissiveBoolean,
+  prerelease: PermissiveBoolean,
   created_at: z.string().datetime({ offset: true }),
   published_at: z.string().datetime({ offset: true }).nullable(),
   author: s_simple_user,
@@ -6780,7 +6778,7 @@ export const s_repository_advisory = z.object({
   published_at: z.string().datetime({ offset: true }).nullable(),
   closed_at: z.string().datetime({ offset: true }).nullable(),
   withdrawn_at: z.string().datetime({ offset: true }).nullable(),
-  submission: z.object({ accepted: z.coerce.boolean() }).nullable(),
+  submission: z.object({ accepted: PermissiveBoolean }).nullable(),
   vulnerabilities: z.array(s_repository_advisory_vulnerability).nullable(),
   cvss: z
     .object({
@@ -6811,7 +6809,7 @@ export const s_repository_invitation = z.object({
   inviter: s_nullable_simple_user,
   permissions: z.enum(["read", "write", "admin", "triage", "maintain"]),
   created_at: z.string().datetime({ offset: true }),
-  expired: z.coerce.boolean().optional(),
+  expired: PermissiveBoolean.optional(),
   url: z.string(),
   html_url: z.string(),
   node_id: z.string(),
@@ -6939,7 +6937,7 @@ export const s_thread = z.object({
     type: z.string(),
   }),
   reason: z.string(),
-  unread: z.coerce.boolean(),
+  unread: PermissiveBoolean,
   updated_at: z.string(),
   last_read_at: z.string().nullable(),
   url: z.string(),
@@ -7072,35 +7070,35 @@ export const s_workflow_run = z.object({
 
 export const s_branch_protection = z.object({
   url: z.string().optional(),
-  enabled: z.coerce.boolean().optional(),
+  enabled: PermissiveBoolean.optional(),
   required_status_checks: s_protected_branch_required_status_check.optional(),
   enforce_admins: s_protected_branch_admin_enforced.optional(),
   required_pull_request_reviews:
     s_protected_branch_pull_request_review.optional(),
   restrictions: s_branch_restriction_policy.optional(),
   required_linear_history: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
   allow_force_pushes: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
   allow_deletions: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
   block_creations: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
   required_conversation_resolution: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
   name: z.string().optional(),
   protection_url: z.string().optional(),
   required_signatures: z
-    .object({ url: z.string(), enabled: z.coerce.boolean() })
+    .object({ url: z.string(), enabled: PermissiveBoolean })
     .optional(),
-  lock_branch: z.object({ enabled: z.coerce.boolean().optional() }).optional(),
+  lock_branch: z.object({ enabled: PermissiveBoolean.optional() }).optional(),
   allow_fork_syncing: z
-    .object({ enabled: z.coerce.boolean().optional() })
+    .object({ enabled: PermissiveBoolean.optional() })
     .optional(),
 })
 
@@ -7157,7 +7155,7 @@ export const s_codespace_with_full_repository = z.object({
   repository: s_full_repository,
   machine: s_nullable_codespace_machine,
   devcontainer_path: z.string().nullable().optional(),
-  prebuild: z.coerce.boolean().nullable(),
+  prebuild: PermissiveBoolean.nullable(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
   last_used_at: z.string().datetime({ offset: true }),
@@ -7184,8 +7182,8 @@ export const s_codespace_with_full_repository = z.object({
   git_status: z.object({
     ahead: z.coerce.number().optional(),
     behind: z.coerce.number().optional(),
-    has_unpushed_changes: z.coerce.boolean().optional(),
-    has_uncommitted_changes: z.coerce.boolean().optional(),
+    has_unpushed_changes: PermissiveBoolean.optional(),
+    has_uncommitted_changes: PermissiveBoolean.optional(),
     ref: z.string().optional(),
   }),
   location: z.enum(["EastUs", "SouthEastAsia", "WestEurope", "WestUs2"]),
@@ -7202,7 +7200,7 @@ export const s_codespace_with_full_repository = z.object({
       allowed_port_privacy_settings: z.array(z.string()).nullable().optional(),
     })
     .optional(),
-  pending_operation: z.coerce.boolean().nullable().optional(),
+  pending_operation: PermissiveBoolean.nullable().optional(),
   pending_operation_disabled_reason: z.string().nullable().optional(),
   idle_timeout_notice: z.string().nullable().optional(),
   retention_period_minutes: z.coerce.number().nullable().optional(),
@@ -7297,7 +7295,7 @@ export const s_event = z.object({
       )
       .optional(),
   }),
-  public: z.coerce.boolean(),
+  public: PermissiveBoolean,
   created_at: z.string().datetime({ offset: true }).nullable(),
 })
 
@@ -7402,7 +7400,7 @@ export const s_branch_with_protection = z.object({
   name: z.string(),
   commit: s_commit,
   _links: z.object({ html: z.string(), self: z.string() }),
-  protected: z.coerce.boolean(),
+  protected: PermissiveBoolean,
   protection: s_branch_protection,
   protection_url: z.string(),
   pattern: z.string().optional(),
@@ -7412,7 +7410,7 @@ export const s_branch_with_protection = z.object({
 export const s_short_branch = z.object({
   name: z.string(),
   commit: z.object({ sha: z.string(), url: z.string() }),
-  protected: z.coerce.boolean(),
+  protected: PermissiveBoolean,
   protection: s_branch_protection.optional(),
   protection_url: z.string().optional(),
 })

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -36,6 +36,7 @@ import {
   t_VerifyPhoneChallengeParamSchema,
 } from "./models"
 import {
+  PermissiveBoolean,
   s_AppAuthenticatorEnrollment,
   s_AppAuthenticatorEnrollmentRequest,
   s_Email,
@@ -977,7 +978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const createEmailBodySchema = z.object({
     profile: z.object({ email: z.string().email() }),
-    sendEmail: z.coerce.boolean().optional(),
+    sendEmail: PermissiveBoolean.optional(),
     state: z.string().optional(),
     role: z.enum(["PRIMARY", "SECONDARY"]).optional(),
   })
@@ -1462,7 +1463,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const createPhoneBodySchema = z.object({
     profile: z.object({ phoneNumber: z.string().optional() }).optional(),
-    sendCode: z.coerce.boolean().optional(),
+    sendCode: PermissiveBoolean.optional(),
     method: z.enum(["SMS", "CALL"]).optional(),
   })
 
@@ -1641,7 +1642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const sendPhoneChallengeBodySchema = z.object({
     method: z.enum(["SMS", "CALL"]),
-    retry: z.coerce.boolean().optional(),
+    retry: PermissiveBoolean.optional(),
   })
 
   const sendPhoneChallengeResponseValidator = responseValidationFactory(

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
@@ -4,6 +4,15 @@
 
 import { z } from "zod"
 
+export const PermissiveBoolean = z.preprocess((value) => {
+  if (typeof value === "string" && (value === "true" || value === "false")) {
+    return value === "true"
+  } else if (typeof value === "number" && (value === 1 || value === 0)) {
+    return value === 1
+  }
+  return value
+}, z.boolean())
+
 export const s_AppAuthenticatorEnrollment = z.object({
   authenticatorId: z.string().optional(),
   createdDate: z.string().datetime({ offset: true }).optional(),
@@ -167,7 +176,7 @@ export const s_KeyObject = z.union([s_KeyEC, s_KeyRSA])
 export const s_AppAuthenticatorEnrollmentRequest = z.object({
   authenticatorId: z.string(),
   device: z.object({
-    secureHardwarePresent: z.coerce.boolean().optional(),
+    secureHardwarePresent: PermissiveBoolean.optional(),
     clientInstanceKey: s_KeyObject,
     osVersion: z.string(),
     clientInstanceBundleId: z.string(),

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
@@ -4,6 +4,15 @@
 
 import { z } from "zod"
 
+export const PermissiveBoolean = z.preprocess((value) => {
+  if (typeof value === "string" && (value === "true" || value === "false")) {
+    return value === "true"
+  } else if (typeof value === "number" && (value === 1 || value === 0)) {
+    return value === 1
+  }
+  return value
+}, z.boolean())
+
 export const s_AcrValue = z.enum([
   "phr",
   "phrh",
@@ -103,7 +112,7 @@ export const s_GrantType = z.enum([
 
 export const s_IntrospectionResponse = z.intersection(
   z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     aud: z.string().optional(),
     client_id: z.string().optional(),
     device_id: z.string().optional(),
@@ -270,7 +279,7 @@ export const s_OAuthMetadata = z.object({
   request_object_signing_alg_values_supported: z
     .array(s_SigningAlgorithm)
     .optional(),
-  request_parameter_supported: z.coerce.boolean().optional(),
+  request_parameter_supported: PermissiveBoolean.optional(),
   response_modes_supported: z.array(s_ResponseMode).optional(),
   response_types_supported: z.array(s_ResponseTypesSupported).optional(),
   revocation_endpoint: z.string().optional(),

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -1257,6 +1257,7 @@ import {
   t_webhook_endpoint,
 } from "./models"
 import {
+  PermissiveBoolean,
   s_account,
   s_account_link,
   s_account_session,
@@ -13337,54 +13338,52 @@ export function createRouter(implementation: Implementation): KoaRouter {
     components: z.object({
       account_onboarding: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           features: z.object({}).optional(),
         })
         .optional(),
       documents: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           features: z.object({}).optional(),
         })
         .optional(),
       payment_details: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           features: z
             .object({
-              capture_payments: z.coerce.boolean().optional(),
-              destination_on_behalf_of_charge_management: z.coerce
-                .boolean()
-                .optional(),
-              dispute_management: z.coerce.boolean().optional(),
-              refund_management: z.coerce.boolean().optional(),
+              capture_payments: PermissiveBoolean.optional(),
+              destination_on_behalf_of_charge_management:
+                PermissiveBoolean.optional(),
+              dispute_management: PermissiveBoolean.optional(),
+              refund_management: PermissiveBoolean.optional(),
             })
             .optional(),
         })
         .optional(),
       payments: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           features: z
             .object({
-              capture_payments: z.coerce.boolean().optional(),
-              destination_on_behalf_of_charge_management: z.coerce
-                .boolean()
-                .optional(),
-              dispute_management: z.coerce.boolean().optional(),
-              refund_management: z.coerce.boolean().optional(),
+              capture_payments: PermissiveBoolean.optional(),
+              destination_on_behalf_of_charge_management:
+                PermissiveBoolean.optional(),
+              dispute_management: PermissiveBoolean.optional(),
+              refund_management: PermissiveBoolean.optional(),
             })
             .optional(),
         })
         .optional(),
       payouts: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           features: z
             .object({
-              edit_payout_schedule: z.coerce.boolean().optional(),
-              instant_payouts: z.coerce.boolean().optional(),
-              standard_payouts: z.coerce.boolean().optional(),
+              edit_payout_schedule: PermissiveBoolean.optional(),
+              instant_payouts: PermissiveBoolean.optional(),
+              standard_payouts: PermissiveBoolean.optional(),
             })
             .optional(),
         })
@@ -13465,7 +13464,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_account)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/accounts")),
         }),
@@ -13585,124 +13584,124 @@ export function createRouter(implementation: Implementation): KoaRouter {
       capabilities: z
         .object({
           acss_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           affirm_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           afterpay_clearpay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           amazon_pay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           au_becs_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           bacs_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           bancontact_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           bank_transfer_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           blik_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           boleto_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           card_issuing: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           card_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           cartes_bancaires_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           cashapp_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           eps_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           fpx_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           giropay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           grabpay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           ideal_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           india_international_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           jcb_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           klarna_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           konbini_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           legacy_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           link_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           mobilepay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           oxxo_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           p24_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           paynow_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           promptpay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           revolut_pay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           sepa_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           sofort_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           swish_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           tax_reporting_us_1099_k: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           tax_reporting_us_1099_misc: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           transfers: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           treasury: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           us_bank_account_ach_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           zip_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
         })
         .optional(),
@@ -13740,14 +13739,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
               town: z.string().max(5000).optional(),
             })
             .optional(),
-          directors_provided: z.coerce.boolean().optional(),
-          executives_provided: z.coerce.boolean().optional(),
+          directors_provided: PermissiveBoolean.optional(),
+          executives_provided: PermissiveBoolean.optional(),
           export_license_id: z.string().max(5000).optional(),
           export_purpose_code: z.string().max(5000).optional(),
           name: z.string().max(100).optional(),
           name_kana: z.string().max(100).optional(),
           name_kanji: z.string().max(100).optional(),
-          owners_provided: z.coerce.boolean().optional(),
+          owners_provided: PermissiveBoolean.optional(),
           ownership_declaration: z
             .object({
               date: z.coerce.number().optional(),
@@ -13903,9 +13902,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           relationship: z
             .object({
-              director: z.coerce.boolean().optional(),
-              executive: z.coerce.boolean().optional(),
-              owner: z.coerce.boolean().optional(),
+              director: PermissiveBoolean.optional(),
+              executive: PermissiveBoolean.optional(),
+              owner: PermissiveBoolean.optional(),
               percent_ownership: z
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
@@ -13962,8 +13961,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               decline_on: z
                 .object({
-                  avs_failure: z.coerce.boolean().optional(),
-                  cvc_failure: z.coerce.boolean().optional(),
+                  avs_failure: PermissiveBoolean.optional(),
+                  cvc_failure: PermissiveBoolean.optional(),
                 })
                 .optional(),
               statement_descriptor_prefix: z.string().max(10).optional(),
@@ -13984,7 +13983,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           payouts: z
             .object({
-              debit_negative_balances: z.coerce.boolean().optional(),
+              debit_negative_balances: PermissiveBoolean.optional(),
               schedule: z
                 .object({
                   delay_days: z
@@ -14244,124 +14243,124 @@ export function createRouter(implementation: Implementation): KoaRouter {
       capabilities: z
         .object({
           acss_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           affirm_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           afterpay_clearpay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           amazon_pay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           au_becs_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           bacs_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           bancontact_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           bank_transfer_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           blik_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           boleto_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           card_issuing: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           card_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           cartes_bancaires_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           cashapp_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           eps_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           fpx_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           giropay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           grabpay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           ideal_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           india_international_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           jcb_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           klarna_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           konbini_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           legacy_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           link_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           mobilepay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           oxxo_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           p24_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           paynow_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           promptpay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           revolut_pay_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           sepa_debit_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           sofort_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           swish_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           tax_reporting_us_1099_k: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           tax_reporting_us_1099_misc: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           transfers: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           treasury: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           us_bank_account_ach_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
           zip_payments: z
-            .object({ requested: z.coerce.boolean().optional() })
+            .object({ requested: PermissiveBoolean.optional() })
             .optional(),
         })
         .optional(),
@@ -14399,14 +14398,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
               town: z.string().max(5000).optional(),
             })
             .optional(),
-          directors_provided: z.coerce.boolean().optional(),
-          executives_provided: z.coerce.boolean().optional(),
+          directors_provided: PermissiveBoolean.optional(),
+          executives_provided: PermissiveBoolean.optional(),
           export_license_id: z.string().max(5000).optional(),
           export_purpose_code: z.string().max(5000).optional(),
           name: z.string().max(100).optional(),
           name_kana: z.string().max(100).optional(),
           name_kanji: z.string().max(100).optional(),
-          owners_provided: z.coerce.boolean().optional(),
+          owners_provided: PermissiveBoolean.optional(),
           ownership_declaration: z
             .object({
               date: z.coerce.number().optional(),
@@ -14561,9 +14560,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           relationship: z
             .object({
-              director: z.coerce.boolean().optional(),
-              executive: z.coerce.boolean().optional(),
-              owner: z.coerce.boolean().optional(),
+              director: PermissiveBoolean.optional(),
+              executive: PermissiveBoolean.optional(),
+              owner: PermissiveBoolean.optional(),
               percent_ownership: z
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
@@ -14620,8 +14619,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               decline_on: z
                 .object({
-                  avs_failure: z.coerce.boolean().optional(),
-                  cvc_failure: z.coerce.boolean().optional(),
+                  avs_failure: PermissiveBoolean.optional(),
+                  cvc_failure: PermissiveBoolean.optional(),
                 })
                 .optional(),
               statement_descriptor_prefix: z.string().max(10).optional(),
@@ -14649,7 +14648,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           payouts: z
             .object({
-              debit_negative_balances: z.coerce.boolean().optional(),
+              debit_negative_balances: PermissiveBoolean.optional(),
               schedule: z
                 .object({
                   delay_days: z
@@ -14781,7 +14780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.string().max(5000),
         ])
         .optional(),
-      default_for_currency: z.coerce.boolean().optional(),
+      default_for_currency: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       external_account: z.string().max(5000).optional(),
       metadata: z.record(z.string()).optional(),
@@ -14973,7 +14972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       address_line2: z.string().max(5000).optional(),
       address_state: z.string().max(5000).optional(),
       address_zip: z.string().max(5000).optional(),
-      default_for_currency: z.coerce.boolean().optional(),
+      default_for_currency: PermissiveBoolean.optional(),
       documents: z
         .object({
           bank_account_ownership_verification: z
@@ -15057,7 +15056,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_capability)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -15196,7 +15195,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postAccountsAccountCapabilitiesCapabilityBodySchema = z
     .object({
       expand: z.array(z.string().max(5000)).optional(),
-      requested: z.coerce.boolean().optional(),
+      requested: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -15274,7 +15273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             data: z.array(
               z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)]),
             ),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -15370,7 +15369,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.string().max(5000),
         ])
         .optional(),
-      default_for_currency: z.coerce.boolean().optional(),
+      default_for_currency: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       external_account: z.string().max(5000).optional(),
       metadata: z.record(z.string()).optional(),
@@ -15570,7 +15569,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       address_line2: z.string().max(5000).optional(),
       address_state: z.string().max(5000).optional(),
       address_zip: z.string().max(5000).optional(),
-      default_for_currency: z.coerce.boolean().optional(),
+      default_for_currency: PermissiveBoolean.optional(),
       documents: z
         .object({
           bank_account_ownership_verification: z
@@ -15703,11 +15702,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     limit: z.coerce.number().optional(),
     relationship: z
       .object({
-        director: z.coerce.boolean().optional(),
-        executive: z.coerce.boolean().optional(),
-        legal_guardian: z.coerce.boolean().optional(),
-        owner: z.coerce.boolean().optional(),
-        representative: z.coerce.boolean().optional(),
+        director: PermissiveBoolean.optional(),
+        executive: PermissiveBoolean.optional(),
+        legal_guardian: PermissiveBoolean.optional(),
+        owner: PermissiveBoolean.optional(),
+        representative: PermissiveBoolean.optional(),
       })
       .optional(),
     starting_after: z.string().max(5000).optional(),
@@ -15721,7 +15720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_person)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -15902,14 +15901,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       relationship: z
         .object({
-          director: z.coerce.boolean().optional(),
-          executive: z.coerce.boolean().optional(),
-          legal_guardian: z.coerce.boolean().optional(),
-          owner: z.coerce.boolean().optional(),
+          director: PermissiveBoolean.optional(),
+          executive: PermissiveBoolean.optional(),
+          legal_guardian: PermissiveBoolean.optional(),
+          owner: PermissiveBoolean.optional(),
           percent_ownership: z
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
-          representative: z.coerce.boolean().optional(),
+          representative: PermissiveBoolean.optional(),
           title: z.string().max(5000).optional(),
         })
         .optional(),
@@ -16223,14 +16222,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       relationship: z
         .object({
-          director: z.coerce.boolean().optional(),
-          executive: z.coerce.boolean().optional(),
-          legal_guardian: z.coerce.boolean().optional(),
-          owner: z.coerce.boolean().optional(),
+          director: PermissiveBoolean.optional(),
+          executive: PermissiveBoolean.optional(),
+          legal_guardian: PermissiveBoolean.optional(),
+          owner: PermissiveBoolean.optional(),
           percent_ownership: z
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
-          representative: z.coerce.boolean().optional(),
+          representative: PermissiveBoolean.optional(),
           title: z.string().max(5000).optional(),
         })
         .optional(),
@@ -16312,11 +16311,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     limit: z.coerce.number().optional(),
     relationship: z
       .object({
-        director: z.coerce.boolean().optional(),
-        executive: z.coerce.boolean().optional(),
-        legal_guardian: z.coerce.boolean().optional(),
-        owner: z.coerce.boolean().optional(),
-        representative: z.coerce.boolean().optional(),
+        director: PermissiveBoolean.optional(),
+        executive: PermissiveBoolean.optional(),
+        legal_guardian: PermissiveBoolean.optional(),
+        owner: PermissiveBoolean.optional(),
+        representative: PermissiveBoolean.optional(),
       })
       .optional(),
     starting_after: z.string().max(5000).optional(),
@@ -16330,7 +16329,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_person)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -16511,14 +16510,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       relationship: z
         .object({
-          director: z.coerce.boolean().optional(),
-          executive: z.coerce.boolean().optional(),
-          legal_guardian: z.coerce.boolean().optional(),
-          owner: z.coerce.boolean().optional(),
+          director: PermissiveBoolean.optional(),
+          executive: PermissiveBoolean.optional(),
+          legal_guardian: PermissiveBoolean.optional(),
+          owner: PermissiveBoolean.optional(),
           percent_ownership: z
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
-          representative: z.coerce.boolean().optional(),
+          representative: PermissiveBoolean.optional(),
           title: z.string().max(5000).optional(),
         })
         .optional(),
@@ -16832,14 +16831,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       relationship: z
         .object({
-          director: z.coerce.boolean().optional(),
-          executive: z.coerce.boolean().optional(),
-          legal_guardian: z.coerce.boolean().optional(),
-          owner: z.coerce.boolean().optional(),
+          director: PermissiveBoolean.optional(),
+          executive: PermissiveBoolean.optional(),
+          legal_guardian: PermissiveBoolean.optional(),
+          owner: PermissiveBoolean.optional(),
           percent_ownership: z
             .union([z.coerce.number(), z.enum([""])])
             .optional(),
-          representative: z.coerce.boolean().optional(),
+          representative: PermissiveBoolean.optional(),
           title: z.string().max(5000).optional(),
         })
         .optional(),
@@ -16986,7 +16985,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_apple_pay_domain),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/apple_pay/domains")),
         }),
@@ -17241,7 +17240,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_application_fee)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/application_fees")),
         }),
@@ -17565,7 +17564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_fee_refund)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -17707,7 +17706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_apps_secret),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/apps/secrets")),
         }),
@@ -18013,7 +18012,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_balance_transaction)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -18163,7 +18162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_balance_transaction)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -18413,7 +18412,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_billing_meter),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/billing/meters")),
         }),
@@ -18728,7 +18727,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_billing_meter_event_summary),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -18851,10 +18850,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getBillingPortalConfigurationsQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    is_default: z.coerce.boolean().optional(),
+    is_default: PermissiveBoolean.optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().max(5000).optional(),
   })
@@ -18868,7 +18867,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_billing_portal_configuration),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -18956,18 +18955,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
               z.enum([""]),
             ])
             .optional(),
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
         })
         .optional(),
-      invoice_history: z.object({ enabled: z.coerce.boolean() }).optional(),
+      invoice_history: z.object({ enabled: PermissiveBoolean }).optional(),
       payment_method_update: z
-        .object({ enabled: z.coerce.boolean() })
+        .object({ enabled: PermissiveBoolean })
         .optional(),
       subscription_cancel: z
         .object({
           cancellation_reason: z
             .object({
-              enabled: z.coerce.boolean(),
+              enabled: PermissiveBoolean,
               options: z.union([
                 z.array(
                   z.enum([
@@ -18985,7 +18984,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               ]),
             })
             .optional(),
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           mode: z.enum(["at_period_end", "immediately"]).optional(),
           proration_behavior: z
             .enum(["always_invoice", "create_prorations", "none"])
@@ -18998,7 +18997,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             z.array(z.enum(["price", "promotion_code", "quantity"])),
             z.enum([""]),
           ]),
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           products: z.union([
             z.array(
               z.object({
@@ -19014,7 +19013,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
     }),
-    login_page: z.object({ enabled: z.coerce.boolean() }).optional(),
+    login_page: z.object({ enabled: PermissiveBoolean }).optional(),
     metadata: z.record(z.string()).optional(),
   })
 
@@ -19141,7 +19140,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postBillingPortalConfigurationsConfigurationBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       business_profile: z
         .object({
           headline: z.union([z.string().max(60), z.enum([""])]).optional(),
@@ -19170,18 +19169,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   z.enum([""]),
                 ])
                 .optional(),
-              enabled: z.coerce.boolean().optional(),
+              enabled: PermissiveBoolean.optional(),
             })
             .optional(),
-          invoice_history: z.object({ enabled: z.coerce.boolean() }).optional(),
+          invoice_history: z.object({ enabled: PermissiveBoolean }).optional(),
           payment_method_update: z
-            .object({ enabled: z.coerce.boolean() })
+            .object({ enabled: PermissiveBoolean })
             .optional(),
           subscription_cancel: z
             .object({
               cancellation_reason: z
                 .object({
-                  enabled: z.coerce.boolean(),
+                  enabled: PermissiveBoolean,
                   options: z
                     .union([
                       z.array(
@@ -19201,7 +19200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     .optional(),
                 })
                 .optional(),
-              enabled: z.coerce.boolean().optional(),
+              enabled: PermissiveBoolean.optional(),
               mode: z.enum(["at_period_end", "immediately"]).optional(),
               proration_behavior: z
                 .enum(["always_invoice", "create_prorations", "none"])
@@ -19216,7 +19215,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   z.enum([""]),
                 ])
                 .optional(),
-              enabled: z.coerce.boolean().optional(),
+              enabled: PermissiveBoolean.optional(),
               products: z
                 .union([
                   z.array(
@@ -19235,7 +19234,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      login_page: z.object({ enabled: z.coerce.boolean() }).optional(),
+      login_page: z.object({ enabled: PermissiveBoolean }).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -19485,7 +19484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_charge)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/charges")),
         }),
@@ -19545,7 +19544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       amount: z.coerce.number().optional(),
       application_fee: z.coerce.number().optional(),
       application_fee_amount: z.coerce.number().optional(),
-      capture: z.coerce.boolean().optional(),
+      capture: PermissiveBoolean.optional(),
       card: z
         .union([
           z.object({
@@ -19671,7 +19670,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_charge)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -20041,7 +20040,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      submit: z.coerce.boolean().optional(),
+      submit: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -20165,8 +20164,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       reason: z
         .enum(["duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
-      refund_application_fee: z.coerce.boolean().optional(),
-      reverse_transfer: z.coerce.boolean().optional(),
+      refund_application_fee: PermissiveBoolean.optional(),
+      reverse_transfer: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -20237,7 +20236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_refund)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -20317,8 +20316,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       reason: z
         .enum(["duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
-      refund_application_fee: z.coerce.boolean().optional(),
-      reverse_transfer: z.coerce.boolean().optional(),
+      refund_application_fee: PermissiveBoolean.optional(),
+      reverse_transfer: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -20527,7 +20526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_checkout_session)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -20592,16 +20591,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({
           recovery: z
             .object({
-              allow_promotion_codes: z.coerce.boolean().optional(),
-              enabled: z.coerce.boolean(),
+              allow_promotion_codes: PermissiveBoolean.optional(),
+              enabled: PermissiveBoolean,
             })
             .optional(),
         })
         .optional(),
-      allow_promotion_codes: z.coerce.boolean().optional(),
+      allow_promotion_codes: PermissiveBoolean.optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -20647,7 +20646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 minimum_length: z.coerce.number().optional(),
               })
               .optional(),
-            optional: z.coerce.boolean().optional(),
+            optional: PermissiveBoolean.optional(),
             text: z
               .object({
                 maximum_length: z.coerce.number().optional(),
@@ -20696,7 +20695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expires_at: z.coerce.number().optional(),
       invoice_creation: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           invoice_data: z
             .object({
               account_tax_ids: z
@@ -20741,7 +20740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.object({
             adjustable_quantity: z
               .object({
-                enabled: z.coerce.boolean(),
+                enabled: PermissiveBoolean,
                 maximum: z.coerce.number().optional(),
                 minimum: z.coerce.number().optional(),
               })
@@ -20927,7 +20926,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card: z
             .object({
               installments: z
-                .object({ enabled: z.coerce.boolean().optional() })
+                .object({ enabled: PermissiveBoolean.optional() })
                 .optional(),
               request_three_d_secure: z
                 .enum(["any", "automatic", "challenge"])
@@ -21017,7 +21016,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           p24: z
             .object({
               setup_future_usage: z.enum(["none"]).optional(),
-              tos_shown_and_accepted: z.coerce.boolean().optional(),
+              tos_shown_and_accepted: PermissiveBoolean.optional(),
             })
             .optional(),
           paynow: z
@@ -21153,7 +21152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         )
         .optional(),
       phone_number_collection: z
-        .object({ enabled: z.coerce.boolean() })
+        .object({ enabled: PermissiveBoolean })
         .optional(),
       redirect_on_completion: z
         .enum(["always", "if_required", "never"])
@@ -21515,7 +21514,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       success_url: z.string().max(5000).optional(),
-      tax_id_collection: z.object({ enabled: z.coerce.boolean() }).optional(),
+      tax_id_collection: z.object({ enabled: PermissiveBoolean }).optional(),
       ui_mode: z.enum(["embedded", "hosted"]).optional(),
     })
     .optional()
@@ -21709,7 +21708,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_item)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -21790,7 +21789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_climate_order),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/orders")),
         }),
@@ -22101,7 +22100,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_climate_product),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/products")),
         }),
@@ -22239,7 +22238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_climate_supplier),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/climate/suppliers")),
         }),
@@ -22442,7 +22441,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_country_spec),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/country_specs")),
         }),
@@ -22587,7 +22586,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_coupon),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/coupons")),
         }),
@@ -22909,7 +22908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_credit_note)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -23225,7 +23224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_credit_note_line_item)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -23304,7 +23303,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_credit_note_line_item)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -23545,8 +23544,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postCustomerSessionsBodySchema = z.object({
     components: z.object({
-      buy_button: z.object({ enabled: z.coerce.boolean() }).optional(),
-      pricing_table: z.object({ enabled: z.coerce.boolean() }).optional(),
+      buy_button: z.object({ enabled: PermissiveBoolean }).optional(),
+      pricing_table: z.object({ enabled: PermissiveBoolean }).optional(),
     }),
     customer: z.string().max(5000),
     expand: z.array(z.string().max(5000)).optional(),
@@ -23626,7 +23625,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_customer)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/customers")),
         }),
@@ -23909,7 +23908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_customer)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -24299,7 +24298,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_customer_balance_transaction)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -24597,7 +24596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_bank_account)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -25079,7 +25078,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_card)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -25618,7 +25617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_customer_cash_balance_transaction)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -26007,7 +26006,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_payment_method)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -26169,7 +26168,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 s_source,
               ]),
             ),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -26640,7 +26639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_subscription)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -26748,7 +26747,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -26763,13 +26762,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([
           z.object({
             amount_gte: z.coerce.number().optional(),
-            reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+            reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
       cancel_at: z.coerce.number().optional(),
-      cancel_at_period_end: z.coerce.boolean().optional(),
+      cancel_at_period_end: PermissiveBoolean.optional(),
       collection_method: z
         .enum(["charge_automatically", "send_invoice"])
         .optional(),
@@ -26850,7 +26849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         )
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      off_session: z.coerce.boolean().optional(),
+      off_session: PermissiveBoolean.optional(),
       payment_behavior: z
         .enum([
           "allow_incomplete",
@@ -27028,7 +27027,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
-      trial_from_plan: z.coerce.boolean().optional(),
+      trial_from_plan: PermissiveBoolean.optional(),
       trial_period_days: z.coerce.number().optional(),
       trial_settings: z
         .object({
@@ -27104,8 +27103,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const deleteCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema = z
     .object({
       expand: z.array(z.string().max(5000)).optional(),
-      invoice_now: z.coerce.boolean().optional(),
-      prorate: z.coerce.boolean().optional(),
+      invoice_now: PermissiveBoolean.optional(),
+      prorate: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -27282,7 +27281,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -27296,13 +27295,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([
           z.object({
             amount_gte: z.coerce.number().optional(),
-            reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+            reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
       cancel_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
-      cancel_at_period_end: z.coerce.boolean().optional(),
+      cancel_at_period_end: PermissiveBoolean.optional(),
       cancellation_details: z
         .object({
           comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
@@ -27363,8 +27362,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
             billing_thresholds: z
               .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
               .optional(),
-            clear_usage: z.coerce.boolean().optional(),
-            deleted: z.coerce.boolean().optional(),
+            clear_usage: PermissiveBoolean.optional(),
+            deleted: PermissiveBoolean.optional(),
             discounts: z
               .union([
                 z.array(
@@ -27403,7 +27402,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         )
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      off_session: z.coerce.boolean().optional(),
+      off_session: PermissiveBoolean.optional(),
       pause_collection: z
         .union([
           z.object({
@@ -27594,7 +27593,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
-      trial_from_plan: z.coerce.boolean().optional(),
+      trial_from_plan: PermissiveBoolean.optional(),
       trial_settings: z
         .object({
           end_behavior: z.object({
@@ -27821,7 +27820,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_tax_id)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -28156,7 +28155,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_dispute)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/disputes")),
         }),
@@ -28314,7 +28313,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      submit: z.coerce.boolean().optional(),
+      submit: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -28548,7 +28547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    delivery_success: z.coerce.boolean().optional(),
+    delivery_success: PermissiveBoolean.optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
@@ -28565,7 +28564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_event),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/events")),
         }),
@@ -28693,7 +28692,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_exchange_rate),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/exchange_rates")),
         }),
@@ -28826,7 +28825,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     ending_before: z.string().optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    expired: z.coerce.boolean().optional(),
+    expired: PermissiveBoolean.optional(),
     file: z.string().max(5000).optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().optional(),
@@ -28840,7 +28839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_file_link)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
         }),
@@ -29109,7 +29108,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_file)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/files")),
         }),
@@ -29169,7 +29168,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     file: z.string(),
     file_link_data: z
       .object({
-        create: z.coerce.boolean(),
+        create: PermissiveBoolean,
         expires_at: z.coerce.number().optional(),
         metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       })
@@ -29311,7 +29310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_financial_connections_account)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -29533,7 +29532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_financial_connections_account_owner),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -29959,7 +29958,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_financial_connections_transaction),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -30120,7 +30119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_forwarding_request),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -30342,7 +30341,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_identity_verification_report),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -30503,7 +30502,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_identity_verification_session),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -30578,22 +30577,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 allowed_types: z
                   .array(z.enum(["driving_license", "id_card", "passport"]))
                   .optional(),
-                require_id_number: z.coerce.boolean().optional(),
-                require_live_capture: z.coerce.boolean().optional(),
-                require_matching_selfie: z.coerce.boolean().optional(),
+                require_id_number: PermissiveBoolean.optional(),
+                require_live_capture: PermissiveBoolean.optional(),
+                require_matching_selfie: PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
             .optional(),
           email: z
             .union([
-              z.object({ require_verification: z.coerce.boolean().optional() }),
+              z.object({ require_verification: PermissiveBoolean.optional() }),
               z.enum([""]),
             ])
             .optional(),
           phone: z
             .union([
-              z.object({ require_verification: z.coerce.boolean().optional() }),
+              z.object({ require_verification: PermissiveBoolean.optional() }),
               z.enum([""]),
             ])
             .optional(),
@@ -30741,22 +30740,22 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 allowed_types: z
                   .array(z.enum(["driving_license", "id_card", "passport"]))
                   .optional(),
-                require_id_number: z.coerce.boolean().optional(),
-                require_live_capture: z.coerce.boolean().optional(),
-                require_matching_selfie: z.coerce.boolean().optional(),
+                require_id_number: PermissiveBoolean.optional(),
+                require_live_capture: PermissiveBoolean.optional(),
+                require_matching_selfie: PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
             .optional(),
           email: z
             .union([
-              z.object({ require_verification: z.coerce.boolean().optional() }),
+              z.object({ require_verification: PermissiveBoolean.optional() }),
               z.enum([""]),
             ])
             .optional(),
           phone: z
             .union([
-              z.object({ require_verification: z.coerce.boolean().optional() }),
+              z.object({ require_verification: PermissiveBoolean.optional() }),
               z.enum([""]),
             ])
             .optional(),
@@ -30964,7 +30963,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     expand: z.array(z.string().max(5000)).optional(),
     invoice: z.string().max(5000).optional(),
     limit: z.coerce.number().optional(),
-    pending: z.coerce.boolean().optional(),
+    pending: PermissiveBoolean.optional(),
     starting_after: z.string().max(5000).optional(),
   })
 
@@ -30976,7 +30975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_invoiceitem)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/invoiceitems")),
         }),
@@ -31036,7 +31035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     currency: z.string().optional(),
     customer: z.string().max(5000),
     description: z.string().max(5000).optional(),
-    discountable: z.coerce.boolean().optional(),
+    discountable: PermissiveBoolean.optional(),
     discounts: z
       .union([
         z.array(
@@ -31244,7 +31243,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       amount: z.coerce.number().optional(),
       description: z.string().max(5000).optional(),
-      discountable: z.coerce.boolean().optional(),
+      discountable: PermissiveBoolean.optional(),
       discounts: z
         .union([
           z.array(
@@ -31380,7 +31379,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_invoice)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/invoices")),
         }),
@@ -31441,10 +31440,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       application_fee_amount: z.coerce.number().optional(),
-      auto_advance: z.coerce.boolean().optional(),
+      auto_advance: PermissiveBoolean.optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -31538,7 +31537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   z.object({
                     installments: z
                       .object({
-                        enabled: z.coerce.boolean().optional(),
+                        enabled: PermissiveBoolean.optional(),
                         plan: z
                           .union([
                             z.object({
@@ -31794,7 +31793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_invoice)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -31856,7 +31855,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getInvoicesUpcomingQuerySchema = z.object({
     automatic_tax: z
       .object({
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
         liability: z
           .object({
             account: z.string().optional(),
@@ -32003,7 +32002,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           amount: z.coerce.number().optional(),
           currency: z.string().optional(),
           description: z.string().max(5000).optional(),
-          discountable: z.coerce.boolean().optional(),
+          discountable: PermissiveBoolean.optional(),
           discounts: z
             .union([
               z.array(
@@ -32061,8 +32060,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_cancel_at: z
       .union([z.coerce.number(), z.enum([""])])
       .optional(),
-    subscription_cancel_at_period_end: z.coerce.boolean().optional(),
-    subscription_cancel_now: z.coerce.boolean().optional(),
+    subscription_cancel_at_period_end: PermissiveBoolean.optional(),
+    subscription_cancel_now: PermissiveBoolean.optional(),
     subscription_default_tax_rates: z
       .union([z.array(z.string().max(5000)), z.enum([""])])
       .optional(),
@@ -32072,8 +32071,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           billing_thresholds: z
             .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
             .optional(),
-          clear_usage: z.coerce.boolean().optional(),
-          deleted: z.coerce.boolean().optional(),
+          clear_usage: PermissiveBoolean.optional(),
+          deleted: PermissiveBoolean.optional(),
           discounts: z
             .union([
               z.array(
@@ -32120,7 +32119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_trial_end: z
       .union([z.enum(["now"]), z.coerce.number()])
       .optional(),
-    subscription_trial_from_plan: z.coerce.boolean().optional(),
+    subscription_trial_from_plan: PermissiveBoolean.optional(),
   })
 
   const getInvoicesUpcomingBodySchema = z.object({}).optional()
@@ -32178,7 +32177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getInvoicesUpcomingLinesQuerySchema = z.object({
     automatic_tax: z
       .object({
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
         liability: z
           .object({
             account: z.string().optional(),
@@ -32326,7 +32325,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           amount: z.coerce.number().optional(),
           currency: z.string().optional(),
           description: z.string().max(5000).optional(),
-          discountable: z.coerce.boolean().optional(),
+          discountable: PermissiveBoolean.optional(),
           discounts: z
             .union([
               z.array(
@@ -32386,8 +32385,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_cancel_at: z
       .union([z.coerce.number(), z.enum([""])])
       .optional(),
-    subscription_cancel_at_period_end: z.coerce.boolean().optional(),
-    subscription_cancel_now: z.coerce.boolean().optional(),
+    subscription_cancel_at_period_end: PermissiveBoolean.optional(),
+    subscription_cancel_now: PermissiveBoolean.optional(),
     subscription_default_tax_rates: z
       .union([z.array(z.string().max(5000)), z.enum([""])])
       .optional(),
@@ -32397,8 +32396,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           billing_thresholds: z
             .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
             .optional(),
-          clear_usage: z.coerce.boolean().optional(),
-          deleted: z.coerce.boolean().optional(),
+          clear_usage: PermissiveBoolean.optional(),
+          deleted: PermissiveBoolean.optional(),
           discounts: z
             .union([
               z.array(
@@ -32445,7 +32444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     subscription_trial_end: z
       .union([z.enum(["now"]), z.coerce.number()])
       .optional(),
-    subscription_trial_from_plan: z.coerce.boolean().optional(),
+    subscription_trial_from_plan: PermissiveBoolean.optional(),
   })
 
   const getInvoicesUpcomingLinesBodySchema = z.object({}).optional()
@@ -32456,7 +32455,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_line_item)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -32645,10 +32644,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([z.array(z.string().max(5000)), z.enum([""])])
         .optional(),
       application_fee_amount: z.coerce.number().optional(),
-      auto_advance: z.coerce.boolean().optional(),
+      auto_advance: PermissiveBoolean.optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -32739,7 +32738,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   z.object({
                     installments: z
                       .object({
-                        enabled: z.coerce.boolean().optional(),
+                        enabled: PermissiveBoolean.optional(),
                         plan: z
                           .union([
                             z.object({
@@ -33001,7 +33000,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postInvoicesInvoiceFinalizeBodySchema = z
     .object({
-      auto_advance: z.coerce.boolean().optional(),
+      auto_advance: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
@@ -33073,7 +33072,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_line_item)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -33145,7 +33144,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       amount: z.coerce.number().optional(),
       description: z.string().max(5000).optional(),
-      discountable: z.coerce.boolean().optional(),
+      discountable: PermissiveBoolean.optional(),
       discounts: z
         .union([
           z.array(
@@ -33194,7 +33193,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 country: z.string().max(5000).optional(),
                 description: z.string().max(5000).optional(),
                 display_name: z.string().max(50),
-                inclusive: z.coerce.boolean(),
+                inclusive: PermissiveBoolean,
                 jurisdiction: z.string().max(50).optional(),
                 percentage: z.coerce.number(),
                 state: z.string().max(2).optional(),
@@ -33344,10 +33343,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postInvoicesInvoicePayBodySchema = z
     .object({
       expand: z.array(z.string().max(5000)).optional(),
-      forgive: z.coerce.boolean().optional(),
+      forgive: PermissiveBoolean.optional(),
       mandate: z.union([z.string().max(5000), z.enum([""])]).optional(),
-      off_session: z.coerce.boolean().optional(),
-      paid_out_of_band: z.coerce.boolean().optional(),
+      off_session: PermissiveBoolean.optional(),
+      paid_out_of_band: PermissiveBoolean.optional(),
       payment_method: z.string().max(5000).optional(),
       source: z.string().max(5000).optional(),
     })
@@ -33548,7 +33547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_issuing_authorization)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -33894,7 +33893,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_issuing_cardholder)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -36121,7 +36120,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_issuing_card)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/issuing/cards")),
         }),
@@ -36206,7 +36205,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         name: z.string().max(5000),
         phone_number: z.string().optional(),
-        require_signature: z.coerce.boolean().optional(),
+        require_signature: PermissiveBoolean.optional(),
         service: z.enum(["express", "priority", "standard"]).optional(),
         type: z.enum(["bulk", "individual"]).optional(),
       })
@@ -38266,7 +38265,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_issuing_dispute)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/issuing/disputes")),
         }),
@@ -38340,7 +38339,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 cancellation_policy_provided: z
-                  .union([z.coerce.boolean(), z.enum([""])])
+                  .union([PermissiveBoolean, z.enum([""])])
                   .optional(),
                 cancellation_reason: z
                   .union([z.string().max(1500), z.enum([""])])
@@ -38628,7 +38627,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   .union([z.coerce.number(), z.enum([""])])
                   .optional(),
                 cancellation_policy_provided: z
-                  .union([z.coerce.boolean(), z.enum([""])])
+                  .union([PermissiveBoolean, z.enum([""])])
                   .optional(),
                 cancellation_reason: z
                   .union([z.string().max(1500), z.enum([""])])
@@ -38901,8 +38900,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     lookup_keys: z.array(z.string().max(200)).optional(),
     preferences: z
       .object({
-        is_default: z.coerce.boolean().optional(),
-        is_platform_default: z.coerce.boolean().optional(),
+        is_default: PermissiveBoolean.optional(),
+        is_platform_default: PermissiveBoolean.optional(),
       })
       .optional(),
     starting_after: z.string().max(5000).optional(),
@@ -38918,7 +38917,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_issuing_personalization_design)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -38995,8 +38994,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     metadata: z.record(z.string()).optional(),
     name: z.string().max(200).optional(),
     physical_bundle: z.string().max(5000),
-    preferences: z.object({ is_default: z.coerce.boolean() }).optional(),
-    transfer_lookup_key: z.coerce.boolean().optional(),
+    preferences: z.object({ is_default: PermissiveBoolean }).optional(),
+    transfer_lookup_key: PermissiveBoolean.optional(),
   })
 
   const postIssuingPersonalizationDesignsResponseValidator =
@@ -39152,8 +39151,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       metadata: z.record(z.string()).optional(),
       name: z.union([z.string().max(200), z.enum([""])]).optional(),
       physical_bundle: z.string().max(5000).optional(),
-      preferences: z.object({ is_default: z.coerce.boolean() }).optional(),
-      transfer_lookup_key: z.coerce.boolean().optional(),
+      preferences: z.object({ is_default: PermissiveBoolean }).optional(),
+      transfer_lookup_key: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -39233,7 +39232,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_issuing_physical_bundle),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -39388,7 +39387,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_issuing_settlement),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -39599,7 +39598,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_issuing_token)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -39806,7 +39805,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_issuing_transaction)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -40145,7 +40144,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_financial_connections_account)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -40350,7 +40349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_financial_connections_account_owner),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -40562,7 +40561,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_payment_intent)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_intents")),
         }),
@@ -40623,19 +40622,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     automatic_payment_methods: z
       .object({
         allow_redirects: z.enum(["always", "never"]).optional(),
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
       })
       .optional(),
     capture_method: z
       .enum(["automatic", "automatic_async", "manual"])
       .optional(),
-    confirm: z.coerce.boolean().optional(),
+    confirm: PermissiveBoolean.optional(),
     confirmation_method: z.enum(["automatic", "manual"]).optional(),
     confirmation_token: z.string().max(5000).optional(),
     currency: z.string(),
     customer: z.string().max(5000).optional(),
     description: z.string().max(1000).optional(),
-    error_on_requires_action: z.coerce.boolean().optional(),
+    error_on_requires_action: PermissiveBoolean.optional(),
     expand: z.array(z.string().max(5000)).optional(),
     mandate: z.string().max(5000).optional(),
     mandate_data: z
@@ -40658,7 +40657,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     metadata: z.record(z.string()).optional(),
     off_session: z
-      .union([z.coerce.boolean(), z.enum(["one_off", "recurring"])])
+      .union([PermissiveBoolean, z.enum(["one_off", "recurring"])])
       .optional(),
     on_behalf_of: z.string().optional(),
     payment_method: z.string().max(5000).optional(),
@@ -41029,7 +41028,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               cvc_token: z.string().max(5000).optional(),
               installments: z
                 .object({
-                  enabled: z.coerce.boolean().optional(),
+                  enabled: PermissiveBoolean.optional(),
                   plan: z
                     .union([
                       z.object({
@@ -41089,7 +41088,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               request_three_d_secure: z
                 .enum(["any", "automatic", "challenge"])
                 .optional(),
-              require_cvc_recollection: z.coerce.boolean().optional(),
+              require_cvc_recollection: PermissiveBoolean.optional(),
               setup_future_usage: z
                 .enum(["", "none", "off_session", "on_session"])
                 .optional(),
@@ -41132,10 +41131,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         card_present: z
           .union([
             z.object({
-              request_extended_authorization: z.coerce.boolean().optional(),
-              request_incremental_authorization_support: z.coerce
-                .boolean()
-                .optional(),
+              request_extended_authorization: PermissiveBoolean.optional(),
+              request_incremental_authorization_support:
+                PermissiveBoolean.optional(),
             }),
             z.enum([""]),
           ])
@@ -41330,7 +41328,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .union([
             z.object({
               setup_future_usage: z.enum(["none"]).optional(),
-              tos_shown_and_accepted: z.coerce.boolean().optional(),
+              tos_shown_and_accepted: PermissiveBoolean.optional(),
             }),
             z.enum([""]),
           ])
@@ -41531,7 +41529,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .object({ amount: z.coerce.number().optional(), destination: z.string() })
       .optional(),
     transfer_group: z.string().optional(),
-    use_stripe_sdk: z.coerce.boolean().optional(),
+    use_stripe_sdk: PermissiveBoolean.optional(),
   })
 
   const postPaymentIntentsResponseValidator = responseValidationFactory(
@@ -41595,7 +41593,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_payment_intent)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -42111,7 +42109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 cvc_token: z.string().max(5000).optional(),
                 installments: z
                   .object({
-                    enabled: z.coerce.boolean().optional(),
+                    enabled: PermissiveBoolean.optional(),
                     plan: z
                       .union([
                         z.object({
@@ -42173,7 +42171,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 request_three_d_secure: z
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
-                require_cvc_recollection: z.coerce.boolean().optional(),
+                require_cvc_recollection: PermissiveBoolean.optional(),
                 setup_future_usage: z
                   .enum(["", "none", "off_session", "on_session"])
                   .optional(),
@@ -42218,10 +42216,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card_present: z
             .union([
               z.object({
-                request_extended_authorization: z.coerce.boolean().optional(),
-                request_incremental_authorization_support: z.coerce
-                  .boolean()
-                  .optional(),
+                request_extended_authorization: PermissiveBoolean.optional(),
+                request_incremental_authorization_support:
+                  PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
@@ -42418,7 +42415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 setup_future_usage: z.enum(["none"]).optional(),
-                tos_shown_and_accepted: z.coerce.boolean().optional(),
+                tos_shown_and_accepted: PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
@@ -42806,7 +42803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       amount_to_capture: z.coerce.number().optional(),
       application_fee_amount: z.coerce.number().optional(),
       expand: z.array(z.string().max(5000)).optional(),
-      final_capture: z.coerce.boolean().optional(),
+      final_capture: PermissiveBoolean.optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
@@ -42875,7 +42872,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       client_secret: z.string().max(5000).optional(),
       confirmation_token: z.string().max(5000).optional(),
-      error_on_requires_action: z.coerce.boolean().optional(),
+      error_on_requires_action: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       mandate: z.string().max(5000).optional(),
       mandate_data: z
@@ -42906,7 +42903,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       off_session: z
-        .union([z.coerce.boolean(), z.enum(["one_off", "recurring"])])
+        .union([PermissiveBoolean, z.enum(["one_off", "recurring"])])
         .optional(),
       payment_method: z.string().max(5000).optional(),
       payment_method_data: z
@@ -43277,7 +43274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 cvc_token: z.string().max(5000).optional(),
                 installments: z
                   .object({
-                    enabled: z.coerce.boolean().optional(),
+                    enabled: PermissiveBoolean.optional(),
                     plan: z
                       .union([
                         z.object({
@@ -43339,7 +43336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 request_three_d_secure: z
                   .enum(["any", "automatic", "challenge"])
                   .optional(),
-                require_cvc_recollection: z.coerce.boolean().optional(),
+                require_cvc_recollection: PermissiveBoolean.optional(),
                 setup_future_usage: z
                   .enum(["", "none", "off_session", "on_session"])
                   .optional(),
@@ -43384,10 +43381,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card_present: z
             .union([
               z.object({
-                request_extended_authorization: z.coerce.boolean().optional(),
-                request_incremental_authorization_support: z.coerce
-                  .boolean()
-                  .optional(),
+                request_extended_authorization: PermissiveBoolean.optional(),
+                request_incremental_authorization_support:
+                  PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
@@ -43584,7 +43580,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 setup_future_usage: z.enum(["none"]).optional(),
-                tos_shown_and_accepted: z.coerce.boolean().optional(),
+                tos_shown_and_accepted: PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
@@ -43784,7 +43780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      use_stripe_sdk: z.coerce.boolean().optional(),
+      use_stripe_sdk: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -43969,7 +43965,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPaymentLinksQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
@@ -43984,7 +43980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_payment_link)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_links")),
         }),
@@ -44049,12 +44045,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
         type: z.enum(["hosted_confirmation", "redirect"]),
       })
       .optional(),
-    allow_promotion_codes: z.coerce.boolean().optional(),
+    allow_promotion_codes: PermissiveBoolean.optional(),
     application_fee_amount: z.coerce.number().optional(),
     application_fee_percent: z.coerce.number().optional(),
     automatic_tax: z
       .object({
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
         liability: z
           .object({
             account: z.string().optional(),
@@ -44098,7 +44094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               minimum_length: z.coerce.number().optional(),
             })
             .optional(),
-          optional: z.coerce.boolean().optional(),
+          optional: PermissiveBoolean.optional(),
           text: z
             .object({
               maximum_length: z.coerce.number().optional(),
@@ -44130,7 +44126,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     inactive_message: z.string().max(500).optional(),
     invoice_creation: z
       .object({
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
         invoice_data: z
           .object({
             account_tax_ids: z
@@ -44174,7 +44170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       z.object({
         adjustable_quantity: z
           .object({
-            enabled: z.coerce.boolean(),
+            enabled: PermissiveBoolean,
             maximum: z.coerce.number().optional(),
             minimum: z.coerce.number().optional(),
           })
@@ -44235,7 +44231,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       )
       .optional(),
     phone_number_collection: z
-      .object({ enabled: z.coerce.boolean() })
+      .object({ enabled: PermissiveBoolean })
       .optional(),
     restrictions: z
       .object({ completed_sessions: z.object({ limit: z.coerce.number() }) })
@@ -44517,7 +44513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
       })
       .optional(),
-    tax_id_collection: z.object({ enabled: z.coerce.boolean() }).optional(),
+    tax_id_collection: z.object({ enabled: PermissiveBoolean }).optional(),
     transfer_data: z
       .object({ amount: z.coerce.number().optional(), destination: z.string() })
       .optional(),
@@ -44635,7 +44631,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPaymentLinksPaymentLinkBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       after_completion: z
         .object({
           hosted_confirmation: z
@@ -44645,10 +44641,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["hosted_confirmation", "redirect"]),
         })
         .optional(),
-      allow_promotion_codes: z.coerce.boolean().optional(),
+      allow_promotion_codes: PermissiveBoolean.optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -44683,7 +44679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   minimum_length: z.coerce.number().optional(),
                 })
                 .optional(),
-              optional: z.coerce.boolean().optional(),
+              optional: PermissiveBoolean.optional(),
               text: z
                 .object({
                   maximum_length: z.coerce.number().optional(),
@@ -44717,7 +44713,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       inactive_message: z.union([z.string().max(500), z.enum([""])]).optional(),
       invoice_creation: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           invoice_data: z
             .object({
               account_tax_ids: z
@@ -44764,7 +44760,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.object({
             adjustable_quantity: z
               .object({
-                enabled: z.coerce.boolean(),
+                enabled: PermissiveBoolean,
                 maximum: z.coerce.number().optional(),
                 minimum: z.coerce.number().optional(),
               })
@@ -45185,7 +45181,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_item)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -45265,7 +45261,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_payment_method_configuration),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -45714,7 +45710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       affirm: z
         .object({
           display_preference: z
@@ -46021,7 +46017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getPaymentMethodDomainsQuerySchema = z.object({
     domain_name: z.string().max(5000).optional(),
-    enabled: z.coerce.boolean().optional(),
+    enabled: PermissiveBoolean.optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
@@ -46036,7 +46032,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_payment_method_domain),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -46100,7 +46096,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPaymentMethodDomainsBodySchema = z.object({
     domain_name: z.string().max(5000),
-    enabled: z.coerce.boolean().optional(),
+    enabled: PermissiveBoolean.optional(),
     expand: z.array(z.string().max(5000)).optional(),
   })
 
@@ -46223,7 +46219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPaymentMethodDomainsPaymentMethodDomainBodySchema = z
     .object({
-      enabled: z.coerce.boolean().optional(),
+      enabled: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
     })
     .optional()
@@ -46396,7 +46392,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_payment_method)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/payment_methods")),
         }),
@@ -47092,7 +47088,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_payout)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/payouts")),
         }),
@@ -47436,7 +47432,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getPlansQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     created: z
       .union([
         z.object({
@@ -47463,7 +47459,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_plan)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/plans")),
         }),
@@ -47519,7 +47515,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postPlansBodySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     aggregate_usage: z
       .enum(["last_during_period", "last_ever", "max", "sum"])
       .optional(),
@@ -47537,7 +47533,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     product: z
       .union([
         z.object({
-          active: z.coerce.boolean().optional(),
+          active: PermissiveBoolean.optional(),
           id: z.string().max(5000).optional(),
           metadata: z.record(z.string()).optional(),
           name: z.string().max(5000),
@@ -47721,7 +47717,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPlansPlanBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       nickname: z.string().max(5000).optional(),
@@ -47777,7 +47773,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getPricesQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     created: z
       .union([
         z.object({
@@ -47814,7 +47810,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_price)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/prices")),
         }),
@@ -47870,7 +47866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postPricesBodySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     billing_scheme: z.enum(["per_unit", "tiered"]).optional(),
     currency: z.string(),
     currency_options: z
@@ -47878,7 +47874,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           custom_unit_amount: z
             .object({
-              enabled: z.coerce.boolean(),
+              enabled: PermissiveBoolean,
               maximum: z.coerce.number().optional(),
               minimum: z.coerce.number().optional(),
               preset: z.coerce.number().optional(),
@@ -47905,7 +47901,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     custom_unit_amount: z
       .object({
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
         maximum: z.coerce.number().optional(),
         minimum: z.coerce.number().optional(),
         preset: z.coerce.number().optional(),
@@ -47918,7 +47914,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     product: z.string().max(5000).optional(),
     product_data: z
       .object({
-        active: z.coerce.boolean().optional(),
+        active: PermissiveBoolean.optional(),
         id: z.string().max(5000).optional(),
         metadata: z.record(z.string()).optional(),
         name: z.string().max(5000),
@@ -47951,7 +47947,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       )
       .optional(),
     tiers_mode: z.enum(["graduated", "volume"]).optional(),
-    transfer_lookup_key: z.coerce.boolean().optional(),
+    transfer_lookup_key: PermissiveBoolean.optional(),
     transform_quantity: z
       .object({ divide_by: z.coerce.number(), round: z.enum(["down", "up"]) })
       .optional(),
@@ -48016,7 +48012,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_price)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -48137,14 +48133,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPricesPriceBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       currency_options: z
         .union([
           z.record(
             z.object({
               custom_unit_amount: z
                 .object({
-                  enabled: z.coerce.boolean(),
+                  enabled: PermissiveBoolean,
                   maximum: z.coerce.number().optional(),
                   minimum: z.coerce.number().optional(),
                   preset: z.coerce.number().optional(),
@@ -48178,7 +48174,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       tax_behavior: z
         .enum(["exclusive", "inclusive", "unspecified"])
         .optional(),
-      transfer_lookup_key: z.coerce.boolean().optional(),
+      transfer_lookup_key: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -48229,7 +48225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getProductsQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     created: z
       .union([
         z.object({
@@ -48245,7 +48241,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     expand: z.array(z.string().max(5000)).optional(),
     ids: z.array(z.string().max(5000)).optional(),
     limit: z.coerce.number().optional(),
-    shippable: z.coerce.boolean().optional(),
+    shippable: PermissiveBoolean.optional(),
     starting_after: z.string().max(5000).optional(),
     url: z.string().max(5000).optional(),
   })
@@ -48258,7 +48254,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_product)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/products")),
         }),
@@ -48314,7 +48310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postProductsBodySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     default_price_data: z
       .object({
         currency: z.string(),
@@ -48323,7 +48319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             z.object({
               custom_unit_amount: z
                 .object({
-                  enabled: z.coerce.boolean(),
+                  enabled: PermissiveBoolean,
                   maximum: z.coerce.number().optional(),
                   minimum: z.coerce.number().optional(),
                   preset: z.coerce.number().optional(),
@@ -48376,7 +48372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         width: z.coerce.number(),
       })
       .optional(),
-    shippable: z.coerce.boolean().optional(),
+    shippable: PermissiveBoolean.optional(),
     statement_descriptor: z.string().max(22).optional(),
     tax_code: z.string().optional(),
     unit_label: z.string().max(12).optional(),
@@ -48440,7 +48436,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_product)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -48611,7 +48607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postProductsIdBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       default_price: z.string().max(5000).optional(),
       description: z.union([z.string().max(40000), z.enum([""])]).optional(),
       expand: z.array(z.string().max(5000)).optional(),
@@ -48635,7 +48631,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           z.enum([""]),
         ])
         .optional(),
-      shippable: z.coerce.boolean().optional(),
+      shippable: PermissiveBoolean.optional(),
       statement_descriptor: z.string().max(22).optional(),
       tax_code: z.union([z.string(), z.enum([""])]).optional(),
       unit_label: z.union([z.string().max(12), z.enum([""])]).optional(),
@@ -48690,7 +48686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getPromotionCodesQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     code: z.string().max(5000).optional(),
     coupon: z.string().max(5000).optional(),
     created: z
@@ -48719,7 +48715,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_promotion_code)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/promotion_codes")),
         }),
@@ -48775,7 +48771,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postPromotionCodesBodySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     code: z.string().max(500).optional(),
     coupon: z.string().max(5000),
     customer: z.string().max(5000).optional(),
@@ -48788,7 +48784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         currency_options: z
           .record(z.object({ minimum_amount: z.coerce.number().optional() }))
           .optional(),
-        first_time_transaction: z.coerce.boolean().optional(),
+        first_time_transaction: PermissiveBoolean.optional(),
         minimum_amount: z.coerce.number().optional(),
         minimum_amount_currency: z.string().optional(),
       })
@@ -48909,7 +48905,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postPromotionCodesPromotionCodeBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       restrictions: z
@@ -48988,7 +48984,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_quote)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/quotes")),
         }),
@@ -49053,7 +49049,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -49087,7 +49083,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       footer: z.union([z.string().max(500), z.enum([""])]).optional(),
       from_quote: z
         .object({
-          is_revision: z.coerce.boolean().optional(),
+          is_revision: PermissiveBoolean.optional(),
           quote: z.string().max(5000),
         })
         .optional(),
@@ -49287,7 +49283,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -49587,7 +49583,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_item)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -49733,7 +49729,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_item)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -49886,7 +49882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_radar_early_fraud_warning)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -50043,7 +50039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_radar_value_list_item),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -50306,7 +50302,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_radar_value_list),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/radar/value_lists")),
         }),
@@ -50637,7 +50633,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_refund)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/refunds")),
         }),
@@ -50706,8 +50702,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       reason: z
         .enum(["duplicate", "fraudulent", "requested_by_customer"])
         .optional(),
-      refund_application_fee: z.coerce.boolean().optional(),
-      reverse_transfer: z.coerce.boolean().optional(),
+      refund_application_fee: PermissiveBoolean.optional(),
+      reverse_transfer: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -50948,7 +50944,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_reporting_report_run)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -51788,7 +51784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_reporting_report_type),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -51938,7 +51934,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_review)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -52136,7 +52132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_setup_attempt)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/setup_attempts")),
         }),
@@ -52192,7 +52188,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getSetupIntentsQuerySchema = z.object({
-    attach_to_self: z.coerce.boolean().optional(),
+    attach_to_self: PermissiveBoolean.optional(),
     created: z
       .union([
         z.object({
@@ -52220,7 +52216,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_setup_intent)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/setup_intents")),
         }),
@@ -52277,14 +52273,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postSetupIntentsBodySchema = z
     .object({
-      attach_to_self: z.coerce.boolean().optional(),
+      attach_to_self: PermissiveBoolean.optional(),
       automatic_payment_methods: z
         .object({
           allow_redirects: z.enum(["always", "never"]).optional(),
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
         })
         .optional(),
-      confirm: z.coerce.boolean().optional(),
+      confirm: PermissiveBoolean.optional(),
       confirmation_token: z.string().max(5000).optional(),
       customer: z.string().max(5000).optional(),
       description: z.string().max(1000).optional(),
@@ -52706,7 +52702,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .object({ amount: z.coerce.number(), currency: z.string() })
         .optional(),
       usage: z.enum(["off_session", "on_session"]).optional(),
-      use_stripe_sdk: z.coerce.boolean().optional(),
+      use_stripe_sdk: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -52823,7 +52819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postSetupIntentsIntentBodySchema = z
     .object({
-      attach_to_self: z.coerce.boolean().optional(),
+      attach_to_self: PermissiveBoolean.optional(),
       customer: z.string().max(5000).optional(),
       description: z.string().max(1000).optional(),
       expand: z.array(z.string().max(5000)).optional(),
@@ -53760,7 +53756,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       return_url: z.string().optional(),
-      use_stripe_sdk: z.coerce.boolean().optional(),
+      use_stripe_sdk: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -53877,7 +53873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getShippingRatesQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     created: z
       .union([
         z.object({
@@ -53904,7 +53900,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_shipping_rate),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/shipping_rates")),
         }),
@@ -54113,7 +54109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postShippingRatesShippingRateTokenBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       fixed_amount: z
         .object({
@@ -54202,7 +54198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_scheduled_query_run)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -54773,7 +54769,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_source_transaction),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -54987,7 +54983,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_subscription_item)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -55154,7 +55150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const deleteSubscriptionItemsItemBodySchema = z
     .object({
-      clear_usage: z.coerce.boolean().optional(),
+      clear_usage: PermissiveBoolean.optional(),
       proration_behavior: z
         .enum(["always_invoice", "create_prorations", "none"])
         .optional(),
@@ -55297,7 +55293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      off_session: z.coerce.boolean().optional(),
+      off_session: PermissiveBoolean.optional(),
       payment_behavior: z
         .enum([
           "allow_incomplete",
@@ -55405,7 +55401,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_usage_record_summary),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -55592,7 +55588,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    scheduled: z.coerce.boolean().optional(),
+    scheduled: PermissiveBoolean.optional(),
     starting_after: z.string().max(5000).optional(),
   })
 
@@ -55604,7 +55600,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_subscription_schedule)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -55674,7 +55670,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           application_fee_percent: z.coerce.number().optional(),
           automatic_tax: z
             .object({
-              enabled: z.coerce.boolean(),
+              enabled: PermissiveBoolean,
               liability: z
                 .object({
                   account: z.string().optional(),
@@ -55688,7 +55684,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 amount_gte: z.coerce.number().optional(),
-                reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+                reset_billing_cycle_anchor: PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
@@ -55765,7 +55761,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             application_fee_percent: z.coerce.number().optional(),
             automatic_tax: z
               .object({
-                enabled: z.coerce.boolean(),
+                enabled: PermissiveBoolean,
                 liability: z
                   .object({
                     account: z.string().optional(),
@@ -55781,7 +55777,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.object({
                   amount_gte: z.coerce.number().optional(),
-                  reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+                  reset_billing_cycle_anchor: PermissiveBoolean.optional(),
                 }),
                 z.enum([""]),
               ])
@@ -55880,7 +55876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 destination: z.string(),
               })
               .optional(),
-            trial: z.coerce.boolean().optional(),
+            trial: PermissiveBoolean.optional(),
             trial_end: z.coerce.number().optional(),
           }),
         )
@@ -56008,7 +56004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           application_fee_percent: z.coerce.number().optional(),
           automatic_tax: z
             .object({
-              enabled: z.coerce.boolean(),
+              enabled: PermissiveBoolean,
               liability: z
                 .object({
                   account: z.string().optional(),
@@ -56022,7 +56018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([
               z.object({
                 amount_gte: z.coerce.number().optional(),
-                reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+                reset_billing_cycle_anchor: PermissiveBoolean.optional(),
               }),
               z.enum([""]),
             ])
@@ -56098,7 +56094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             application_fee_percent: z.coerce.number().optional(),
             automatic_tax: z
               .object({
-                enabled: z.coerce.boolean(),
+                enabled: PermissiveBoolean,
                 liability: z
                   .object({
                     account: z.string().optional(),
@@ -56114,7 +56110,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .union([
                 z.object({
                   amount_gte: z.coerce.number().optional(),
-                  reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+                  reset_billing_cycle_anchor: PermissiveBoolean.optional(),
                 }),
                 z.enum([""]),
               ])
@@ -56215,7 +56211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 destination: z.string(),
               })
               .optional(),
-            trial: z.coerce.boolean().optional(),
+            trial: PermissiveBoolean.optional(),
             trial_end: z.union([z.coerce.number(), z.enum(["now"])]).optional(),
           }),
         )
@@ -56284,8 +56280,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postSubscriptionSchedulesScheduleCancelBodySchema = z
     .object({
       expand: z.array(z.string().max(5000)).optional(),
-      invoice_now: z.coerce.boolean().optional(),
-      prorate: z.coerce.boolean().optional(),
+      invoice_now: PermissiveBoolean.optional(),
+      prorate: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -56347,7 +56343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postSubscriptionSchedulesScheduleReleaseBodySchema = z
     .object({
       expand: z.array(z.string().max(5000)).optional(),
-      preserve_cancel_date: z.coerce.boolean().optional(),
+      preserve_cancel_date: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -56403,7 +56399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSubscriptionsQuerySchema = z.object({
-    automatic_tax: z.object({ enabled: z.coerce.boolean() }).optional(),
+    automatic_tax: z.object({ enabled: PermissiveBoolean }).optional(),
     collection_method: z
       .enum(["charge_automatically", "send_invoice"])
       .optional(),
@@ -56471,7 +56467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_subscription)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/subscriptions")),
         }),
@@ -56563,7 +56559,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     automatic_tax: z
       .object({
-        enabled: z.coerce.boolean(),
+        enabled: PermissiveBoolean,
         liability: z
           .object({
             account: z.string().optional(),
@@ -56587,13 +56583,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .union([
         z.object({
           amount_gte: z.coerce.number().optional(),
-          reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+          reset_billing_cycle_anchor: PermissiveBoolean.optional(),
         }),
         z.enum([""]),
       ])
       .optional(),
     cancel_at: z.coerce.number().optional(),
-    cancel_at_period_end: z.coerce.boolean().optional(),
+    cancel_at_period_end: PermissiveBoolean.optional(),
     collection_method: z
       .enum(["charge_automatically", "send_invoice"])
       .optional(),
@@ -56676,7 +56672,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       )
       .optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-    off_session: z.coerce.boolean().optional(),
+    off_session: PermissiveBoolean.optional(),
     on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
     payment_behavior: z
       .enum([
@@ -56855,7 +56851,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
-    trial_from_plan: z.coerce.boolean().optional(),
+    trial_from_plan: PermissiveBoolean.optional(),
     trial_period_days: z.coerce.number().optional(),
     trial_settings: z
       .object({
@@ -56923,7 +56919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_subscription)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           next_page: z.string().max(5000).nullable().optional(),
           object: z.enum(["search_result"]),
           total_count: z.coerce.number().optional(),
@@ -57011,8 +57007,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
-      invoice_now: z.coerce.boolean().optional(),
-      prorate: z.coerce.boolean().optional(),
+      invoice_now: PermissiveBoolean.optional(),
+      prorate: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -57176,7 +57172,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       automatic_tax: z
         .object({
-          enabled: z.coerce.boolean(),
+          enabled: PermissiveBoolean,
           liability: z
             .object({
               account: z.string().optional(),
@@ -57190,13 +57186,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .union([
           z.object({
             amount_gte: z.coerce.number().optional(),
-            reset_billing_cycle_anchor: z.coerce.boolean().optional(),
+            reset_billing_cycle_anchor: PermissiveBoolean.optional(),
           }),
           z.enum([""]),
         ])
         .optional(),
       cancel_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
-      cancel_at_period_end: z.coerce.boolean().optional(),
+      cancel_at_period_end: PermissiveBoolean.optional(),
       cancellation_details: z
         .object({
           comment: z.union([z.string().max(5000), z.enum([""])]).optional(),
@@ -57258,8 +57254,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
             billing_thresholds: z
               .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
               .optional(),
-            clear_usage: z.coerce.boolean().optional(),
-            deleted: z.coerce.boolean().optional(),
+            clear_usage: PermissiveBoolean.optional(),
+            deleted: PermissiveBoolean.optional(),
             discounts: z
               .union([
                 z.array(
@@ -57298,7 +57294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         )
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      off_session: z.coerce.boolean().optional(),
+      off_session: PermissiveBoolean.optional(),
       on_behalf_of: z.union([z.string(), z.enum([""])]).optional(),
       pause_collection: z
         .union([
@@ -57490,7 +57486,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       trial_end: z.union([z.enum(["now"]), z.coerce.number()]).optional(),
-      trial_from_plan: z.coerce.boolean().optional(),
+      trial_from_plan: PermissiveBoolean.optional(),
       trial_settings: z
         .object({
           end_behavior: z.object({
@@ -57872,7 +57868,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_tax_calculation_line_item),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -57957,7 +57953,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_tax_registration),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/tax/registrations")),
         }),
@@ -58843,7 +58839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_tax_transaction_line_item),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -58927,7 +58923,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_tax_code),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -59062,7 +59058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_tax_id)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -59349,7 +59345,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getTaxRatesQuerySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     created: z
       .union([
         z.object({
@@ -59363,7 +59359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    inclusive: z.coerce.boolean().optional(),
+    inclusive: PermissiveBoolean.optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().max(5000).optional(),
   })
@@ -59376,7 +59372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_tax_rate),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/tax_rates")),
         }),
@@ -59432,12 +59428,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTaxRatesBodySchema = z.object({
-    active: z.coerce.boolean().optional(),
+    active: PermissiveBoolean.optional(),
     country: z.string().max(5000).optional(),
     description: z.string().max(5000).optional(),
     display_name: z.string().max(50),
     expand: z.array(z.string().max(5000)).optional(),
-    inclusive: z.coerce.boolean(),
+    inclusive: PermissiveBoolean,
     jurisdiction: z.string().max(50).optional(),
     metadata: z.record(z.string()).optional(),
     percentage: z.coerce.number(),
@@ -59572,7 +59568,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTaxRatesTaxRateBodySchema = z
     .object({
-      active: z.coerce.boolean().optional(),
+      active: PermissiveBoolean.optional(),
       country: z.string().max(5000).optional(),
       description: z.string().max(5000).optional(),
       display_name: z.string().max(50).optional(),
@@ -59652,7 +59648,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const getTerminalConfigurationsQuerySchema = z.object({
     ending_before: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    is_account_default: z.coerce.boolean().optional(),
+    is_account_default: PermissiveBoolean.optional(),
     limit: z.coerce.number().optional(),
     starting_after: z.string().max(5000).optional(),
   })
@@ -59665,7 +59661,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_terminal_configuration)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -59737,7 +59733,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       name: z.string().max(100).optional(),
       offline: z
-        .union([z.object({ enabled: z.coerce.boolean() }), z.enum([""])])
+        .union([z.object({ enabled: PermissiveBoolean }), z.enum([""])])
         .optional(),
       tipping: z
         .union([
@@ -60057,7 +60053,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       name: z.string().max(100).optional(),
       offline: z
-        .union([z.object({ enabled: z.coerce.boolean() }), z.enum([""])])
+        .union([z.object({ enabled: PermissiveBoolean }), z.enum([""])])
         .optional(),
       tipping: z
         .union([
@@ -60305,7 +60301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_terminal_location),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -60656,7 +60652,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_terminal_reader)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -61031,8 +61027,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     payment_intent: z.string().max(5000),
     process_config: z
       .object({
-        enable_customer_cancellation: z.coerce.boolean().optional(),
-        skip_tipping: z.coerce.boolean().optional(),
+        enable_customer_cancellation: PermissiveBoolean.optional(),
+        skip_tipping: PermissiveBoolean.optional(),
         tipping: z
           .object({ amount_eligible: z.coerce.number().optional() })
           .optional(),
@@ -61096,10 +61092,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTerminalReadersReaderProcessSetupIntentBodySchema = z.object({
-    customer_consent_collected: z.coerce.boolean(),
+    customer_consent_collected: PermissiveBoolean,
     expand: z.array(z.string().max(5000)).optional(),
     process_config: z
-      .object({ enable_customer_cancellation: z.coerce.boolean().optional() })
+      .object({ enable_customer_cancellation: PermissiveBoolean.optional() })
       .optional(),
     setup_intent: z.string().max(5000),
   })
@@ -61166,11 +61162,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
       payment_intent: z.string().max(5000).optional(),
-      refund_application_fee: z.coerce.boolean().optional(),
+      refund_application_fee: PermissiveBoolean.optional(),
       refund_payment_config: z
-        .object({ enable_customer_cancellation: z.coerce.boolean().optional() })
+        .object({ enable_customer_cancellation: PermissiveBoolean.optional() })
         .optional(),
-      reverse_transfer: z.coerce.boolean().optional(),
+      reverse_transfer: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -61702,7 +61698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     card: z.string().max(5000),
     currency: z.string().optional(),
     expand: z.array(z.string().max(5000)).optional(),
-    is_amount_controllable: z.coerce.boolean().optional(),
+    is_amount_controllable: PermissiveBoolean.optional(),
     merchant_data: z
       .object({
         category: z
@@ -62104,7 +62100,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureBodySchema = z
     .object({
       capture_amount: z.coerce.number().optional(),
-      close_authorization: z.coerce.boolean().optional(),
+      close_authorization: PermissiveBoolean.optional(),
       expand: z.array(z.string().max(5000)).optional(),
       purchase_details: z
         .object({
@@ -62112,7 +62108,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               departure_at: z.coerce.number().optional(),
               passenger_name: z.string().max(5000).optional(),
-              refundable: z.coerce.boolean().optional(),
+              refundable: PermissiveBoolean.optional(),
               segments: z
                 .array(
                   z.object({
@@ -62121,7 +62117,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     departure_airport_code: z.string().max(3).optional(),
                     flight_number: z.string().max(5000).optional(),
                     service_class: z.string().max(5000).optional(),
-                    stopover_allowed: z.coerce.boolean().optional(),
+                    stopover_allowed: PermissiveBoolean.optional(),
                   }),
                 )
                 .optional(),
@@ -62292,7 +62288,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     z.object({
       expand: z.array(z.string().max(5000)).optional(),
       increment_amount: z.coerce.number(),
-      is_amount_controllable: z.coerce.boolean().optional(),
+      is_amount_controllable: PermissiveBoolean.optional(),
     })
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementResponseValidator =
@@ -63202,7 +63198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               departure_at: z.coerce.number().optional(),
               passenger_name: z.string().max(5000).optional(),
-              refundable: z.coerce.boolean().optional(),
+              refundable: PermissiveBoolean.optional(),
               segments: z
                 .array(
                   z.object({
@@ -63211,7 +63207,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     departure_airport_code: z.string().max(3).optional(),
                     flight_number: z.string().max(5000).optional(),
                     service_class: z.string().max(5000).optional(),
-                    stopover_allowed: z.coerce.boolean().optional(),
+                    stopover_allowed: PermissiveBoolean.optional(),
                   }),
                 )
                 .optional(),
@@ -63629,7 +63625,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               departure_at: z.coerce.number().optional(),
               passenger_name: z.string().max(5000).optional(),
-              refundable: z.coerce.boolean().optional(),
+              refundable: PermissiveBoolean.optional(),
               segments: z
                 .array(
                   z.object({
@@ -63638,7 +63634,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     departure_airport_code: z.string().max(3).optional(),
                     flight_number: z.string().max(5000).optional(),
                     service_class: z.string().max(5000).optional(),
-                    stopover_allowed: z.coerce.boolean().optional(),
+                    stopover_allowed: PermissiveBoolean.optional(),
                   }),
                 )
                 .optional(),
@@ -63947,7 +63943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_test_helpers_test_clock),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z
             .string()
@@ -65031,14 +65027,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   town: z.string().max(5000).optional(),
                 })
                 .optional(),
-              directors_provided: z.coerce.boolean().optional(),
-              executives_provided: z.coerce.boolean().optional(),
+              directors_provided: PermissiveBoolean.optional(),
+              executives_provided: PermissiveBoolean.optional(),
               export_license_id: z.string().max(5000).optional(),
               export_purpose_code: z.string().max(5000).optional(),
               name: z.string().max(100).optional(),
               name_kana: z.string().max(100).optional(),
               name_kanji: z.string().max(100).optional(),
-              owners_provided: z.coerce.boolean().optional(),
+              owners_provided: PermissiveBoolean.optional(),
               ownership_declaration: z
                 .object({
                   date: z.coerce.number().optional(),
@@ -65046,9 +65042,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   user_agent: z.string().max(5000).optional(),
                 })
                 .optional(),
-              ownership_declaration_shown_and_signed: z.coerce
-                .boolean()
-                .optional(),
+              ownership_declaration_shown_and_signed:
+                PermissiveBoolean.optional(),
               phone: z.string().max(5000).optional(),
               registration_number: z.string().max(5000).optional(),
               structure: z
@@ -65169,9 +65164,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .optional(),
               relationship: z
                 .object({
-                  director: z.coerce.boolean().optional(),
-                  executive: z.coerce.boolean().optional(),
-                  owner: z.coerce.boolean().optional(),
+                  director: PermissiveBoolean.optional(),
+                  executive: PermissiveBoolean.optional(),
+                  owner: PermissiveBoolean.optional(),
                   percent_ownership: z
                     .union([z.coerce.number(), z.enum([""])])
                     .optional(),
@@ -65197,7 +65192,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 .optional(),
             })
             .optional(),
-          tos_shown_and_accepted: z.coerce.boolean().optional(),
+          tos_shown_and_accepted: PermissiveBoolean.optional(),
         })
         .optional(),
       bank_account: z
@@ -65355,14 +65350,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           relationship: z
             .object({
-              director: z.coerce.boolean().optional(),
-              executive: z.coerce.boolean().optional(),
-              legal_guardian: z.coerce.boolean().optional(),
-              owner: z.coerce.boolean().optional(),
+              director: PermissiveBoolean.optional(),
+              executive: PermissiveBoolean.optional(),
+              legal_guardian: PermissiveBoolean.optional(),
+              owner: PermissiveBoolean.optional(),
               percent_ownership: z
                 .union([z.coerce.number(), z.enum([""])])
                 .optional(),
-              representative: z.coerce.boolean().optional(),
+              representative: PermissiveBoolean.optional(),
               title: z.string().max(5000).optional(),
             })
             .optional(),
@@ -65527,7 +65522,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_topup)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/topups")),
         }),
@@ -65835,7 +65830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_transfer)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/transfers")),
         }),
@@ -65963,7 +65958,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_transfer_reversal)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -66036,7 +66031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       description: z.string().max(5000).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
-      refund_application_fee: z.coerce.boolean().optional(),
+      refund_application_fee: PermissiveBoolean.optional(),
     })
     .optional()
 
@@ -66357,7 +66352,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_treasury_credit_reversal)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -66552,7 +66547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_treasury_debit_reversal)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -66757,7 +66752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(s_treasury_financial_account),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -66823,36 +66818,36 @@ export function createRouter(implementation: Implementation): KoaRouter {
     expand: z.array(z.string().max(5000)).optional(),
     features: z
       .object({
-        card_issuing: z.object({ requested: z.coerce.boolean() }).optional(),
+        card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
         deposit_insurance: z
-          .object({ requested: z.coerce.boolean() })
+          .object({ requested: PermissiveBoolean })
           .optional(),
         financial_addresses: z
           .object({
-            aba: z.object({ requested: z.coerce.boolean() }).optional(),
+            aba: z.object({ requested: PermissiveBoolean }).optional(),
           })
           .optional(),
         inbound_transfers: z
           .object({
-            ach: z.object({ requested: z.coerce.boolean() }).optional(),
+            ach: z.object({ requested: PermissiveBoolean }).optional(),
           })
           .optional(),
         intra_stripe_flows: z
-          .object({ requested: z.coerce.boolean() })
+          .object({ requested: PermissiveBoolean })
           .optional(),
         outbound_payments: z
           .object({
-            ach: z.object({ requested: z.coerce.boolean() }).optional(),
+            ach: z.object({ requested: PermissiveBoolean }).optional(),
             us_domestic_wire: z
-              .object({ requested: z.coerce.boolean() })
+              .object({ requested: PermissiveBoolean })
               .optional(),
           })
           .optional(),
         outbound_transfers: z
           .object({
-            ach: z.object({ requested: z.coerce.boolean() }).optional(),
+            ach: z.object({ requested: PermissiveBoolean }).optional(),
             us_domestic_wire: z
-              .object({ requested: z.coerce.boolean() })
+              .object({ requested: PermissiveBoolean })
               .optional(),
           })
           .optional(),
@@ -66988,36 +66983,36 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       features: z
         .object({
-          card_issuing: z.object({ requested: z.coerce.boolean() }).optional(),
+          card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
           deposit_insurance: z
-            .object({ requested: z.coerce.boolean() })
+            .object({ requested: PermissiveBoolean })
             .optional(),
           financial_addresses: z
             .object({
-              aba: z.object({ requested: z.coerce.boolean() }).optional(),
+              aba: z.object({ requested: PermissiveBoolean }).optional(),
             })
             .optional(),
           inbound_transfers: z
             .object({
-              ach: z.object({ requested: z.coerce.boolean() }).optional(),
+              ach: z.object({ requested: PermissiveBoolean }).optional(),
             })
             .optional(),
           intra_stripe_flows: z
-            .object({ requested: z.coerce.boolean() })
+            .object({ requested: PermissiveBoolean })
             .optional(),
           outbound_payments: z
             .object({
-              ach: z.object({ requested: z.coerce.boolean() }).optional(),
+              ach: z.object({ requested: PermissiveBoolean }).optional(),
               us_domestic_wire: z
-                .object({ requested: z.coerce.boolean() })
+                .object({ requested: PermissiveBoolean })
                 .optional(),
             })
             .optional(),
           outbound_transfers: z
             .object({
-              ach: z.object({ requested: z.coerce.boolean() }).optional(),
+              ach: z.object({ requested: PermissiveBoolean }).optional(),
               us_domestic_wire: z
-                .object({ requested: z.coerce.boolean() })
+                .object({ requested: PermissiveBoolean })
                 .optional(),
             })
             .optional(),
@@ -67164,31 +67159,29 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema = z
     .object({
-      card_issuing: z.object({ requested: z.coerce.boolean() }).optional(),
-      deposit_insurance: z.object({ requested: z.coerce.boolean() }).optional(),
+      card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
+      deposit_insurance: z.object({ requested: PermissiveBoolean }).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       financial_addresses: z
-        .object({ aba: z.object({ requested: z.coerce.boolean() }).optional() })
+        .object({ aba: z.object({ requested: PermissiveBoolean }).optional() })
         .optional(),
       inbound_transfers: z
-        .object({ ach: z.object({ requested: z.coerce.boolean() }).optional() })
+        .object({ ach: z.object({ requested: PermissiveBoolean }).optional() })
         .optional(),
-      intra_stripe_flows: z
-        .object({ requested: z.coerce.boolean() })
-        .optional(),
+      intra_stripe_flows: z.object({ requested: PermissiveBoolean }).optional(),
       outbound_payments: z
         .object({
-          ach: z.object({ requested: z.coerce.boolean() }).optional(),
+          ach: z.object({ requested: PermissiveBoolean }).optional(),
           us_domestic_wire: z
-            .object({ requested: z.coerce.boolean() })
+            .object({ requested: PermissiveBoolean })
             .optional(),
         })
         .optional(),
       outbound_transfers: z
         .object({
-          ach: z.object({ requested: z.coerce.boolean() }).optional(),
+          ach: z.object({ requested: PermissiveBoolean }).optional(),
           us_domestic_wire: z
-            .object({ requested: z.coerce.boolean() })
+            .object({ requested: PermissiveBoolean })
             .optional(),
         })
         .optional(),
@@ -67276,7 +67269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_treasury_inbound_transfer)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -67548,7 +67541,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_treasury_outbound_payment)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -67665,10 +67658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     end_user_details: z
-      .object({
-        ip_address: z.string().optional(),
-        present: z.coerce.boolean(),
-      })
+      .object({ ip_address: z.string().optional(), present: PermissiveBoolean })
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
@@ -67861,7 +67851,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_treasury_outbound_transfer)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z.string().max(5000),
           }),
@@ -68144,7 +68134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_treasury_received_credit)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -68282,7 +68272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_treasury_received_debit)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -68444,7 +68434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           "200",
           z.object({
             data: z.array(z.lazy(() => s_treasury_transaction_entry)),
-            has_more: z.coerce.boolean(),
+            has_more: PermissiveBoolean,
             object: z.enum(["list"]),
             url: z
               .string()
@@ -68612,7 +68602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(z.lazy(() => s_treasury_transaction)),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000),
         }),
@@ -68750,7 +68740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "200",
         z.object({
           data: z.array(s_webhook_endpoint),
-          has_more: z.coerce.boolean(),
+          has_more: PermissiveBoolean,
           object: z.enum(["list"]),
           url: z.string().max(5000).regex(new RegExp("^/v1/webhook_endpoints")),
         }),
@@ -68915,7 +68905,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "2024-04-10",
       ])
       .optional(),
-    connect: z.coerce.boolean().optional(),
+    connect: PermissiveBoolean.optional(),
     description: z.union([z.string().max(5000), z.enum([""])]).optional(),
     enabled_events: z.array(
       z.enum([
@@ -69330,7 +69320,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postWebhookEndpointsWebhookEndpointBodySchema = z
     .object({
       description: z.union([z.string().max(5000), z.enum([""])]).optional(),
-      disabled: z.coerce.boolean().optional(),
+      disabled: PermissiveBoolean.optional(),
       enabled_events: z
         .array(
           z.enum([

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
@@ -181,6 +181,15 @@ import {
 } from "./models"
 import { z } from "zod"
 
+export const PermissiveBoolean = z.preprocess((value) => {
+  if (typeof value === "string" && (value === "true" || value === "false")) {
+    return value === "true"
+  } else if (typeof value === "number" && (value === 1 || value === 0)) {
+    return value === 1
+  }
+  return value
+}, z.boolean())
+
 export const s_account_annual_revenue = z.object({
   amount: z.coerce.number().nullable().optional(),
   currency: z.string().nullable().optional(),
@@ -251,8 +260,8 @@ export const s_account_dashboard_settings = z.object({
 })
 
 export const s_account_decline_charge_on = z.object({
-  avs_failure: z.coerce.boolean(),
-  cvc_failure: z.coerce.boolean(),
+  avs_failure: PermissiveBoolean,
+  cvc_failure: PermissiveBoolean,
 })
 
 export const s_account_link = z.object({
@@ -392,7 +401,7 @@ export const s_account_tos_acceptance = z.object({
 })
 
 export const s_account_unification_account_controller = z.object({
-  is_controller: z.coerce.boolean().optional(),
+  is_controller: PermissiveBoolean.optional(),
   type: z.enum(["account", "application"]),
 })
 
@@ -409,7 +418,7 @@ export const s_apple_pay_domain = z.object({
   created: z.coerce.number(),
   domain_name: z.string().max(5000),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["apple_pay_domain"]),
 })
 
@@ -462,7 +471,7 @@ export const s_billing_meter_event = z.object({
   created: z.coerce.number(),
   event_name: z.string().max(100),
   identifier: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["billing.meter_event"]),
   payload: z.record(z.string().max(100)),
   timestamp: z.coerce.number(),
@@ -472,7 +481,7 @@ export const s_billing_meter_event_summary = z.object({
   aggregated_value: z.coerce.number(),
   end_time: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   meter: z.string().max(5000),
   object: z.enum(["billing.meter_event_summary"]),
   start_time: z.coerce.number(),
@@ -572,7 +581,7 @@ export const s_checkout_boleto_payment_method_options = z.object({
 })
 
 export const s_checkout_card_installments_options = z.object({
-  enabled: z.coerce.boolean().optional(),
+  enabled: PermissiveBoolean.optional(),
 })
 
 export const s_checkout_cashapp_payment_method_options = z.object({
@@ -679,16 +688,16 @@ export const s_connect_embedded_account_features = z.object({})
 export const s_connect_embedded_base_features = z.object({})
 
 export const s_connect_embedded_payments_features = z.object({
-  capture_payments: z.coerce.boolean(),
-  destination_on_behalf_of_charge_management: z.coerce.boolean().optional(),
-  dispute_management: z.coerce.boolean(),
-  refund_management: z.coerce.boolean(),
+  capture_payments: PermissiveBoolean,
+  destination_on_behalf_of_charge_management: PermissiveBoolean.optional(),
+  dispute_management: PermissiveBoolean,
+  refund_management: PermissiveBoolean,
 })
 
 export const s_connect_embedded_payouts_features = z.object({
-  edit_payout_schedule: z.coerce.boolean(),
-  instant_payouts: z.coerce.boolean(),
-  standard_payouts: z.coerce.boolean(),
+  edit_payout_schedule: PermissiveBoolean,
+  instant_payouts: PermissiveBoolean,
+  standard_payouts: PermissiveBoolean,
 })
 
 export const s_country_spec_verification_field_details = z.object({
@@ -712,7 +721,7 @@ export const s_custom_unit_amount = z.object({
 
 export const s_customer_balance_customer_balance_settings = z.object({
   reconciliation_mode: z.enum(["automatic", "manual"]),
-  using_merchant_default: z.coerce.boolean(),
+  using_merchant_default: PermissiveBoolean,
 })
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_eu_bank_transfer =
@@ -743,10 +752,10 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_funde
   })
 
 export const s_customer_session_resource_components_resource_buy_button =
-  z.object({ enabled: z.coerce.boolean() })
+  z.object({ enabled: PermissiveBoolean })
 
 export const s_customer_session_resource_components_resource_pricing_table =
-  z.object({ enabled: z.coerce.boolean() })
+  z.object({ enabled: PermissiveBoolean })
 
 export const s_customer_tax_location = z.object({
   country: z.string().max(5000),
@@ -760,19 +769,19 @@ export const s_customer_tax_location = z.object({
 })
 
 export const s_deleted_account = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["account"]),
 })
 
 export const s_deleted_apple_pay_domain = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["apple_pay_domain"]),
 })
 
 export const s_deleted_application = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   name: z.string().max(5000).nullable().optional(),
   object: z.enum(["application"]),
@@ -780,116 +789,116 @@ export const s_deleted_application = z.object({
 
 export const s_deleted_bank_account = z.object({
   currency: z.string().max(5000).nullable().optional(),
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["bank_account"]),
 })
 
 export const s_deleted_card = z.object({
   currency: z.string().max(5000).nullable().optional(),
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["card"]),
 })
 
 export const s_deleted_coupon = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["coupon"]),
 })
 
 export const s_deleted_customer = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["customer"]),
 })
 
 export const s_deleted_invoice = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["invoice"]),
 })
 
 export const s_deleted_invoiceitem = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["invoiceitem"]),
 })
 
 export const s_deleted_person = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["person"]),
 })
 
 export const s_deleted_plan = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["plan"]),
 })
 
 export const s_deleted_price = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["price"]),
 })
 
 export const s_deleted_product = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["product"]),
 })
 
 export const s_deleted_radar_value_list = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["radar.value_list"]),
 })
 
 export const s_deleted_radar_value_list_item = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["radar.value_list_item"]),
 })
 
 export const s_deleted_subscription_item = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["subscription_item"]),
 })
 
 export const s_deleted_tax_id = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["tax_id"]),
 })
 
 export const s_deleted_terminal_configuration = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["terminal.configuration"]),
 })
 
 export const s_deleted_terminal_location = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["terminal.location"]),
 })
 
 export const s_deleted_terminal_reader = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["terminal.reader"]),
 })
 
 export const s_deleted_test_helpers_test_clock = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["test_helpers.test_clock"]),
 })
 
 export const s_deleted_webhook_endpoint = z.object({
-  deleted: z.coerce.boolean(),
+  deleted: PermissiveBoolean,
   id: z.string().max(5000),
   object: z.enum(["webhook_endpoint"]),
 })
@@ -898,8 +907,8 @@ export const s_destination_details_unimplemented = z.object({})
 
 export const s_dispute_evidence_details = z.object({
   due_by: z.coerce.number().nullable().optional(),
-  has_evidence: z.coerce.boolean(),
-  past_due: z.coerce.boolean(),
+  has_evidence: PermissiveBoolean,
+  past_due: PermissiveBoolean,
   submission_count: z.coerce.number(),
 })
 
@@ -917,7 +926,7 @@ export const s_ephemeral_key = z.object({
   created: z.coerce.number(),
   expires: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["ephemeral_key"]),
   secret: z.string().max(5000).optional(),
 })
@@ -1090,9 +1099,9 @@ export const s_gelato_report_document_options = z.object({
   allowed_types: z
     .array(z.enum(["driving_license", "id_card", "passport"]))
     .optional(),
-  require_id_number: z.coerce.boolean().optional(),
-  require_live_capture: z.coerce.boolean().optional(),
-  require_matching_selfie: z.coerce.boolean().optional(),
+  require_id_number: PermissiveBoolean.optional(),
+  require_live_capture: PermissiveBoolean.optional(),
+  require_matching_selfie: PermissiveBoolean.optional(),
 })
 
 export const s_gelato_report_id_number_options = z.object({})
@@ -1114,13 +1123,13 @@ export const s_gelato_session_document_options = z.object({
   allowed_types: z
     .array(z.enum(["driving_license", "id_card", "passport"]))
     .optional(),
-  require_id_number: z.coerce.boolean().optional(),
-  require_live_capture: z.coerce.boolean().optional(),
-  require_matching_selfie: z.coerce.boolean().optional(),
+  require_id_number: PermissiveBoolean.optional(),
+  require_live_capture: PermissiveBoolean.optional(),
+  require_matching_selfie: PermissiveBoolean.optional(),
 })
 
 export const s_gelato_session_email_options = z.object({
-  require_verification: z.coerce.boolean().optional(),
+  require_verification: PermissiveBoolean.optional(),
 })
 
 export const s_gelato_session_id_number_options = z.object({})
@@ -1154,7 +1163,7 @@ export const s_gelato_session_last_error = z.object({
 })
 
 export const s_gelato_session_phone_options = z.object({
-  require_verification: z.coerce.boolean().optional(),
+  require_verification: PermissiveBoolean.optional(),
 })
 
 export const s_internal_card = z.object({
@@ -1166,7 +1175,7 @@ export const s_internal_card = z.object({
 })
 
 export const s_invoice_installments_card = z.object({
-  enabled: z.coerce.boolean().nullable().optional(),
+  enabled: PermissiveBoolean.nullable().optional(),
 })
 
 export const s_invoice_item_threshold_reason = z.object({
@@ -1360,7 +1369,7 @@ export const s_issuing_authorization_treasury = z.object({
 })
 
 export const s_issuing_card_apple_pay = z.object({
-  eligible: z.coerce.boolean(),
+  eligible: PermissiveBoolean,
   ineligible_reason: z
     .enum([
       "missing_agreement",
@@ -1372,7 +1381,7 @@ export const s_issuing_card_apple_pay = z.object({
 })
 
 export const s_issuing_card_google_pay = z.object({
-  eligible: z.coerce.boolean(),
+  eligible: PermissiveBoolean,
   ineligible_reason: z
     .enum([
       "missing_agreement",
@@ -1702,7 +1711,7 @@ export const s_issuing_card_spending_limit = z.object({
 })
 
 export const s_issuing_cardholder_company = z.object({
-  tax_id_provided: z.coerce.boolean(),
+  tax_id_provided: PermissiveBoolean,
 })
 
 export const s_issuing_cardholder_individual_dob = z.object({
@@ -2100,8 +2109,8 @@ export const s_issuing_personalization_design_carrier_text = z.object({
 })
 
 export const s_issuing_personalization_design_preferences = z.object({
-  is_default: z.coerce.boolean(),
-  is_platform_default: z.coerce.boolean().nullable().optional(),
+  is_default: PermissiveBoolean,
+  is_platform_default: PermissiveBoolean.nullable().optional(),
 })
 
 export const s_issuing_personalization_design_rejection_reasons = z.object({
@@ -2149,7 +2158,7 @@ export const s_issuing_settlement = z.object({
   currency: z.string(),
   id: z.string().max(5000),
   interchange_fees: z.coerce.number(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   net_total: z.coerce.number(),
   network: z.enum(["visa"]),
@@ -2172,7 +2181,7 @@ export const s_issuing_transaction_flight_data_leg = z.object({
   departure_airport_code: z.string().max(5000).nullable().optional(),
   flight_number: z.string().max(5000).nullable().optional(),
   service_class: z.string().max(5000).nullable().optional(),
-  stopover_allowed: z.coerce.boolean().nullable().optional(),
+  stopover_allowed: PermissiveBoolean.nullable().optional(),
 })
 
 export const s_issuing_transaction_fuel_data = z.object({
@@ -2333,12 +2342,12 @@ export const s_payment_flows_amount_details_resource_tip = z.object({
 export const s_payment_flows_automatic_payment_methods_payment_intent =
   z.object({
     allow_redirects: z.enum(["always", "never"]).optional(),
-    enabled: z.coerce.boolean(),
+    enabled: PermissiveBoolean,
   })
 
 export const s_payment_flows_automatic_payment_methods_setup_intent = z.object({
   allow_redirects: z.enum(["always", "never"]).optional(),
-  enabled: z.coerce.boolean().nullable().optional(),
+  enabled: PermissiveBoolean.nullable().optional(),
 })
 
 export const s_payment_flows_private_payment_methods_alipay = z.object({})
@@ -2386,7 +2395,7 @@ export const s_payment_intent_next_action_boleto = z.object({
 
 export const s_payment_intent_next_action_card_await_notification = z.object({
   charge_attempt_at: z.coerce.number().nullable().optional(),
-  customer_approval_required: z.coerce.boolean().nullable().optional(),
+  customer_approval_required: PermissiveBoolean.nullable().optional(),
 })
 
 export const s_payment_intent_next_action_cashapp_qr_code = z.object({
@@ -2529,7 +2538,7 @@ export const s_payment_intent_payment_method_options_swish = z.object({
 })
 
 export const s_payment_intent_processing_customer_notification = z.object({
-  approval_requested: z.coerce.boolean().nullable().optional(),
+  approval_requested: PermissiveBoolean.nullable().optional(),
   completes_at: z.coerce.number().nullable().optional(),
 })
 
@@ -2590,7 +2599,7 @@ export const s_payment_links_resource_payment_method_reuse_agreement = z.object(
 )
 
 export const s_payment_links_resource_phone_number_collection = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
 })
 
 export const s_payment_links_resource_shipping_address_collection = z.object({
@@ -2838,7 +2847,7 @@ export const s_payment_links_resource_shipping_address_collection = z.object({
 })
 
 export const s_payment_links_resource_tax_id_collection = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
 })
 
 export const s_payment_method_acss_debit = z.object({
@@ -2906,7 +2915,7 @@ export const s_payment_method_config_biz_payment_method_configuration_details =
   })
 
 export const s_payment_method_config_resource_display_preference = z.object({
-  overridable: z.coerce.boolean().nullable().optional(),
+  overridable: PermissiveBoolean.nullable().optional(),
   preference: z.enum(["none", "off", "on"]),
   value: z.enum(["off", "on"]),
 })
@@ -2978,7 +2987,7 @@ export const s_payment_method_details_card_installments_plan = z.object({
 })
 
 export const s_payment_method_details_card_network_token = z.object({
-  used: z.coerce.boolean(),
+  used: PermissiveBoolean,
 })
 
 export const s_payment_method_details_card_present_offline = z.object({
@@ -3374,11 +3383,9 @@ export const s_payment_method_options_card_mandate_options = z.object({
 })
 
 export const s_payment_method_options_card_present = z.object({
-  request_extended_authorization: z.coerce.boolean().nullable().optional(),
-  request_incremental_authorization_support: z.coerce
-    .boolean()
-    .nullable()
-    .optional(),
+  request_extended_authorization: PermissiveBoolean.nullable().optional(),
+  request_incremental_authorization_support:
+    PermissiveBoolean.nullable().optional(),
 })
 
 export const s_payment_method_options_cashapp = z.object({
@@ -3566,8 +3573,8 @@ export const s_payment_method_zip = z.object({})
 
 export const s_payment_pages_checkout_session_after_expiration_recovery =
   z.object({
-    allow_promotion_codes: z.coerce.boolean(),
-    enabled: z.coerce.boolean(),
+    allow_promotion_codes: PermissiveBoolean,
+    enabled: PermissiveBoolean,
     expires_at: z.coerce.number().nullable().optional(),
     url: z.string().max(5000).nullable().optional(),
   })
@@ -3614,7 +3621,7 @@ export const s_payment_pages_checkout_session_payment_method_reuse_agreement =
   z.object({ position: z.enum(["auto", "hidden"]) })
 
 export const s_payment_pages_checkout_session_phone_number_collection =
-  z.object({ enabled: z.coerce.boolean() })
+  z.object({ enabled: PermissiveBoolean })
 
 export const s_payment_pages_checkout_session_shipping_address_collection =
   z.object({
@@ -3936,7 +3943,7 @@ export const s_payment_pages_checkout_session_tax_id = z.object({
 })
 
 export const s_payment_pages_checkout_session_tax_id_collection = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
 })
 
 export const s_paypal_seller_protection = z.object({
@@ -3959,12 +3966,12 @@ export const s_person_additional_tos_acceptance = z.object({
 })
 
 export const s_person_relationship = z.object({
-  director: z.coerce.boolean().nullable().optional(),
-  executive: z.coerce.boolean().nullable().optional(),
-  legal_guardian: z.coerce.boolean().nullable().optional(),
-  owner: z.coerce.boolean().nullable().optional(),
+  director: PermissiveBoolean.nullable().optional(),
+  executive: PermissiveBoolean.nullable().optional(),
+  legal_guardian: PermissiveBoolean.nullable().optional(),
+  owner: PermissiveBoolean.nullable().optional(),
   percent_ownership: z.coerce.number().nullable().optional(),
-  representative: z.coerce.boolean().nullable().optional(),
+  representative: PermissiveBoolean.nullable().optional(),
   title: z.string().max(5000).nullable().optional(),
 })
 
@@ -3994,7 +4001,7 @@ export const s_portal_customer_update = z.object({
   allowed_updates: z.array(
     z.enum(["address", "email", "name", "phone", "shipping", "tax_id"]),
   ),
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
 })
 
 export const s_portal_flows_after_completion_hosted_confirmation = z.object({
@@ -4024,19 +4031,19 @@ export const s_portal_flows_subscription_update_confirm_item = z.object({
   quantity: z.coerce.number().optional(),
 })
 
-export const s_portal_invoice_list = z.object({ enabled: z.coerce.boolean() })
+export const s_portal_invoice_list = z.object({ enabled: PermissiveBoolean })
 
 export const s_portal_login_page = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   url: z.string().max(5000).nullable().optional(),
 })
 
 export const s_portal_payment_method_update = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
 })
 
 export const s_portal_subscription_cancellation_reason = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   options: z.array(
     z.enum([
       "customer_service",
@@ -4108,7 +4115,7 @@ export const s_radar_value_list_item = z.object({
   created: z.coerce.number(),
   created_by: z.string().max(5000),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["radar.value_list_item"]),
   value: z.string().max(5000),
   value_list: z.string().max(5000),
@@ -4147,7 +4154,7 @@ export const s_reporting_report_type = z.object({
   data_available_start: z.coerce.number(),
   default_columns: z.array(z.string().max(5000)).nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   name: z.string().max(5000),
   object: z.enum(["reporting.report_type"]),
   updated: z.coerce.number(),
@@ -4541,7 +4548,7 @@ export const s_source_type_sofort = z.object({
 export const s_source_type_three_d_secure = z.object({
   address_line1_check: z.string().nullable().optional(),
   address_zip_check: z.string().nullable().optional(),
-  authenticated: z.coerce.boolean().nullable().optional(),
+  authenticated: PermissiveBoolean.nullable().optional(),
   brand: z.string().nullable().optional(),
   card: z.string().nullable().optional(),
   country: z.string().nullable().optional(),
@@ -4566,7 +4573,7 @@ export const s_source_type_wechat = z.object({
 
 export const s_subscription_billing_thresholds = z.object({
   amount_gte: z.coerce.number().nullable().optional(),
-  reset_billing_cycle_anchor: z.coerce.boolean().nullable().optional(),
+  reset_billing_cycle_anchor: PermissiveBoolean.nullable().optional(),
 })
 
 export const s_subscription_details_data = z.object({
@@ -4808,20 +4815,20 @@ export const s_tax_product_resource_tax_transaction_shipping_cost = z.object({
 })
 
 export const s_tax_rate = z.object({
-  active: z.coerce.boolean(),
+  active: PermissiveBoolean,
   country: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   description: z.string().max(5000).nullable().optional(),
   display_name: z.string().max(5000),
   effective_percentage: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  inclusive: z.coerce.boolean(),
+  inclusive: PermissiveBoolean,
   jurisdiction: z.string().max(5000).nullable().optional(),
   jurisdiction_level: z
     .enum(["city", "country", "county", "district", "multiple", "state"])
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["tax_rate"]),
   percentage: z.coerce.number(),
@@ -4853,7 +4860,7 @@ export const s_terminal_configuration_configuration_resource_currency_specific_c
   })
 
 export const s_terminal_configuration_configuration_resource_offline_config =
-  z.object({ enabled: z.coerce.boolean().nullable().optional() })
+  z.object({ enabled: PermissiveBoolean.nullable().optional() })
 
 export const s_terminal_connection_token = z.object({
   location: z.string().max(5000).optional(),
@@ -4868,11 +4875,11 @@ export const s_terminal_reader_reader_resource_line_item = z.object({
 })
 
 export const s_terminal_reader_reader_resource_process_setup_config = z.object({
-  enable_customer_cancellation: z.coerce.boolean().optional(),
+  enable_customer_cancellation: PermissiveBoolean.optional(),
 })
 
 export const s_terminal_reader_reader_resource_refund_payment_config = z.object(
-  { enable_customer_cancellation: z.coerce.boolean().optional() },
+  { enable_customer_cancellation: PermissiveBoolean.optional() },
 )
 
 export const s_terminal_reader_reader_resource_tipping_config = z.object({
@@ -4884,7 +4891,7 @@ export const s_test_helpers_test_clock = z.object({
   deletes_after: z.coerce.number(),
   frozen_time: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   name: z.string().max(5000).nullable().optional(),
   object: z.enum(["test_helpers.test_clock"]),
   status: z.enum(["advancing", "internal_failure", "ready"]),
@@ -4936,7 +4943,7 @@ export const s_three_d_secure_details_charge = z.object({
     .nullable()
     .optional(),
   exemption_indicator: z.enum(["low_risk", "none"]).nullable().optional(),
-  exemption_indicator_applied: z.coerce.boolean().optional(),
+  exemption_indicator_applied: PermissiveBoolean.optional(),
   result: z
     .enum([
       "attempt_acknowledged",
@@ -4964,9 +4971,7 @@ export const s_three_d_secure_details_charge = z.object({
   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).nullable().optional(),
 })
 
-export const s_three_d_secure_usage = z.object({
-  supported: z.coerce.boolean(),
-})
+export const s_three_d_secure_usage = z.object({ supported: PermissiveBoolean })
 
 export const s_token_card_networks = z.object({
   preferred: z.string().max(5000).nullable().optional(),
@@ -5070,7 +5075,7 @@ export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_sta
 export const s_treasury_outbound_payments_resource_outbound_payment_resource_end_user_details =
   z.object({
     ip_address: z.string().max(5000).nullable().optional(),
-    present: z.coerce.boolean(),
+    present: PermissiveBoolean,
   })
 
 export const s_treasury_outbound_payments_resource_outbound_payment_resource_status_transitions =
@@ -5162,7 +5167,7 @@ export const s_us_bank_account_networks = z.object({
 
 export const s_usage_record = z.object({
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["usage_record"]),
   quantity: z.coerce.number(),
   subscription_item: z.string().max(5000),
@@ -5180,7 +5185,7 @@ export const s_webhook_endpoint = z.object({
   description: z.string().max(5000).nullable().optional(),
   enabled_events: z.array(z.string().max(5000)),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["webhook_endpoint"]),
   secret: z.string().max(5000).optional(),
@@ -5256,7 +5261,7 @@ export const s_account_future_requirements = z.object({
 })
 
 export const s_account_payout_settings = z.object({
-  debit_negative_balances: z.coerce.boolean(),
+  debit_negative_balances: PermissiveBoolean,
   schedule: s_transfer_schedule,
   statement_descriptor: z.string().max(5000).nullable().optional(),
 })
@@ -5281,10 +5286,10 @@ export const s_account_treasury_settings = z.object({
 
 export const s_apps_secret = z.object({
   created: z.coerce.number(),
-  deleted: z.coerce.boolean().optional(),
+  deleted: PermissiveBoolean.optional(),
   expires_at: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   name: z.string().max(5000),
   object: z.enum(["apps.secret"]),
   payload: z.string().max(5000).nullable().optional(),
@@ -5327,7 +5332,7 @@ export const s_billing_meter = z.object({
   event_name: z.string().max(5000),
   event_time_window: z.enum(["day", "hour"]).nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["billing.meter"]),
   status: z.enum(["active", "inactive"]),
   status_transitions: s_billing_meter_resource_billing_meter_status_transitions,
@@ -5338,7 +5343,7 @@ export const s_billing_meter = z.object({
 export const s_billing_meter_event_adjustment = z.object({
   cancel: s_billing_meter_resource_billing_meter_event_adjustment_cancel,
   event_name: z.string().max(100),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["billing.meter_event_adjustment"]),
   status: z.enum(["complete", "pending"]),
   type: z.enum(["cancel"]),
@@ -5347,7 +5352,7 @@ export const s_billing_meter_event_adjustment = z.object({
 export const s_cash_balance = z.object({
   available: z.record(z.coerce.number()).nullable().optional(),
   customer: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["cash_balance"]),
   settings: s_customer_balance_customer_balance_settings,
 })
@@ -5409,7 +5414,7 @@ export const s_checkout_us_bank_account_payment_method_options = z.object({
 export const s_climate_supplier = z.object({
   id: z.string().max(5000),
   info_url: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   locations: z.array(s_climate_removals_location),
   name: z.string().max(5000),
   object: z.enum(["climate.supplier"]),
@@ -5436,22 +5441,22 @@ export const s_confirmation_tokens_resource_shipping = z.object({
 })
 
 export const s_connect_embedded_account_config = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   features: s_connect_embedded_account_features,
 })
 
 export const s_connect_embedded_base_config_claim = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   features: s_connect_embedded_base_features,
 })
 
 export const s_connect_embedded_payments_config = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   features: s_connect_embedded_payments_features,
 })
 
 export const s_connect_embedded_payouts_config = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   features: s_connect_embedded_payouts_features,
 })
 
@@ -5469,7 +5474,7 @@ export const s_coupon = z.object({
   duration: z.enum(["forever", "once", "repeating"]),
   duration_in_months: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   max_redemptions: z.coerce.number().nullable().optional(),
   metadata: z.record(z.string().max(500)).nullable().optional(),
   name: z.string().max(5000).nullable().optional(),
@@ -5477,12 +5482,12 @@ export const s_coupon = z.object({
   percent_off: z.coerce.number().nullable().optional(),
   redeem_by: z.coerce.number().nullable().optional(),
   times_redeemed: z.coerce.number(),
-  valid: z.coerce.boolean(),
+  valid: PermissiveBoolean,
 })
 
 export const s_credit_note_tax_amount = z.object({
   amount: z.coerce.number(),
-  inclusive: z.coerce.boolean(),
+  inclusive: PermissiveBoolean,
   tax_rate: z.union([z.string().max(5000), s_tax_rate]),
   taxability_reason: z
     .enum([
@@ -5582,7 +5587,7 @@ export const s_event = z.object({
   created: z.coerce.number(),
   data: s_notification_event_data,
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["event"]),
   pending_webhooks: z.coerce.number(),
   request: s_notification_event_request.nullable().optional(),
@@ -5602,7 +5607,7 @@ export const s_financial_connections_account_ownership = z.object({
   object: z.enum(["financial_connections.account_ownership"]),
   owners: z.object({
     data: z.array(s_financial_connections_account_owner),
-    has_more: z.coerce.boolean(),
+    has_more: PermissiveBoolean,
     object: z.enum(["list"]),
     url: z.string().max(5000),
   }),
@@ -5614,7 +5619,7 @@ export const s_financial_connections_transaction = z.object({
   currency: z.string().max(5000),
   description: z.string().max(5000),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["financial_connections.transaction"]),
   status: z.enum(["pending", "posted", "void"]),
   status_transitions:
@@ -5765,7 +5770,7 @@ export const s_invoice_payment_method_options_us_bank_account = z.object({
 
 export const s_invoice_tax_amount = z.object({
   amount: z.coerce.number(),
-  inclusive: z.coerce.boolean(),
+  inclusive: PermissiveBoolean,
   tax_rate: z.union([z.string().max(5000), s_tax_rate]),
   taxability_reason: z
     .enum([
@@ -5810,7 +5815,7 @@ export const s_issuing_authorization_pending_request = z.object({
   amount: z.coerce.number(),
   amount_details: s_issuing_authorization_amount_details.nullable().optional(),
   currency: z.string(),
-  is_amount_controllable: z.coerce.boolean(),
+  is_amount_controllable: PermissiveBoolean,
   merchant_amount: z.coerce.number(),
   merchant_currency: z.string(),
   network_risk_score: z.coerce.number().nullable().optional(),
@@ -5819,7 +5824,7 @@ export const s_issuing_authorization_pending_request = z.object({
 export const s_issuing_authorization_request = z.object({
   amount: z.coerce.number(),
   amount_details: s_issuing_authorization_amount_details.nullable().optional(),
-  approved: z.coerce.boolean(),
+  approved: PermissiveBoolean,
   authorization_code: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   currency: z.string().max(5000),
@@ -6482,7 +6487,7 @@ export const s_issuing_card_shipping = z.object({
   eta: z.coerce.number().nullable().optional(),
   name: z.string().max(5000),
   phone_number: z.string().max(5000).nullable().optional(),
-  require_signature: z.coerce.boolean().nullable().optional(),
+  require_signature: PermissiveBoolean.nullable().optional(),
   service: z.enum(["express", "priority", "standard"]),
   status: z
     .enum([
@@ -7183,7 +7188,7 @@ export const s_issuing_network_token_wallet_provider = z.object({
 export const s_issuing_physical_bundle = z.object({
   features: s_issuing_physical_bundle_features.optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   name: z.string().max(5000),
   object: z.enum(["issuing.physical_bundle"]),
   status: z.enum(["active", "inactive", "review"]),
@@ -7193,7 +7198,7 @@ export const s_issuing_physical_bundle = z.object({
 export const s_issuing_transaction_flight_data = z.object({
   departure_at: z.coerce.number().nullable().optional(),
   passenger_name: z.string().max(5000).nullable().optional(),
-  refundable: z.coerce.boolean().nullable().optional(),
+  refundable: PermissiveBoolean.nullable().optional(),
   segments: z
     .array(s_issuing_transaction_flight_data_leg)
     .nullable()
@@ -7245,7 +7250,7 @@ export const s_payment_flows_amount_details = z.object({
 })
 
 export const s_payment_flows_installment_options = z.object({
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   plan: s_payment_method_details_card_installments_plan.optional(),
 })
 
@@ -7383,7 +7388,7 @@ export const s_payment_method_card_wallet_visa_checkout = z.object({
 
 export const s_payment_method_config_resource_payment_method_properties =
   z.object({
-    available: z.coerce.boolean(),
+    available: PermissiveBoolean,
     display_preference: s_payment_method_config_resource_display_preference,
   })
 
@@ -7403,11 +7408,11 @@ export const s_payment_method_details_card_present = z.object({
   fingerprint: z.string().max(5000).nullable().optional(),
   funding: z.string().max(5000).nullable().optional(),
   generated_card: z.string().max(5000).nullable().optional(),
-  incremental_authorization_supported: z.coerce.boolean(),
+  incremental_authorization_supported: PermissiveBoolean,
   last4: z.string().max(5000).nullable().optional(),
   network: z.string().max(5000).nullable().optional(),
   offline: s_payment_method_details_card_present_offline.nullable().optional(),
-  overcapture_supported: z.coerce.boolean(),
+  overcapture_supported: PermissiveBoolean,
   read_method: z
     .enum([
       "contact_emv",
@@ -7517,7 +7522,7 @@ export const s_payment_method_options_card_installments = z.object({
     .array(s_payment_method_details_card_installments_plan)
     .nullable()
     .optional(),
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   plan: s_payment_method_details_card_installments_plan.nullable().optional(),
 })
 
@@ -7647,7 +7652,7 @@ export const s_portal_flows_retention = z.object({
 
 export const s_portal_subscription_cancel = z.object({
   cancellation_reason: s_portal_subscription_cancellation_reason,
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   mode: z.enum(["at_period_end", "immediately"]),
   proration_behavior: z.enum(["always_invoice", "create_prorations", "none"]),
 })
@@ -7656,14 +7661,14 @@ export const s_portal_subscription_update = z.object({
   default_allowed_updates: z.array(
     z.enum(["price", "promotion_code", "quantity"]),
   ),
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   products: z.array(s_portal_subscription_update_product).nullable().optional(),
   proration_behavior: z.enum(["always_invoice", "create_prorations", "none"]),
 })
 
 export const s_promotion_codes_resource_restrictions = z.object({
   currency_options: z.record(s_promotion_code_currency_option).optional(),
-  first_time_transaction: z.coerce.boolean(),
+  first_time_transaction: PermissiveBoolean,
   minimum_amount: z.coerce.number().nullable().optional(),
   minimum_amount_currency: z.string().max(5000).nullable().optional(),
 })
@@ -7687,11 +7692,11 @@ export const s_radar_value_list = z.object({
   ]),
   list_items: z.object({
     data: z.array(s_radar_value_list_item),
-    has_more: z.coerce.boolean(),
+    has_more: PermissiveBoolean,
     object: z.enum(["list"]),
     url: z.string().max(5000),
   }),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   name: z.string().max(5000),
   object: z.enum(["radar.value_list"]),
@@ -7827,7 +7832,7 @@ export const s_source_transaction = z.object({
   currency: z.string(),
   gbp_credit_transfer: s_source_transaction_gbp_credit_transfer_data.optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["source_transaction"]),
   paper_check: s_source_transaction_paper_check_data.optional(),
   sepa_credit_transfer:
@@ -7948,7 +7953,7 @@ export const s_tax_product_resource_line_item_tax_breakdown = z.object({
 
 export const s_tax_product_resource_tax_breakdown = z.object({
   amount: z.coerce.number(),
-  inclusive: z.coerce.boolean(),
+  inclusive: PermissiveBoolean,
   tax_rate_details: s_tax_product_resource_tax_rate_details,
   taxability_reason: z.enum([
     "customer_exempt",
@@ -7985,7 +7990,7 @@ export const s_tax_transaction_line_item = z.object({
   amount: z.coerce.number(),
   amount_tax: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["tax.transaction_line_item"]),
   product: z.string().max(5000).nullable().optional(),
@@ -8023,7 +8028,7 @@ export const s_terminal_location = z.object({
   configuration_overrides: z.string().max(5000).optional(),
   display_name: z.string().max(5000),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["terminal.location"]),
 })
@@ -8036,14 +8041,14 @@ export const s_terminal_reader_reader_resource_cart = z.object({
 })
 
 export const s_terminal_reader_reader_resource_process_config = z.object({
-  enable_customer_cancellation: z.coerce.boolean().optional(),
-  skip_tipping: z.coerce.boolean().optional(),
+  enable_customer_cancellation: PermissiveBoolean.optional(),
+  skip_tipping: PermissiveBoolean.optional(),
   tipping: s_terminal_reader_reader_resource_tipping_config.optional(),
 })
 
 export const s_treasury_financial_accounts_resource_aba_toggle_settings =
   z.object({
-    requested: z.coerce.boolean(),
+    requested: PermissiveBoolean,
     status: z.enum(["active", "pending", "restricted"]),
     status_details: z.array(
       s_treasury_financial_accounts_resource_toggles_setting_status_details,
@@ -8052,7 +8057,7 @@ export const s_treasury_financial_accounts_resource_aba_toggle_settings =
 
 export const s_treasury_financial_accounts_resource_ach_toggle_settings =
   z.object({
-    requested: z.coerce.boolean(),
+    requested: PermissiveBoolean,
     status: z.enum(["active", "pending", "restricted"]),
     status_details: z.array(
       s_treasury_financial_accounts_resource_toggles_setting_status_details,
@@ -8073,7 +8078,7 @@ export const s_treasury_financial_accounts_resource_status_details = z.object({
 })
 
 export const s_treasury_financial_accounts_resource_toggle_settings = z.object({
-  requested: z.coerce.boolean(),
+  requested: PermissiveBoolean,
   status: z.enum(["active", "pending", "restricted"]),
   status_details: z.array(
     s_treasury_financial_accounts_resource_toggles_setting_status_details,
@@ -8089,7 +8094,7 @@ export const s_treasury_shared_resource_billing_details = z.object({
 export const s_usage_record_summary = z.object({
   id: z.string().max(5000),
   invoice: z.string().max(5000).nullable().optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["usage_record_summary"]),
   period: s_period,
   subscription_item: z.string().max(5000),
@@ -8117,7 +8122,7 @@ export const s_climate_product = z.object({
   current_prices_per_metric_ton: z.record(s_climate_removals_products_price),
   delivery_year: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metric_tons_available: z.string(),
   name: z.string().max(5000),
   object: z.enum(["climate.product"]),
@@ -8166,7 +8171,7 @@ export const s_forwarding_request = z.object({
   config: z.string().max(5000),
   created: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["forwarding.request"]),
   payment_method: z.string().max(5000),
   replacements: z.array(
@@ -8193,7 +8198,7 @@ export const s_identity_verification_report = z.object({
   email: s_gelato_email_report.optional(),
   id: z.string().max(5000),
   id_number: s_gelato_id_number_report.optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["identity.verification_report"]),
   options: s_gelato_verification_report_options.optional(),
   phone: s_gelato_phone_report.optional(),
@@ -8283,7 +8288,7 @@ export const s_payment_intent_payment_method_options_card = z.object({
     .enum(["any", "automatic", "challenge"])
     .nullable()
     .optional(),
-  require_cvc_recollection: z.coerce.boolean().optional(),
+  require_cvc_recollection: PermissiveBoolean.optional(),
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
   statement_descriptor_suffix_kana: z.string().max(5000).optional(),
   statement_descriptor_suffix_kanji: z.string().max(5000).optional(),
@@ -8298,7 +8303,7 @@ export const s_payment_intent_type_specific_payment_method_options_client =
   z.object({
     capture_method: z.enum(["manual", "manual_preferred"]).optional(),
     installments: s_payment_flows_installment_options.optional(),
-    require_cvc_recollection: z.coerce.boolean().optional(),
+    require_cvc_recollection: PermissiveBoolean.optional(),
     setup_future_usage: z
       .enum(["none", "off_session", "on_session"])
       .optional(),
@@ -8312,7 +8317,7 @@ export const s_payment_links_resource_custom_fields = z.object({
   key: z.string().max(5000),
   label: s_payment_links_resource_custom_fields_label,
   numeric: s_payment_links_resource_custom_fields_numeric.optional(),
-  optional: z.coerce.boolean(),
+  optional: PermissiveBoolean,
   text: s_payment_links_resource_custom_fields_text.optional(),
   type: z.enum(["dropdown", "numeric", "text"]),
 })
@@ -8341,7 +8346,7 @@ export const s_payment_method_card_wallet = z.object({
 export const s_payment_method_configuration = z.object({
   acss_debit:
     s_payment_method_config_resource_payment_method_properties.optional(),
-  active: z.coerce.boolean(),
+  active: PermissiveBoolean,
   affirm: s_payment_method_config_resource_payment_method_properties.optional(),
   afterpay_clearpay:
     s_payment_method_config_resource_payment_method_properties.optional(),
@@ -8374,13 +8379,13 @@ export const s_payment_method_configuration = z.object({
     s_payment_method_config_resource_payment_method_properties.optional(),
   id: z.string().max(5000),
   ideal: s_payment_method_config_resource_payment_method_properties.optional(),
-  is_default: z.coerce.boolean(),
+  is_default: PermissiveBoolean,
   jcb: s_payment_method_config_resource_payment_method_properties.optional(),
   klarna: s_payment_method_config_resource_payment_method_properties.optional(),
   konbini:
     s_payment_method_config_resource_payment_method_properties.optional(),
   link: s_payment_method_config_resource_payment_method_properties.optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   name: z.string().max(5000),
   object: z.enum(["payment_method_configuration"]),
   oxxo: s_payment_method_config_resource_payment_method_properties.optional(),
@@ -8427,11 +8432,11 @@ export const s_payment_method_domain = z.object({
   apple_pay: s_payment_method_domain_resource_payment_method_status,
   created: z.coerce.number(),
   domain_name: z.string().max(5000),
-  enabled: z.coerce.boolean(),
+  enabled: PermissiveBoolean,
   google_pay: s_payment_method_domain_resource_payment_method_status,
   id: z.string().max(5000),
   link: s_payment_method_domain_resource_payment_method_status,
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["payment_method_domain"]),
   paypal: s_payment_method_domain_resource_payment_method_status,
 })
@@ -8462,7 +8467,7 @@ export const s_payment_pages_checkout_session_custom_fields = z.object({
   key: z.string().max(5000),
   label: s_payment_pages_checkout_session_custom_fields_label,
   numeric: s_payment_pages_checkout_session_custom_fields_numeric.optional(),
-  optional: z.coerce.boolean(),
+  optional: PermissiveBoolean,
   text: s_payment_pages_checkout_session_custom_fields_text.optional(),
   type: z.enum(["dropdown", "numeric", "text"]),
 })
@@ -8554,13 +8559,13 @@ export const s_setup_intent_payment_method_options = z.object({
 })
 
 export const s_shipping_rate = z.object({
-  active: z.coerce.boolean(),
+  active: PermissiveBoolean,
   created: z.coerce.number(),
   delivery_estimate: s_shipping_rate_delivery_estimate.nullable().optional(),
   display_name: z.string().max(5000).nullable().optional(),
   fixed_amount: s_shipping_rate_fixed_amount.optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["shipping_rate"]),
   tax_behavior: z
@@ -8586,7 +8591,7 @@ export const s_tax_calculation_line_item = z.object({
   amount: z.coerce.number(),
   amount_tax: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["tax.calculation_line_item"]),
   product: z.string().max(5000).nullable().optional(),
   quantity: z.coerce.number(),
@@ -8667,7 +8672,7 @@ export const s_tax_settings = z.object({
   head_office: s_tax_product_resource_tax_settings_head_office
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["tax.settings"]),
   status: z.enum(["active", "pending"]),
   status_details: s_tax_product_resource_tax_settings_status_details,
@@ -8682,7 +8687,7 @@ export const s_tax_transaction = z.object({
   line_items: z
     .object({
       data: z.array(s_tax_transaction_line_item),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z
         .string()
@@ -8691,7 +8696,7 @@ export const s_tax_transaction = z.object({
     })
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["tax.transaction"]),
   reference: z.string().max(5000),
@@ -8758,7 +8763,7 @@ export const s_account_session = z.object({
   client_secret: z.string().max(5000),
   components: s_connect_embedded_account_session_create_components,
   expires_at: z.coerce.number(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["account_session"]),
 })
 
@@ -8767,13 +8772,13 @@ export const s_balance = z.object({
   connect_reserved: z.array(s_balance_amount).optional(),
   instant_available: z.array(s_balance_amount_net).optional(),
   issuing: s_balance_detail.optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["balance"]),
   pending: z.array(s_balance_amount),
 })
 
 export const s_billing_portal_configuration = z.object({
-  active: z.coerce.boolean(),
+  active: PermissiveBoolean,
   application: z
     .union([z.string().max(5000), s_application, s_deleted_application])
     .nullable()
@@ -8783,8 +8788,8 @@ export const s_billing_portal_configuration = z.object({
   default_return_url: z.string().max(5000).nullable().optional(),
   features: s_portal_features,
   id: z.string().max(5000),
-  is_default: z.coerce.boolean(),
-  livemode: z.coerce.boolean(),
+  is_default: PermissiveBoolean,
+  livemode: PermissiveBoolean,
   login_page: s_portal_login_page,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["billing_portal.configuration"]),
@@ -8844,7 +8849,7 @@ export const s_climate_order = z.object({
   delivery_details: z.array(s_climate_removals_order_deliveries),
   expected_delivery_year: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   metric_tons: z.string(),
   object: z.enum(["climate.order"]),
@@ -8863,7 +8868,7 @@ export const s_funding_instructions = z.object({
   bank_transfer: s_funding_instructions_bank_transfer,
   currency: z.string().max(5000),
   funding_type: z.enum(["bank_transfer"]),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["funding_instructions"]),
 })
 
@@ -8877,7 +8882,7 @@ export const s_identity_verification_session = z.object({
     .union([z.string().max(5000), s_identity_verification_report])
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["identity.verification_session"]),
   options: s_gelato_verification_session_options.nullable().optional(),
@@ -9260,7 +9265,7 @@ export const s_source = z.object({
   id: z.string().max(5000),
   ideal: s_source_type_ideal.optional(),
   klarna: s_source_type_klarna.optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   multibanco: s_source_type_multibanco.optional(),
   object: z.enum(["source"]),
@@ -9322,7 +9327,7 @@ export const s_tax_calculation = z.object({
   line_items: z
     .object({
       data: z.array(s_tax_calculation_line_item),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z
         .string()
@@ -9331,7 +9336,7 @@ export const s_tax_calculation = z.object({
     })
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["tax.calculation"]),
   shipping_cost: s_tax_product_resource_tax_calculation_shipping_cost
     .nullable()
@@ -9349,7 +9354,7 @@ export const s_tax_registration = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["tax.registration"]),
   status: z.enum(["active", "expired", "scheduled"]),
 })
@@ -9381,7 +9386,7 @@ export const s_billing_portal_session = z.object({
   customer: z.string().max(5000),
   flow: s_portal_flows_flow.nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   locale: z
     .enum([
       "auto",
@@ -9485,7 +9490,7 @@ export const s_source_mandate_notification = z.object({
   bacs_debit: s_source_mandate_notification_bacs_debit_data.optional(),
   created: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["source_mandate_notification"]),
   reason: z.string().max(5000),
   sepa_debit: s_source_mandate_notification_sepa_debit_data.optional(),
@@ -9561,7 +9566,7 @@ export const s_treasury_financial_account = z.object({
     s_treasury_financial_accounts_resource_financial_address,
   ),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["treasury.financial_account"]),
   pending_features: z
@@ -9605,27 +9610,27 @@ export const s_treasury_financial_account = z.object({
   supported_currencies: z.array(z.string()),
 })
 
-export const s_account: z.ZodType<t_account> = z.object({
+export const s_account: z.ZodType<t_account, z.ZodTypeDef, unknown> = z.object({
   business_profile: s_account_business_profile.nullable().optional(),
   business_type: z
     .enum(["company", "government_entity", "individual", "non_profit"])
     .nullable()
     .optional(),
   capabilities: s_account_capabilities.optional(),
-  charges_enabled: z.coerce.boolean().optional(),
+  charges_enabled: PermissiveBoolean.optional(),
   company: z.lazy(() => s_legal_entity_company.optional()),
   controller: s_account_unification_account_controller.optional(),
   country: z.string().max(5000).optional(),
   created: z.coerce.number().optional(),
   default_currency: z.string().max(5000).optional(),
-  details_submitted: z.coerce.boolean().optional(),
+  details_submitted: PermissiveBoolean.optional(),
   email: z.string().max(5000).nullable().optional(),
   external_accounts: z
     .object({
       data: z.array(
         z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)]),
       ),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z.string().max(5000),
     })
@@ -9635,65 +9640,78 @@ export const s_account: z.ZodType<t_account> = z.object({
   individual: z.lazy(() => s_person.optional()),
   metadata: z.record(z.string().max(500)).optional(),
   object: z.enum(["account"]),
-  payouts_enabled: z.coerce.boolean().optional(),
+  payouts_enabled: PermissiveBoolean.optional(),
   requirements: s_account_requirements.optional(),
   settings: z.lazy(() => s_account_settings.nullable().optional()),
   tos_acceptance: s_account_tos_acceptance.optional(),
   type: z.enum(["custom", "express", "standard"]).optional(),
 })
 
-export const s_error: z.ZodType<t_error> = z.object({
+export const s_error: z.ZodType<t_error, z.ZodTypeDef, unknown> = z.object({
   error: z.lazy(() => s_api_errors),
 })
 
-export const s_external_account: z.ZodType<t_external_account> = z.union([
-  z.lazy(() => s_bank_account),
-  z.lazy(() => s_card),
-])
+export const s_external_account: z.ZodType<
+  t_external_account,
+  z.ZodTypeDef,
+  unknown
+> = z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card)])
 
-export const s_capability: z.ZodType<t_capability> = z.object({
-  account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-  future_requirements: s_account_capability_future_requirements.optional(),
-  id: z.string().max(5000),
-  object: z.enum(["capability"]),
-  requested: z.coerce.boolean(),
-  requested_at: z.coerce.number().nullable().optional(),
-  requirements: s_account_capability_requirements.optional(),
-  status: z.enum(["active", "disabled", "inactive", "pending", "unrequested"]),
-})
+export const s_capability: z.ZodType<t_capability, z.ZodTypeDef, unknown> =
+  z.object({
+    account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+    future_requirements: s_account_capability_future_requirements.optional(),
+    id: z.string().max(5000),
+    object: z.enum(["capability"]),
+    requested: PermissiveBoolean,
+    requested_at: z.coerce.number().nullable().optional(),
+    requirements: s_account_capability_requirements.optional(),
+    status: z.enum([
+      "active",
+      "disabled",
+      "inactive",
+      "pending",
+      "unrequested",
+    ]),
+  })
 
-export const s_bank_account: z.ZodType<t_bank_account> = z.object({
-  account: z
-    .union([z.string().max(5000), z.lazy(() => s_account)])
-    .nullable()
-    .optional(),
-  account_holder_name: z.string().max(5000).nullable().optional(),
-  account_holder_type: z.string().max(5000).nullable().optional(),
-  account_type: z.string().max(5000).nullable().optional(),
-  available_payout_methods: z
-    .array(z.enum(["instant", "standard"]))
-    .nullable()
-    .optional(),
-  bank_name: z.string().max(5000).nullable().optional(),
-  country: z.string().max(5000),
-  currency: z.string(),
-  customer: z
-    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
-    .nullable()
-    .optional(),
-  default_for_currency: z.coerce.boolean().nullable().optional(),
-  fingerprint: z.string().max(5000).nullable().optional(),
-  future_requirements: s_external_account_requirements.nullable().optional(),
-  id: z.string().max(5000),
-  last4: z.string().max(5000),
-  metadata: z.record(z.string().max(500)).nullable().optional(),
-  object: z.enum(["bank_account"]),
-  requirements: s_external_account_requirements.nullable().optional(),
-  routing_number: z.string().max(5000).nullable().optional(),
-  status: z.string().max(5000),
-})
+export const s_bank_account: z.ZodType<t_bank_account, z.ZodTypeDef, unknown> =
+  z.object({
+    account: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .nullable()
+      .optional(),
+    account_holder_name: z.string().max(5000).nullable().optional(),
+    account_holder_type: z.string().max(5000).nullable().optional(),
+    account_type: z.string().max(5000).nullable().optional(),
+    available_payout_methods: z
+      .array(z.enum(["instant", "standard"]))
+      .nullable()
+      .optional(),
+    bank_name: z.string().max(5000).nullable().optional(),
+    country: z.string().max(5000),
+    currency: z.string(),
+    customer: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_customer),
+        s_deleted_customer,
+      ])
+      .nullable()
+      .optional(),
+    default_for_currency: PermissiveBoolean.nullable().optional(),
+    fingerprint: z.string().max(5000).nullable().optional(),
+    future_requirements: s_external_account_requirements.nullable().optional(),
+    id: z.string().max(5000),
+    last4: z.string().max(5000),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
+    object: z.enum(["bank_account"]),
+    requirements: s_external_account_requirements.nullable().optional(),
+    routing_number: z.string().max(5000).nullable().optional(),
+    status: z.string().max(5000),
+  })
 
-export const s_card: z.ZodType<t_card> = z.object({
+export const s_card: z.ZodType<t_card, z.ZodTypeDef, unknown> = z.object({
   account: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
@@ -9718,7 +9736,7 @@ export const s_card: z.ZodType<t_card> = z.object({
     .nullable()
     .optional(),
   cvc_check: z.string().max(5000).nullable().optional(),
-  default_for_currency: z.coerce.boolean().nullable().optional(),
+  default_for_currency: PermissiveBoolean.nullable().optional(),
   dynamic_last4: z.string().max(5000).nullable().optional(),
   exp_month: z.coerce.number(),
   exp_year: z.coerce.number(),
@@ -9734,7 +9752,7 @@ export const s_card: z.ZodType<t_card> = z.object({
   tokenization_method: z.string().max(5000).nullable().optional(),
 })
 
-export const s_person: z.ZodType<t_person> = z.object({
+export const s_person: z.ZodType<t_person, z.ZodTypeDef, unknown> = z.object({
   account: z.string().max(5000),
   additional_tos_acceptances: s_person_additional_tos_acceptances.optional(),
   address: s_address.optional(),
@@ -9750,8 +9768,8 @@ export const s_person: z.ZodType<t_person> = z.object({
   future_requirements: s_person_future_requirements.nullable().optional(),
   gender: z.string().nullable().optional(),
   id: z.string().max(5000),
-  id_number_provided: z.coerce.boolean().optional(),
-  id_number_secondary_provided: z.coerce.boolean().optional(),
+  id_number_provided: PermissiveBoolean.optional(),
+  id_number_secondary_provided: PermissiveBoolean.optional(),
   last_name: z.string().max(5000).nullable().optional(),
   last_name_kana: z.string().max(5000).nullable().optional(),
   last_name_kanji: z.string().max(5000).nullable().optional(),
@@ -9764,11 +9782,15 @@ export const s_person: z.ZodType<t_person> = z.object({
   registered_address: s_address.optional(),
   relationship: s_person_relationship.optional(),
   requirements: s_person_requirements.nullable().optional(),
-  ssn_last_4_provided: z.coerce.boolean().optional(),
+  ssn_last_4_provided: PermissiveBoolean.optional(),
   verification: z.lazy(() => s_legal_entity_person_verification.optional()),
 })
 
-export const s_application_fee: z.ZodType<t_application_fee> = z.object({
+export const s_application_fee: z.ZodType<
+  t_application_fee,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   account: z.union([z.string().max(5000), z.lazy(() => s_account)]),
   amount: z.coerce.number(),
   amount_refunded: z.coerce.number(),
@@ -9781,119 +9803,122 @@ export const s_application_fee: z.ZodType<t_application_fee> = z.object({
   created: z.coerce.number(),
   currency: z.string(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["application_fee"]),
   originating_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
-  refunded: z.coerce.boolean(),
+  refunded: PermissiveBoolean,
   refunds: z.object({
     data: z.array(z.lazy(() => s_fee_refund)),
-    has_more: z.coerce.boolean(),
+    has_more: PermissiveBoolean,
     object: z.enum(["list"]),
     url: z.string().max(5000),
   }),
 })
 
-export const s_fee_refund: z.ZodType<t_fee_refund> = z.object({
-  amount: z.coerce.number(),
-  balance_transaction: z
-    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
-    .nullable()
-    .optional(),
-  created: z.coerce.number(),
-  currency: z.string(),
-  fee: z.union([z.string().max(5000), z.lazy(() => s_application_fee)]),
-  id: z.string().max(5000),
-  metadata: z.record(z.string().max(500)).nullable().optional(),
-  object: z.enum(["fee_refund"]),
-})
-
-export const s_balance_transaction: z.ZodType<t_balance_transaction> = z.object(
-  {
+export const s_fee_refund: z.ZodType<t_fee_refund, z.ZodTypeDef, unknown> =
+  z.object({
     amount: z.coerce.number(),
-    available_on: z.coerce.number(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    description: z.string().max(5000).nullable().optional(),
-    exchange_rate: z.coerce.number().nullable().optional(),
-    fee: z.coerce.number(),
-    fee_details: z.array(s_fee),
-    id: z.string().max(5000),
-    net: z.coerce.number(),
-    object: z.enum(["balance_transaction"]),
-    reporting_category: z.string().max(5000),
-    source: z
-      .union([
-        z.string().max(5000),
-        z.lazy(() => s_application_fee),
-        z.lazy(() => s_charge),
-        z.lazy(() => s_connect_collection_transfer),
-        z.lazy(() => s_customer_cash_balance_transaction),
-        z.lazy(() => s_dispute),
-        z.lazy(() => s_fee_refund),
-        z.lazy(() => s_issuing_authorization),
-        z.lazy(() => s_issuing_dispute),
-        z.lazy(() => s_issuing_transaction),
-        z.lazy(() => s_payout),
-        s_platform_tax_fee,
-        z.lazy(() => s_refund),
-        s_reserve_transaction,
-        s_tax_deducted_at_source,
-        z.lazy(() => s_topup),
-        z.lazy(() => s_transfer),
-        z.lazy(() => s_transfer_reversal),
-      ])
+    balance_transaction: z
+      .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
       .nullable()
       .optional(),
-    status: z.string().max(5000),
-    type: z.enum([
-      "adjustment",
-      "advance",
-      "advance_funding",
-      "anticipation_repayment",
-      "application_fee",
-      "application_fee_refund",
-      "charge",
-      "climate_order_purchase",
-      "climate_order_refund",
-      "connect_collection_transfer",
-      "contribution",
-      "issuing_authorization_hold",
-      "issuing_authorization_release",
-      "issuing_dispute",
-      "issuing_transaction",
-      "obligation_outbound",
-      "obligation_reversal_inbound",
-      "payment",
-      "payment_failure_refund",
-      "payment_network_reserve_hold",
-      "payment_network_reserve_release",
-      "payment_refund",
-      "payment_reversal",
-      "payment_unreconciled",
-      "payout",
-      "payout_cancel",
-      "payout_failure",
-      "refund",
-      "refund_failure",
-      "reserve_transaction",
-      "reserved_funds",
-      "stripe_fee",
-      "stripe_fx_fee",
-      "tax_fee",
-      "topup",
-      "topup_reversal",
-      "transfer",
-      "transfer_cancel",
-      "transfer_failure",
-      "transfer_refund",
-    ]),
-  },
-)
+    created: z.coerce.number(),
+    currency: z.string(),
+    fee: z.union([z.string().max(5000), z.lazy(() => s_application_fee)]),
+    id: z.string().max(5000),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
+    object: z.enum(["fee_refund"]),
+  })
 
-export const s_charge: z.ZodType<t_charge> = z.object({
+export const s_balance_transaction: z.ZodType<
+  t_balance_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  available_on: z.coerce.number(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  exchange_rate: z.coerce.number().nullable().optional(),
+  fee: z.coerce.number(),
+  fee_details: z.array(s_fee),
+  id: z.string().max(5000),
+  net: z.coerce.number(),
+  object: z.enum(["balance_transaction"]),
+  reporting_category: z.string().max(5000),
+  source: z
+    .union([
+      z.string().max(5000),
+      z.lazy(() => s_application_fee),
+      z.lazy(() => s_charge),
+      z.lazy(() => s_connect_collection_transfer),
+      z.lazy(() => s_customer_cash_balance_transaction),
+      z.lazy(() => s_dispute),
+      z.lazy(() => s_fee_refund),
+      z.lazy(() => s_issuing_authorization),
+      z.lazy(() => s_issuing_dispute),
+      z.lazy(() => s_issuing_transaction),
+      z.lazy(() => s_payout),
+      s_platform_tax_fee,
+      z.lazy(() => s_refund),
+      s_reserve_transaction,
+      s_tax_deducted_at_source,
+      z.lazy(() => s_topup),
+      z.lazy(() => s_transfer),
+      z.lazy(() => s_transfer_reversal),
+    ])
+    .nullable()
+    .optional(),
+  status: z.string().max(5000),
+  type: z.enum([
+    "adjustment",
+    "advance",
+    "advance_funding",
+    "anticipation_repayment",
+    "application_fee",
+    "application_fee_refund",
+    "charge",
+    "climate_order_purchase",
+    "climate_order_refund",
+    "connect_collection_transfer",
+    "contribution",
+    "issuing_authorization_hold",
+    "issuing_authorization_release",
+    "issuing_dispute",
+    "issuing_transaction",
+    "obligation_outbound",
+    "obligation_reversal_inbound",
+    "payment",
+    "payment_failure_refund",
+    "payment_network_reserve_hold",
+    "payment_network_reserve_release",
+    "payment_refund",
+    "payment_reversal",
+    "payment_unreconciled",
+    "payout",
+    "payout_cancel",
+    "payout_failure",
+    "refund",
+    "refund_failure",
+    "reserve_transaction",
+    "reserved_funds",
+    "stripe_fee",
+    "stripe_fx_fee",
+    "tax_fee",
+    "topup",
+    "topup_reversal",
+    "transfer",
+    "transfer_cancel",
+    "transfer_failure",
+    "transfer_refund",
+  ]),
+})
+
+export const s_charge: z.ZodType<t_charge, z.ZodTypeDef, unknown> = z.object({
   amount: z.coerce.number(),
   amount_captured: z.coerce.number(),
   amount_refunded: z.coerce.number(),
@@ -9912,7 +9937,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
     .optional(),
   billing_details: s_billing_details,
   calculated_statement_descriptor: z.string().max(5000).nullable().optional(),
-  captured: z.coerce.boolean(),
+  captured: PermissiveBoolean,
   created: z.coerce.number(),
   currency: z.string(),
   customer: z
@@ -9920,7 +9945,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
     .nullable()
     .optional(),
   description: z.string().max(40000).nullable().optional(),
-  disputed: z.coerce.boolean(),
+  disputed: PermissiveBoolean,
   failure_balance_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
@@ -9933,7 +9958,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
     .union([z.string().max(5000), z.lazy(() => s_invoice)])
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["charge"]),
   on_behalf_of: z
@@ -9941,7 +9966,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
     .nullable()
     .optional(),
   outcome: s_charge_outcome.nullable().optional(),
-  paid: z.coerce.boolean(),
+  paid: PermissiveBoolean,
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
@@ -9954,11 +9979,11 @@ export const s_charge: z.ZodType<t_charge> = z.object({
   receipt_email: z.string().max(5000).nullable().optional(),
   receipt_number: z.string().max(5000).nullable().optional(),
   receipt_url: z.string().max(5000).nullable().optional(),
-  refunded: z.coerce.boolean(),
+  refunded: PermissiveBoolean,
   refunds: z
     .object({
       data: z.array(z.lazy(() => s_refund)),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z.string().max(5000),
     })
@@ -9983,7 +10008,7 @@ export const s_charge: z.ZodType<t_charge> = z.object({
   transfer_group: z.string().max(5000).nullable().optional(),
 })
 
-export const s_dispute: z.ZodType<t_dispute> = z.object({
+export const s_dispute: z.ZodType<t_dispute, z.ZodTypeDef, unknown> = z.object({
   amount: z.coerce.number(),
   balance_transactions: z.array(z.lazy(() => s_balance_transaction)),
   charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]),
@@ -9992,8 +10017,8 @@ export const s_dispute: z.ZodType<t_dispute> = z.object({
   evidence: z.lazy(() => s_dispute_evidence),
   evidence_details: s_dispute_evidence_details,
   id: z.string().max(5000),
-  is_charge_refundable: z.coerce.boolean(),
-  livemode: z.coerce.boolean(),
+  is_charge_refundable: PermissiveBoolean,
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["dispute"]),
   payment_intent: z
@@ -10013,7 +10038,7 @@ export const s_dispute: z.ZodType<t_dispute> = z.object({
   ]),
 })
 
-export const s_refund: z.ZodType<t_refund> = z.object({
+export const s_refund: z.ZodType<t_refund, z.ZodTypeDef, unknown> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
@@ -10061,11 +10086,15 @@ export const s_refund: z.ZodType<t_refund> = z.object({
     .optional(),
 })
 
-export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
+export const s_checkout_session: z.ZodType<
+  t_checkout_session,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   after_expiration: s_payment_pages_checkout_session_after_expiration
     .nullable()
     .optional(),
-  allow_promotion_codes: z.coerce.boolean().nullable().optional(),
+  allow_promotion_codes: PermissiveBoolean.nullable().optional(),
   amount_subtotal: z.coerce.number().nullable().optional(),
   amount_total: z.coerce.number().nullable().optional(),
   automatic_tax: z.lazy(() => s_payment_pages_checkout_session_automatic_tax),
@@ -10108,12 +10137,12 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
   line_items: z
     .object({
       data: z.array(z.lazy(() => s_item)),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z.string().max(5000),
     })
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   locale: z
     .enum([
       "auto",
@@ -10218,7 +10247,7 @@ export const s_checkout_session: z.ZodType<t_checkout_session> = z.object({
   url: z.string().max(5000).nullable().optional(),
 })
 
-export const s_item: z.ZodType<t_item> = z.object({
+export const s_item: z.ZodType<t_item, z.ZodTypeDef, unknown> = z.object({
   amount_discount: z.coerce.number(),
   amount_subtotal: z.coerce.number(),
   amount_tax: z.coerce.number(),
@@ -10233,11 +10262,15 @@ export const s_item: z.ZodType<t_item> = z.object({
   taxes: z.array(s_line_items_tax_amount).optional(),
 })
 
-export const s_confirmation_token: z.ZodType<t_confirmation_token> = z.object({
+export const s_confirmation_token: z.ZodType<
+  t_confirmation_token,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   mandate_data: s_confirmation_tokens_resource_mandate_data
     .nullable()
     .optional(),
@@ -10253,281 +10286,327 @@ export const s_confirmation_token: z.ZodType<t_confirmation_token> = z.object({
     .optional(),
   setup_intent: z.string().max(5000).nullable().optional(),
   shipping: s_confirmation_tokens_resource_shipping.nullable().optional(),
-  use_stripe_sdk: z.coerce.boolean(),
+  use_stripe_sdk: PermissiveBoolean,
 })
 
-export const s_credit_note: z.ZodType<t_credit_note> = z.object({
-  amount: z.coerce.number(),
-  amount_shipping: z.coerce.number(),
-  created: z.coerce.number(),
-  currency: z.string(),
-  customer: z.union([
-    z.string().max(5000),
-    z.lazy(() => s_customer),
-    s_deleted_customer,
-  ]),
-  customer_balance_transaction: z
-    .union([z.string().max(5000), z.lazy(() => s_customer_balance_transaction)])
-    .nullable()
-    .optional(),
-  discount_amount: z.coerce.number(),
-  discount_amounts: z.array(z.lazy(() => s_discounts_resource_discount_amount)),
-  effective_at: z.coerce.number().nullable().optional(),
-  id: z.string().max(5000),
-  invoice: z.union([z.string().max(5000), z.lazy(() => s_invoice)]),
-  lines: z.object({
-    data: z.array(z.lazy(() => s_credit_note_line_item)),
-    has_more: z.coerce.boolean(),
-    object: z.enum(["list"]),
-    url: z.string().max(5000),
-  }),
-  livemode: z.coerce.boolean(),
-  memo: z.string().max(5000).nullable().optional(),
-  metadata: z.record(z.string().max(500)).nullable().optional(),
-  number: z.string().max(5000),
-  object: z.enum(["credit_note"]),
-  out_of_band_amount: z.coerce.number().nullable().optional(),
-  pdf: z.string().max(5000),
-  reason: z
-    .enum(["duplicate", "fraudulent", "order_change", "product_unsatisfactory"])
-    .nullable()
-    .optional(),
-  refund: z
-    .union([z.string().max(5000), z.lazy(() => s_refund)])
-    .nullable()
-    .optional(),
-  shipping_cost: s_invoices_resource_shipping_cost.nullable().optional(),
-  status: z.enum(["issued", "void"]),
-  subtotal: z.coerce.number(),
-  subtotal_excluding_tax: z.coerce.number().nullable().optional(),
-  tax_amounts: z.array(s_credit_note_tax_amount),
-  total: z.coerce.number(),
-  total_excluding_tax: z.coerce.number().nullable().optional(),
-  type: z.enum(["post_payment", "pre_payment"]),
-  voided_at: z.coerce.number().nullable().optional(),
-})
-
-export const s_credit_note_line_item: z.ZodType<t_credit_note_line_item> =
+export const s_credit_note: z.ZodType<t_credit_note, z.ZodTypeDef, unknown> =
   z.object({
     amount: z.coerce.number(),
-    amount_excluding_tax: z.coerce.number().nullable().optional(),
-    description: z.string().max(5000).nullable().optional(),
+    amount_shipping: z.coerce.number(),
+    created: z.coerce.number(),
+    currency: z.string(),
+    customer: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_customer),
+      s_deleted_customer,
+    ]),
+    customer_balance_transaction: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_customer_balance_transaction),
+      ])
+      .nullable()
+      .optional(),
     discount_amount: z.coerce.number(),
     discount_amounts: z.array(
       z.lazy(() => s_discounts_resource_discount_amount),
     ),
+    effective_at: z.coerce.number().nullable().optional(),
     id: z.string().max(5000),
-    invoice_line_item: z.string().max(5000).optional(),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["credit_note_line_item"]),
-    quantity: z.coerce.number().nullable().optional(),
+    invoice: z.union([z.string().max(5000), z.lazy(() => s_invoice)]),
+    lines: z.object({
+      data: z.array(z.lazy(() => s_credit_note_line_item)),
+      has_more: PermissiveBoolean,
+      object: z.enum(["list"]),
+      url: z.string().max(5000),
+    }),
+    livemode: PermissiveBoolean,
+    memo: z.string().max(5000).nullable().optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
+    number: z.string().max(5000),
+    object: z.enum(["credit_note"]),
+    out_of_band_amount: z.coerce.number().nullable().optional(),
+    pdf: z.string().max(5000),
+    reason: z
+      .enum([
+        "duplicate",
+        "fraudulent",
+        "order_change",
+        "product_unsatisfactory",
+      ])
+      .nullable()
+      .optional(),
+    refund: z
+      .union([z.string().max(5000), z.lazy(() => s_refund)])
+      .nullable()
+      .optional(),
+    shipping_cost: s_invoices_resource_shipping_cost.nullable().optional(),
+    status: z.enum(["issued", "void"]),
+    subtotal: z.coerce.number(),
+    subtotal_excluding_tax: z.coerce.number().nullable().optional(),
     tax_amounts: z.array(s_credit_note_tax_amount),
-    tax_rates: z.array(s_tax_rate),
-    type: z.enum(["custom_line_item", "invoice_line_item"]),
-    unit_amount: z.coerce.number().nullable().optional(),
-    unit_amount_decimal: z.string().nullable().optional(),
-    unit_amount_excluding_tax: z.string().nullable().optional(),
+    total: z.coerce.number(),
+    total_excluding_tax: z.coerce.number().nullable().optional(),
+    type: z.enum(["post_payment", "pre_payment"]),
+    voided_at: z.coerce.number().nullable().optional(),
   })
 
-export const s_customer_session: z.ZodType<t_customer_session> = z.object({
+export const s_credit_note_line_item: z.ZodType<
+  t_credit_note_line_item,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  amount_excluding_tax: z.coerce.number().nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  discount_amount: z.coerce.number(),
+  discount_amounts: z.array(z.lazy(() => s_discounts_resource_discount_amount)),
+  id: z.string().max(5000),
+  invoice_line_item: z.string().max(5000).optional(),
+  livemode: PermissiveBoolean,
+  object: z.enum(["credit_note_line_item"]),
+  quantity: z.coerce.number().nullable().optional(),
+  tax_amounts: z.array(s_credit_note_tax_amount),
+  tax_rates: z.array(s_tax_rate),
+  type: z.enum(["custom_line_item", "invoice_line_item"]),
+  unit_amount: z.coerce.number().nullable().optional(),
+  unit_amount_decimal: z.string().nullable().optional(),
+  unit_amount_excluding_tax: z.string().nullable().optional(),
+})
+
+export const s_customer_session: z.ZodType<
+  t_customer_session,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   client_secret: z.string().max(5000),
   components: s_customer_session_resource_components.optional(),
   created: z.coerce.number(),
   customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
   expires_at: z.coerce.number(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["customer_session"]),
 })
 
-export const s_customer: z.ZodType<t_customer> = z.object({
-  address: s_address.nullable().optional(),
-  balance: z.coerce.number().optional(),
-  cash_balance: s_cash_balance.nullable().optional(),
-  created: z.coerce.number(),
-  currency: z.string().max(5000).nullable().optional(),
-  default_source: z
-    .union([
-      z.string().max(5000),
-      z.lazy(() => s_bank_account),
-      z.lazy(() => s_card),
-      s_source,
-    ])
-    .nullable()
-    .optional(),
-  delinquent: z.coerce.boolean().nullable().optional(),
-  description: z.string().max(5000).nullable().optional(),
-  discount: z.lazy(() => s_discount.nullable().optional()),
-  email: z.string().max(5000).nullable().optional(),
-  id: z.string().max(5000),
-  invoice_credit_balance: z.record(z.coerce.number()).optional(),
-  invoice_prefix: z.string().max(5000).nullable().optional(),
-  invoice_settings: z.lazy(() => s_invoice_setting_customer_setting.optional()),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)).optional(),
-  name: z.string().max(5000).nullable().optional(),
-  next_invoice_sequence: z.coerce.number().optional(),
-  object: z.enum(["customer"]),
-  phone: z.string().max(5000).nullable().optional(),
-  preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
-  shipping: s_shipping.nullable().optional(),
-  sources: z
-    .object({
-      data: z.array(
-        z.union([z.lazy(() => s_bank_account), z.lazy(() => s_card), s_source]),
-      ),
-      has_more: z.coerce.boolean(),
-      object: z.enum(["list"]),
-      url: z.string().max(5000),
-    })
-    .optional(),
-  subscriptions: z
-    .object({
-      data: z.array(z.lazy(() => s_subscription)),
-      has_more: z.coerce.boolean(),
-      object: z.enum(["list"]),
-      url: z.string().max(5000),
-    })
-    .optional(),
-  tax: s_customer_tax.optional(),
-  tax_exempt: z.enum(["exempt", "none", "reverse"]).nullable().optional(),
-  tax_ids: z
-    .object({
-      data: z.array(z.lazy(() => s_tax_id)),
-      has_more: z.coerce.boolean(),
-      object: z.enum(["list"]),
-      url: z.string().max(5000),
-    })
-    .optional(),
-  test_clock: z
-    .union([z.string().max(5000), s_test_helpers_test_clock])
-    .nullable()
-    .optional(),
-})
-
-export const s_customer_balance_transaction: z.ZodType<t_customer_balance_transaction> =
+export const s_customer: z.ZodType<t_customer, z.ZodTypeDef, unknown> =
   z.object({
-    amount: z.coerce.number(),
+    address: s_address.nullable().optional(),
+    balance: z.coerce.number().optional(),
+    cash_balance: s_cash_balance.nullable().optional(),
     created: z.coerce.number(),
-    credit_note: z
-      .union([z.string().max(5000), z.lazy(() => s_credit_note)])
+    currency: z.string().max(5000).nullable().optional(),
+    default_source: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_bank_account),
+        z.lazy(() => s_card),
+        s_source,
+      ])
       .nullable()
       .optional(),
-    currency: z.string(),
-    customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
+    delinquent: PermissiveBoolean.nullable().optional(),
     description: z.string().max(5000).nullable().optional(),
-    ending_balance: z.coerce.number(),
+    discount: z.lazy(() => s_discount.nullable().optional()),
+    email: z.string().max(5000).nullable().optional(),
     id: z.string().max(5000),
-    invoice: z
-      .union([z.string().max(5000), z.lazy(() => s_invoice)])
+    invoice_credit_balance: z.record(z.coerce.number()).optional(),
+    invoice_prefix: z.string().max(5000).nullable().optional(),
+    invoice_settings: z.lazy(() =>
+      s_invoice_setting_customer_setting.optional(),
+    ),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)).optional(),
+    name: z.string().max(5000).nullable().optional(),
+    next_invoice_sequence: z.coerce.number().optional(),
+    object: z.enum(["customer"]),
+    phone: z.string().max(5000).nullable().optional(),
+    preferred_locales: z.array(z.string().max(5000)).nullable().optional(),
+    shipping: s_shipping.nullable().optional(),
+    sources: z
+      .object({
+        data: z.array(
+          z.union([
+            z.lazy(() => s_bank_account),
+            z.lazy(() => s_card),
+            s_source,
+          ]),
+        ),
+        has_more: PermissiveBoolean,
+        object: z.enum(["list"]),
+        url: z.string().max(5000),
+      })
+      .optional(),
+    subscriptions: z
+      .object({
+        data: z.array(z.lazy(() => s_subscription)),
+        has_more: PermissiveBoolean,
+        object: z.enum(["list"]),
+        url: z.string().max(5000),
+      })
+      .optional(),
+    tax: s_customer_tax.optional(),
+    tax_exempt: z.enum(["exempt", "none", "reverse"]).nullable().optional(),
+    tax_ids: z
+      .object({
+        data: z.array(z.lazy(() => s_tax_id)),
+        has_more: PermissiveBoolean,
+        object: z.enum(["list"]),
+        url: z.string().max(5000),
+      })
+      .optional(),
+    test_clock: z
+      .union([z.string().max(5000), s_test_helpers_test_clock])
       .nullable()
       .optional(),
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)).nullable().optional(),
-    object: z.enum(["customer_balance_transaction"]),
-    type: z.enum([
-      "adjustment",
-      "applied_to_invoice",
-      "credit_note",
-      "initial",
-      "invoice_overpaid",
-      "invoice_too_large",
-      "invoice_too_small",
-      "migration",
-      "unapplied_from_invoice",
-      "unspent_receiver_credit",
-    ]),
   })
 
-export const s_payment_source: z.ZodType<t_payment_source> = z.union([
+export const s_customer_balance_transaction: z.ZodType<
+  t_customer_balance_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  created: z.coerce.number(),
+  credit_note: z
+    .union([z.string().max(5000), z.lazy(() => s_credit_note)])
+    .nullable()
+    .optional(),
+  currency: z.string(),
+  customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
+  description: z.string().max(5000).nullable().optional(),
+  ending_balance: z.coerce.number(),
+  id: z.string().max(5000),
+  invoice: z
+    .union([z.string().max(5000), z.lazy(() => s_invoice)])
+    .nullable()
+    .optional(),
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  object: z.enum(["customer_balance_transaction"]),
+  type: z.enum([
+    "adjustment",
+    "applied_to_invoice",
+    "credit_note",
+    "initial",
+    "invoice_overpaid",
+    "invoice_too_large",
+    "invoice_too_small",
+    "migration",
+    "unapplied_from_invoice",
+    "unspent_receiver_credit",
+  ]),
+})
+
+export const s_payment_source: z.ZodType<
+  t_payment_source,
+  z.ZodTypeDef,
+  unknown
+> = z.union([
   z.lazy(() => s_account),
   z.lazy(() => s_bank_account),
   z.lazy(() => s_card),
   s_source,
 ])
 
-export const s_customer_cash_balance_transaction: z.ZodType<t_customer_cash_balance_transaction> =
+export const s_customer_cash_balance_transaction: z.ZodType<
+  t_customer_cash_balance_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  adjusted_for_overdraft: z.lazy(() =>
+    s_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft.optional(),
+  ),
+  applied_to_payment: z.lazy(() =>
+    s_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction.optional(),
+  ),
+  created: z.coerce.number(),
+  currency: z.string().max(5000),
+  customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
+  ending_balance: z.coerce.number(),
+  funded:
+    s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction.optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  net_amount: z.coerce.number(),
+  object: z.enum(["customer_cash_balance_transaction"]),
+  refunded_from_payment: z.lazy(() =>
+    s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction.optional(),
+  ),
+  transferred_to_balance: z.lazy(() =>
+    s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance.optional(),
+  ),
+  type: z.enum([
+    "adjusted_for_overdraft",
+    "applied_to_payment",
+    "funded",
+    "funding_reversed",
+    "refunded_from_payment",
+    "return_canceled",
+    "return_initiated",
+    "transferred_to_balance",
+    "unapplied_from_payment",
+  ]),
+  unapplied_from_payment: z.lazy(() =>
+    s_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction.optional(),
+  ),
+})
+
+export const s_deleted_discount: z.ZodType<
+  t_deleted_discount,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  checkout_session: z.string().max(5000).nullable().optional(),
+  coupon: s_coupon,
+  customer: z
+    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
+    .nullable()
+    .optional(),
+  deleted: PermissiveBoolean,
+  id: z.string().max(5000),
+  invoice: z.string().max(5000).nullable().optional(),
+  invoice_item: z.string().max(5000).nullable().optional(),
+  object: z.enum(["discount"]),
+  promotion_code: z
+    .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
+    .nullable()
+    .optional(),
+  start: z.coerce.number(),
+  subscription: z.string().max(5000).nullable().optional(),
+  subscription_item: z.string().max(5000).nullable().optional(),
+})
+
+export const s_discount: z.ZodType<t_discount, z.ZodTypeDef, unknown> =
   z.object({
-    adjusted_for_overdraft: z.lazy(() =>
-      s_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft.optional(),
-    ),
-    applied_to_payment: z.lazy(() =>
-      s_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction.optional(),
-    ),
-    created: z.coerce.number(),
-    currency: z.string().max(5000),
-    customer: z.union([z.string().max(5000), z.lazy(() => s_customer)]),
-    ending_balance: z.coerce.number(),
-    funded:
-      s_customer_balance_resource_cash_balance_transaction_resource_funded_transaction.optional(),
+    checkout_session: z.string().max(5000).nullable().optional(),
+    coupon: s_coupon,
+    customer: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_customer),
+        s_deleted_customer,
+      ])
+      .nullable()
+      .optional(),
+    end: z.coerce.number().nullable().optional(),
     id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    net_amount: z.coerce.number(),
-    object: z.enum(["customer_cash_balance_transaction"]),
-    refunded_from_payment: z.lazy(() =>
-      s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction.optional(),
-    ),
-    transferred_to_balance: z.lazy(() =>
-      s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance.optional(),
-    ),
-    type: z.enum([
-      "adjusted_for_overdraft",
-      "applied_to_payment",
-      "funded",
-      "funding_reversed",
-      "refunded_from_payment",
-      "return_canceled",
-      "return_initiated",
-      "transferred_to_balance",
-      "unapplied_from_payment",
-    ]),
-    unapplied_from_payment: z.lazy(() =>
-      s_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction.optional(),
-    ),
+    invoice: z.string().max(5000).nullable().optional(),
+    invoice_item: z.string().max(5000).nullable().optional(),
+    object: z.enum(["discount"]),
+    promotion_code: z
+      .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
+      .nullable()
+      .optional(),
+    start: z.coerce.number(),
+    subscription: z.string().max(5000).nullable().optional(),
+    subscription_item: z.string().max(5000).nullable().optional(),
   })
 
-export const s_deleted_discount: z.ZodType<t_deleted_discount> = z.object({
-  checkout_session: z.string().max(5000).nullable().optional(),
-  coupon: s_coupon,
-  customer: z
-    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
-    .nullable()
-    .optional(),
-  deleted: z.coerce.boolean(),
-  id: z.string().max(5000),
-  invoice: z.string().max(5000).nullable().optional(),
-  invoice_item: z.string().max(5000).nullable().optional(),
-  object: z.enum(["discount"]),
-  promotion_code: z
-    .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
-    .nullable()
-    .optional(),
-  start: z.coerce.number(),
-  subscription: z.string().max(5000).nullable().optional(),
-  subscription_item: z.string().max(5000).nullable().optional(),
-})
-
-export const s_discount: z.ZodType<t_discount> = z.object({
-  checkout_session: z.string().max(5000).nullable().optional(),
-  coupon: s_coupon,
-  customer: z
-    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
-    .nullable()
-    .optional(),
-  end: z.coerce.number().nullable().optional(),
-  id: z.string().max(5000),
-  invoice: z.string().max(5000).nullable().optional(),
-  invoice_item: z.string().max(5000).nullable().optional(),
-  object: z.enum(["discount"]),
-  promotion_code: z
-    .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
-    .nullable()
-    .optional(),
-  start: z.coerce.number(),
-  subscription: z.string().max(5000).nullable().optional(),
-  subscription_item: z.string().max(5000).nullable().optional(),
-})
-
-export const s_payment_method: z.ZodType<t_payment_method> = z.object({
+export const s_payment_method: z.ZodType<
+  t_payment_method,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   acss_debit: s_payment_method_acss_debit.optional(),
   affirm: s_payment_method_affirm.optional(),
   afterpay_clearpay: s_payment_method_afterpay_clearpay.optional(),
@@ -10557,7 +10636,7 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
   klarna: s_payment_method_klarna.optional(),
   konbini: s_payment_method_konbini.optional(),
   link: s_payment_method_link.optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   mobilepay: s_payment_method_mobilepay.optional(),
   object: z.enum(["payment_method"]),
@@ -10615,115 +10694,120 @@ export const s_payment_method: z.ZodType<t_payment_method> = z.object({
   zip: s_payment_method_zip.optional(),
 })
 
-export const s_subscription: z.ZodType<t_subscription> = z.object({
-  application: z
-    .union([z.string().max(5000), s_application, s_deleted_application])
-    .nullable()
-    .optional(),
-  application_fee_percent: z.coerce.number().nullable().optional(),
-  automatic_tax: z.lazy(() => s_subscription_automatic_tax),
-  billing_cycle_anchor: z.coerce.number(),
-  billing_cycle_anchor_config:
-    s_subscriptions_resource_billing_cycle_anchor_config.nullable().optional(),
-  billing_thresholds: s_subscription_billing_thresholds.nullable().optional(),
-  cancel_at: z.coerce.number().nullable().optional(),
-  cancel_at_period_end: z.coerce.boolean(),
-  canceled_at: z.coerce.number().nullable().optional(),
-  cancellation_details: s_cancellation_details.nullable().optional(),
-  collection_method: z.enum(["charge_automatically", "send_invoice"]),
-  created: z.coerce.number(),
-  currency: z.string(),
-  current_period_end: z.coerce.number(),
-  current_period_start: z.coerce.number(),
-  customer: z.union([
-    z.string().max(5000),
-    z.lazy(() => s_customer),
-    s_deleted_customer,
-  ]),
-  days_until_due: z.coerce.number().nullable().optional(),
-  default_payment_method: z
-    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-    .nullable()
-    .optional(),
-  default_source: z
-    .union([
+export const s_subscription: z.ZodType<t_subscription, z.ZodTypeDef, unknown> =
+  z.object({
+    application: z
+      .union([z.string().max(5000), s_application, s_deleted_application])
+      .nullable()
+      .optional(),
+    application_fee_percent: z.coerce.number().nullable().optional(),
+    automatic_tax: z.lazy(() => s_subscription_automatic_tax),
+    billing_cycle_anchor: z.coerce.number(),
+    billing_cycle_anchor_config:
+      s_subscriptions_resource_billing_cycle_anchor_config
+        .nullable()
+        .optional(),
+    billing_thresholds: s_subscription_billing_thresholds.nullable().optional(),
+    cancel_at: z.coerce.number().nullable().optional(),
+    cancel_at_period_end: PermissiveBoolean,
+    canceled_at: z.coerce.number().nullable().optional(),
+    cancellation_details: s_cancellation_details.nullable().optional(),
+    collection_method: z.enum(["charge_automatically", "send_invoice"]),
+    created: z.coerce.number(),
+    currency: z.string(),
+    current_period_end: z.coerce.number(),
+    current_period_start: z.coerce.number(),
+    customer: z.union([
       z.string().max(5000),
-      z.lazy(() => s_bank_account),
-      z.lazy(() => s_card),
-      s_source,
-    ])
-    .nullable()
-    .optional(),
-  default_tax_rates: z.array(s_tax_rate).nullable().optional(),
-  description: z.string().max(500).nullable().optional(),
-  discount: z.lazy(() => s_discount.nullable().optional()),
-  discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
-  ended_at: z.coerce.number().nullable().optional(),
-  id: z.string().max(5000),
-  items: z.object({
-    data: z.array(z.lazy(() => s_subscription_item)),
-    has_more: z.coerce.boolean(),
-    object: z.enum(["list"]),
-    url: z.string().max(5000),
-  }),
-  latest_invoice: z
-    .union([z.string().max(5000), z.lazy(() => s_invoice)])
-    .nullable()
-    .optional(),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)),
-  next_pending_invoice_item_invoice: z.coerce.number().nullable().optional(),
-  object: z.enum(["subscription"]),
-  on_behalf_of: z
-    .union([z.string().max(5000), z.lazy(() => s_account)])
-    .nullable()
-    .optional(),
-  pause_collection: s_subscriptions_resource_pause_collection
-    .nullable()
-    .optional(),
-  payment_settings: s_subscriptions_resource_payment_settings
-    .nullable()
-    .optional(),
-  pending_invoice_item_interval: s_subscription_pending_invoice_item_interval
-    .nullable()
-    .optional(),
-  pending_setup_intent: z
-    .union([z.string().max(5000), z.lazy(() => s_setup_intent)])
-    .nullable()
-    .optional(),
-  pending_update: z.lazy(() =>
-    s_subscriptions_resource_pending_update.nullable().optional(),
-  ),
-  schedule: z
-    .union([z.string().max(5000), z.lazy(() => s_subscription_schedule)])
-    .nullable()
-    .optional(),
-  start_date: z.coerce.number(),
-  status: z.enum([
-    "active",
-    "canceled",
-    "incomplete",
-    "incomplete_expired",
-    "past_due",
-    "paused",
-    "trialing",
-    "unpaid",
-  ]),
-  test_clock: z
-    .union([z.string().max(5000), s_test_helpers_test_clock])
-    .nullable()
-    .optional(),
-  transfer_data: z.lazy(() =>
-    s_subscription_transfer_data.nullable().optional(),
-  ),
-  trial_end: z.coerce.number().nullable().optional(),
-  trial_settings: s_subscriptions_trials_resource_trial_settings
-    .nullable()
-    .optional(),
-  trial_start: z.coerce.number().nullable().optional(),
-})
+      z.lazy(() => s_customer),
+      s_deleted_customer,
+    ]),
+    days_until_due: z.coerce.number().nullable().optional(),
+    default_payment_method: z
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+      .nullable()
+      .optional(),
+    default_source: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_bank_account),
+        z.lazy(() => s_card),
+        s_source,
+      ])
+      .nullable()
+      .optional(),
+    default_tax_rates: z.array(s_tax_rate).nullable().optional(),
+    description: z.string().max(500).nullable().optional(),
+    discount: z.lazy(() => s_discount.nullable().optional()),
+    discounts: z.array(
+      z.union([z.string().max(5000), z.lazy(() => s_discount)]),
+    ),
+    ended_at: z.coerce.number().nullable().optional(),
+    id: z.string().max(5000),
+    items: z.object({
+      data: z.array(z.lazy(() => s_subscription_item)),
+      has_more: PermissiveBoolean,
+      object: z.enum(["list"]),
+      url: z.string().max(5000),
+    }),
+    latest_invoice: z
+      .union([z.string().max(5000), z.lazy(() => s_invoice)])
+      .nullable()
+      .optional(),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)),
+    next_pending_invoice_item_invoice: z.coerce.number().nullable().optional(),
+    object: z.enum(["subscription"]),
+    on_behalf_of: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .nullable()
+      .optional(),
+    pause_collection: s_subscriptions_resource_pause_collection
+      .nullable()
+      .optional(),
+    payment_settings: s_subscriptions_resource_payment_settings
+      .nullable()
+      .optional(),
+    pending_invoice_item_interval: s_subscription_pending_invoice_item_interval
+      .nullable()
+      .optional(),
+    pending_setup_intent: z
+      .union([z.string().max(5000), z.lazy(() => s_setup_intent)])
+      .nullable()
+      .optional(),
+    pending_update: z.lazy(() =>
+      s_subscriptions_resource_pending_update.nullable().optional(),
+    ),
+    schedule: z
+      .union([z.string().max(5000), z.lazy(() => s_subscription_schedule)])
+      .nullable()
+      .optional(),
+    start_date: z.coerce.number(),
+    status: z.enum([
+      "active",
+      "canceled",
+      "incomplete",
+      "incomplete_expired",
+      "past_due",
+      "paused",
+      "trialing",
+      "unpaid",
+    ]),
+    test_clock: z
+      .union([z.string().max(5000), s_test_helpers_test_clock])
+      .nullable()
+      .optional(),
+    transfer_data: z.lazy(() =>
+      s_subscription_transfer_data.nullable().optional(),
+    ),
+    trial_end: z.coerce.number().nullable().optional(),
+    trial_settings: s_subscriptions_trials_resource_trial_settings
+      .nullable()
+      .optional(),
+    trial_start: z.coerce.number().nullable().optional(),
+  })
 
-export const s_tax_id: z.ZodType<t_tax_id> = z.object({
+export const s_tax_id: z.ZodType<t_tax_id, z.ZodTypeDef, unknown> = z.object({
   country: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   customer: z
@@ -10731,7 +10815,7 @@ export const s_tax_id: z.ZodType<t_tax_id> = z.object({
     .nullable()
     .optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["tax_id"]),
   owner: z.lazy(() => s_tax_i_ds_owner.nullable().optional()),
   type: z.enum([
@@ -10808,19 +10892,20 @@ export const s_tax_id: z.ZodType<t_tax_id> = z.object({
   verification: s_tax_id_verification.nullable().optional(),
 })
 
-export const s_file_link: z.ZodType<t_file_link> = z.object({
-  created: z.coerce.number(),
-  expired: z.coerce.boolean(),
-  expires_at: z.coerce.number().nullable().optional(),
-  file: z.union([z.string().max(5000), z.lazy(() => s_file)]),
-  id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)),
-  object: z.enum(["file_link"]),
-  url: z.string().max(5000).nullable().optional(),
-})
+export const s_file_link: z.ZodType<t_file_link, z.ZodTypeDef, unknown> =
+  z.object({
+    created: z.coerce.number(),
+    expired: PermissiveBoolean,
+    expires_at: z.coerce.number().nullable().optional(),
+    file: z.union([z.string().max(5000), z.lazy(() => s_file)]),
+    id: z.string().max(5000),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)),
+    object: z.enum(["file_link"]),
+    url: z.string().max(5000).nullable().optional(),
+  })
 
-export const s_file: z.ZodType<t_file> = z.object({
+export const s_file: z.ZodType<t_file, z.ZodTypeDef, unknown> = z.object({
   created: z.coerce.number(),
   expires_at: z.coerce.number().nullable().optional(),
   filename: z.string().max(5000).nullable().optional(),
@@ -10828,7 +10913,7 @@ export const s_file: z.ZodType<t_file> = z.object({
   links: z
     .object({
       data: z.array(z.lazy(() => s_file_link)),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z.string().max(5000).regex(new RegExp("^/v1/file_links")),
     })
@@ -10858,129 +10943,131 @@ export const s_file: z.ZodType<t_file> = z.object({
   url: z.string().max(5000).nullable().optional(),
 })
 
-export const s_financial_connections_account: z.ZodType<t_financial_connections_account> =
-  z.object({
-    account_holder: z.lazy(() =>
-      s_bank_connections_resource_accountholder.nullable().optional(),
-    ),
-    balance: s_bank_connections_resource_balance.nullable().optional(),
-    balance_refresh: s_bank_connections_resource_balance_refresh
-      .nullable()
-      .optional(),
-    category: z.enum(["cash", "credit", "investment", "other"]),
-    created: z.coerce.number(),
-    display_name: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    institution_name: z.string().max(5000),
-    last4: z.string().max(5000).nullable().optional(),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["financial_connections.account"]),
-    ownership: z
-      .union([z.string().max(5000), s_financial_connections_account_ownership])
-      .nullable()
-      .optional(),
-    ownership_refresh: s_bank_connections_resource_ownership_refresh
-      .nullable()
-      .optional(),
-    permissions: z
-      .array(
-        z.enum(["balances", "ownership", "payment_method", "transactions"]),
-      )
-      .nullable()
-      .optional(),
-    status: z.enum(["active", "disconnected", "inactive"]),
-    subcategory: z.enum([
-      "checking",
-      "credit_card",
-      "line_of_credit",
-      "mortgage",
-      "other",
-      "savings",
-    ]),
-    subscriptions: z
-      .array(z.enum(["transactions"]))
-      .nullable()
-      .optional(),
-    supported_payment_method_types: z.array(
-      z.enum(["link", "us_bank_account"]),
-    ),
-    transaction_refresh: s_bank_connections_resource_transaction_refresh
-      .nullable()
-      .optional(),
-  })
-
-export const s_financial_connections_session: z.ZodType<t_financial_connections_session> =
-  z.object({
-    account_holder: z.lazy(() =>
-      s_bank_connections_resource_accountholder.nullable().optional(),
-    ),
-    accounts: z.object({
-      data: z.array(z.lazy(() => s_financial_connections_account)),
-      has_more: z.coerce.boolean(),
-      object: z.enum(["list"]),
-      url: z
-        .string()
-        .max(5000)
-        .regex(new RegExp("^/v1/financial_connections/accounts")),
-    }),
-    client_secret: z.string().max(5000),
-    filters:
-      s_bank_connections_resource_link_account_session_filters.optional(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["financial_connections.session"]),
-    permissions: z.array(
-      z.enum(["balances", "ownership", "payment_method", "transactions"]),
-    ),
-    prefetch: z
-      .array(z.enum(["balances", "ownership", "transactions"]))
-      .nullable()
-      .optional(),
-    return_url: z.string().max(5000).optional(),
-  })
-
-export const s_invoiceitem: z.ZodType<t_invoiceitem> = z.object({
-  amount: z.coerce.number(),
-  currency: z.string(),
-  customer: z.union([
-    z.string().max(5000),
-    z.lazy(() => s_customer),
-    s_deleted_customer,
-  ]),
-  date: z.coerce.number(),
-  description: z.string().max(5000).nullable().optional(),
-  discountable: z.coerce.boolean(),
-  discounts: z
-    .array(z.union([z.string().max(5000), z.lazy(() => s_discount)]))
+export const s_financial_connections_account: z.ZodType<
+  t_financial_connections_account,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_holder: z.lazy(() =>
+    s_bank_connections_resource_accountholder.nullable().optional(),
+  ),
+  balance: s_bank_connections_resource_balance.nullable().optional(),
+  balance_refresh: s_bank_connections_resource_balance_refresh
     .nullable()
     .optional(),
+  category: z.enum(["cash", "credit", "investment", "other"]),
+  created: z.coerce.number(),
+  display_name: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
-  invoice: z
-    .union([z.string().max(5000), z.lazy(() => s_invoice)])
+  institution_name: z.string().max(5000),
+  last4: z.string().max(5000).nullable().optional(),
+  livemode: PermissiveBoolean,
+  object: z.enum(["financial_connections.account"]),
+  ownership: z
+    .union([z.string().max(5000), s_financial_connections_account_ownership])
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)).nullable().optional(),
-  object: z.enum(["invoiceitem"]),
-  period: s_invoice_line_item_period,
-  price: z.lazy(() => s_price.nullable().optional()),
-  proration: z.coerce.boolean(),
-  quantity: z.coerce.number(),
-  subscription: z
-    .union([z.string().max(5000), z.lazy(() => s_subscription)])
+  ownership_refresh: s_bank_connections_resource_ownership_refresh
     .nullable()
     .optional(),
-  subscription_item: z.string().max(5000).optional(),
-  tax_rates: z.array(s_tax_rate).nullable().optional(),
-  test_clock: z
-    .union([z.string().max(5000), s_test_helpers_test_clock])
+  permissions: z
+    .array(z.enum(["balances", "ownership", "payment_method", "transactions"]))
     .nullable()
     .optional(),
-  unit_amount: z.coerce.number().nullable().optional(),
-  unit_amount_decimal: z.string().nullable().optional(),
+  status: z.enum(["active", "disconnected", "inactive"]),
+  subcategory: z.enum([
+    "checking",
+    "credit_card",
+    "line_of_credit",
+    "mortgage",
+    "other",
+    "savings",
+  ]),
+  subscriptions: z
+    .array(z.enum(["transactions"]))
+    .nullable()
+    .optional(),
+  supported_payment_method_types: z.array(z.enum(["link", "us_bank_account"])),
+  transaction_refresh: s_bank_connections_resource_transaction_refresh
+    .nullable()
+    .optional(),
 })
 
-export const s_invoice: z.ZodType<t_invoice> = z.object({
+export const s_financial_connections_session: z.ZodType<
+  t_financial_connections_session,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_holder: z.lazy(() =>
+    s_bank_connections_resource_accountholder.nullable().optional(),
+  ),
+  accounts: z.object({
+    data: z.array(z.lazy(() => s_financial_connections_account)),
+    has_more: PermissiveBoolean,
+    object: z.enum(["list"]),
+    url: z
+      .string()
+      .max(5000)
+      .regex(new RegExp("^/v1/financial_connections/accounts")),
+  }),
+  client_secret: z.string().max(5000),
+  filters: s_bank_connections_resource_link_account_session_filters.optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["financial_connections.session"]),
+  permissions: z.array(
+    z.enum(["balances", "ownership", "payment_method", "transactions"]),
+  ),
+  prefetch: z
+    .array(z.enum(["balances", "ownership", "transactions"]))
+    .nullable()
+    .optional(),
+  return_url: z.string().max(5000).optional(),
+})
+
+export const s_invoiceitem: z.ZodType<t_invoiceitem, z.ZodTypeDef, unknown> =
+  z.object({
+    amount: z.coerce.number(),
+    currency: z.string(),
+    customer: z.union([
+      z.string().max(5000),
+      z.lazy(() => s_customer),
+      s_deleted_customer,
+    ]),
+    date: z.coerce.number(),
+    description: z.string().max(5000).nullable().optional(),
+    discountable: PermissiveBoolean,
+    discounts: z
+      .array(z.union([z.string().max(5000), z.lazy(() => s_discount)]))
+      .nullable()
+      .optional(),
+    id: z.string().max(5000),
+    invoice: z
+      .union([z.string().max(5000), z.lazy(() => s_invoice)])
+      .nullable()
+      .optional(),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)).nullable().optional(),
+    object: z.enum(["invoiceitem"]),
+    period: s_invoice_line_item_period,
+    price: z.lazy(() => s_price.nullable().optional()),
+    proration: PermissiveBoolean,
+    quantity: z.coerce.number(),
+    subscription: z
+      .union([z.string().max(5000), z.lazy(() => s_subscription)])
+      .nullable()
+      .optional(),
+    subscription_item: z.string().max(5000).optional(),
+    tax_rates: z.array(s_tax_rate).nullable().optional(),
+    test_clock: z
+      .union([z.string().max(5000), s_test_helpers_test_clock])
+      .nullable()
+      .optional(),
+    unit_amount: z.coerce.number().nullable().optional(),
+    unit_amount_decimal: z.string().nullable().optional(),
+  })
+
+export const s_invoice: z.ZodType<t_invoice, z.ZodTypeDef, unknown> = z.object({
   account_country: z.string().max(5000).nullable().optional(),
   account_name: z.string().max(5000).nullable().optional(),
   account_tax_ids: z
@@ -10999,8 +11086,8 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .optional(),
   application_fee_amount: z.coerce.number().nullable().optional(),
   attempt_count: z.coerce.number(),
-  attempted: z.coerce.boolean(),
-  auto_advance: z.coerce.boolean().optional(),
+  attempted: PermissiveBoolean,
+  auto_advance: PermissiveBoolean.optional(),
   automatic_tax: z.lazy(() => s_automatic_tax),
   billing_reason: z
     .enum([
@@ -11082,11 +11169,11 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .optional(),
   lines: z.object({
     data: z.array(z.lazy(() => s_line_item)),
-    has_more: z.coerce.boolean(),
+    has_more: PermissiveBoolean,
     object: z.enum(["list"]),
     url: z.string().max(5000),
   }),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   next_payment_attempt: z.coerce.number().nullable().optional(),
   number: z.string().max(5000).nullable().optional(),
@@ -11095,8 +11182,8 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
     .union([z.string().max(5000), z.lazy(() => s_account)])
     .nullable()
     .optional(),
-  paid: z.coerce.boolean(),
-  paid_out_of_band: z.coerce.boolean(),
+  paid: PermissiveBoolean,
+  paid_out_of_band: PermissiveBoolean,
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
     .nullable()
@@ -11146,91 +11233,99 @@ export const s_invoice: z.ZodType<t_invoice> = z.object({
   webhooks_delivered_at: z.coerce.number().nullable().optional(),
 })
 
-export const s_line_item: z.ZodType<t_line_item> = z.object({
-  amount: z.coerce.number(),
-  amount_excluding_tax: z.coerce.number().nullable().optional(),
-  currency: z.string(),
-  description: z.string().max(5000).nullable().optional(),
-  discount_amounts: z
-    .array(z.lazy(() => s_discounts_resource_discount_amount))
-    .nullable()
-    .optional(),
-  discountable: z.coerce.boolean(),
-  discounts: z.array(z.union([z.string().max(5000), z.lazy(() => s_discount)])),
-  id: z.string().max(5000),
-  invoice: z.string().max(5000).nullable().optional(),
-  invoice_item: z
-    .union([z.string().max(5000), z.lazy(() => s_invoiceitem)])
-    .optional(),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)),
-  object: z.enum(["line_item"]),
-  period: s_invoice_line_item_period,
-  price: z.lazy(() => s_price.nullable().optional()),
-  proration: z.coerce.boolean(),
-  proration_details: s_invoices_resource_line_items_proration_details
-    .nullable()
-    .optional(),
-  quantity: z.coerce.number().nullable().optional(),
-  subscription: z
-    .union([z.string().max(5000), z.lazy(() => s_subscription)])
-    .nullable()
-    .optional(),
-  subscription_item: z
-    .union([z.string().max(5000), z.lazy(() => s_subscription_item)])
-    .optional(),
-  tax_amounts: z.array(s_invoice_tax_amount).optional(),
-  tax_rates: z.array(s_tax_rate).optional(),
-  type: z.enum(["invoiceitem", "subscription"]),
-  unit_amount_excluding_tax: z.string().nullable().optional(),
-})
-
-export const s_issuing_authorization: z.ZodType<t_issuing_authorization> =
+export const s_line_item: z.ZodType<t_line_item, z.ZodTypeDef, unknown> =
   z.object({
     amount: z.coerce.number(),
-    amount_details: s_issuing_authorization_amount_details
-      .nullable()
-      .optional(),
-    approved: z.coerce.boolean(),
-    authorization_method: z.enum([
-      "chip",
-      "contactless",
-      "keyed_in",
-      "online",
-      "swipe",
-    ]),
-    balance_transactions: z.array(z.lazy(() => s_balance_transaction)),
-    card: z.lazy(() => s_issuing_card),
-    cardholder: z
-      .union([z.string().max(5000), z.lazy(() => s_issuing_cardholder)])
-      .nullable()
-      .optional(),
-    created: z.coerce.number(),
+    amount_excluding_tax: z.coerce.number().nullable().optional(),
     currency: z.string(),
+    description: z.string().max(5000).nullable().optional(),
+    discount_amounts: z
+      .array(z.lazy(() => s_discounts_resource_discount_amount))
+      .nullable()
+      .optional(),
+    discountable: PermissiveBoolean,
+    discounts: z.array(
+      z.union([z.string().max(5000), z.lazy(() => s_discount)]),
+    ),
     id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    merchant_amount: z.coerce.number(),
-    merchant_currency: z.string(),
-    merchant_data: s_issuing_authorization_merchant_data,
+    invoice: z.string().max(5000).nullable().optional(),
+    invoice_item: z
+      .union([z.string().max(5000), z.lazy(() => s_invoiceitem)])
+      .optional(),
+    livemode: PermissiveBoolean,
     metadata: z.record(z.string().max(500)),
-    network_data: s_issuing_authorization_network_data.nullable().optional(),
-    object: z.enum(["issuing.authorization"]),
-    pending_request: s_issuing_authorization_pending_request
+    object: z.enum(["line_item"]),
+    period: s_invoice_line_item_period,
+    price: z.lazy(() => s_price.nullable().optional()),
+    proration: PermissiveBoolean,
+    proration_details: s_invoices_resource_line_items_proration_details
       .nullable()
       .optional(),
-    request_history: z.array(s_issuing_authorization_request),
-    status: z.enum(["closed", "pending", "reversed"]),
-    token: z
-      .union([z.string().max(5000), z.lazy(() => s_issuing_token)])
+    quantity: z.coerce.number().nullable().optional(),
+    subscription: z
+      .union([z.string().max(5000), z.lazy(() => s_subscription)])
       .nullable()
       .optional(),
-    transactions: z.array(z.lazy(() => s_issuing_transaction)),
-    treasury: s_issuing_authorization_treasury.nullable().optional(),
-    verification_data: s_issuing_authorization_verification_data,
-    wallet: z.string().max(5000).nullable().optional(),
+    subscription_item: z
+      .union([z.string().max(5000), z.lazy(() => s_subscription_item)])
+      .optional(),
+    tax_amounts: z.array(s_invoice_tax_amount).optional(),
+    tax_rates: z.array(s_tax_rate).optional(),
+    type: z.enum(["invoiceitem", "subscription"]),
+    unit_amount_excluding_tax: z.string().nullable().optional(),
   })
 
-export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
+export const s_issuing_authorization: z.ZodType<
+  t_issuing_authorization,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  amount_details: s_issuing_authorization_amount_details.nullable().optional(),
+  approved: PermissiveBoolean,
+  authorization_method: z.enum([
+    "chip",
+    "contactless",
+    "keyed_in",
+    "online",
+    "swipe",
+  ]),
+  balance_transactions: z.array(z.lazy(() => s_balance_transaction)),
+  card: z.lazy(() => s_issuing_card),
+  cardholder: z
+    .union([z.string().max(5000), z.lazy(() => s_issuing_cardholder)])
+    .nullable()
+    .optional(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  merchant_amount: z.coerce.number(),
+  merchant_currency: z.string(),
+  merchant_data: s_issuing_authorization_merchant_data,
+  metadata: z.record(z.string().max(500)),
+  network_data: s_issuing_authorization_network_data.nullable().optional(),
+  object: z.enum(["issuing.authorization"]),
+  pending_request: s_issuing_authorization_pending_request
+    .nullable()
+    .optional(),
+  request_history: z.array(s_issuing_authorization_request),
+  status: z.enum(["closed", "pending", "reversed"]),
+  token: z
+    .union([z.string().max(5000), z.lazy(() => s_issuing_token)])
+    .nullable()
+    .optional(),
+  transactions: z.array(z.lazy(() => s_issuing_transaction)),
+  treasury: s_issuing_authorization_treasury.nullable().optional(),
+  verification_data: s_issuing_authorization_verification_data,
+  wallet: z.string().max(5000).nullable().optional(),
+})
+
+export const s_issuing_cardholder: z.ZodType<
+  t_issuing_cardholder,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   billing: s_issuing_cardholder_address,
   company: s_issuing_cardholder_company.nullable().optional(),
   created: z.coerce.number(),
@@ -11239,7 +11334,7 @@ export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
   individual: z.lazy(() =>
     s_issuing_cardholder_individual.nullable().optional(),
   ),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   name: z.string().max(5000),
   object: z.enum(["issuing.cardholder"]),
@@ -11256,52 +11351,57 @@ export const s_issuing_cardholder: z.ZodType<t_issuing_cardholder> = z.object({
   type: z.enum(["company", "individual"]),
 })
 
-export const s_issuing_card: z.ZodType<t_issuing_card> = z.object({
-  brand: z.string().max(5000),
-  cancellation_reason: z
-    .enum(["design_rejected", "lost", "stolen"])
-    .nullable()
-    .optional(),
-  cardholder: z.lazy(() => s_issuing_cardholder),
-  created: z.coerce.number(),
-  currency: z.string(),
-  cvc: z.string().max(5000).optional(),
-  exp_month: z.coerce.number(),
-  exp_year: z.coerce.number(),
-  financial_account: z.string().max(5000).nullable().optional(),
-  id: z.string().max(5000),
-  last4: z.string().max(5000),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)),
-  number: z.string().max(5000).optional(),
-  object: z.enum(["issuing.card"]),
-  personalization_design: z
-    .union([
-      z.string().max(5000),
-      z.lazy(() => s_issuing_personalization_design),
-    ])
-    .nullable()
-    .optional(),
-  replaced_by: z
-    .union([z.string().max(5000), z.lazy(() => s_issuing_card)])
-    .nullable()
-    .optional(),
-  replacement_for: z
-    .union([z.string().max(5000), z.lazy(() => s_issuing_card)])
-    .nullable()
-    .optional(),
-  replacement_reason: z
-    .enum(["damaged", "expired", "lost", "stolen"])
-    .nullable()
-    .optional(),
-  shipping: s_issuing_card_shipping.nullable().optional(),
-  spending_controls: s_issuing_card_authorization_controls,
-  status: z.enum(["active", "canceled", "inactive"]),
-  type: z.enum(["physical", "virtual"]),
-  wallets: s_issuing_card_wallets.nullable().optional(),
-})
+export const s_issuing_card: z.ZodType<t_issuing_card, z.ZodTypeDef, unknown> =
+  z.object({
+    brand: z.string().max(5000),
+    cancellation_reason: z
+      .enum(["design_rejected", "lost", "stolen"])
+      .nullable()
+      .optional(),
+    cardholder: z.lazy(() => s_issuing_cardholder),
+    created: z.coerce.number(),
+    currency: z.string(),
+    cvc: z.string().max(5000).optional(),
+    exp_month: z.coerce.number(),
+    exp_year: z.coerce.number(),
+    financial_account: z.string().max(5000).nullable().optional(),
+    id: z.string().max(5000),
+    last4: z.string().max(5000),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)),
+    number: z.string().max(5000).optional(),
+    object: z.enum(["issuing.card"]),
+    personalization_design: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_issuing_personalization_design),
+      ])
+      .nullable()
+      .optional(),
+    replaced_by: z
+      .union([z.string().max(5000), z.lazy(() => s_issuing_card)])
+      .nullable()
+      .optional(),
+    replacement_for: z
+      .union([z.string().max(5000), z.lazy(() => s_issuing_card)])
+      .nullable()
+      .optional(),
+    replacement_reason: z
+      .enum(["damaged", "expired", "lost", "stolen"])
+      .nullable()
+      .optional(),
+    shipping: s_issuing_card_shipping.nullable().optional(),
+    spending_controls: s_issuing_card_authorization_controls,
+    status: z.enum(["active", "canceled", "inactive"]),
+    type: z.enum(["physical", "virtual"]),
+    wallets: s_issuing_card_wallets.nullable().optional(),
+  })
 
-export const s_issuing_dispute: z.ZodType<t_issuing_dispute> = z.object({
+export const s_issuing_dispute: z.ZodType<
+  t_issuing_dispute,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   amount: z.coerce.number(),
   balance_transactions: z
     .array(z.lazy(() => s_balance_transaction))
@@ -11311,7 +11411,7 @@ export const s_issuing_dispute: z.ZodType<t_issuing_dispute> = z.object({
   currency: z.string(),
   evidence: z.lazy(() => s_issuing_dispute_evidence),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["issuing.dispute"]),
   status: z.enum(["expired", "lost", "submitted", "unsubmitted", "won"]),
@@ -11322,35 +11422,42 @@ export const s_issuing_dispute: z.ZodType<t_issuing_dispute> = z.object({
   treasury: s_issuing_dispute_treasury.nullable().optional(),
 })
 
-export const s_issuing_personalization_design: z.ZodType<t_issuing_personalization_design> =
-  z.object({
-    card_logo: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    carrier_text: s_issuing_personalization_design_carrier_text
-      .nullable()
-      .optional(),
-    created: z.coerce.number(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    lookup_key: z.string().max(5000).nullable().optional(),
-    metadata: z.record(z.string().max(500)),
-    name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["issuing.personalization_design"]),
-    physical_bundle: z.union([z.string().max(5000), s_issuing_physical_bundle]),
-    preferences: s_issuing_personalization_design_preferences,
-    rejection_reasons: s_issuing_personalization_design_rejection_reasons,
-    status: z.enum(["active", "inactive", "rejected", "review"]),
-  })
+export const s_issuing_personalization_design: z.ZodType<
+  t_issuing_personalization_design,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  card_logo: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  carrier_text: s_issuing_personalization_design_carrier_text
+    .nullable()
+    .optional(),
+  created: z.coerce.number(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  lookup_key: z.string().max(5000).nullable().optional(),
+  metadata: z.record(z.string().max(500)),
+  name: z.string().max(5000).nullable().optional(),
+  object: z.enum(["issuing.personalization_design"]),
+  physical_bundle: z.union([z.string().max(5000), s_issuing_physical_bundle]),
+  preferences: s_issuing_personalization_design_preferences,
+  rejection_reasons: s_issuing_personalization_design_rejection_reasons,
+  status: z.enum(["active", "inactive", "rejected", "review"]),
+})
 
-export const s_issuing_token: z.ZodType<t_issuing_token> = z.object({
+export const s_issuing_token: z.ZodType<
+  t_issuing_token,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   card: z.union([z.string().max(5000), z.lazy(() => s_issuing_card)]),
   created: z.coerce.number(),
   device_fingerprint: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
   last4: z.string().max(5000).optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   network: z.enum(["mastercard", "visa"]),
   network_data: s_issuing_network_token_network_data.optional(),
   network_updated_at: z.coerce.number(),
@@ -11361,57 +11468,59 @@ export const s_issuing_token: z.ZodType<t_issuing_token> = z.object({
     .optional(),
 })
 
-export const s_issuing_transaction: z.ZodType<t_issuing_transaction> = z.object(
-  {
-    amount: z.coerce.number(),
-    amount_details: s_issuing_transaction_amount_details.nullable().optional(),
-    authorization: z
-      .union([z.string().max(5000), z.lazy(() => s_issuing_authorization)])
-      .nullable()
-      .optional(),
-    balance_transaction: z
-      .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
-      .nullable()
-      .optional(),
-    card: z.union([z.string().max(5000), z.lazy(() => s_issuing_card)]),
-    cardholder: z
-      .union([z.string().max(5000), z.lazy(() => s_issuing_cardholder)])
-      .nullable()
-      .optional(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    dispute: z
-      .union([z.string().max(5000), z.lazy(() => s_issuing_dispute)])
-      .nullable()
-      .optional(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    merchant_amount: z.coerce.number(),
-    merchant_currency: z.string(),
-    merchant_data: s_issuing_authorization_merchant_data,
-    metadata: z.record(z.string().max(500)),
-    network_data: s_issuing_transaction_network_data.nullable().optional(),
-    object: z.enum(["issuing.transaction"]),
-    purchase_details: s_issuing_transaction_purchase_details
-      .nullable()
-      .optional(),
-    token: z
-      .union([z.string().max(5000), z.lazy(() => s_issuing_token)])
-      .nullable()
-      .optional(),
-    treasury: s_issuing_transaction_treasury.nullable().optional(),
-    type: z.enum(["capture", "refund"]),
-    wallet: z
-      .enum(["apple_pay", "google_pay", "samsung_pay"])
-      .nullable()
-      .optional(),
-  },
-)
+export const s_issuing_transaction: z.ZodType<
+  t_issuing_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  amount_details: s_issuing_transaction_amount_details.nullable().optional(),
+  authorization: z
+    .union([z.string().max(5000), z.lazy(() => s_issuing_authorization)])
+    .nullable()
+    .optional(),
+  balance_transaction: z
+    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
+    .nullable()
+    .optional(),
+  card: z.union([z.string().max(5000), z.lazy(() => s_issuing_card)]),
+  cardholder: z
+    .union([z.string().max(5000), z.lazy(() => s_issuing_cardholder)])
+    .nullable()
+    .optional(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  dispute: z
+    .union([z.string().max(5000), z.lazy(() => s_issuing_dispute)])
+    .nullable()
+    .optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  merchant_amount: z.coerce.number(),
+  merchant_currency: z.string(),
+  merchant_data: s_issuing_authorization_merchant_data,
+  metadata: z.record(z.string().max(500)),
+  network_data: s_issuing_transaction_network_data.nullable().optional(),
+  object: z.enum(["issuing.transaction"]),
+  purchase_details: s_issuing_transaction_purchase_details
+    .nullable()
+    .optional(),
+  token: z
+    .union([z.string().max(5000), z.lazy(() => s_issuing_token)])
+    .nullable()
+    .optional(),
+  treasury: s_issuing_transaction_treasury.nullable().optional(),
+  type: z.enum(["capture", "refund"]),
+  wallet: z
+    .enum(["apple_pay", "google_pay", "samsung_pay"])
+    .nullable()
+    .optional(),
+})
 
-export const s_mandate: z.ZodType<t_mandate> = z.object({
+export const s_mandate: z.ZodType<t_mandate, z.ZodTypeDef, unknown> = z.object({
   customer_acceptance: s_customer_acceptance,
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   multi_use: s_mandate_multi_use.optional(),
   object: z.enum(["mandate"]),
   on_behalf_of: z.string().max(5000).optional(),
@@ -11425,7 +11534,11 @@ export const s_mandate: z.ZodType<t_mandate> = z.object({
   type: z.enum(["multi_use", "single_use"]),
 })
 
-export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
+export const s_payment_intent: z.ZodType<
+  t_payment_intent,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   amount: z.coerce.number(),
   amount_capturable: z.coerce.number().optional(),
   amount_details: s_payment_flows_amount_details.optional(),
@@ -11472,7 +11585,7 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
     .union([z.string().max(5000), z.lazy(() => s_charge)])
     .nullable()
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).optional(),
   next_action: s_payment_intent_next_action.nullable().optional(),
   object: z.enum(["payment_intent"]),
@@ -11518,105 +11631,108 @@ export const s_payment_intent: z.ZodType<t_payment_intent> = z.object({
   transfer_group: z.string().max(5000).nullable().optional(),
 })
 
-export const s_payment_link: z.ZodType<t_payment_link> = z.object({
-  active: z.coerce.boolean(),
-  after_completion: s_payment_links_resource_after_completion,
-  allow_promotion_codes: z.coerce.boolean(),
-  application: z
-    .union([z.string().max(5000), s_application, s_deleted_application])
-    .nullable()
-    .optional(),
-  application_fee_amount: z.coerce.number().nullable().optional(),
-  application_fee_percent: z.coerce.number().nullable().optional(),
-  automatic_tax: z.lazy(() => s_payment_links_resource_automatic_tax),
-  billing_address_collection: z.enum(["auto", "required"]),
-  consent_collection: s_payment_links_resource_consent_collection
-    .nullable()
-    .optional(),
-  currency: z.string(),
-  custom_fields: z.array(s_payment_links_resource_custom_fields),
-  custom_text: s_payment_links_resource_custom_text,
-  customer_creation: z.enum(["always", "if_required"]),
-  id: z.string().max(5000),
-  inactive_message: z.string().max(5000).nullable().optional(),
-  invoice_creation: z.lazy(() =>
-    s_payment_links_resource_invoice_creation.nullable().optional(),
-  ),
-  line_items: z
-    .object({
-      data: z.array(z.lazy(() => s_item)),
-      has_more: z.coerce.boolean(),
-      object: z.enum(["list"]),
-      url: z.string().max(5000),
-    })
-    .optional(),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)),
-  object: z.enum(["payment_link"]),
-  on_behalf_of: z
-    .union([z.string().max(5000), z.lazy(() => s_account)])
-    .nullable()
-    .optional(),
-  payment_intent_data: s_payment_links_resource_payment_intent_data
-    .nullable()
-    .optional(),
-  payment_method_collection: z.enum(["always", "if_required"]),
-  payment_method_types: z
-    .array(
-      z.enum([
-        "affirm",
-        "afterpay_clearpay",
-        "alipay",
-        "au_becs_debit",
-        "bacs_debit",
-        "bancontact",
-        "blik",
-        "boleto",
-        "card",
-        "cashapp",
-        "eps",
-        "fpx",
-        "giropay",
-        "grabpay",
-        "ideal",
-        "klarna",
-        "konbini",
-        "link",
-        "oxxo",
-        "p24",
-        "paynow",
-        "paypal",
-        "pix",
-        "promptpay",
-        "sepa_debit",
-        "sofort",
-        "swish",
-        "us_bank_account",
-        "wechat_pay",
-      ]),
-    )
-    .nullable()
-    .optional(),
-  phone_number_collection: s_payment_links_resource_phone_number_collection,
-  restrictions: s_payment_links_resource_restrictions.nullable().optional(),
-  shipping_address_collection:
-    s_payment_links_resource_shipping_address_collection.nullable().optional(),
-  shipping_options: z.array(s_payment_links_resource_shipping_option),
-  submit_type: z.enum(["auto", "book", "donate", "pay"]),
-  subscription_data: z.lazy(() =>
-    s_payment_links_resource_subscription_data.nullable().optional(),
-  ),
-  tax_id_collection: s_payment_links_resource_tax_id_collection,
-  transfer_data: z.lazy(() =>
-    s_payment_links_resource_transfer_data.nullable().optional(),
-  ),
-  url: z.string().max(5000),
-})
+export const s_payment_link: z.ZodType<t_payment_link, z.ZodTypeDef, unknown> =
+  z.object({
+    active: PermissiveBoolean,
+    after_completion: s_payment_links_resource_after_completion,
+    allow_promotion_codes: PermissiveBoolean,
+    application: z
+      .union([z.string().max(5000), s_application, s_deleted_application])
+      .nullable()
+      .optional(),
+    application_fee_amount: z.coerce.number().nullable().optional(),
+    application_fee_percent: z.coerce.number().nullable().optional(),
+    automatic_tax: z.lazy(() => s_payment_links_resource_automatic_tax),
+    billing_address_collection: z.enum(["auto", "required"]),
+    consent_collection: s_payment_links_resource_consent_collection
+      .nullable()
+      .optional(),
+    currency: z.string(),
+    custom_fields: z.array(s_payment_links_resource_custom_fields),
+    custom_text: s_payment_links_resource_custom_text,
+    customer_creation: z.enum(["always", "if_required"]),
+    id: z.string().max(5000),
+    inactive_message: z.string().max(5000).nullable().optional(),
+    invoice_creation: z.lazy(() =>
+      s_payment_links_resource_invoice_creation.nullable().optional(),
+    ),
+    line_items: z
+      .object({
+        data: z.array(z.lazy(() => s_item)),
+        has_more: PermissiveBoolean,
+        object: z.enum(["list"]),
+        url: z.string().max(5000),
+      })
+      .optional(),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)),
+    object: z.enum(["payment_link"]),
+    on_behalf_of: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .nullable()
+      .optional(),
+    payment_intent_data: s_payment_links_resource_payment_intent_data
+      .nullable()
+      .optional(),
+    payment_method_collection: z.enum(["always", "if_required"]),
+    payment_method_types: z
+      .array(
+        z.enum([
+          "affirm",
+          "afterpay_clearpay",
+          "alipay",
+          "au_becs_debit",
+          "bacs_debit",
+          "bancontact",
+          "blik",
+          "boleto",
+          "card",
+          "cashapp",
+          "eps",
+          "fpx",
+          "giropay",
+          "grabpay",
+          "ideal",
+          "klarna",
+          "konbini",
+          "link",
+          "oxxo",
+          "p24",
+          "paynow",
+          "paypal",
+          "pix",
+          "promptpay",
+          "sepa_debit",
+          "sofort",
+          "swish",
+          "us_bank_account",
+          "wechat_pay",
+        ]),
+      )
+      .nullable()
+      .optional(),
+    phone_number_collection: s_payment_links_resource_phone_number_collection,
+    restrictions: s_payment_links_resource_restrictions.nullable().optional(),
+    shipping_address_collection:
+      s_payment_links_resource_shipping_address_collection
+        .nullable()
+        .optional(),
+    shipping_options: z.array(s_payment_links_resource_shipping_option),
+    submit_type: z.enum(["auto", "book", "donate", "pay"]),
+    subscription_data: z.lazy(() =>
+      s_payment_links_resource_subscription_data.nullable().optional(),
+    ),
+    tax_id_collection: s_payment_links_resource_tax_id_collection,
+    transfer_data: z.lazy(() =>
+      s_payment_links_resource_transfer_data.nullable().optional(),
+    ),
+    url: z.string().max(5000),
+  })
 
-export const s_payout: z.ZodType<t_payout> = z.object({
+export const s_payout: z.ZodType<t_payout, z.ZodTypeDef, unknown> = z.object({
   amount: z.coerce.number(),
   arrival_date: z.coerce.number(),
-  automatic: z.coerce.boolean(),
+  automatic: PermissiveBoolean,
   balance_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
     .nullable()
@@ -11641,7 +11757,7 @@ export const s_payout: z.ZodType<t_payout> = z.object({
   failure_code: z.string().max(5000).nullable().optional(),
   failure_message: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   method: z.string().max(5000),
   object: z.enum(["payout"]),
@@ -11660,8 +11776,8 @@ export const s_payout: z.ZodType<t_payout> = z.object({
   type: z.enum(["bank_account", "card"]),
 })
 
-export const s_plan: z.ZodType<t_plan> = z.object({
-  active: z.coerce.boolean(),
+export const s_plan: z.ZodType<t_plan, z.ZodTypeDef, unknown> = z.object({
+  active: PermissiveBoolean,
   aggregate_usage: z
     .enum(["last_during_period", "last_ever", "max", "sum"])
     .nullable()
@@ -11674,7 +11790,7 @@ export const s_plan: z.ZodType<t_plan> = z.object({
   id: z.string().max(5000),
   interval: z.enum(["day", "month", "week", "year"]),
   interval_count: z.coerce.number(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)).nullable().optional(),
   meter: z.string().max(5000).nullable().optional(),
   nickname: z.string().max(5000).nullable().optional(),
@@ -11690,15 +11806,15 @@ export const s_plan: z.ZodType<t_plan> = z.object({
   usage_type: z.enum(["licensed", "metered"]),
 })
 
-export const s_price: z.ZodType<t_price> = z.object({
-  active: z.coerce.boolean(),
+export const s_price: z.ZodType<t_price, z.ZodTypeDef, unknown> = z.object({
+  active: PermissiveBoolean,
   billing_scheme: z.enum(["per_unit", "tiered"]),
   created: z.coerce.number(),
   currency: z.string(),
   currency_options: z.record(s_currency_option).optional(),
   custom_unit_amount: s_custom_unit_amount.nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   lookup_key: z.string().max(5000).nullable().optional(),
   metadata: z.record(z.string().max(500)),
   nickname: z.string().max(5000).nullable().optional(),
@@ -11721,8 +11837,8 @@ export const s_price: z.ZodType<t_price> = z.object({
   unit_amount_decimal: z.string().nullable().optional(),
 })
 
-export const s_product: z.ZodType<t_product> = z.object({
-  active: z.coerce.boolean(),
+export const s_product: z.ZodType<t_product, z.ZodTypeDef, unknown> = z.object({
+  active: PermissiveBoolean,
   created: z.coerce.number(),
   default_price: z
     .union([z.string().max(5000), z.lazy(() => s_price)])
@@ -11732,12 +11848,12 @@ export const s_product: z.ZodType<t_product> = z.object({
   features: z.array(s_product_marketing_feature),
   id: z.string().max(5000),
   images: z.array(z.string().max(5000)),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   name: z.string().max(5000),
   object: z.enum(["product"]),
   package_dimensions: s_package_dimensions.nullable().optional(),
-  shippable: z.coerce.boolean().nullable().optional(),
+  shippable: PermissiveBoolean.nullable().optional(),
   statement_descriptor: z.string().max(5000).nullable().optional(),
   tax_code: z
     .union([z.string().max(5000), s_tax_code])
@@ -11748,8 +11864,12 @@ export const s_product: z.ZodType<t_product> = z.object({
   url: z.string().max(2048).nullable().optional(),
 })
 
-export const s_promotion_code: z.ZodType<t_promotion_code> = z.object({
-  active: z.coerce.boolean(),
+export const s_promotion_code: z.ZodType<
+  t_promotion_code,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  active: PermissiveBoolean,
   code: z.string().max(5000),
   coupon: s_coupon,
   created: z.coerce.number(),
@@ -11759,7 +11879,7 @@ export const s_promotion_code: z.ZodType<t_promotion_code> = z.object({
     .optional(),
   expires_at: z.coerce.number().nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   max_redemptions: z.coerce.number().nullable().optional(),
   metadata: z.record(z.string().max(500)).nullable().optional(),
   object: z.enum(["promotion_code"]),
@@ -11767,7 +11887,7 @@ export const s_promotion_code: z.ZodType<t_promotion_code> = z.object({
   times_redeemed: z.coerce.number(),
 })
 
-export const s_quote: z.ZodType<t_quote> = z.object({
+export const s_quote: z.ZodType<t_quote, z.ZodTypeDef, unknown> = z.object({
   amount_subtotal: z.coerce.number(),
   amount_total: z.coerce.number(),
   application: z
@@ -11803,12 +11923,12 @@ export const s_quote: z.ZodType<t_quote> = z.object({
   line_items: z
     .object({
       data: z.array(z.lazy(() => s_item)),
-      has_more: z.coerce.boolean(),
+      has_more: PermissiveBoolean,
       object: z.enum(["list"]),
       url: z.string().max(5000),
     })
     .optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   number: z.string().max(5000).nullable().optional(),
   object: z.enum(["quote"]),
@@ -11837,35 +11957,41 @@ export const s_quote: z.ZodType<t_quote> = z.object({
   ),
 })
 
-export const s_radar_early_fraud_warning: z.ZodType<t_radar_early_fraud_warning> =
-  z.object({
-    actionable: z.coerce.boolean(),
-    charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]),
-    created: z.coerce.number(),
-    fraud_type: z.string().max(5000),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["radar.early_fraud_warning"]),
-    payment_intent: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
-      .optional(),
-  })
+export const s_radar_early_fraud_warning: z.ZodType<
+  t_radar_early_fraud_warning,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  actionable: PermissiveBoolean,
+  charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]),
+  created: z.coerce.number(),
+  fraud_type: z.string().max(5000),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["radar.early_fraud_warning"]),
+  payment_intent: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
+    .optional(),
+})
 
-export const s_reporting_report_run: z.ZodType<t_reporting_report_run> =
-  z.object({
-    created: z.coerce.number(),
-    error: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["reporting.report_run"]),
-    parameters: s_financial_reporting_finance_report_run_run_parameters,
-    report_type: z.string().max(5000),
-    result: z.lazy(() => s_file.nullable().optional()),
-    status: z.string().max(5000),
-    succeeded_at: z.coerce.number().nullable().optional(),
-  })
+export const s_reporting_report_run: z.ZodType<
+  t_reporting_report_run,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  created: z.coerce.number(),
+  error: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["reporting.report_run"]),
+  parameters: s_financial_reporting_finance_report_run_run_parameters,
+  report_type: z.string().max(5000),
+  result: z.lazy(() => s_file.nullable().optional()),
+  status: z.string().max(5000),
+  succeeded_at: z.coerce.number().nullable().optional(),
+})
 
-export const s_review: z.ZodType<t_review> = z.object({
+export const s_review: z.ZodType<t_review, z.ZodTypeDef, unknown> = z.object({
   billing_zip: z.string().max(5000).nullable().optional(),
   charge: z
     .union([z.string().max(5000), z.lazy(() => s_charge)])
@@ -11879,9 +12005,9 @@ export const s_review: z.ZodType<t_review> = z.object({
   id: z.string().max(5000),
   ip_address: z.string().max(5000).nullable().optional(),
   ip_address_location: s_radar_review_resource_location.nullable().optional(),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["review"]),
-  open: z.coerce.boolean(),
+  open: PermissiveBoolean,
   opened_reason: z.enum(["manual", "rule"]),
   payment_intent: z
     .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
@@ -11890,12 +12016,16 @@ export const s_review: z.ZodType<t_review> = z.object({
   session: s_radar_review_resource_session.nullable().optional(),
 })
 
-export const s_setup_attempt: z.ZodType<t_setup_attempt> = z.object({
+export const s_setup_attempt: z.ZodType<
+  t_setup_attempt,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   application: z
     .union([z.string().max(5000), s_application])
     .nullable()
     .optional(),
-  attach_to_self: z.coerce.boolean().optional(),
+  attach_to_self: PermissiveBoolean.optional(),
   created: z.coerce.number(),
   customer: z
     .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
@@ -11906,7 +12036,7 @@ export const s_setup_attempt: z.ZodType<t_setup_attempt> = z.object({
     .nullable()
     .optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["setup_attempt"]),
   on_behalf_of: z
     .union([z.string().max(5000), z.lazy(() => s_account)])
@@ -11923,93 +12053,104 @@ export const s_setup_attempt: z.ZodType<t_setup_attempt> = z.object({
   usage: z.string().max(5000),
 })
 
-export const s_setup_intent: z.ZodType<t_setup_intent> = z.object({
-  application: z
-    .union([z.string().max(5000), s_application])
-    .nullable()
-    .optional(),
-  attach_to_self: z.coerce.boolean().optional(),
-  automatic_payment_methods:
-    s_payment_flows_automatic_payment_methods_setup_intent
+export const s_setup_intent: z.ZodType<t_setup_intent, z.ZodTypeDef, unknown> =
+  z.object({
+    application: z
+      .union([z.string().max(5000), s_application])
       .nullable()
       .optional(),
-  cancellation_reason: z
-    .enum(["abandoned", "duplicate", "requested_by_customer"])
-    .nullable()
-    .optional(),
-  client_secret: z.string().max(5000).nullable().optional(),
+    attach_to_self: PermissiveBoolean.optional(),
+    automatic_payment_methods:
+      s_payment_flows_automatic_payment_methods_setup_intent
+        .nullable()
+        .optional(),
+    cancellation_reason: z
+      .enum(["abandoned", "duplicate", "requested_by_customer"])
+      .nullable()
+      .optional(),
+    client_secret: z.string().max(5000).nullable().optional(),
+    created: z.coerce.number(),
+    customer: z
+      .union([
+        z.string().max(5000),
+        z.lazy(() => s_customer),
+        s_deleted_customer,
+      ])
+      .nullable()
+      .optional(),
+    description: z.string().max(5000).nullable().optional(),
+    flow_directions: z
+      .array(z.enum(["inbound", "outbound"]))
+      .nullable()
+      .optional(),
+    id: z.string().max(5000),
+    last_setup_error: z.lazy(() => s_api_errors.nullable().optional()),
+    latest_attempt: z
+      .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
+      .nullable()
+      .optional(),
+    livemode: PermissiveBoolean,
+    mandate: z
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
+      .nullable()
+      .optional(),
+    metadata: z.record(z.string().max(500)).nullable().optional(),
+    next_action: s_setup_intent_next_action.nullable().optional(),
+    object: z.enum(["setup_intent"]),
+    on_behalf_of: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .nullable()
+      .optional(),
+    payment_method: z
+      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+      .nullable()
+      .optional(),
+    payment_method_configuration_details:
+      s_payment_method_config_biz_payment_method_configuration_details
+        .nullable()
+        .optional(),
+    payment_method_options: s_setup_intent_payment_method_options
+      .nullable()
+      .optional(),
+    payment_method_types: z.array(z.string().max(5000)),
+    single_use_mandate: z
+      .union([z.string().max(5000), z.lazy(() => s_mandate)])
+      .nullable()
+      .optional(),
+    status: z.enum([
+      "canceled",
+      "processing",
+      "requires_action",
+      "requires_confirmation",
+      "requires_payment_method",
+      "succeeded",
+    ]),
+    usage: z.string().max(5000),
+  })
+
+export const s_scheduled_query_run: z.ZodType<
+  t_scheduled_query_run,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   created: z.coerce.number(),
-  customer: z
-    .union([z.string().max(5000), z.lazy(() => s_customer), s_deleted_customer])
-    .nullable()
-    .optional(),
-  description: z.string().max(5000).nullable().optional(),
-  flow_directions: z
-    .array(z.enum(["inbound", "outbound"]))
-    .nullable()
-    .optional(),
+  data_load_time: z.coerce.number(),
+  error: s_sigma_scheduled_query_run_error.optional(),
+  file: z.lazy(() => s_file.nullable().optional()),
   id: z.string().max(5000),
-  last_setup_error: z.lazy(() => s_api_errors.nullable().optional()),
-  latest_attempt: z
-    .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
-    .nullable()
-    .optional(),
-  livemode: z.coerce.boolean(),
-  mandate: z
-    .union([z.string().max(5000), z.lazy(() => s_mandate)])
-    .nullable()
-    .optional(),
-  metadata: z.record(z.string().max(500)).nullable().optional(),
-  next_action: s_setup_intent_next_action.nullable().optional(),
-  object: z.enum(["setup_intent"]),
-  on_behalf_of: z
-    .union([z.string().max(5000), z.lazy(() => s_account)])
-    .nullable()
-    .optional(),
-  payment_method: z
-    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-    .nullable()
-    .optional(),
-  payment_method_configuration_details:
-    s_payment_method_config_biz_payment_method_configuration_details
-      .nullable()
-      .optional(),
-  payment_method_options: s_setup_intent_payment_method_options
-    .nullable()
-    .optional(),
-  payment_method_types: z.array(z.string().max(5000)),
-  single_use_mandate: z
-    .union([z.string().max(5000), z.lazy(() => s_mandate)])
-    .nullable()
-    .optional(),
-  status: z.enum([
-    "canceled",
-    "processing",
-    "requires_action",
-    "requires_confirmation",
-    "requires_payment_method",
-    "succeeded",
-  ]),
-  usage: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["scheduled_query_run"]),
+  result_available_until: z.coerce.number(),
+  sql: z.string().max(100000),
+  status: z.string().max(5000),
+  title: z.string().max(5000),
 })
 
-export const s_scheduled_query_run: z.ZodType<t_scheduled_query_run> = z.object(
-  {
-    created: z.coerce.number(),
-    data_load_time: z.coerce.number(),
-    error: s_sigma_scheduled_query_run_error.optional(),
-    file: z.lazy(() => s_file.nullable().optional()),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["scheduled_query_run"]),
-    result_available_until: z.coerce.number(),
-    sql: z.string().max(100000),
-    status: z.string().max(5000),
-    title: z.string().max(5000),
-  },
-)
-
-export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
+export const s_subscription_item: z.ZodType<
+  t_subscription_item,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   billing_thresholds: s_subscription_item_billing_thresholds
     .nullable()
     .optional(),
@@ -12024,68 +12165,78 @@ export const s_subscription_item: z.ZodType<t_subscription_item> = z.object({
   tax_rates: z.array(s_tax_rate).nullable().optional(),
 })
 
-export const s_subscription_schedule: z.ZodType<t_subscription_schedule> =
-  z.object({
-    application: z
-      .union([z.string().max(5000), s_application, s_deleted_application])
-      .nullable()
-      .optional(),
-    canceled_at: z.coerce.number().nullable().optional(),
-    completed_at: z.coerce.number().nullable().optional(),
-    created: z.coerce.number(),
-    current_phase: s_subscription_schedule_current_phase.nullable().optional(),
-    customer: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_customer),
-      s_deleted_customer,
-    ]),
-    default_settings: z.lazy(
-      () => s_subscription_schedules_resource_default_settings,
-    ),
-    end_behavior: z.enum(["cancel", "none", "release", "renew"]),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)).nullable().optional(),
-    object: z.enum(["subscription_schedule"]),
-    phases: z.array(z.lazy(() => s_subscription_schedule_phase_configuration)),
-    released_at: z.coerce.number().nullable().optional(),
-    released_subscription: z.string().max(5000).nullable().optional(),
-    status: z.enum([
-      "active",
-      "canceled",
-      "completed",
-      "not_started",
-      "released",
-    ]),
-    subscription: z
-      .union([z.string().max(5000), z.lazy(() => s_subscription)])
-      .nullable()
-      .optional(),
-    test_clock: z
-      .union([z.string().max(5000), s_test_helpers_test_clock])
-      .nullable()
-      .optional(),
-  })
+export const s_subscription_schedule: z.ZodType<
+  t_subscription_schedule,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  application: z
+    .union([z.string().max(5000), s_application, s_deleted_application])
+    .nullable()
+    .optional(),
+  canceled_at: z.coerce.number().nullable().optional(),
+  completed_at: z.coerce.number().nullable().optional(),
+  created: z.coerce.number(),
+  current_phase: s_subscription_schedule_current_phase.nullable().optional(),
+  customer: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_customer),
+    s_deleted_customer,
+  ]),
+  default_settings: z.lazy(
+    () => s_subscription_schedules_resource_default_settings,
+  ),
+  end_behavior: z.enum(["cancel", "none", "release", "renew"]),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  object: z.enum(["subscription_schedule"]),
+  phases: z.array(z.lazy(() => s_subscription_schedule_phase_configuration)),
+  released_at: z.coerce.number().nullable().optional(),
+  released_subscription: z.string().max(5000).nullable().optional(),
+  status: z.enum([
+    "active",
+    "canceled",
+    "completed",
+    "not_started",
+    "released",
+  ]),
+  subscription: z
+    .union([z.string().max(5000), z.lazy(() => s_subscription)])
+    .nullable()
+    .optional(),
+  test_clock: z
+    .union([z.string().max(5000), s_test_helpers_test_clock])
+    .nullable()
+    .optional(),
+})
 
-export const s_terminal_configuration: z.ZodType<t_terminal_configuration> =
-  z.object({
-    bbpos_wisepos_e: z.lazy(() =>
-      s_terminal_configuration_configuration_resource_device_type_specific_config.optional(),
-    ),
-    id: z.string().max(5000),
-    is_account_default: z.coerce.boolean().nullable().optional(),
-    livemode: z.coerce.boolean(),
-    name: z.string().max(5000).nullable().optional(),
-    object: z.enum(["terminal.configuration"]),
-    offline:
-      s_terminal_configuration_configuration_resource_offline_config.optional(),
-    tipping: s_terminal_configuration_configuration_resource_tipping.optional(),
-    verifone_p400: z.lazy(() =>
-      s_terminal_configuration_configuration_resource_device_type_specific_config.optional(),
-    ),
-  })
+export const s_terminal_configuration: z.ZodType<
+  t_terminal_configuration,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bbpos_wisepos_e: z.lazy(() =>
+    s_terminal_configuration_configuration_resource_device_type_specific_config.optional(),
+  ),
+  id: z.string().max(5000),
+  is_account_default: PermissiveBoolean.nullable().optional(),
+  livemode: PermissiveBoolean,
+  name: z.string().max(5000).nullable().optional(),
+  object: z.enum(["terminal.configuration"]),
+  offline:
+    s_terminal_configuration_configuration_resource_offline_config.optional(),
+  tipping: s_terminal_configuration_configuration_resource_tipping.optional(),
+  verifone_p400: z.lazy(() =>
+    s_terminal_configuration_configuration_resource_device_type_specific_config.optional(),
+  ),
+})
 
-export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
+export const s_terminal_reader: z.ZodType<
+  t_terminal_reader,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   action: z.lazy(() =>
     s_terminal_reader_reader_resource_reader_action.nullable().optional(),
   ),
@@ -12102,7 +12253,7 @@ export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
   id: z.string().max(5000),
   ip_address: z.string().max(5000).nullable().optional(),
   label: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   location: z
     .union([z.string().max(5000), s_terminal_location])
     .nullable()
@@ -12113,183 +12264,193 @@ export const s_terminal_reader: z.ZodType<t_terminal_reader> = z.object({
   status: z.enum(["offline", "online"]).nullable().optional(),
 })
 
-export const s_treasury_inbound_transfer: z.ZodType<t_treasury_inbound_transfer> =
-  z.object({
-    amount: z.coerce.number(),
-    cancelable: z.coerce.boolean(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    description: z.string().max(5000).nullable().optional(),
-    failure_details: s_treasury_inbound_transfers_resource_failure_details
-      .nullable()
-      .optional(),
-    financial_account: z.string().max(5000),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    linked_flows:
-      s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows,
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)),
-    object: z.enum(["treasury.inbound_transfer"]),
-    origin_payment_method: z.string().max(5000),
-    origin_payment_method_details: z.lazy(() =>
-      s_inbound_transfers.nullable().optional(),
-    ),
-    returned: z.coerce.boolean().nullable().optional(),
-    statement_descriptor: z.string().max(5000),
-    status: z.enum(["canceled", "failed", "processing", "succeeded"]),
-    status_transitions:
-      s_treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions,
-    transaction: z
-      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
-      .nullable()
-      .optional(),
-  })
+export const s_treasury_inbound_transfer: z.ZodType<
+  t_treasury_inbound_transfer,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  cancelable: PermissiveBoolean,
+  created: z.coerce.number(),
+  currency: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  failure_details: s_treasury_inbound_transfers_resource_failure_details
+    .nullable()
+    .optional(),
+  financial_account: z.string().max(5000),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  linked_flows:
+    s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows,
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)),
+  object: z.enum(["treasury.inbound_transfer"]),
+  origin_payment_method: z.string().max(5000),
+  origin_payment_method_details: z.lazy(() =>
+    s_inbound_transfers.nullable().optional(),
+  ),
+  returned: PermissiveBoolean.nullable().optional(),
+  statement_descriptor: z.string().max(5000),
+  status: z.enum(["canceled", "failed", "processing", "succeeded"]),
+  status_transitions:
+    s_treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions,
+  transaction: z
+    .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
+    .nullable()
+    .optional(),
+})
 
-export const s_treasury_outbound_payment: z.ZodType<t_treasury_outbound_payment> =
-  z.object({
-    amount: z.coerce.number(),
-    cancelable: z.coerce.boolean(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    customer: z.string().max(5000).nullable().optional(),
-    description: z.string().max(5000).nullable().optional(),
-    destination_payment_method: z.string().max(5000).nullable().optional(),
-    destination_payment_method_details: z.lazy(() =>
-      s_outbound_payments_payment_method_details.nullable().optional(),
-    ),
-    end_user_details:
-      s_treasury_outbound_payments_resource_outbound_payment_resource_end_user_details
-        .nullable()
-        .optional(),
-    expected_arrival_date: z.coerce.number(),
-    financial_account: z.string().max(5000),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)),
-    object: z.enum(["treasury.outbound_payment"]),
-    returned_details: z.lazy(() =>
-      s_treasury_outbound_payments_resource_returned_status
-        .nullable()
-        .optional(),
-    ),
-    statement_descriptor: z.string().max(5000),
-    status: z.enum(["canceled", "failed", "posted", "processing", "returned"]),
-    status_transitions:
-      s_treasury_outbound_payments_resource_outbound_payment_resource_status_transitions,
-    transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_treasury_transaction),
-    ]),
-  })
+export const s_treasury_outbound_payment: z.ZodType<
+  t_treasury_outbound_payment,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  cancelable: PermissiveBoolean,
+  created: z.coerce.number(),
+  currency: z.string(),
+  customer: z.string().max(5000).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  destination_payment_method: z.string().max(5000).nullable().optional(),
+  destination_payment_method_details: z.lazy(() =>
+    s_outbound_payments_payment_method_details.nullable().optional(),
+  ),
+  end_user_details:
+    s_treasury_outbound_payments_resource_outbound_payment_resource_end_user_details
+      .nullable()
+      .optional(),
+  expected_arrival_date: z.coerce.number(),
+  financial_account: z.string().max(5000),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)),
+  object: z.enum(["treasury.outbound_payment"]),
+  returned_details: z.lazy(() =>
+    s_treasury_outbound_payments_resource_returned_status.nullable().optional(),
+  ),
+  statement_descriptor: z.string().max(5000),
+  status: z.enum(["canceled", "failed", "posted", "processing", "returned"]),
+  status_transitions:
+    s_treasury_outbound_payments_resource_outbound_payment_resource_status_transitions,
+  transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_treasury_transaction),
+  ]),
+})
 
-export const s_treasury_outbound_transfer: z.ZodType<t_treasury_outbound_transfer> =
-  z.object({
-    amount: z.coerce.number(),
-    cancelable: z.coerce.boolean(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    description: z.string().max(5000).nullable().optional(),
-    destination_payment_method: z.string().max(5000).nullable().optional(),
-    destination_payment_method_details: z.lazy(
-      () => s_outbound_transfers_payment_method_details,
-    ),
-    expected_arrival_date: z.coerce.number(),
-    financial_account: z.string().max(5000),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)),
-    object: z.enum(["treasury.outbound_transfer"]),
-    returned_details: z.lazy(() =>
-      s_treasury_outbound_transfers_resource_returned_details
-        .nullable()
-        .optional(),
-    ),
-    statement_descriptor: z.string().max(5000),
-    status: z.enum(["canceled", "failed", "posted", "processing", "returned"]),
-    status_transitions:
-      s_treasury_outbound_transfers_resource_status_transitions,
-    transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_treasury_transaction),
-    ]),
-  })
+export const s_treasury_outbound_transfer: z.ZodType<
+  t_treasury_outbound_transfer,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  cancelable: PermissiveBoolean,
+  created: z.coerce.number(),
+  currency: z.string(),
+  description: z.string().max(5000).nullable().optional(),
+  destination_payment_method: z.string().max(5000).nullable().optional(),
+  destination_payment_method_details: z.lazy(
+    () => s_outbound_transfers_payment_method_details,
+  ),
+  expected_arrival_date: z.coerce.number(),
+  financial_account: z.string().max(5000),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)),
+  object: z.enum(["treasury.outbound_transfer"]),
+  returned_details: z.lazy(() =>
+    s_treasury_outbound_transfers_resource_returned_details
+      .nullable()
+      .optional(),
+  ),
+  statement_descriptor: z.string().max(5000),
+  status: z.enum(["canceled", "failed", "posted", "processing", "returned"]),
+  status_transitions: s_treasury_outbound_transfers_resource_status_transitions,
+  transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_treasury_transaction),
+  ]),
+})
 
-export const s_treasury_received_credit: z.ZodType<t_treasury_received_credit> =
-  z.object({
-    amount: z.coerce.number(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    description: z.string().max(5000),
-    failure_code: z
-      .enum(["account_closed", "account_frozen", "other"])
-      .nullable()
-      .optional(),
-    financial_account: z.string().max(5000).nullable().optional(),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    initiating_payment_method_details:
-      s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details,
-    linked_flows: z.lazy(
-      () => s_treasury_received_credits_resource_linked_flows,
-    ),
-    livemode: z.coerce.boolean(),
-    network: z.enum(["ach", "card", "stripe", "us_domestic_wire"]),
-    object: z.enum(["treasury.received_credit"]),
-    reversal_details: s_treasury_received_credits_resource_reversal_details
-      .nullable()
-      .optional(),
-    status: z.enum(["failed", "succeeded"]),
-    transaction: z
-      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
-      .nullable()
-      .optional(),
-  })
+export const s_treasury_received_credit: z.ZodType<
+  t_treasury_received_credit,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  description: z.string().max(5000),
+  failure_code: z
+    .enum(["account_closed", "account_frozen", "other"])
+    .nullable()
+    .optional(),
+  financial_account: z.string().max(5000).nullable().optional(),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  initiating_payment_method_details:
+    s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details,
+  linked_flows: z.lazy(() => s_treasury_received_credits_resource_linked_flows),
+  livemode: PermissiveBoolean,
+  network: z.enum(["ach", "card", "stripe", "us_domestic_wire"]),
+  object: z.enum(["treasury.received_credit"]),
+  reversal_details: s_treasury_received_credits_resource_reversal_details
+    .nullable()
+    .optional(),
+  status: z.enum(["failed", "succeeded"]),
+  transaction: z
+    .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
+    .nullable()
+    .optional(),
+})
 
-export const s_treasury_received_debit: z.ZodType<t_treasury_received_debit> =
-  z.object({
-    amount: z.coerce.number(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    description: z.string().max(5000),
-    failure_code: z
-      .enum(["account_closed", "account_frozen", "insufficient_funds", "other"])
-      .nullable()
-      .optional(),
-    financial_account: z.string().max(5000).nullable().optional(),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    initiating_payment_method_details:
-      s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details.optional(),
-    linked_flows: s_treasury_received_debits_resource_linked_flows,
-    livemode: z.coerce.boolean(),
-    network: z.enum(["ach", "card", "stripe"]),
-    object: z.enum(["treasury.received_debit"]),
-    reversal_details: s_treasury_received_debits_resource_reversal_details
-      .nullable()
-      .optional(),
-    status: z.enum(["failed", "succeeded"]),
-    transaction: z
-      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
-      .nullable()
-      .optional(),
-  })
+export const s_treasury_received_debit: z.ZodType<
+  t_treasury_received_debit,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  description: z.string().max(5000),
+  failure_code: z
+    .enum(["account_closed", "account_frozen", "insufficient_funds", "other"])
+    .nullable()
+    .optional(),
+  financial_account: z.string().max(5000).nullable().optional(),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  initiating_payment_method_details:
+    s_treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details.optional(),
+  linked_flows: s_treasury_received_debits_resource_linked_flows,
+  livemode: PermissiveBoolean,
+  network: z.enum(["ach", "card", "stripe"]),
+  object: z.enum(["treasury.received_debit"]),
+  reversal_details: s_treasury_received_debits_resource_reversal_details
+    .nullable()
+    .optional(),
+  status: z.enum(["failed", "succeeded"]),
+  transaction: z
+    .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
+    .nullable()
+    .optional(),
+})
 
-export const s_token: z.ZodType<t_token> = z.object({
+export const s_token: z.ZodType<t_token, z.ZodTypeDef, unknown> = z.object({
   bank_account: z.lazy(() => s_bank_account.optional()),
   card: z.lazy(() => s_card.optional()),
   client_ip: z.string().max(5000).nullable().optional(),
   created: z.coerce.number(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   object: z.enum(["token"]),
   type: z.string().max(5000),
-  used: z.coerce.boolean(),
+  used: PermissiveBoolean,
 })
 
-export const s_topup: z.ZodType<t_topup> = z.object({
+export const s_topup: z.ZodType<t_topup, z.ZodTypeDef, unknown> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
@@ -12302,7 +12463,7 @@ export const s_topup: z.ZodType<t_topup> = z.object({
   failure_code: z.string().max(5000).nullable().optional(),
   failure_message: z.string().max(5000).nullable().optional(),
   id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
+  livemode: PermissiveBoolean,
   metadata: z.record(z.string().max(500)),
   object: z.enum(["topup"]),
   source: s_source.nullable().optional(),
@@ -12311,43 +12472,48 @@ export const s_topup: z.ZodType<t_topup> = z.object({
   transfer_group: z.string().max(5000).nullable().optional(),
 })
 
-export const s_transfer: z.ZodType<t_transfer> = z.object({
-  amount: z.coerce.number(),
-  amount_reversed: z.coerce.number(),
-  balance_transaction: z
-    .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
-    .nullable()
-    .optional(),
-  created: z.coerce.number(),
-  currency: z.string(),
-  description: z.string().max(5000).nullable().optional(),
-  destination: z
-    .union([z.string().max(5000), z.lazy(() => s_account)])
-    .nullable()
-    .optional(),
-  destination_payment: z
-    .union([z.string().max(5000), z.lazy(() => s_charge)])
-    .optional(),
-  id: z.string().max(5000),
-  livemode: z.coerce.boolean(),
-  metadata: z.record(z.string().max(500)),
-  object: z.enum(["transfer"]),
-  reversals: z.object({
-    data: z.array(z.lazy(() => s_transfer_reversal)),
-    has_more: z.coerce.boolean(),
-    object: z.enum(["list"]),
-    url: z.string().max(5000),
-  }),
-  reversed: z.coerce.boolean(),
-  source_transaction: z
-    .union([z.string().max(5000), z.lazy(() => s_charge)])
-    .nullable()
-    .optional(),
-  source_type: z.string().max(5000).optional(),
-  transfer_group: z.string().max(5000).nullable().optional(),
-})
+export const s_transfer: z.ZodType<t_transfer, z.ZodTypeDef, unknown> =
+  z.object({
+    amount: z.coerce.number(),
+    amount_reversed: z.coerce.number(),
+    balance_transaction: z
+      .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
+      .nullable()
+      .optional(),
+    created: z.coerce.number(),
+    currency: z.string(),
+    description: z.string().max(5000).nullable().optional(),
+    destination: z
+      .union([z.string().max(5000), z.lazy(() => s_account)])
+      .nullable()
+      .optional(),
+    destination_payment: z
+      .union([z.string().max(5000), z.lazy(() => s_charge)])
+      .optional(),
+    id: z.string().max(5000),
+    livemode: PermissiveBoolean,
+    metadata: z.record(z.string().max(500)),
+    object: z.enum(["transfer"]),
+    reversals: z.object({
+      data: z.array(z.lazy(() => s_transfer_reversal)),
+      has_more: PermissiveBoolean,
+      object: z.enum(["list"]),
+      url: z.string().max(5000),
+    }),
+    reversed: PermissiveBoolean,
+    source_transaction: z
+      .union([z.string().max(5000), z.lazy(() => s_charge)])
+      .nullable()
+      .optional(),
+    source_type: z.string().max(5000).optional(),
+    transfer_group: z.string().max(5000).nullable().optional(),
+  })
 
-export const s_transfer_reversal: z.ZodType<t_transfer_reversal> = z.object({
+export const s_transfer_reversal: z.ZodType<
+  t_transfer_reversal,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   amount: z.coerce.number(),
   balance_transaction: z
     .union([z.string().max(5000), z.lazy(() => s_balance_transaction)])
@@ -12369,199 +12535,217 @@ export const s_transfer_reversal: z.ZodType<t_transfer_reversal> = z.object({
   transfer: z.union([z.string().max(5000), z.lazy(() => s_transfer)]),
 })
 
-export const s_treasury_credit_reversal: z.ZodType<t_treasury_credit_reversal> =
-  z.object({
-    amount: z.coerce.number(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    financial_account: z.string().max(5000),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)),
-    network: z.enum(["ach", "stripe"]),
-    object: z.enum(["treasury.credit_reversal"]),
-    received_credit: z.string().max(5000),
-    status: z.enum(["canceled", "posted", "processing"]),
-    status_transitions: s_treasury_received_credits_resource_status_transitions,
-    transaction: z
-      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
-      .nullable()
-      .optional(),
-  })
+export const s_treasury_credit_reversal: z.ZodType<
+  t_treasury_credit_reversal,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  financial_account: z.string().max(5000),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)),
+  network: z.enum(["ach", "stripe"]),
+  object: z.enum(["treasury.credit_reversal"]),
+  received_credit: z.string().max(5000),
+  status: z.enum(["canceled", "posted", "processing"]),
+  status_transitions: s_treasury_received_credits_resource_status_transitions,
+  transaction: z
+    .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
+    .nullable()
+    .optional(),
+})
 
-export const s_treasury_debit_reversal: z.ZodType<t_treasury_debit_reversal> =
-  z.object({
-    amount: z.coerce.number(),
-    created: z.coerce.number(),
-    currency: z.string(),
-    financial_account: z.string().max(5000).nullable().optional(),
-    hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
-    id: z.string().max(5000),
-    linked_flows:
-      s_treasury_received_debits_resource_debit_reversal_linked_flows
-        .nullable()
-        .optional(),
-    livemode: z.coerce.boolean(),
-    metadata: z.record(z.string().max(500)),
-    network: z.enum(["ach", "card"]),
-    object: z.enum(["treasury.debit_reversal"]),
-    received_debit: z.string().max(5000),
-    status: z.enum(["failed", "processing", "succeeded"]),
-    status_transitions: s_treasury_received_debits_resource_status_transitions,
-    transaction: z
-      .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
-      .nullable()
-      .optional(),
-  })
+export const s_treasury_debit_reversal: z.ZodType<
+  t_treasury_debit_reversal,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  created: z.coerce.number(),
+  currency: z.string(),
+  financial_account: z.string().max(5000).nullable().optional(),
+  hosted_regulatory_receipt_url: z.string().max(5000).nullable().optional(),
+  id: z.string().max(5000),
+  linked_flows: s_treasury_received_debits_resource_debit_reversal_linked_flows
+    .nullable()
+    .optional(),
+  livemode: PermissiveBoolean,
+  metadata: z.record(z.string().max(500)),
+  network: z.enum(["ach", "card"]),
+  object: z.enum(["treasury.debit_reversal"]),
+  received_debit: z.string().max(5000),
+  status: z.enum(["failed", "processing", "succeeded"]),
+  status_transitions: s_treasury_received_debits_resource_status_transitions,
+  transaction: z
+    .union([z.string().max(5000), z.lazy(() => s_treasury_transaction)])
+    .nullable()
+    .optional(),
+})
 
-export const s_treasury_transaction_entry: z.ZodType<t_treasury_transaction_entry> =
-  z.object({
-    balance_impact: s_treasury_transactions_resource_balance_impact,
-    created: z.coerce.number(),
-    currency: z.string(),
-    effective_at: z.coerce.number(),
-    financial_account: z.string().max(5000),
-    flow: z.string().max(5000).nullable().optional(),
-    flow_details: z.lazy(() =>
-      s_treasury_transactions_resource_flow_details.nullable().optional(),
-    ),
-    flow_type: z.enum([
-      "credit_reversal",
-      "debit_reversal",
-      "inbound_transfer",
-      "issuing_authorization",
-      "other",
-      "outbound_payment",
-      "outbound_transfer",
-      "received_credit",
-      "received_debit",
-    ]),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["treasury.transaction_entry"]),
-    transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_treasury_transaction),
-    ]),
-    type: z.enum([
-      "credit_reversal",
-      "credit_reversal_posting",
-      "debit_reversal",
-      "inbound_transfer",
-      "inbound_transfer_return",
-      "issuing_authorization_hold",
-      "issuing_authorization_release",
-      "other",
-      "outbound_payment",
-      "outbound_payment_cancellation",
-      "outbound_payment_failure",
-      "outbound_payment_posting",
-      "outbound_payment_return",
-      "outbound_transfer",
-      "outbound_transfer_cancellation",
-      "outbound_transfer_failure",
-      "outbound_transfer_posting",
-      "outbound_transfer_return",
-      "received_credit",
-      "received_debit",
-    ]),
-  })
+export const s_treasury_transaction_entry: z.ZodType<
+  t_treasury_transaction_entry,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  balance_impact: s_treasury_transactions_resource_balance_impact,
+  created: z.coerce.number(),
+  currency: z.string(),
+  effective_at: z.coerce.number(),
+  financial_account: z.string().max(5000),
+  flow: z.string().max(5000).nullable().optional(),
+  flow_details: z.lazy(() =>
+    s_treasury_transactions_resource_flow_details.nullable().optional(),
+  ),
+  flow_type: z.enum([
+    "credit_reversal",
+    "debit_reversal",
+    "inbound_transfer",
+    "issuing_authorization",
+    "other",
+    "outbound_payment",
+    "outbound_transfer",
+    "received_credit",
+    "received_debit",
+  ]),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["treasury.transaction_entry"]),
+  transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_treasury_transaction),
+  ]),
+  type: z.enum([
+    "credit_reversal",
+    "credit_reversal_posting",
+    "debit_reversal",
+    "inbound_transfer",
+    "inbound_transfer_return",
+    "issuing_authorization_hold",
+    "issuing_authorization_release",
+    "other",
+    "outbound_payment",
+    "outbound_payment_cancellation",
+    "outbound_payment_failure",
+    "outbound_payment_posting",
+    "outbound_payment_return",
+    "outbound_transfer",
+    "outbound_transfer_cancellation",
+    "outbound_transfer_failure",
+    "outbound_transfer_posting",
+    "outbound_transfer_return",
+    "received_credit",
+    "received_debit",
+  ]),
+})
 
-export const s_treasury_transaction: z.ZodType<t_treasury_transaction> =
-  z.object({
-    amount: z.coerce.number(),
-    balance_impact: s_treasury_transactions_resource_balance_impact,
-    created: z.coerce.number(),
-    currency: z.string(),
-    description: z.string().max(5000),
-    entries: z
-      .object({
-        data: z.array(z.lazy(() => s_treasury_transaction_entry)),
-        has_more: z.coerce.boolean(),
-        object: z.enum(["list"]),
-        url: z
-          .string()
-          .max(5000)
-          .regex(new RegExp("^/v1/treasury/transaction_entries")),
-      })
-      .nullable()
-      .optional(),
-    financial_account: z.string().max(5000),
-    flow: z.string().max(5000).nullable().optional(),
-    flow_details: z.lazy(() =>
-      s_treasury_transactions_resource_flow_details.nullable().optional(),
-    ),
-    flow_type: z.enum([
-      "credit_reversal",
-      "debit_reversal",
-      "inbound_transfer",
-      "issuing_authorization",
-      "other",
-      "outbound_payment",
-      "outbound_transfer",
-      "received_credit",
-      "received_debit",
-    ]),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["treasury.transaction"]),
-    status: z.enum(["open", "posted", "void"]),
-    status_transitions:
-      s_treasury_transactions_resource_abstract_transaction_resource_status_transitions,
-  })
+export const s_treasury_transaction: z.ZodType<
+  t_treasury_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  balance_impact: s_treasury_transactions_resource_balance_impact,
+  created: z.coerce.number(),
+  currency: z.string(),
+  description: z.string().max(5000),
+  entries: z
+    .object({
+      data: z.array(z.lazy(() => s_treasury_transaction_entry)),
+      has_more: PermissiveBoolean,
+      object: z.enum(["list"]),
+      url: z
+        .string()
+        .max(5000)
+        .regex(new RegExp("^/v1/treasury/transaction_entries")),
+    })
+    .nullable()
+    .optional(),
+  financial_account: z.string().max(5000),
+  flow: z.string().max(5000).nullable().optional(),
+  flow_details: z.lazy(() =>
+    s_treasury_transactions_resource_flow_details.nullable().optional(),
+  ),
+  flow_type: z.enum([
+    "credit_reversal",
+    "debit_reversal",
+    "inbound_transfer",
+    "issuing_authorization",
+    "other",
+    "outbound_payment",
+    "outbound_transfer",
+    "received_credit",
+    "received_debit",
+  ]),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["treasury.transaction"]),
+  status: z.enum(["open", "posted", "void"]),
+  status_transitions:
+    s_treasury_transactions_resource_abstract_transaction_resource_status_transitions,
+})
 
-export const s_legal_entity_company: z.ZodType<t_legal_entity_company> =
-  z.object({
-    address: s_address.optional(),
-    address_kana: s_legal_entity_japan_address.nullable().optional(),
-    address_kanji: s_legal_entity_japan_address.nullable().optional(),
-    directors_provided: z.coerce.boolean().optional(),
-    executives_provided: z.coerce.boolean().optional(),
-    export_license_id: z.string().max(5000).optional(),
-    export_purpose_code: z.string().max(5000).optional(),
-    name: z.string().max(5000).nullable().optional(),
-    name_kana: z.string().max(5000).nullable().optional(),
-    name_kanji: z.string().max(5000).nullable().optional(),
-    owners_provided: z.coerce.boolean().optional(),
-    ownership_declaration: s_legal_entity_ubo_declaration.nullable().optional(),
-    phone: z.string().max(5000).nullable().optional(),
-    structure: z
-      .enum([
-        "free_zone_establishment",
-        "free_zone_llc",
-        "government_instrumentality",
-        "governmental_unit",
-        "incorporated_non_profit",
-        "incorporated_partnership",
-        "limited_liability_partnership",
-        "llc",
-        "multi_member_llc",
-        "private_company",
-        "private_corporation",
-        "private_partnership",
-        "public_company",
-        "public_corporation",
-        "public_partnership",
-        "registered_charity",
-        "single_member_llc",
-        "sole_establishment",
-        "sole_proprietorship",
-        "tax_exempt_government_instrumentality",
-        "unincorporated_association",
-        "unincorporated_non_profit",
-        "unincorporated_partnership",
-      ])
-      .optional(),
-    tax_id_provided: z.coerce.boolean().optional(),
-    tax_id_registrar: z.string().max(5000).optional(),
-    vat_id_provided: z.coerce.boolean().optional(),
-    verification: z.lazy(() =>
-      s_legal_entity_company_verification.nullable().optional(),
-    ),
-  })
+export const s_legal_entity_company: z.ZodType<
+  t_legal_entity_company,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  address: s_address.optional(),
+  address_kana: s_legal_entity_japan_address.nullable().optional(),
+  address_kanji: s_legal_entity_japan_address.nullable().optional(),
+  directors_provided: PermissiveBoolean.optional(),
+  executives_provided: PermissiveBoolean.optional(),
+  export_license_id: z.string().max(5000).optional(),
+  export_purpose_code: z.string().max(5000).optional(),
+  name: z.string().max(5000).nullable().optional(),
+  name_kana: z.string().max(5000).nullable().optional(),
+  name_kanji: z.string().max(5000).nullable().optional(),
+  owners_provided: PermissiveBoolean.optional(),
+  ownership_declaration: s_legal_entity_ubo_declaration.nullable().optional(),
+  phone: z.string().max(5000).nullable().optional(),
+  structure: z
+    .enum([
+      "free_zone_establishment",
+      "free_zone_llc",
+      "government_instrumentality",
+      "governmental_unit",
+      "incorporated_non_profit",
+      "incorporated_partnership",
+      "limited_liability_partnership",
+      "llc",
+      "multi_member_llc",
+      "private_company",
+      "private_corporation",
+      "private_partnership",
+      "public_company",
+      "public_corporation",
+      "public_partnership",
+      "registered_charity",
+      "single_member_llc",
+      "sole_establishment",
+      "sole_proprietorship",
+      "tax_exempt_government_instrumentality",
+      "unincorporated_association",
+      "unincorporated_non_profit",
+      "unincorporated_partnership",
+    ])
+    .optional(),
+  tax_id_provided: PermissiveBoolean.optional(),
+  tax_id_registrar: z.string().max(5000).optional(),
+  vat_id_provided: PermissiveBoolean.optional(),
+  verification: z.lazy(() =>
+    s_legal_entity_company_verification.nullable().optional(),
+  ),
+})
 
-export const s_account_settings: z.ZodType<t_account_settings> = z.object({
+export const s_account_settings: z.ZodType<
+  t_account_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   bacs_debit_payments: s_account_bacs_debit_payments_settings.optional(),
   branding: z.lazy(() => s_account_branding_settings),
   card_issuing: s_account_card_issuing_settings.optional(),
@@ -12574,108 +12758,124 @@ export const s_account_settings: z.ZodType<t_account_settings> = z.object({
   treasury: s_account_treasury_settings.optional(),
 })
 
-export const s_api_errors: z.ZodType<t_api_errors> = z.object({
-  charge: z.string().max(5000).optional(),
-  code: z.string().max(5000).optional(),
-  decline_code: z.string().max(5000).optional(),
-  doc_url: z.string().max(5000).optional(),
-  message: z.string().max(40000).optional(),
-  param: z.string().max(5000).optional(),
-  payment_intent: z.lazy(() => s_payment_intent.optional()),
-  payment_method: z.lazy(() => s_payment_method.optional()),
-  payment_method_type: z.string().max(5000).optional(),
-  request_log_url: z.string().max(5000).optional(),
-  setup_intent: z.lazy(() => s_setup_intent.optional()),
-  source: z
-    .union([z.lazy(() => s_bank_account), z.lazy(() => s_card), s_source])
-    .optional(),
-  type: z.enum([
-    "api_error",
-    "card_error",
-    "idempotency_error",
-    "invalid_request_error",
-  ]),
+export const s_api_errors: z.ZodType<t_api_errors, z.ZodTypeDef, unknown> =
+  z.object({
+    charge: z.string().max(5000).optional(),
+    code: z.string().max(5000).optional(),
+    decline_code: z.string().max(5000).optional(),
+    doc_url: z.string().max(5000).optional(),
+    message: z.string().max(40000).optional(),
+    param: z.string().max(5000).optional(),
+    payment_intent: z.lazy(() => s_payment_intent.optional()),
+    payment_method: z.lazy(() => s_payment_method.optional()),
+    payment_method_type: z.string().max(5000).optional(),
+    request_log_url: z.string().max(5000).optional(),
+    setup_intent: z.lazy(() => s_setup_intent.optional()),
+    source: z
+      .union([z.lazy(() => s_bank_account), z.lazy(() => s_card), s_source])
+      .optional(),
+    type: z.enum([
+      "api_error",
+      "card_error",
+      "idempotency_error",
+      "invalid_request_error",
+    ]),
+  })
+
+export const s_legal_entity_person_verification: z.ZodType<
+  t_legal_entity_person_verification,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_document: z.lazy(() =>
+    s_legal_entity_person_verification_document.nullable().optional(),
+  ),
+  details: z.string().max(5000).nullable().optional(),
+  details_code: z.string().max(5000).nullable().optional(),
+  document: z.lazy(() =>
+    s_legal_entity_person_verification_document.optional(),
+  ),
+  status: z.string().max(5000),
 })
 
-export const s_legal_entity_person_verification: z.ZodType<t_legal_entity_person_verification> =
-  z.object({
-    additional_document: z.lazy(() =>
-      s_legal_entity_person_verification_document.nullable().optional(),
-    ),
-    details: z.string().max(5000).nullable().optional(),
-    details_code: z.string().max(5000).nullable().optional(),
-    document: z.lazy(() =>
-      s_legal_entity_person_verification_document.optional(),
-    ),
-    status: z.string().max(5000),
-  })
+export const s_connect_collection_transfer: z.ZodType<
+  t_connect_collection_transfer,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  currency: z.string(),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+  id: z.string().max(5000),
+  livemode: PermissiveBoolean,
+  object: z.enum(["connect_collection_transfer"]),
+})
 
-export const s_connect_collection_transfer: z.ZodType<t_connect_collection_transfer> =
-  z.object({
-    amount: z.coerce.number(),
-    currency: z.string(),
-    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-    id: z.string().max(5000),
-    livemode: z.coerce.boolean(),
-    object: z.enum(["connect_collection_transfer"]),
-  })
+export const s_payment_method_details: z.ZodType<
+  t_payment_method_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  ach_credit_transfer: s_payment_method_details_ach_credit_transfer.optional(),
+  ach_debit: s_payment_method_details_ach_debit.optional(),
+  acss_debit: s_payment_method_details_acss_debit.optional(),
+  affirm: s_payment_method_details_affirm.optional(),
+  afterpay_clearpay: s_payment_method_details_afterpay_clearpay.optional(),
+  alipay: s_payment_flows_private_payment_methods_alipay_details.optional(),
+  au_becs_debit: s_payment_method_details_au_becs_debit.optional(),
+  bacs_debit: s_payment_method_details_bacs_debit.optional(),
+  bancontact: z.lazy(() => s_payment_method_details_bancontact.optional()),
+  blik: s_payment_method_details_blik.optional(),
+  boleto: s_payment_method_details_boleto.optional(),
+  card: s_payment_method_details_card.optional(),
+  card_present: s_payment_method_details_card_present.optional(),
+  cashapp: s_payment_method_details_cashapp.optional(),
+  customer_balance: s_payment_method_details_customer_balance.optional(),
+  eps: s_payment_method_details_eps.optional(),
+  fpx: s_payment_method_details_fpx.optional(),
+  giropay: s_payment_method_details_giropay.optional(),
+  grabpay: s_payment_method_details_grabpay.optional(),
+  ideal: z.lazy(() => s_payment_method_details_ideal.optional()),
+  interac_present: s_payment_method_details_interac_present.optional(),
+  klarna: s_payment_method_details_klarna.optional(),
+  konbini: s_payment_method_details_konbini.optional(),
+  link: s_payment_method_details_link.optional(),
+  mobilepay: s_payment_method_details_mobilepay.optional(),
+  multibanco: s_payment_method_details_multibanco.optional(),
+  oxxo: s_payment_method_details_oxxo.optional(),
+  p24: s_payment_method_details_p24.optional(),
+  paynow: s_payment_method_details_paynow.optional(),
+  paypal: s_payment_method_details_paypal.optional(),
+  pix: s_payment_method_details_pix.optional(),
+  promptpay: s_payment_method_details_promptpay.optional(),
+  revolut_pay: s_payment_method_details_revolut_pay.optional(),
+  sepa_debit: s_payment_method_details_sepa_debit.optional(),
+  sofort: z.lazy(() => s_payment_method_details_sofort.optional()),
+  stripe_account: s_payment_method_details_stripe_account.optional(),
+  swish: s_payment_method_details_swish.optional(),
+  type: z.string().max(5000),
+  us_bank_account: z.lazy(() =>
+    s_payment_method_details_us_bank_account.optional(),
+  ),
+  wechat: s_payment_method_details_wechat.optional(),
+  wechat_pay: s_payment_method_details_wechat_pay.optional(),
+  zip: s_payment_method_details_zip.optional(),
+})
 
-export const s_payment_method_details: z.ZodType<t_payment_method_details> =
-  z.object({
-    ach_credit_transfer:
-      s_payment_method_details_ach_credit_transfer.optional(),
-    ach_debit: s_payment_method_details_ach_debit.optional(),
-    acss_debit: s_payment_method_details_acss_debit.optional(),
-    affirm: s_payment_method_details_affirm.optional(),
-    afterpay_clearpay: s_payment_method_details_afterpay_clearpay.optional(),
-    alipay: s_payment_flows_private_payment_methods_alipay_details.optional(),
-    au_becs_debit: s_payment_method_details_au_becs_debit.optional(),
-    bacs_debit: s_payment_method_details_bacs_debit.optional(),
-    bancontact: z.lazy(() => s_payment_method_details_bancontact.optional()),
-    blik: s_payment_method_details_blik.optional(),
-    boleto: s_payment_method_details_boleto.optional(),
-    card: s_payment_method_details_card.optional(),
-    card_present: s_payment_method_details_card_present.optional(),
-    cashapp: s_payment_method_details_cashapp.optional(),
-    customer_balance: s_payment_method_details_customer_balance.optional(),
-    eps: s_payment_method_details_eps.optional(),
-    fpx: s_payment_method_details_fpx.optional(),
-    giropay: s_payment_method_details_giropay.optional(),
-    grabpay: s_payment_method_details_grabpay.optional(),
-    ideal: z.lazy(() => s_payment_method_details_ideal.optional()),
-    interac_present: s_payment_method_details_interac_present.optional(),
-    klarna: s_payment_method_details_klarna.optional(),
-    konbini: s_payment_method_details_konbini.optional(),
-    link: s_payment_method_details_link.optional(),
-    mobilepay: s_payment_method_details_mobilepay.optional(),
-    multibanco: s_payment_method_details_multibanco.optional(),
-    oxxo: s_payment_method_details_oxxo.optional(),
-    p24: s_payment_method_details_p24.optional(),
-    paynow: s_payment_method_details_paynow.optional(),
-    paypal: s_payment_method_details_paypal.optional(),
-    pix: s_payment_method_details_pix.optional(),
-    promptpay: s_payment_method_details_promptpay.optional(),
-    revolut_pay: s_payment_method_details_revolut_pay.optional(),
-    sepa_debit: s_payment_method_details_sepa_debit.optional(),
-    sofort: z.lazy(() => s_payment_method_details_sofort.optional()),
-    stripe_account: s_payment_method_details_stripe_account.optional(),
-    swish: s_payment_method_details_swish.optional(),
-    type: z.string().max(5000),
-    us_bank_account: z.lazy(() =>
-      s_payment_method_details_us_bank_account.optional(),
-    ),
-    wechat: s_payment_method_details_wechat.optional(),
-    wechat_pay: s_payment_method_details_wechat_pay.optional(),
-    zip: s_payment_method_details_zip.optional(),
-  })
+export const s_charge_transfer_data: z.ZodType<
+  t_charge_transfer_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number().nullable().optional(),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+})
 
-export const s_charge_transfer_data: z.ZodType<t_charge_transfer_data> =
-  z.object({
-    amount: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-  })
-
-export const s_dispute_evidence: z.ZodType<t_dispute_evidence> = z.object({
+export const s_dispute_evidence: z.ZodType<
+  t_dispute_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   access_activity_log: z.string().max(150000).nullable().optional(),
   billing_address: z.string().max(5000).nullable().optional(),
   cancellation_policy: z
@@ -12732,238 +12932,287 @@ export const s_dispute_evidence: z.ZodType<t_dispute_evidence> = z.object({
   uncategorized_text: z.string().max(150000).nullable().optional(),
 })
 
-export const s_payment_pages_checkout_session_automatic_tax: z.ZodType<t_payment_pages_checkout_session_automatic_tax> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
-    status: z
-      .enum(["complete", "failed", "requires_location_inputs"])
-      .nullable()
-      .optional(),
-  })
+export const s_payment_pages_checkout_session_automatic_tax: z.ZodType<
+  t_payment_pages_checkout_session_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
+  status: z
+    .enum(["complete", "failed", "requires_location_inputs"])
+    .nullable()
+    .optional(),
+})
 
-export const s_payment_pages_checkout_session_invoice_creation: z.ZodType<t_payment_pages_checkout_session_invoice_creation> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    invoice_data: z.lazy(
-      () => s_payment_pages_checkout_session_invoice_settings,
-    ),
-  })
+export const s_payment_pages_checkout_session_invoice_creation: z.ZodType<
+  t_payment_pages_checkout_session_invoice_creation,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  invoice_data: z.lazy(() => s_payment_pages_checkout_session_invoice_settings),
+})
 
-export const s_payment_pages_checkout_session_total_details: z.ZodType<t_payment_pages_checkout_session_total_details> =
-  z.object({
-    amount_discount: z.coerce.number(),
-    amount_shipping: z.coerce.number().nullable().optional(),
-    amount_tax: z.coerce.number(),
-    breakdown: z.lazy(() =>
-      s_payment_pages_checkout_session_total_details_resource_breakdown.optional(),
-    ),
-  })
+export const s_payment_pages_checkout_session_total_details: z.ZodType<
+  t_payment_pages_checkout_session_total_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount_discount: z.coerce.number(),
+  amount_shipping: z.coerce.number().nullable().optional(),
+  amount_tax: z.coerce.number(),
+  breakdown: z.lazy(() =>
+    s_payment_pages_checkout_session_total_details_resource_breakdown.optional(),
+  ),
+})
 
-export const s_line_items_discount_amount: z.ZodType<t_line_items_discount_amount> =
-  z.object({ amount: z.coerce.number(), discount: z.lazy(() => s_discount) })
+export const s_line_items_discount_amount: z.ZodType<
+  t_line_items_discount_amount,
+  z.ZodTypeDef,
+  unknown
+> = z.object({ amount: z.coerce.number(), discount: z.lazy(() => s_discount) })
 
-export const s_confirmation_tokens_resource_payment_method_preview: z.ZodType<t_confirmation_tokens_resource_payment_method_preview> =
-  z.object({
-    acss_debit: s_payment_method_acss_debit.optional(),
-    affirm: s_payment_method_affirm.optional(),
-    afterpay_clearpay: s_payment_method_afterpay_clearpay.optional(),
-    alipay: s_payment_flows_private_payment_methods_alipay.optional(),
-    au_becs_debit: s_payment_method_au_becs_debit.optional(),
-    bacs_debit: s_payment_method_bacs_debit.optional(),
-    bancontact: s_payment_method_bancontact.optional(),
-    billing_details: s_billing_details,
-    blik: s_payment_method_blik.optional(),
-    boleto: s_payment_method_boleto.optional(),
-    card: z.lazy(() => s_payment_method_card.optional()),
-    card_present: s_payment_method_card_present.optional(),
-    cashapp: s_payment_method_cashapp.optional(),
-    customer_balance: s_payment_method_customer_balance.optional(),
-    eps: s_payment_method_eps.optional(),
-    fpx: s_payment_method_fpx.optional(),
-    giropay: s_payment_method_giropay.optional(),
-    grabpay: s_payment_method_grabpay.optional(),
-    ideal: s_payment_method_ideal.optional(),
-    interac_present: s_payment_method_interac_present.optional(),
-    klarna: s_payment_method_klarna.optional(),
-    konbini: s_payment_method_konbini.optional(),
-    link: s_payment_method_link.optional(),
-    mobilepay: s_payment_method_mobilepay.optional(),
-    oxxo: s_payment_method_oxxo.optional(),
-    p24: s_payment_method_p24.optional(),
-    paynow: s_payment_method_paynow.optional(),
-    paypal: s_payment_method_paypal.optional(),
-    pix: s_payment_method_pix.optional(),
-    promptpay: s_payment_method_promptpay.optional(),
-    revolut_pay: s_payment_method_revolut_pay.optional(),
-    sepa_debit: z.lazy(() => s_payment_method_sepa_debit.optional()),
-    sofort: s_payment_method_sofort.optional(),
-    swish: s_payment_method_swish.optional(),
-    type: z.enum([
-      "acss_debit",
-      "affirm",
-      "afterpay_clearpay",
-      "alipay",
-      "au_becs_debit",
-      "bacs_debit",
-      "bancontact",
-      "blik",
-      "boleto",
-      "card",
-      "card_present",
-      "cashapp",
-      "customer_balance",
-      "eps",
-      "fpx",
-      "giropay",
-      "grabpay",
-      "ideal",
-      "interac_present",
-      "klarna",
-      "konbini",
-      "link",
-      "mobilepay",
-      "oxxo",
-      "p24",
-      "paynow",
-      "paypal",
-      "pix",
-      "promptpay",
-      "revolut_pay",
-      "sepa_debit",
-      "sofort",
-      "swish",
-      "us_bank_account",
-      "wechat_pay",
-      "zip",
-    ]),
-    us_bank_account: s_payment_method_us_bank_account.optional(),
-    wechat_pay: s_payment_method_wechat_pay.optional(),
-    zip: s_payment_method_zip.optional(),
-  })
+export const s_confirmation_tokens_resource_payment_method_preview: z.ZodType<
+  t_confirmation_tokens_resource_payment_method_preview,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  acss_debit: s_payment_method_acss_debit.optional(),
+  affirm: s_payment_method_affirm.optional(),
+  afterpay_clearpay: s_payment_method_afterpay_clearpay.optional(),
+  alipay: s_payment_flows_private_payment_methods_alipay.optional(),
+  au_becs_debit: s_payment_method_au_becs_debit.optional(),
+  bacs_debit: s_payment_method_bacs_debit.optional(),
+  bancontact: s_payment_method_bancontact.optional(),
+  billing_details: s_billing_details,
+  blik: s_payment_method_blik.optional(),
+  boleto: s_payment_method_boleto.optional(),
+  card: z.lazy(() => s_payment_method_card.optional()),
+  card_present: s_payment_method_card_present.optional(),
+  cashapp: s_payment_method_cashapp.optional(),
+  customer_balance: s_payment_method_customer_balance.optional(),
+  eps: s_payment_method_eps.optional(),
+  fpx: s_payment_method_fpx.optional(),
+  giropay: s_payment_method_giropay.optional(),
+  grabpay: s_payment_method_grabpay.optional(),
+  ideal: s_payment_method_ideal.optional(),
+  interac_present: s_payment_method_interac_present.optional(),
+  klarna: s_payment_method_klarna.optional(),
+  konbini: s_payment_method_konbini.optional(),
+  link: s_payment_method_link.optional(),
+  mobilepay: s_payment_method_mobilepay.optional(),
+  oxxo: s_payment_method_oxxo.optional(),
+  p24: s_payment_method_p24.optional(),
+  paynow: s_payment_method_paynow.optional(),
+  paypal: s_payment_method_paypal.optional(),
+  pix: s_payment_method_pix.optional(),
+  promptpay: s_payment_method_promptpay.optional(),
+  revolut_pay: s_payment_method_revolut_pay.optional(),
+  sepa_debit: z.lazy(() => s_payment_method_sepa_debit.optional()),
+  sofort: s_payment_method_sofort.optional(),
+  swish: s_payment_method_swish.optional(),
+  type: z.enum([
+    "acss_debit",
+    "affirm",
+    "afterpay_clearpay",
+    "alipay",
+    "au_becs_debit",
+    "bacs_debit",
+    "bancontact",
+    "blik",
+    "boleto",
+    "card",
+    "card_present",
+    "cashapp",
+    "customer_balance",
+    "eps",
+    "fpx",
+    "giropay",
+    "grabpay",
+    "ideal",
+    "interac_present",
+    "klarna",
+    "konbini",
+    "link",
+    "mobilepay",
+    "oxxo",
+    "p24",
+    "paynow",
+    "paypal",
+    "pix",
+    "promptpay",
+    "revolut_pay",
+    "sepa_debit",
+    "sofort",
+    "swish",
+    "us_bank_account",
+    "wechat_pay",
+    "zip",
+  ]),
+  us_bank_account: s_payment_method_us_bank_account.optional(),
+  wechat_pay: s_payment_method_wechat_pay.optional(),
+  zip: s_payment_method_zip.optional(),
+})
 
-export const s_discounts_resource_discount_amount: z.ZodType<t_discounts_resource_discount_amount> =
-  z.object({
-    amount: z.coerce.number(),
-    discount: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_discount),
-      z.lazy(() => s_deleted_discount),
-    ]),
-  })
+export const s_discounts_resource_discount_amount: z.ZodType<
+  t_discounts_resource_discount_amount,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number(),
+  discount: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_discount),
+    z.lazy(() => s_deleted_discount),
+  ]),
+})
 
-export const s_invoice_setting_customer_setting: z.ZodType<t_invoice_setting_customer_setting> =
-  z.object({
-    custom_fields: z
-      .array(s_invoice_setting_custom_field)
-      .nullable()
-      .optional(),
-    default_payment_method: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    footer: z.string().max(5000).nullable().optional(),
-    rendering_options: s_invoice_setting_rendering_options
-      .nullable()
-      .optional(),
-  })
+export const s_invoice_setting_customer_setting: z.ZodType<
+  t_invoice_setting_customer_setting,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  custom_fields: z.array(s_invoice_setting_custom_field).nullable().optional(),
+  default_payment_method: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  footer: z.string().max(5000).nullable().optional(),
+  rendering_options: s_invoice_setting_rendering_options.nullable().optional(),
+})
 
-export const s_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft> =
-  z.object({
-    balance_transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_balance_transaction),
-    ]),
-    linked_transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_customer_cash_balance_transaction),
-    ]),
-  })
+export const s_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft: z.ZodType<
+  t_customer_balance_resource_cash_balance_transaction_resource_adjusted_for_overdraft,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  balance_transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_balance_transaction),
+  ]),
+  linked_transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_customer_cash_balance_transaction),
+  ]),
+})
 
-export const s_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction> =
-  z.object({
-    payment_intent: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_payment_intent),
-    ]),
-  })
+export const s_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction: z.ZodType<
+  t_customer_balance_resource_cash_balance_transaction_resource_applied_to_payment_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  payment_intent: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_payment_intent),
+  ]),
+})
 
-export const s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction> =
-  z.object({ refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]) })
+export const s_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction: z.ZodType<
+  t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]),
+})
 
-export const s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance> =
-  z.object({
-    balance_transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_balance_transaction),
-    ]),
-  })
+export const s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance: z.ZodType<
+  t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  balance_transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_balance_transaction),
+  ]),
+})
 
-export const s_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction: z.ZodType<t_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction> =
-  z.object({
-    payment_intent: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_payment_intent),
-    ]),
-  })
+export const s_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction: z.ZodType<
+  t_customer_balance_resource_cash_balance_transaction_resource_unapplied_from_payment_transaction,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  payment_intent: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_payment_intent),
+  ]),
+})
 
-export const s_payment_method_card: z.ZodType<t_payment_method_card> = z.object(
-  {
-    brand: z.string().max(5000),
-    checks: s_payment_method_card_checks.nullable().optional(),
-    country: z.string().max(5000).nullable().optional(),
-    display_brand: z.string().max(5000).nullable().optional(),
-    exp_month: z.coerce.number(),
-    exp_year: z.coerce.number(),
-    fingerprint: z.string().max(5000).nullable().optional(),
-    funding: z.string().max(5000),
-    generated_from: z.lazy(() =>
-      s_payment_method_card_generated_card.nullable().optional(),
-    ),
-    last4: z.string().max(5000),
-    networks: s_networks.nullable().optional(),
-    three_d_secure_usage: s_three_d_secure_usage.nullable().optional(),
-    wallet: s_payment_method_card_wallet.nullable().optional(),
-  },
-)
+export const s_payment_method_card: z.ZodType<
+  t_payment_method_card,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  brand: z.string().max(5000),
+  checks: s_payment_method_card_checks.nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  display_brand: z.string().max(5000).nullable().optional(),
+  exp_month: z.coerce.number(),
+  exp_year: z.coerce.number(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  funding: z.string().max(5000),
+  generated_from: z.lazy(() =>
+    s_payment_method_card_generated_card.nullable().optional(),
+  ),
+  last4: z.string().max(5000),
+  networks: s_networks.nullable().optional(),
+  three_d_secure_usage: s_three_d_secure_usage.nullable().optional(),
+  wallet: s_payment_method_card_wallet.nullable().optional(),
+})
 
-export const s_payment_method_sepa_debit: z.ZodType<t_payment_method_sepa_debit> =
-  z.object({
-    bank_code: z.string().max(5000).nullable().optional(),
-    branch_code: z.string().max(5000).nullable().optional(),
-    country: z.string().max(5000).nullable().optional(),
-    fingerprint: z.string().max(5000).nullable().optional(),
-    generated_from: z.lazy(() =>
-      s_sepa_debit_generated_from.nullable().optional(),
-    ),
-    last4: z.string().max(5000).nullable().optional(),
-  })
+export const s_payment_method_sepa_debit: z.ZodType<
+  t_payment_method_sepa_debit,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank_code: z.string().max(5000).nullable().optional(),
+  branch_code: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  generated_from: z.lazy(() =>
+    s_sepa_debit_generated_from.nullable().optional(),
+  ),
+  last4: z.string().max(5000).nullable().optional(),
+})
 
-export const s_subscription_automatic_tax: z.ZodType<t_subscription_automatic_tax> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
-  })
+export const s_subscription_automatic_tax: z.ZodType<
+  t_subscription_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
+})
 
-export const s_subscriptions_resource_pending_update: z.ZodType<t_subscriptions_resource_pending_update> =
-  z.object({
-    billing_cycle_anchor: z.coerce.number().nullable().optional(),
-    expires_at: z.coerce.number(),
-    subscription_items: z
-      .array(z.lazy(() => s_subscription_item))
-      .nullable()
-      .optional(),
-    trial_end: z.coerce.number().nullable().optional(),
-    trial_from_plan: z.coerce.boolean().nullable().optional(),
-  })
+export const s_subscriptions_resource_pending_update: z.ZodType<
+  t_subscriptions_resource_pending_update,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  billing_cycle_anchor: z.coerce.number().nullable().optional(),
+  expires_at: z.coerce.number(),
+  subscription_items: z
+    .array(z.lazy(() => s_subscription_item))
+    .nullable()
+    .optional(),
+  trial_end: z.coerce.number().nullable().optional(),
+  trial_from_plan: PermissiveBoolean.nullable().optional(),
+})
 
-export const s_subscription_transfer_data: z.ZodType<t_subscription_transfer_data> =
-  z.object({
-    amount_percent: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-  })
+export const s_subscription_transfer_data: z.ZodType<
+  t_subscription_transfer_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount_percent: z.coerce.number().nullable().optional(),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+})
 
-export const s_tax_i_ds_owner: z.ZodType<t_tax_i_ds_owner> = z.object({
+export const s_tax_i_ds_owner: z.ZodType<
+  t_tax_i_ds_owner,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   account: z.union([z.string().max(5000), z.lazy(() => s_account)]).optional(),
   application: z.union([z.string().max(5000), s_application]).optional(),
   customer: z
@@ -12972,19 +13221,24 @@ export const s_tax_i_ds_owner: z.ZodType<t_tax_i_ds_owner> = z.object({
   type: z.enum(["account", "application", "customer", "self"]),
 })
 
-export const s_bank_connections_resource_accountholder: z.ZodType<t_bank_connections_resource_accountholder> =
-  z.object({
-    account: z
-      .union([z.string().max(5000), z.lazy(() => s_account)])
-      .optional(),
-    customer: z
-      .union([z.string().max(5000), z.lazy(() => s_customer)])
-      .optional(),
-    type: z.enum(["account", "customer"]),
-  })
+export const s_bank_connections_resource_accountholder: z.ZodType<
+  t_bank_connections_resource_accountholder,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account: z.union([z.string().max(5000), z.lazy(() => s_account)]).optional(),
+  customer: z
+    .union([z.string().max(5000), z.lazy(() => s_customer)])
+    .optional(),
+  type: z.enum(["account", "customer"]),
+})
 
-export const s_automatic_tax: z.ZodType<t_automatic_tax> = z.object({
-  enabled: z.coerce.boolean(),
+export const s_automatic_tax: z.ZodType<
+  t_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
   liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
   status: z
     .enum(["complete", "failed", "requires_location_inputs"])
@@ -12992,285 +13246,347 @@ export const s_automatic_tax: z.ZodType<t_automatic_tax> = z.object({
     .optional(),
 })
 
-export const s_invoices_resource_from_invoice: z.ZodType<t_invoices_resource_from_invoice> =
-  z.object({
-    action: z.string().max(5000),
-    invoice: z.union([z.string().max(5000), z.lazy(() => s_invoice)]),
-  })
+export const s_invoices_resource_from_invoice: z.ZodType<
+  t_invoices_resource_from_invoice,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  action: z.string().max(5000),
+  invoice: z.union([z.string().max(5000), z.lazy(() => s_invoice)]),
+})
 
-export const s_connect_account_reference: z.ZodType<t_connect_account_reference> =
-  z.object({
-    account: z
-      .union([z.string().max(5000), z.lazy(() => s_account)])
-      .optional(),
-    type: z.enum(["account", "self"]),
-  })
+export const s_connect_account_reference: z.ZodType<
+  t_connect_account_reference,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account: z.union([z.string().max(5000), z.lazy(() => s_account)]).optional(),
+  type: z.enum(["account", "self"]),
+})
 
-export const s_invoice_transfer_data: z.ZodType<t_invoice_transfer_data> =
-  z.object({
-    amount: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-  })
+export const s_invoice_transfer_data: z.ZodType<
+  t_invoice_transfer_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number().nullable().optional(),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+})
 
-export const s_issuing_cardholder_individual: z.ZodType<t_issuing_cardholder_individual> =
-  z.object({
-    card_issuing: s_issuing_cardholder_card_issuing.nullable().optional(),
-    dob: s_issuing_cardholder_individual_dob.nullable().optional(),
-    first_name: z.string().max(5000).nullable().optional(),
-    last_name: z.string().max(5000).nullable().optional(),
-    verification: z.lazy(() =>
-      s_issuing_cardholder_verification.nullable().optional(),
-    ),
-  })
+export const s_issuing_cardholder_individual: z.ZodType<
+  t_issuing_cardholder_individual,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  card_issuing: s_issuing_cardholder_card_issuing.nullable().optional(),
+  dob: s_issuing_cardholder_individual_dob.nullable().optional(),
+  first_name: z.string().max(5000).nullable().optional(),
+  last_name: z.string().max(5000).nullable().optional(),
+  verification: z.lazy(() =>
+    s_issuing_cardholder_verification.nullable().optional(),
+  ),
+})
 
-export const s_issuing_dispute_evidence: z.ZodType<t_issuing_dispute_evidence> =
-  z.object({
-    canceled: z.lazy(() => s_issuing_dispute_canceled_evidence.optional()),
-    duplicate: z.lazy(() => s_issuing_dispute_duplicate_evidence.optional()),
-    fraudulent: z.lazy(() => s_issuing_dispute_fraudulent_evidence.optional()),
-    merchandise_not_as_described: z.lazy(() =>
-      s_issuing_dispute_merchandise_not_as_described_evidence.optional(),
-    ),
-    not_received: z.lazy(() =>
-      s_issuing_dispute_not_received_evidence.optional(),
-    ),
-    other: z.lazy(() => s_issuing_dispute_other_evidence.optional()),
-    reason: z.enum([
-      "canceled",
-      "duplicate",
-      "fraudulent",
-      "merchandise_not_as_described",
-      "not_received",
-      "other",
-      "service_not_as_described",
-    ]),
-    service_not_as_described: z.lazy(() =>
-      s_issuing_dispute_service_not_as_described_evidence.optional(),
-    ),
-  })
+export const s_issuing_dispute_evidence: z.ZodType<
+  t_issuing_dispute_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  canceled: z.lazy(() => s_issuing_dispute_canceled_evidence.optional()),
+  duplicate: z.lazy(() => s_issuing_dispute_duplicate_evidence.optional()),
+  fraudulent: z.lazy(() => s_issuing_dispute_fraudulent_evidence.optional()),
+  merchandise_not_as_described: z.lazy(() =>
+    s_issuing_dispute_merchandise_not_as_described_evidence.optional(),
+  ),
+  not_received: z.lazy(() =>
+    s_issuing_dispute_not_received_evidence.optional(),
+  ),
+  other: z.lazy(() => s_issuing_dispute_other_evidence.optional()),
+  reason: z.enum([
+    "canceled",
+    "duplicate",
+    "fraudulent",
+    "merchandise_not_as_described",
+    "not_received",
+    "other",
+    "service_not_as_described",
+  ]),
+  service_not_as_described: z.lazy(() =>
+    s_issuing_dispute_service_not_as_described_evidence.optional(),
+  ),
+})
 
-export const s_transfer_data: z.ZodType<t_transfer_data> = z.object({
+export const s_transfer_data: z.ZodType<
+  t_transfer_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   amount: z.coerce.number().optional(),
   destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
 })
 
-export const s_payment_links_resource_automatic_tax: z.ZodType<t_payment_links_resource_automatic_tax> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
-  })
+export const s_payment_links_resource_automatic_tax: z.ZodType<
+  t_payment_links_resource_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
+})
 
-export const s_payment_links_resource_invoice_creation: z.ZodType<t_payment_links_resource_invoice_creation> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    invoice_data: z.lazy(() =>
-      s_payment_links_resource_invoice_settings.nullable().optional(),
-    ),
-  })
+export const s_payment_links_resource_invoice_creation: z.ZodType<
+  t_payment_links_resource_invoice_creation,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  invoice_data: z.lazy(() =>
+    s_payment_links_resource_invoice_settings.nullable().optional(),
+  ),
+})
 
-export const s_payment_links_resource_subscription_data: z.ZodType<t_payment_links_resource_subscription_data> =
-  z.object({
-    description: z.string().max(5000).nullable().optional(),
-    invoice_settings: z.lazy(
-      () => s_payment_links_resource_subscription_data_invoice_settings,
-    ),
-    metadata: z.record(z.string().max(500)),
-    trial_period_days: z.coerce.number().nullable().optional(),
-    trial_settings: s_subscriptions_trials_resource_trial_settings
-      .nullable()
-      .optional(),
-  })
+export const s_payment_links_resource_subscription_data: z.ZodType<
+  t_payment_links_resource_subscription_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  description: z.string().max(5000).nullable().optional(),
+  invoice_settings: z.lazy(
+    () => s_payment_links_resource_subscription_data_invoice_settings,
+  ),
+  metadata: z.record(z.string().max(500)),
+  trial_period_days: z.coerce.number().nullable().optional(),
+  trial_settings: s_subscriptions_trials_resource_trial_settings
+    .nullable()
+    .optional(),
+})
 
-export const s_payment_links_resource_transfer_data: z.ZodType<t_payment_links_resource_transfer_data> =
-  z.object({
-    amount: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-  })
+export const s_payment_links_resource_transfer_data: z.ZodType<
+  t_payment_links_resource_transfer_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number().nullable().optional(),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+})
 
-export const s_quotes_resource_automatic_tax: z.ZodType<t_quotes_resource_automatic_tax> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
-    status: z
-      .enum(["complete", "failed", "requires_location_inputs"])
-      .nullable()
-      .optional(),
-  })
+export const s_quotes_resource_automatic_tax: z.ZodType<
+  t_quotes_resource_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
+  status: z
+    .enum(["complete", "failed", "requires_location_inputs"])
+    .nullable()
+    .optional(),
+})
 
-export const s_quotes_resource_computed: z.ZodType<t_quotes_resource_computed> =
-  z.object({
-    recurring: z.lazy(() => s_quotes_resource_recurring.nullable().optional()),
-    upfront: z.lazy(() => s_quotes_resource_upfront),
-  })
+export const s_quotes_resource_computed: z.ZodType<
+  t_quotes_resource_computed,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  recurring: z.lazy(() => s_quotes_resource_recurring.nullable().optional()),
+  upfront: z.lazy(() => s_quotes_resource_upfront),
+})
 
-export const s_quotes_resource_from_quote: z.ZodType<t_quotes_resource_from_quote> =
-  z.object({
-    is_revision: z.coerce.boolean(),
-    quote: z.union([z.string().max(5000), z.lazy(() => s_quote)]),
-  })
+export const s_quotes_resource_from_quote: z.ZodType<
+  t_quotes_resource_from_quote,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  is_revision: PermissiveBoolean,
+  quote: z.union([z.string().max(5000), z.lazy(() => s_quote)]),
+})
 
-export const s_invoice_setting_quote_setting: z.ZodType<t_invoice_setting_quote_setting> =
-  z.object({
-    days_until_due: z.coerce.number().nullable().optional(),
-    issuer: z.lazy(() => s_connect_account_reference),
-  })
+export const s_invoice_setting_quote_setting: z.ZodType<
+  t_invoice_setting_quote_setting,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  days_until_due: z.coerce.number().nullable().optional(),
+  issuer: z.lazy(() => s_connect_account_reference),
+})
 
-export const s_quotes_resource_total_details: z.ZodType<t_quotes_resource_total_details> =
-  z.object({
-    amount_discount: z.coerce.number(),
-    amount_shipping: z.coerce.number().nullable().optional(),
-    amount_tax: z.coerce.number(),
-    breakdown: z.lazy(() =>
-      s_quotes_resource_total_details_resource_breakdown.optional(),
-    ),
-  })
+export const s_quotes_resource_total_details: z.ZodType<
+  t_quotes_resource_total_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount_discount: z.coerce.number(),
+  amount_shipping: z.coerce.number().nullable().optional(),
+  amount_tax: z.coerce.number(),
+  breakdown: z.lazy(() =>
+    s_quotes_resource_total_details_resource_breakdown.optional(),
+  ),
+})
 
-export const s_quotes_resource_transfer_data: z.ZodType<t_quotes_resource_transfer_data> =
-  z.object({
-    amount: z.coerce.number().nullable().optional(),
-    amount_percent: z.coerce.number().nullable().optional(),
-    destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
-  })
+export const s_quotes_resource_transfer_data: z.ZodType<
+  t_quotes_resource_transfer_data,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number().nullable().optional(),
+  amount_percent: z.coerce.number().nullable().optional(),
+  destination: z.union([z.string().max(5000), z.lazy(() => s_account)]),
+})
 
-export const s_setup_attempt_payment_method_details: z.ZodType<t_setup_attempt_payment_method_details> =
-  z.object({
-    acss_debit: s_setup_attempt_payment_method_details_acss_debit.optional(),
-    au_becs_debit:
-      s_setup_attempt_payment_method_details_au_becs_debit.optional(),
-    bacs_debit: s_setup_attempt_payment_method_details_bacs_debit.optional(),
-    bancontact: z.lazy(() =>
-      s_setup_attempt_payment_method_details_bancontact.optional(),
-    ),
-    boleto: s_setup_attempt_payment_method_details_boleto.optional(),
-    card: s_setup_attempt_payment_method_details_card.optional(),
-    card_present: z.lazy(() =>
-      s_setup_attempt_payment_method_details_card_present.optional(),
-    ),
-    cashapp: s_setup_attempt_payment_method_details_cashapp.optional(),
-    ideal: z.lazy(() =>
-      s_setup_attempt_payment_method_details_ideal.optional(),
-    ),
-    klarna: s_setup_attempt_payment_method_details_klarna.optional(),
-    link: s_setup_attempt_payment_method_details_link.optional(),
-    paypal: s_setup_attempt_payment_method_details_paypal.optional(),
-    sepa_debit: s_setup_attempt_payment_method_details_sepa_debit.optional(),
-    sofort: z.lazy(() =>
-      s_setup_attempt_payment_method_details_sofort.optional(),
-    ),
-    type: z.string().max(5000),
-    us_bank_account:
-      s_setup_attempt_payment_method_details_us_bank_account.optional(),
-  })
+export const s_setup_attempt_payment_method_details: z.ZodType<
+  t_setup_attempt_payment_method_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  acss_debit: s_setup_attempt_payment_method_details_acss_debit.optional(),
+  au_becs_debit:
+    s_setup_attempt_payment_method_details_au_becs_debit.optional(),
+  bacs_debit: s_setup_attempt_payment_method_details_bacs_debit.optional(),
+  bancontact: z.lazy(() =>
+    s_setup_attempt_payment_method_details_bancontact.optional(),
+  ),
+  boleto: s_setup_attempt_payment_method_details_boleto.optional(),
+  card: s_setup_attempt_payment_method_details_card.optional(),
+  card_present: z.lazy(() =>
+    s_setup_attempt_payment_method_details_card_present.optional(),
+  ),
+  cashapp: s_setup_attempt_payment_method_details_cashapp.optional(),
+  ideal: z.lazy(() => s_setup_attempt_payment_method_details_ideal.optional()),
+  klarna: s_setup_attempt_payment_method_details_klarna.optional(),
+  link: s_setup_attempt_payment_method_details_link.optional(),
+  paypal: s_setup_attempt_payment_method_details_paypal.optional(),
+  sepa_debit: s_setup_attempt_payment_method_details_sepa_debit.optional(),
+  sofort: z.lazy(() =>
+    s_setup_attempt_payment_method_details_sofort.optional(),
+  ),
+  type: z.string().max(5000),
+  us_bank_account:
+    s_setup_attempt_payment_method_details_us_bank_account.optional(),
+})
 
-export const s_subscription_schedules_resource_default_settings: z.ZodType<t_subscription_schedules_resource_default_settings> =
-  z.object({
-    application_fee_percent: z.coerce.number().nullable().optional(),
-    automatic_tax: z.lazy(() =>
-      s_subscription_schedules_resource_default_settings_automatic_tax.optional(),
-    ),
-    billing_cycle_anchor: z.enum(["automatic", "phase_start"]),
-    billing_thresholds: s_subscription_billing_thresholds.nullable().optional(),
-    collection_method: z
-      .enum(["charge_automatically", "send_invoice"])
-      .nullable()
-      .optional(),
-    default_payment_method: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    description: z.string().max(5000).nullable().optional(),
-    invoice_settings: z.lazy(
-      () => s_invoice_setting_subscription_schedule_setting,
-    ),
-    on_behalf_of: z
-      .union([z.string().max(5000), z.lazy(() => s_account)])
-      .nullable()
-      .optional(),
-    transfer_data: z.lazy(() =>
-      s_subscription_transfer_data.nullable().optional(),
-    ),
-  })
+export const s_subscription_schedules_resource_default_settings: z.ZodType<
+  t_subscription_schedules_resource_default_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  application_fee_percent: z.coerce.number().nullable().optional(),
+  automatic_tax: z.lazy(() =>
+    s_subscription_schedules_resource_default_settings_automatic_tax.optional(),
+  ),
+  billing_cycle_anchor: z.enum(["automatic", "phase_start"]),
+  billing_thresholds: s_subscription_billing_thresholds.nullable().optional(),
+  collection_method: z
+    .enum(["charge_automatically", "send_invoice"])
+    .nullable()
+    .optional(),
+  default_payment_method: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  description: z.string().max(5000).nullable().optional(),
+  invoice_settings: z.lazy(
+    () => s_invoice_setting_subscription_schedule_setting,
+  ),
+  on_behalf_of: z
+    .union([z.string().max(5000), z.lazy(() => s_account)])
+    .nullable()
+    .optional(),
+  transfer_data: z.lazy(() =>
+    s_subscription_transfer_data.nullable().optional(),
+  ),
+})
 
-export const s_subscription_schedule_phase_configuration: z.ZodType<t_subscription_schedule_phase_configuration> =
-  z.object({
-    add_invoice_items: z.array(
-      z.lazy(() => s_subscription_schedule_add_invoice_item),
-    ),
-    application_fee_percent: z.coerce.number().nullable().optional(),
-    automatic_tax: z.lazy(() => s_schedules_phase_automatic_tax.optional()),
-    billing_cycle_anchor: z
-      .enum(["automatic", "phase_start"])
-      .nullable()
-      .optional(),
-    billing_thresholds: s_subscription_billing_thresholds.nullable().optional(),
-    collection_method: z
-      .enum(["charge_automatically", "send_invoice"])
-      .nullable()
-      .optional(),
-    coupon: z
-      .union([z.string().max(5000), s_coupon, s_deleted_coupon])
-      .nullable()
-      .optional(),
-    currency: z.string(),
-    default_payment_method: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    default_tax_rates: z.array(s_tax_rate).nullable().optional(),
-    description: z.string().max(5000).nullable().optional(),
-    discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
-    end_date: z.coerce.number(),
-    invoice_settings: z.lazy(() =>
-      s_invoice_setting_subscription_schedule_phase_setting
-        .nullable()
-        .optional(),
-    ),
-    items: z.array(z.lazy(() => s_subscription_schedule_configuration_item)),
-    metadata: z.record(z.string().max(500)).nullable().optional(),
-    on_behalf_of: z
-      .union([z.string().max(5000), z.lazy(() => s_account)])
-      .nullable()
-      .optional(),
-    proration_behavior: z.enum(["always_invoice", "create_prorations", "none"]),
-    start_date: z.coerce.number(),
-    transfer_data: z.lazy(() =>
-      s_subscription_transfer_data.nullable().optional(),
-    ),
-    trial_end: z.coerce.number().nullable().optional(),
-  })
+export const s_subscription_schedule_phase_configuration: z.ZodType<
+  t_subscription_schedule_phase_configuration,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  add_invoice_items: z.array(
+    z.lazy(() => s_subscription_schedule_add_invoice_item),
+  ),
+  application_fee_percent: z.coerce.number().nullable().optional(),
+  automatic_tax: z.lazy(() => s_schedules_phase_automatic_tax.optional()),
+  billing_cycle_anchor: z
+    .enum(["automatic", "phase_start"])
+    .nullable()
+    .optional(),
+  billing_thresholds: s_subscription_billing_thresholds.nullable().optional(),
+  collection_method: z
+    .enum(["charge_automatically", "send_invoice"])
+    .nullable()
+    .optional(),
+  coupon: z
+    .union([z.string().max(5000), s_coupon, s_deleted_coupon])
+    .nullable()
+    .optional(),
+  currency: z.string(),
+  default_payment_method: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  default_tax_rates: z.array(s_tax_rate).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
+  end_date: z.coerce.number(),
+  invoice_settings: z.lazy(() =>
+    s_invoice_setting_subscription_schedule_phase_setting.nullable().optional(),
+  ),
+  items: z.array(z.lazy(() => s_subscription_schedule_configuration_item)),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  on_behalf_of: z
+    .union([z.string().max(5000), z.lazy(() => s_account)])
+    .nullable()
+    .optional(),
+  proration_behavior: z.enum(["always_invoice", "create_prorations", "none"]),
+  start_date: z.coerce.number(),
+  transfer_data: z.lazy(() =>
+    s_subscription_transfer_data.nullable().optional(),
+  ),
+  trial_end: z.coerce.number().nullable().optional(),
+})
 
-export const s_terminal_configuration_configuration_resource_device_type_specific_config: z.ZodType<t_terminal_configuration_configuration_resource_device_type_specific_config> =
-  z.object({
-    splashscreen: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .optional(),
-  })
+export const s_terminal_configuration_configuration_resource_device_type_specific_config: z.ZodType<
+  t_terminal_configuration_configuration_resource_device_type_specific_config,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  splashscreen: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .optional(),
+})
 
-export const s_terminal_reader_reader_resource_reader_action: z.ZodType<t_terminal_reader_reader_resource_reader_action> =
-  z.object({
-    failure_code: z.string().max(5000).nullable().optional(),
-    failure_message: z.string().max(5000).nullable().optional(),
-    process_payment_intent: z.lazy(() =>
-      s_terminal_reader_reader_resource_process_payment_intent_action.optional(),
-    ),
-    process_setup_intent: z.lazy(() =>
-      s_terminal_reader_reader_resource_process_setup_intent_action.optional(),
-    ),
-    refund_payment: z.lazy(() =>
-      s_terminal_reader_reader_resource_refund_payment_action.optional(),
-    ),
-    set_reader_display:
-      s_terminal_reader_reader_resource_set_reader_display_action.optional(),
-    status: z.enum(["failed", "in_progress", "succeeded"]),
-    type: z.enum([
-      "process_payment_intent",
-      "process_setup_intent",
-      "refund_payment",
-      "set_reader_display",
-    ]),
-  })
+export const s_terminal_reader_reader_resource_reader_action: z.ZodType<
+  t_terminal_reader_reader_resource_reader_action,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  failure_code: z.string().max(5000).nullable().optional(),
+  failure_message: z.string().max(5000).nullable().optional(),
+  process_payment_intent: z.lazy(() =>
+    s_terminal_reader_reader_resource_process_payment_intent_action.optional(),
+  ),
+  process_setup_intent: z.lazy(() =>
+    s_terminal_reader_reader_resource_process_setup_intent_action.optional(),
+  ),
+  refund_payment: z.lazy(() =>
+    s_terminal_reader_reader_resource_refund_payment_action.optional(),
+  ),
+  set_reader_display:
+    s_terminal_reader_reader_resource_set_reader_display_action.optional(),
+  status: z.enum(["failed", "in_progress", "succeeded"]),
+  type: z.enum([
+    "process_payment_intent",
+    "process_setup_intent",
+    "refund_payment",
+    "set_reader_display",
+  ]),
+})
 
-export const s_inbound_transfers: z.ZodType<t_inbound_transfers> = z.object({
+export const s_inbound_transfers: z.ZodType<
+  t_inbound_transfers,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   billing_details: s_treasury_shared_resource_billing_details,
   type: z.enum(["us_bank_account"]),
   us_bank_account: z.lazy(() =>
@@ -13278,788 +13594,893 @@ export const s_inbound_transfers: z.ZodType<t_inbound_transfers> = z.object({
   ),
 })
 
-export const s_outbound_payments_payment_method_details: z.ZodType<t_outbound_payments_payment_method_details> =
-  z.object({
-    billing_details: s_treasury_shared_resource_billing_details,
-    financial_account:
-      s_outbound_payments_payment_method_details_financial_account.optional(),
-    type: z.enum(["financial_account", "us_bank_account"]),
-    us_bank_account: z.lazy(() =>
-      s_outbound_payments_payment_method_details_us_bank_account.optional(),
-    ),
-  })
+export const s_outbound_payments_payment_method_details: z.ZodType<
+  t_outbound_payments_payment_method_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  billing_details: s_treasury_shared_resource_billing_details,
+  financial_account:
+    s_outbound_payments_payment_method_details_financial_account.optional(),
+  type: z.enum(["financial_account", "us_bank_account"]),
+  us_bank_account: z.lazy(() =>
+    s_outbound_payments_payment_method_details_us_bank_account.optional(),
+  ),
+})
 
-export const s_treasury_outbound_payments_resource_returned_status: z.ZodType<t_treasury_outbound_payments_resource_returned_status> =
-  z.object({
-    code: z.enum([
-      "account_closed",
-      "account_frozen",
-      "bank_account_restricted",
-      "bank_ownership_changed",
-      "declined",
-      "incorrect_account_holder_name",
-      "invalid_account_number",
-      "invalid_currency",
-      "no_account",
-      "other",
-    ]),
-    transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_treasury_transaction),
-    ]),
-  })
+export const s_treasury_outbound_payments_resource_returned_status: z.ZodType<
+  t_treasury_outbound_payments_resource_returned_status,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  code: z.enum([
+    "account_closed",
+    "account_frozen",
+    "bank_account_restricted",
+    "bank_ownership_changed",
+    "declined",
+    "incorrect_account_holder_name",
+    "invalid_account_number",
+    "invalid_currency",
+    "no_account",
+    "other",
+  ]),
+  transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_treasury_transaction),
+  ]),
+})
 
-export const s_outbound_transfers_payment_method_details: z.ZodType<t_outbound_transfers_payment_method_details> =
-  z.object({
-    billing_details: s_treasury_shared_resource_billing_details,
-    type: z.enum(["us_bank_account"]),
-    us_bank_account: z.lazy(() =>
-      s_outbound_transfers_payment_method_details_us_bank_account.optional(),
-    ),
-  })
+export const s_outbound_transfers_payment_method_details: z.ZodType<
+  t_outbound_transfers_payment_method_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  billing_details: s_treasury_shared_resource_billing_details,
+  type: z.enum(["us_bank_account"]),
+  us_bank_account: z.lazy(() =>
+    s_outbound_transfers_payment_method_details_us_bank_account.optional(),
+  ),
+})
 
-export const s_treasury_outbound_transfers_resource_returned_details: z.ZodType<t_treasury_outbound_transfers_resource_returned_details> =
-  z.object({
-    code: z.enum([
-      "account_closed",
-      "account_frozen",
-      "bank_account_restricted",
-      "bank_ownership_changed",
-      "declined",
-      "incorrect_account_holder_name",
-      "invalid_account_number",
-      "invalid_currency",
-      "no_account",
-      "other",
-    ]),
-    transaction: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_treasury_transaction),
-    ]),
-  })
+export const s_treasury_outbound_transfers_resource_returned_details: z.ZodType<
+  t_treasury_outbound_transfers_resource_returned_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  code: z.enum([
+    "account_closed",
+    "account_frozen",
+    "bank_account_restricted",
+    "bank_ownership_changed",
+    "declined",
+    "incorrect_account_holder_name",
+    "invalid_account_number",
+    "invalid_currency",
+    "no_account",
+    "other",
+  ]),
+  transaction: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_treasury_transaction),
+  ]),
+})
 
-export const s_treasury_received_credits_resource_linked_flows: z.ZodType<t_treasury_received_credits_resource_linked_flows> =
-  z.object({
-    credit_reversal: z.string().max(5000).nullable().optional(),
-    issuing_authorization: z.string().max(5000).nullable().optional(),
-    issuing_transaction: z.string().max(5000).nullable().optional(),
-    source_flow: z.string().max(5000).nullable().optional(),
-    source_flow_details: z.lazy(() =>
-      s_treasury_received_credits_resource_source_flows_details
-        .nullable()
-        .optional(),
-    ),
-    source_flow_type: z.string().max(5000).nullable().optional(),
-  })
+export const s_treasury_received_credits_resource_linked_flows: z.ZodType<
+  t_treasury_received_credits_resource_linked_flows,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  credit_reversal: z.string().max(5000).nullable().optional(),
+  issuing_authorization: z.string().max(5000).nullable().optional(),
+  issuing_transaction: z.string().max(5000).nullable().optional(),
+  source_flow: z.string().max(5000).nullable().optional(),
+  source_flow_details: z.lazy(() =>
+    s_treasury_received_credits_resource_source_flows_details
+      .nullable()
+      .optional(),
+  ),
+  source_flow_type: z.string().max(5000).nullable().optional(),
+})
 
-export const s_treasury_transactions_resource_flow_details: z.ZodType<t_treasury_transactions_resource_flow_details> =
-  z.object({
-    credit_reversal: z.lazy(() => s_treasury_credit_reversal.optional()),
-    debit_reversal: z.lazy(() => s_treasury_debit_reversal.optional()),
-    inbound_transfer: z.lazy(() => s_treasury_inbound_transfer.optional()),
-    issuing_authorization: z.lazy(() => s_issuing_authorization.optional()),
-    outbound_payment: z.lazy(() => s_treasury_outbound_payment.optional()),
-    outbound_transfer: z.lazy(() => s_treasury_outbound_transfer.optional()),
-    received_credit: z.lazy(() => s_treasury_received_credit.optional()),
-    received_debit: z.lazy(() => s_treasury_received_debit.optional()),
-    type: z.enum([
-      "credit_reversal",
-      "debit_reversal",
-      "inbound_transfer",
-      "issuing_authorization",
-      "other",
-      "outbound_payment",
-      "outbound_transfer",
-      "received_credit",
-      "received_debit",
-    ]),
-  })
+export const s_treasury_transactions_resource_flow_details: z.ZodType<
+  t_treasury_transactions_resource_flow_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  credit_reversal: z.lazy(() => s_treasury_credit_reversal.optional()),
+  debit_reversal: z.lazy(() => s_treasury_debit_reversal.optional()),
+  inbound_transfer: z.lazy(() => s_treasury_inbound_transfer.optional()),
+  issuing_authorization: z.lazy(() => s_issuing_authorization.optional()),
+  outbound_payment: z.lazy(() => s_treasury_outbound_payment.optional()),
+  outbound_transfer: z.lazy(() => s_treasury_outbound_transfer.optional()),
+  received_credit: z.lazy(() => s_treasury_received_credit.optional()),
+  received_debit: z.lazy(() => s_treasury_received_debit.optional()),
+  type: z.enum([
+    "credit_reversal",
+    "debit_reversal",
+    "inbound_transfer",
+    "issuing_authorization",
+    "other",
+    "outbound_payment",
+    "outbound_transfer",
+    "received_credit",
+    "received_debit",
+  ]),
+})
 
-export const s_legal_entity_company_verification: z.ZodType<t_legal_entity_company_verification> =
-  z.object({
-    document: z.lazy(() => s_legal_entity_company_verification_document),
-  })
+export const s_legal_entity_company_verification: z.ZodType<
+  t_legal_entity_company_verification,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  document: z.lazy(() => s_legal_entity_company_verification_document),
+})
 
-export const s_account_branding_settings: z.ZodType<t_account_branding_settings> =
-  z.object({
-    icon: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    logo: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    primary_color: z.string().max(5000).nullable().optional(),
-    secondary_color: z.string().max(5000).nullable().optional(),
-  })
+export const s_account_branding_settings: z.ZodType<
+  t_account_branding_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  icon: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  logo: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  primary_color: z.string().max(5000).nullable().optional(),
+  secondary_color: z.string().max(5000).nullable().optional(),
+})
 
-export const s_account_invoices_settings: z.ZodType<t_account_invoices_settings> =
-  z.object({
-    default_account_tax_ids: z
-      .array(z.union([z.string().max(5000), z.lazy(() => s_tax_id)]))
-      .nullable()
-      .optional(),
-  })
+export const s_account_invoices_settings: z.ZodType<
+  t_account_invoices_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  default_account_tax_ids: z
+    .array(z.union([z.string().max(5000), z.lazy(() => s_tax_id)]))
+    .nullable()
+    .optional(),
+})
 
-export const s_legal_entity_person_verification_document: z.ZodType<t_legal_entity_person_verification_document> =
-  z.object({
-    back: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    details: z.string().max(5000).nullable().optional(),
-    details_code: z.string().max(5000).nullable().optional(),
-    front: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-  })
+export const s_legal_entity_person_verification_document: z.ZodType<
+  t_legal_entity_person_verification_document,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  back: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  details: z.string().max(5000).nullable().optional(),
+  details_code: z.string().max(5000).nullable().optional(),
+  front: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+})
 
-export const s_payment_method_details_bancontact: z.ZodType<t_payment_method_details_bancontact> =
-  z.object({
-    bank_code: z.string().max(5000).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    bic: z.string().max(5000).nullable().optional(),
-    generated_sepa_debit: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    generated_sepa_debit_mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .nullable()
-      .optional(),
-    iban_last4: z.string().max(5000).nullable().optional(),
-    preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
-    verified_name: z.string().max(5000).nullable().optional(),
-  })
+export const s_payment_method_details_bancontact: z.ZodType<
+  t_payment_method_details_bancontact,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank_code: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  bic: z.string().max(5000).nullable().optional(),
+  generated_sepa_debit: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  generated_sepa_debit_mandate: z
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
+    .nullable()
+    .optional(),
+  iban_last4: z.string().max(5000).nullable().optional(),
+  preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+})
 
-export const s_payment_method_details_ideal: z.ZodType<t_payment_method_details_ideal> =
-  z.object({
-    bank: z
-      .enum([
-        "abn_amro",
-        "asn_bank",
-        "bunq",
-        "handelsbanken",
-        "ing",
-        "knab",
-        "moneyou",
-        "n26",
-        "nn",
-        "rabobank",
-        "regiobank",
-        "revolut",
-        "sns_bank",
-        "triodos_bank",
-        "van_lanschot",
-        "yoursafe",
-      ])
-      .nullable()
-      .optional(),
-    bic: z
-      .enum([
-        "ABNANL2A",
-        "ASNBNL21",
-        "BITSNL2A",
-        "BUNQNL2A",
-        "FVLBNL22",
-        "HANDNL2A",
-        "INGBNL2A",
-        "KNABNL2H",
-        "MOYONL21",
-        "NNBANL2G",
-        "NTSBDEB1",
-        "RABONL2U",
-        "RBRBNL21",
-        "REVOIE23",
-        "REVOLT21",
-        "SNSBNL2A",
-        "TRIONL2U",
-      ])
-      .nullable()
-      .optional(),
-    generated_sepa_debit: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    generated_sepa_debit_mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .nullable()
-      .optional(),
-    iban_last4: z.string().max(5000).nullable().optional(),
-    verified_name: z.string().max(5000).nullable().optional(),
-  })
+export const s_payment_method_details_ideal: z.ZodType<
+  t_payment_method_details_ideal,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank: z
+    .enum([
+      "abn_amro",
+      "asn_bank",
+      "bunq",
+      "handelsbanken",
+      "ing",
+      "knab",
+      "moneyou",
+      "n26",
+      "nn",
+      "rabobank",
+      "regiobank",
+      "revolut",
+      "sns_bank",
+      "triodos_bank",
+      "van_lanschot",
+      "yoursafe",
+    ])
+    .nullable()
+    .optional(),
+  bic: z
+    .enum([
+      "ABNANL2A",
+      "ASNBNL21",
+      "BITSNL2A",
+      "BUNQNL2A",
+      "FVLBNL22",
+      "HANDNL2A",
+      "INGBNL2A",
+      "KNABNL2H",
+      "MOYONL21",
+      "NNBANL2G",
+      "NTSBDEB1",
+      "RABONL2U",
+      "RBRBNL21",
+      "REVOIE23",
+      "REVOLT21",
+      "SNSBNL2A",
+      "TRIONL2U",
+    ])
+    .nullable()
+    .optional(),
+  generated_sepa_debit: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  generated_sepa_debit_mandate: z
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
+    .nullable()
+    .optional(),
+  iban_last4: z.string().max(5000).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+})
 
-export const s_payment_method_details_sofort: z.ZodType<t_payment_method_details_sofort> =
-  z.object({
-    bank_code: z.string().max(5000).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    bic: z.string().max(5000).nullable().optional(),
-    country: z.string().max(5000).nullable().optional(),
-    generated_sepa_debit: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    generated_sepa_debit_mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .nullable()
-      .optional(),
-    iban_last4: z.string().max(5000).nullable().optional(),
-    preferred_language: z
-      .enum(["de", "en", "es", "fr", "it", "nl", "pl"])
-      .nullable()
-      .optional(),
-    verified_name: z.string().max(5000).nullable().optional(),
-  })
+export const s_payment_method_details_sofort: z.ZodType<
+  t_payment_method_details_sofort,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank_code: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  bic: z.string().max(5000).nullable().optional(),
+  country: z.string().max(5000).nullable().optional(),
+  generated_sepa_debit: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  generated_sepa_debit_mandate: z
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
+    .nullable()
+    .optional(),
+  iban_last4: z.string().max(5000).nullable().optional(),
+  preferred_language: z
+    .enum(["de", "en", "es", "fr", "it", "nl", "pl"])
+    .nullable()
+    .optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+})
 
-export const s_payment_method_details_us_bank_account: z.ZodType<t_payment_method_details_us_bank_account> =
-  z.object({
-    account_holder_type: z
-      .enum(["company", "individual"])
-      .nullable()
-      .optional(),
-    account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    fingerprint: z.string().max(5000).nullable().optional(),
-    last4: z.string().max(5000).nullable().optional(),
-    mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .optional(),
-    payment_reference: z.string().max(5000).nullable().optional(),
-    routing_number: z.string().max(5000).nullable().optional(),
-  })
+export const s_payment_method_details_us_bank_account: z.ZodType<
+  t_payment_method_details_us_bank_account,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_holder_type: z.enum(["company", "individual"]).nullable().optional(),
+  account_type: z.enum(["checking", "savings"]).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.union([z.string().max(5000), z.lazy(() => s_mandate)]).optional(),
+  payment_reference: z.string().max(5000).nullable().optional(),
+  routing_number: z.string().max(5000).nullable().optional(),
+})
 
-export const s_payment_pages_checkout_session_invoice_settings: z.ZodType<t_payment_pages_checkout_session_invoice_settings> =
-  z.object({
-    account_tax_ids: z
-      .array(
-        z.union([
-          z.string().max(5000),
-          z.lazy(() => s_tax_id),
-          s_deleted_tax_id,
-        ]),
-      )
-      .nullable()
-      .optional(),
-    custom_fields: z
-      .array(s_invoice_setting_custom_field)
-      .nullable()
-      .optional(),
-    description: z.string().max(5000).nullable().optional(),
-    footer: z.string().max(5000).nullable().optional(),
-    issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
-    metadata: z.record(z.string().max(500)).nullable().optional(),
-    rendering_options: s_invoice_setting_rendering_options
-      .nullable()
-      .optional(),
-  })
+export const s_payment_pages_checkout_session_invoice_settings: z.ZodType<
+  t_payment_pages_checkout_session_invoice_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_tax_ids: z
+    .array(
+      z.union([z.string().max(5000), z.lazy(() => s_tax_id), s_deleted_tax_id]),
+    )
+    .nullable()
+    .optional(),
+  custom_fields: z.array(s_invoice_setting_custom_field).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  footer: z.string().max(5000).nullable().optional(),
+  issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  rendering_options: s_invoice_setting_rendering_options.nullable().optional(),
+})
 
-export const s_payment_pages_checkout_session_total_details_resource_breakdown: z.ZodType<t_payment_pages_checkout_session_total_details_resource_breakdown> =
-  z.object({
-    discounts: z.array(z.lazy(() => s_line_items_discount_amount)),
-    taxes: z.array(s_line_items_tax_amount),
-  })
+export const s_payment_pages_checkout_session_total_details_resource_breakdown: z.ZodType<
+  t_payment_pages_checkout_session_total_details_resource_breakdown,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  discounts: z.array(z.lazy(() => s_line_items_discount_amount)),
+  taxes: z.array(s_line_items_tax_amount),
+})
 
-export const s_payment_method_card_generated_card: z.ZodType<t_payment_method_card_generated_card> =
-  z.object({
-    charge: z.string().max(5000).nullable().optional(),
-    payment_method_details: s_card_generated_from_payment_method_details
-      .nullable()
-      .optional(),
-    setup_attempt: z
-      .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
-      .nullable()
-      .optional(),
-  })
+export const s_payment_method_card_generated_card: z.ZodType<
+  t_payment_method_card_generated_card,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  charge: z.string().max(5000).nullable().optional(),
+  payment_method_details: s_card_generated_from_payment_method_details
+    .nullable()
+    .optional(),
+  setup_attempt: z
+    .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
+    .nullable()
+    .optional(),
+})
 
-export const s_sepa_debit_generated_from: z.ZodType<t_sepa_debit_generated_from> =
-  z.object({
-    charge: z
-      .union([z.string().max(5000), z.lazy(() => s_charge)])
-      .nullable()
-      .optional(),
-    setup_attempt: z
-      .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
-      .nullable()
-      .optional(),
-  })
+export const s_sepa_debit_generated_from: z.ZodType<
+  t_sepa_debit_generated_from,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  charge: z
+    .union([z.string().max(5000), z.lazy(() => s_charge)])
+    .nullable()
+    .optional(),
+  setup_attempt: z
+    .union([z.string().max(5000), z.lazy(() => s_setup_attempt)])
+    .nullable()
+    .optional(),
+})
 
-export const s_issuing_cardholder_verification: z.ZodType<t_issuing_cardholder_verification> =
-  z.object({
-    document: z.lazy(() =>
-      s_issuing_cardholder_id_document.nullable().optional(),
-    ),
-  })
+export const s_issuing_cardholder_verification: z.ZodType<
+  t_issuing_cardholder_verification,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  document: z.lazy(() =>
+    s_issuing_cardholder_id_document.nullable().optional(),
+  ),
+})
 
-export const s_issuing_dispute_canceled_evidence: z.ZodType<t_issuing_dispute_canceled_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    canceled_at: z.coerce.number().nullable().optional(),
-    cancellation_policy_provided: z.coerce.boolean().nullable().optional(),
-    cancellation_reason: z.string().max(5000).nullable().optional(),
-    expected_at: z.coerce.number().nullable().optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-    product_description: z.string().max(5000).nullable().optional(),
-    product_type: z.enum(["merchandise", "service"]).nullable().optional(),
-    return_status: z
-      .enum(["merchant_rejected", "successful"])
-      .nullable()
-      .optional(),
-    returned_at: z.coerce.number().nullable().optional(),
-  })
+export const s_issuing_dispute_canceled_evidence: z.ZodType<
+  t_issuing_dispute_canceled_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  canceled_at: z.coerce.number().nullable().optional(),
+  cancellation_policy_provided: PermissiveBoolean.nullable().optional(),
+  cancellation_reason: z.string().max(5000).nullable().optional(),
+  expected_at: z.coerce.number().nullable().optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+  product_description: z.string().max(5000).nullable().optional(),
+  product_type: z.enum(["merchandise", "service"]).nullable().optional(),
+  return_status: z
+    .enum(["merchant_rejected", "successful"])
+    .nullable()
+    .optional(),
+  returned_at: z.coerce.number().nullable().optional(),
+})
 
-export const s_issuing_dispute_duplicate_evidence: z.ZodType<t_issuing_dispute_duplicate_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    card_statement: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    cash_receipt: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    check_image: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-    original_transaction: z.string().max(5000).nullable().optional(),
-  })
+export const s_issuing_dispute_duplicate_evidence: z.ZodType<
+  t_issuing_dispute_duplicate_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  card_statement: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  cash_receipt: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  check_image: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+  original_transaction: z.string().max(5000).nullable().optional(),
+})
 
-export const s_issuing_dispute_fraudulent_evidence: z.ZodType<t_issuing_dispute_fraudulent_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-  })
+export const s_issuing_dispute_fraudulent_evidence: z.ZodType<
+  t_issuing_dispute_fraudulent_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+})
 
-export const s_issuing_dispute_merchandise_not_as_described_evidence: z.ZodType<t_issuing_dispute_merchandise_not_as_described_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-    received_at: z.coerce.number().nullable().optional(),
-    return_description: z.string().max(5000).nullable().optional(),
-    return_status: z
-      .enum(["merchant_rejected", "successful"])
-      .nullable()
-      .optional(),
-    returned_at: z.coerce.number().nullable().optional(),
-  })
+export const s_issuing_dispute_merchandise_not_as_described_evidence: z.ZodType<
+  t_issuing_dispute_merchandise_not_as_described_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+  received_at: z.coerce.number().nullable().optional(),
+  return_description: z.string().max(5000).nullable().optional(),
+  return_status: z
+    .enum(["merchant_rejected", "successful"])
+    .nullable()
+    .optional(),
+  returned_at: z.coerce.number().nullable().optional(),
+})
 
-export const s_issuing_dispute_not_received_evidence: z.ZodType<t_issuing_dispute_not_received_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    expected_at: z.coerce.number().nullable().optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-    product_description: z.string().max(5000).nullable().optional(),
-    product_type: z.enum(["merchandise", "service"]).nullable().optional(),
-  })
+export const s_issuing_dispute_not_received_evidence: z.ZodType<
+  t_issuing_dispute_not_received_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  expected_at: z.coerce.number().nullable().optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+  product_description: z.string().max(5000).nullable().optional(),
+  product_type: z.enum(["merchandise", "service"]).nullable().optional(),
+})
 
-export const s_issuing_dispute_other_evidence: z.ZodType<t_issuing_dispute_other_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-    product_description: z.string().max(5000).nullable().optional(),
-    product_type: z.enum(["merchandise", "service"]).nullable().optional(),
-  })
+export const s_issuing_dispute_other_evidence: z.ZodType<
+  t_issuing_dispute_other_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+  product_description: z.string().max(5000).nullable().optional(),
+  product_type: z.enum(["merchandise", "service"]).nullable().optional(),
+})
 
-export const s_issuing_dispute_service_not_as_described_evidence: z.ZodType<t_issuing_dispute_service_not_as_described_evidence> =
-  z.object({
-    additional_documentation: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    canceled_at: z.coerce.number().nullable().optional(),
-    cancellation_reason: z.string().max(5000).nullable().optional(),
-    explanation: z.string().max(5000).nullable().optional(),
-    received_at: z.coerce.number().nullable().optional(),
-  })
+export const s_issuing_dispute_service_not_as_described_evidence: z.ZodType<
+  t_issuing_dispute_service_not_as_described_evidence,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  additional_documentation: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  canceled_at: z.coerce.number().nullable().optional(),
+  cancellation_reason: z.string().max(5000).nullable().optional(),
+  explanation: z.string().max(5000).nullable().optional(),
+  received_at: z.coerce.number().nullable().optional(),
+})
 
-export const s_payment_links_resource_invoice_settings: z.ZodType<t_payment_links_resource_invoice_settings> =
-  z.object({
-    account_tax_ids: z
-      .array(
-        z.union([
-          z.string().max(5000),
-          z.lazy(() => s_tax_id),
-          s_deleted_tax_id,
-        ]),
-      )
-      .nullable()
-      .optional(),
-    custom_fields: z
-      .array(s_invoice_setting_custom_field)
-      .nullable()
-      .optional(),
-    description: z.string().max(5000).nullable().optional(),
-    footer: z.string().max(5000).nullable().optional(),
-    issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
-    metadata: z.record(z.string().max(500)).nullable().optional(),
-    rendering_options: s_invoice_setting_rendering_options
-      .nullable()
-      .optional(),
-  })
+export const s_payment_links_resource_invoice_settings: z.ZodType<
+  t_payment_links_resource_invoice_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_tax_ids: z
+    .array(
+      z.union([z.string().max(5000), z.lazy(() => s_tax_id), s_deleted_tax_id]),
+    )
+    .nullable()
+    .optional(),
+  custom_fields: z.array(s_invoice_setting_custom_field).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  footer: z.string().max(5000).nullable().optional(),
+  issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  rendering_options: s_invoice_setting_rendering_options.nullable().optional(),
+})
 
-export const s_payment_links_resource_subscription_data_invoice_settings: z.ZodType<t_payment_links_resource_subscription_data_invoice_settings> =
-  z.object({ issuer: z.lazy(() => s_connect_account_reference) })
+export const s_payment_links_resource_subscription_data_invoice_settings: z.ZodType<
+  t_payment_links_resource_subscription_data_invoice_settings,
+  z.ZodTypeDef,
+  unknown
+> = z.object({ issuer: z.lazy(() => s_connect_account_reference) })
 
-export const s_quotes_resource_recurring: z.ZodType<t_quotes_resource_recurring> =
-  z.object({
-    amount_subtotal: z.coerce.number(),
-    amount_total: z.coerce.number(),
-    interval: z.enum(["day", "month", "week", "year"]),
-    interval_count: z.coerce.number(),
-    total_details: z.lazy(() => s_quotes_resource_total_details),
-  })
+export const s_quotes_resource_recurring: z.ZodType<
+  t_quotes_resource_recurring,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount_subtotal: z.coerce.number(),
+  amount_total: z.coerce.number(),
+  interval: z.enum(["day", "month", "week", "year"]),
+  interval_count: z.coerce.number(),
+  total_details: z.lazy(() => s_quotes_resource_total_details),
+})
 
-export const s_quotes_resource_upfront: z.ZodType<t_quotes_resource_upfront> =
-  z.object({
-    amount_subtotal: z.coerce.number(),
-    amount_total: z.coerce.number(),
-    line_items: z
-      .object({
-        data: z.array(z.lazy(() => s_item)),
-        has_more: z.coerce.boolean(),
-        object: z.enum(["list"]),
-        url: z.string().max(5000),
-      })
-      .optional(),
-    total_details: z.lazy(() => s_quotes_resource_total_details),
-  })
+export const s_quotes_resource_upfront: z.ZodType<
+  t_quotes_resource_upfront,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount_subtotal: z.coerce.number(),
+  amount_total: z.coerce.number(),
+  line_items: z
+    .object({
+      data: z.array(z.lazy(() => s_item)),
+      has_more: PermissiveBoolean,
+      object: z.enum(["list"]),
+      url: z.string().max(5000),
+    })
+    .optional(),
+  total_details: z.lazy(() => s_quotes_resource_total_details),
+})
 
-export const s_quotes_resource_total_details_resource_breakdown: z.ZodType<t_quotes_resource_total_details_resource_breakdown> =
-  z.object({
-    discounts: z.array(z.lazy(() => s_line_items_discount_amount)),
-    taxes: z.array(s_line_items_tax_amount),
-  })
+export const s_quotes_resource_total_details_resource_breakdown: z.ZodType<
+  t_quotes_resource_total_details_resource_breakdown,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  discounts: z.array(z.lazy(() => s_line_items_discount_amount)),
+  taxes: z.array(s_line_items_tax_amount),
+})
 
-export const s_setup_attempt_payment_method_details_bancontact: z.ZodType<t_setup_attempt_payment_method_details_bancontact> =
-  z.object({
-    bank_code: z.string().max(5000).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    bic: z.string().max(5000).nullable().optional(),
-    generated_sepa_debit: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    generated_sepa_debit_mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .nullable()
-      .optional(),
-    iban_last4: z.string().max(5000).nullable().optional(),
-    preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
-    verified_name: z.string().max(5000).nullable().optional(),
-  })
+export const s_setup_attempt_payment_method_details_bancontact: z.ZodType<
+  t_setup_attempt_payment_method_details_bancontact,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank_code: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  bic: z.string().max(5000).nullable().optional(),
+  generated_sepa_debit: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  generated_sepa_debit_mandate: z
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
+    .nullable()
+    .optional(),
+  iban_last4: z.string().max(5000).nullable().optional(),
+  preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+})
 
-export const s_setup_attempt_payment_method_details_card_present: z.ZodType<t_setup_attempt_payment_method_details_card_present> =
-  z.object({
-    generated_card: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    offline: s_payment_method_details_card_present_offline
-      .nullable()
-      .optional(),
-  })
+export const s_setup_attempt_payment_method_details_card_present: z.ZodType<
+  t_setup_attempt_payment_method_details_card_present,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  generated_card: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  offline: s_payment_method_details_card_present_offline.nullable().optional(),
+})
 
-export const s_setup_attempt_payment_method_details_ideal: z.ZodType<t_setup_attempt_payment_method_details_ideal> =
-  z.object({
-    bank: z
-      .enum([
-        "abn_amro",
-        "asn_bank",
-        "bunq",
-        "handelsbanken",
-        "ing",
-        "knab",
-        "moneyou",
-        "n26",
-        "nn",
-        "rabobank",
-        "regiobank",
-        "revolut",
-        "sns_bank",
-        "triodos_bank",
-        "van_lanschot",
-        "yoursafe",
-      ])
-      .nullable()
-      .optional(),
-    bic: z
-      .enum([
-        "ABNANL2A",
-        "ASNBNL21",
-        "BITSNL2A",
-        "BUNQNL2A",
-        "FVLBNL22",
-        "HANDNL2A",
-        "INGBNL2A",
-        "KNABNL2H",
-        "MOYONL21",
-        "NNBANL2G",
-        "NTSBDEB1",
-        "RABONL2U",
-        "RBRBNL21",
-        "REVOIE23",
-        "REVOLT21",
-        "SNSBNL2A",
-        "TRIONL2U",
-      ])
-      .nullable()
-      .optional(),
-    generated_sepa_debit: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    generated_sepa_debit_mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .nullable()
-      .optional(),
-    iban_last4: z.string().max(5000).nullable().optional(),
-    verified_name: z.string().max(5000).nullable().optional(),
-  })
+export const s_setup_attempt_payment_method_details_ideal: z.ZodType<
+  t_setup_attempt_payment_method_details_ideal,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank: z
+    .enum([
+      "abn_amro",
+      "asn_bank",
+      "bunq",
+      "handelsbanken",
+      "ing",
+      "knab",
+      "moneyou",
+      "n26",
+      "nn",
+      "rabobank",
+      "regiobank",
+      "revolut",
+      "sns_bank",
+      "triodos_bank",
+      "van_lanschot",
+      "yoursafe",
+    ])
+    .nullable()
+    .optional(),
+  bic: z
+    .enum([
+      "ABNANL2A",
+      "ASNBNL21",
+      "BITSNL2A",
+      "BUNQNL2A",
+      "FVLBNL22",
+      "HANDNL2A",
+      "INGBNL2A",
+      "KNABNL2H",
+      "MOYONL21",
+      "NNBANL2G",
+      "NTSBDEB1",
+      "RABONL2U",
+      "RBRBNL21",
+      "REVOIE23",
+      "REVOLT21",
+      "SNSBNL2A",
+      "TRIONL2U",
+    ])
+    .nullable()
+    .optional(),
+  generated_sepa_debit: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  generated_sepa_debit_mandate: z
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
+    .nullable()
+    .optional(),
+  iban_last4: z.string().max(5000).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+})
 
-export const s_setup_attempt_payment_method_details_sofort: z.ZodType<t_setup_attempt_payment_method_details_sofort> =
-  z.object({
-    bank_code: z.string().max(5000).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    bic: z.string().max(5000).nullable().optional(),
-    generated_sepa_debit: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_method)])
-      .nullable()
-      .optional(),
-    generated_sepa_debit_mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .nullable()
-      .optional(),
-    iban_last4: z.string().max(5000).nullable().optional(),
-    preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
-    verified_name: z.string().max(5000).nullable().optional(),
-  })
+export const s_setup_attempt_payment_method_details_sofort: z.ZodType<
+  t_setup_attempt_payment_method_details_sofort,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  bank_code: z.string().max(5000).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  bic: z.string().max(5000).nullable().optional(),
+  generated_sepa_debit: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_method)])
+    .nullable()
+    .optional(),
+  generated_sepa_debit_mandate: z
+    .union([z.string().max(5000), z.lazy(() => s_mandate)])
+    .nullable()
+    .optional(),
+  iban_last4: z.string().max(5000).nullable().optional(),
+  preferred_language: z.enum(["de", "en", "fr", "nl"]).nullable().optional(),
+  verified_name: z.string().max(5000).nullable().optional(),
+})
 
-export const s_subscription_schedules_resource_default_settings_automatic_tax: z.ZodType<t_subscription_schedules_resource_default_settings_automatic_tax> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
-  })
+export const s_subscription_schedules_resource_default_settings_automatic_tax: z.ZodType<
+  t_subscription_schedules_resource_default_settings_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
+})
 
-export const s_invoice_setting_subscription_schedule_setting: z.ZodType<t_invoice_setting_subscription_schedule_setting> =
-  z.object({
-    account_tax_ids: z
-      .array(
-        z.union([
-          z.string().max(5000),
-          z.lazy(() => s_tax_id),
-          s_deleted_tax_id,
-        ]),
-      )
-      .nullable()
-      .optional(),
-    days_until_due: z.coerce.number().nullable().optional(),
-    issuer: z.lazy(() => s_connect_account_reference),
-  })
+export const s_invoice_setting_subscription_schedule_setting: z.ZodType<
+  t_invoice_setting_subscription_schedule_setting,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_tax_ids: z
+    .array(
+      z.union([z.string().max(5000), z.lazy(() => s_tax_id), s_deleted_tax_id]),
+    )
+    .nullable()
+    .optional(),
+  days_until_due: z.coerce.number().nullable().optional(),
+  issuer: z.lazy(() => s_connect_account_reference),
+})
 
-export const s_subscription_schedule_add_invoice_item: z.ZodType<t_subscription_schedule_add_invoice_item> =
-  z.object({
-    discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
-    price: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_price),
-      s_deleted_price,
-    ]),
-    quantity: z.coerce.number().nullable().optional(),
-    tax_rates: z.array(s_tax_rate).nullable().optional(),
-  })
+export const s_subscription_schedule_add_invoice_item: z.ZodType<
+  t_subscription_schedule_add_invoice_item,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
+  price: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_price),
+    s_deleted_price,
+  ]),
+  quantity: z.coerce.number().nullable().optional(),
+  tax_rates: z.array(s_tax_rate).nullable().optional(),
+})
 
-export const s_schedules_phase_automatic_tax: z.ZodType<t_schedules_phase_automatic_tax> =
-  z.object({
-    enabled: z.coerce.boolean(),
-    liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
-  })
+export const s_schedules_phase_automatic_tax: z.ZodType<
+  t_schedules_phase_automatic_tax,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  enabled: PermissiveBoolean,
+  liability: z.lazy(() => s_connect_account_reference.nullable().optional()),
+})
 
-export const s_discounts_resource_stackable_discount: z.ZodType<t_discounts_resource_stackable_discount> =
-  z.object({
-    coupon: z
-      .union([z.string().max(5000), s_coupon])
-      .nullable()
-      .optional(),
-    discount: z
-      .union([z.string().max(5000), z.lazy(() => s_discount)])
-      .nullable()
-      .optional(),
-    promotion_code: z
-      .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
-      .nullable()
-      .optional(),
-  })
+export const s_discounts_resource_stackable_discount: z.ZodType<
+  t_discounts_resource_stackable_discount,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  coupon: z
+    .union([z.string().max(5000), s_coupon])
+    .nullable()
+    .optional(),
+  discount: z
+    .union([z.string().max(5000), z.lazy(() => s_discount)])
+    .nullable()
+    .optional(),
+  promotion_code: z
+    .union([z.string().max(5000), z.lazy(() => s_promotion_code)])
+    .nullable()
+    .optional(),
+})
 
-export const s_invoice_setting_subscription_schedule_phase_setting: z.ZodType<t_invoice_setting_subscription_schedule_phase_setting> =
-  z.object({
-    account_tax_ids: z
-      .array(
-        z.union([
-          z.string().max(5000),
-          z.lazy(() => s_tax_id),
-          s_deleted_tax_id,
-        ]),
-      )
-      .nullable()
-      .optional(),
-    days_until_due: z.coerce.number().nullable().optional(),
-    issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
-  })
+export const s_invoice_setting_subscription_schedule_phase_setting: z.ZodType<
+  t_invoice_setting_subscription_schedule_phase_setting,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_tax_ids: z
+    .array(
+      z.union([z.string().max(5000), z.lazy(() => s_tax_id), s_deleted_tax_id]),
+    )
+    .nullable()
+    .optional(),
+  days_until_due: z.coerce.number().nullable().optional(),
+  issuer: z.lazy(() => s_connect_account_reference.nullable().optional()),
+})
 
-export const s_subscription_schedule_configuration_item: z.ZodType<t_subscription_schedule_configuration_item> =
-  z.object({
-    billing_thresholds: s_subscription_item_billing_thresholds
-      .nullable()
-      .optional(),
-    discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
-    metadata: z.record(z.string().max(500)).nullable().optional(),
-    price: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_price),
-      s_deleted_price,
-    ]),
-    quantity: z.coerce.number().optional(),
-    tax_rates: z.array(s_tax_rate).nullable().optional(),
-  })
+export const s_subscription_schedule_configuration_item: z.ZodType<
+  t_subscription_schedule_configuration_item,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  billing_thresholds: s_subscription_item_billing_thresholds
+    .nullable()
+    .optional(),
+  discounts: z.array(z.lazy(() => s_discounts_resource_stackable_discount)),
+  metadata: z.record(z.string().max(500)).nullable().optional(),
+  price: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_price),
+    s_deleted_price,
+  ]),
+  quantity: z.coerce.number().optional(),
+  tax_rates: z.array(s_tax_rate).nullable().optional(),
+})
 
-export const s_terminal_reader_reader_resource_process_payment_intent_action: z.ZodType<t_terminal_reader_reader_resource_process_payment_intent_action> =
-  z.object({
-    payment_intent: z.union([
-      z.string().max(5000),
-      z.lazy(() => s_payment_intent),
-    ]),
-    process_config: s_terminal_reader_reader_resource_process_config.optional(),
-  })
+export const s_terminal_reader_reader_resource_process_payment_intent_action: z.ZodType<
+  t_terminal_reader_reader_resource_process_payment_intent_action,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  payment_intent: z.union([
+    z.string().max(5000),
+    z.lazy(() => s_payment_intent),
+  ]),
+  process_config: s_terminal_reader_reader_resource_process_config.optional(),
+})
 
-export const s_terminal_reader_reader_resource_process_setup_intent_action: z.ZodType<t_terminal_reader_reader_resource_process_setup_intent_action> =
-  z.object({
-    generated_card: z.string().max(5000).optional(),
-    process_config:
-      s_terminal_reader_reader_resource_process_setup_config.optional(),
-    setup_intent: z.union([z.string().max(5000), z.lazy(() => s_setup_intent)]),
-  })
+export const s_terminal_reader_reader_resource_process_setup_intent_action: z.ZodType<
+  t_terminal_reader_reader_resource_process_setup_intent_action,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  generated_card: z.string().max(5000).optional(),
+  process_config:
+    s_terminal_reader_reader_resource_process_setup_config.optional(),
+  setup_intent: z.union([z.string().max(5000), z.lazy(() => s_setup_intent)]),
+})
 
-export const s_terminal_reader_reader_resource_refund_payment_action: z.ZodType<t_terminal_reader_reader_resource_refund_payment_action> =
-  z.object({
-    amount: z.coerce.number().optional(),
-    charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]).optional(),
-    metadata: z.record(z.string().max(500)).optional(),
-    payment_intent: z
-      .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
-      .optional(),
-    reason: z
-      .enum(["duplicate", "fraudulent", "requested_by_customer"])
-      .optional(),
-    refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]).optional(),
-    refund_application_fee: z.coerce.boolean().optional(),
-    refund_payment_config:
-      s_terminal_reader_reader_resource_refund_payment_config.optional(),
-    reverse_transfer: z.coerce.boolean().optional(),
-  })
+export const s_terminal_reader_reader_resource_refund_payment_action: z.ZodType<
+  t_terminal_reader_reader_resource_refund_payment_action,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  amount: z.coerce.number().optional(),
+  charge: z.union([z.string().max(5000), z.lazy(() => s_charge)]).optional(),
+  metadata: z.record(z.string().max(500)).optional(),
+  payment_intent: z
+    .union([z.string().max(5000), z.lazy(() => s_payment_intent)])
+    .optional(),
+  reason: z
+    .enum(["duplicate", "fraudulent", "requested_by_customer"])
+    .optional(),
+  refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]).optional(),
+  refund_application_fee: PermissiveBoolean.optional(),
+  refund_payment_config:
+    s_terminal_reader_reader_resource_refund_payment_config.optional(),
+  reverse_transfer: PermissiveBoolean.optional(),
+})
 
-export const s_inbound_transfers_payment_method_details_us_bank_account: z.ZodType<t_inbound_transfers_payment_method_details_us_bank_account> =
-  z.object({
-    account_holder_type: z
-      .enum(["company", "individual"])
-      .nullable()
-      .optional(),
-    account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    fingerprint: z.string().max(5000).nullable().optional(),
-    last4: z.string().max(5000).nullable().optional(),
-    mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .optional(),
-    network: z.enum(["ach"]),
-    routing_number: z.string().max(5000).nullable().optional(),
-  })
+export const s_inbound_transfers_payment_method_details_us_bank_account: z.ZodType<
+  t_inbound_transfers_payment_method_details_us_bank_account,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_holder_type: z.enum(["company", "individual"]).nullable().optional(),
+  account_type: z.enum(["checking", "savings"]).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.union([z.string().max(5000), z.lazy(() => s_mandate)]).optional(),
+  network: z.enum(["ach"]),
+  routing_number: z.string().max(5000).nullable().optional(),
+})
 
-export const s_outbound_payments_payment_method_details_us_bank_account: z.ZodType<t_outbound_payments_payment_method_details_us_bank_account> =
-  z.object({
-    account_holder_type: z
-      .enum(["company", "individual"])
-      .nullable()
-      .optional(),
-    account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    fingerprint: z.string().max(5000).nullable().optional(),
-    last4: z.string().max(5000).nullable().optional(),
-    mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .optional(),
-    network: z.enum(["ach", "us_domestic_wire"]),
-    routing_number: z.string().max(5000).nullable().optional(),
-  })
+export const s_outbound_payments_payment_method_details_us_bank_account: z.ZodType<
+  t_outbound_payments_payment_method_details_us_bank_account,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_holder_type: z.enum(["company", "individual"]).nullable().optional(),
+  account_type: z.enum(["checking", "savings"]).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.union([z.string().max(5000), z.lazy(() => s_mandate)]).optional(),
+  network: z.enum(["ach", "us_domestic_wire"]),
+  routing_number: z.string().max(5000).nullable().optional(),
+})
 
-export const s_outbound_transfers_payment_method_details_us_bank_account: z.ZodType<t_outbound_transfers_payment_method_details_us_bank_account> =
-  z.object({
-    account_holder_type: z
-      .enum(["company", "individual"])
-      .nullable()
-      .optional(),
-    account_type: z.enum(["checking", "savings"]).nullable().optional(),
-    bank_name: z.string().max(5000).nullable().optional(),
-    fingerprint: z.string().max(5000).nullable().optional(),
-    last4: z.string().max(5000).nullable().optional(),
-    mandate: z
-      .union([z.string().max(5000), z.lazy(() => s_mandate)])
-      .optional(),
-    network: z.enum(["ach", "us_domestic_wire"]),
-    routing_number: z.string().max(5000).nullable().optional(),
-  })
+export const s_outbound_transfers_payment_method_details_us_bank_account: z.ZodType<
+  t_outbound_transfers_payment_method_details_us_bank_account,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  account_holder_type: z.enum(["company", "individual"]).nullable().optional(),
+  account_type: z.enum(["checking", "savings"]).nullable().optional(),
+  bank_name: z.string().max(5000).nullable().optional(),
+  fingerprint: z.string().max(5000).nullable().optional(),
+  last4: z.string().max(5000).nullable().optional(),
+  mandate: z.union([z.string().max(5000), z.lazy(() => s_mandate)]).optional(),
+  network: z.enum(["ach", "us_domestic_wire"]),
+  routing_number: z.string().max(5000).nullable().optional(),
+})
 
-export const s_treasury_received_credits_resource_source_flows_details: z.ZodType<t_treasury_received_credits_resource_source_flows_details> =
-  z.object({
-    credit_reversal: z.lazy(() => s_treasury_credit_reversal.optional()),
-    outbound_payment: z.lazy(() => s_treasury_outbound_payment.optional()),
-    payout: z.lazy(() => s_payout.optional()),
-    type: z.enum(["credit_reversal", "other", "outbound_payment", "payout"]),
-  })
+export const s_treasury_received_credits_resource_source_flows_details: z.ZodType<
+  t_treasury_received_credits_resource_source_flows_details,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  credit_reversal: z.lazy(() => s_treasury_credit_reversal.optional()),
+  outbound_payment: z.lazy(() => s_treasury_outbound_payment.optional()),
+  payout: z.lazy(() => s_payout.optional()),
+  type: z.enum(["credit_reversal", "other", "outbound_payment", "payout"]),
+})
 
-export const s_legal_entity_company_verification_document: z.ZodType<t_legal_entity_company_verification_document> =
-  z.object({
-    back: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    details: z.string().max(5000).nullable().optional(),
-    details_code: z.string().max(5000).nullable().optional(),
-    front: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-  })
+export const s_legal_entity_company_verification_document: z.ZodType<
+  t_legal_entity_company_verification_document,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  back: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  details: z.string().max(5000).nullable().optional(),
+  details_code: z.string().max(5000).nullable().optional(),
+  front: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+})
 
-export const s_issuing_cardholder_id_document: z.ZodType<t_issuing_cardholder_id_document> =
-  z.object({
-    back: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-    front: z
-      .union([z.string().max(5000), z.lazy(() => s_file)])
-      .nullable()
-      .optional(),
-  })
+export const s_issuing_cardholder_id_document: z.ZodType<
+  t_issuing_cardholder_id_document,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
+  back: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+  front: z
+    .union([z.string().max(5000), z.lazy(() => s_file)])
+    .nullable()
+    .optional(),
+})

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -182,7 +182,9 @@ export class JoiBuilder extends AbstractSchemaBuilder<JoiBuilder> {
   }
 
   protected boolean() {
-    return [joi, "boolean()"].filter(isDefined).join(".")
+    return [joi, "boolean()", "truthy(1)", "falsy(0)"]
+      .filter(isDefined)
+      .join(".")
   }
 
   public any(): string {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -13,13 +13,27 @@ import {AbstractSchemaBuilder} from "./abstract-schema-builder"
 
 const joi = "joi"
 
-export class JoiBuilder extends AbstractSchemaBuilder<JoiBuilder> {
+const staticSchemas = {}
+type StaticSchemas = typeof staticSchemas
+
+export class JoiBuilder extends AbstractSchemaBuilder<
+  JoiBuilder,
+  StaticSchemas
+> {
   static async fromInput(filename: string, input: Input): Promise<JoiBuilder> {
-    return new JoiBuilder(filename, input)
+    return new JoiBuilder(filename, input, staticSchemas)
   }
 
   override withImports(imports: ImportBuilder): JoiBuilder {
-    return new JoiBuilder(this.filename, this.input, {}, imports, this)
+    return new JoiBuilder(
+      this.filename,
+      this.input,
+      staticSchemas,
+      {},
+      new Set(),
+      imports,
+      this,
+    )
   }
 
   protected importHelpers(imports: ImportBuilder) {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -16,9 +16,6 @@ import {AbstractSchemaBuilder} from "./abstract-schema-builder"
 
 const zod = "z"
 
-// todo: coerce is cool for input where everything starts as strings,
-//       but for output we probably don't want that as its more likely
-//       to mask mistakes. https://en.wikipedia.org/wiki/Robustness_principle
 export class ZodBuilder extends AbstractSchemaBuilder<ZodBuilder> {
   static async fromInput(filename: string, input: Input): Promise<ZodBuilder> {
     return new ZodBuilder(filename, input)
@@ -55,7 +52,7 @@ export class ZodBuilder extends AbstractSchemaBuilder<ZodBuilder> {
 
     return {
       name,
-      type: type ? `${zod}.ZodType<${type}>` : "",
+      type: type ? `${zod}.ZodType<${type}, z.ZodTypeDef, unknown>` : "",
       value,
       kind: "const",
     }


### PR DESCRIPTION
Booleans now must be one of:
- `true | "true" | 1`  -> `true`
- `false | "false" | 0` -> `false`
- anything else -> error

Where previously any truthy value would be accepted as `true`

Introduces the concept of a "static schema" to create a `PermissiveBoolean` schema to aid with generation. This is a little annoying to unit test as it introduces `import` statements that don't work in the test harness properly.