### PR TITLE
fix: only allow publish of releases from latest main

### DIFF
--- a/scripts/publish.release.sh
+++ b/scripts/publish.release.sh
@@ -2,6 +2,13 @@
 
 set -ex
 
+if [[ $(git branch --show-current) != "main" ]]; then
+  echo 'releases must be published from main'
+  exit 1
+fi
+
+git pull origin main
+
 yarn clean
 
 yarn --immutable


### PR DESCRIPTION
added bit of protection until I get around to publishing through github actions.