### PR TITLE
refactor: split cli to allow programmatic use

### DIFF
--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/mnahkies/openapi-code-generator/issues"
   },
-  "bin": "./dist/index.js",
+  "bin": "./dist/cli.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import "source-map-support/register"
+
+import {Command, Option} from "@commander-js/extra-typings"
+import {NodeFsAdaptor} from "./core/file-system/node-fs-adaptor"
+import {OperationGroupStrategy} from "./core/input"
+import {logger} from "./core/logger"
+import {generate} from "./index"
+import {templates} from "./templates"
+import {TypescriptFormatter} from "./typescript/common/typescript-formatter"
+
+const program = new Command()
+  .addOption(
+    new Option("-i --input <value>", "input file to generate from")
+      .env("OPENAPI_INPUT")
+      .makeOptionMandatory(),
+  )
+  .addOption(
+    new Option(
+      "--input-type <value>",
+      "type of input file. this can be openapi3 or typespec",
+    )
+      .env("OPENAPI_INPUT_TYPE")
+      .choices(["openapi3", "typespec"] as const)
+      .default("openapi3" as const)
+      .makeOptionMandatory(),
+  )
+  .addOption(
+    new Option("-o --output <value>", "directory to output generated code")
+      .env("OPENAPI_OUTPUT")
+      .makeOptionMandatory(),
+  )
+  .addOption(
+    new Option("-t --template <value>", "template to use")
+      .env("OPENAPI_TEMPLATE")
+      .choices([
+        "typescript-koa",
+        "typescript-axios",
+        "typescript-fetch",
+        "typescript-angular",
+      ] as const satisfies Readonly<Array<keyof typeof templates>>)
+      .makeOptionMandatory(),
+  )
+  .addOption(
+    new Option(
+      "-s --schema-builder <value>",
+      "runtime schema parsing library to use",
+    )
+      .env("OPENAPI_SCHEMA_BUILDER")
+      .choices(["zod", "joi"] as const)
+      .default("zod" as const)
+      .makeOptionMandatory(),
+  )
+  .addOption(
+    new Option(
+      "--enable-runtime-response-validation",
+      "(experimental) whether to validate response bodies using the chosen runtime schema library",
+    )
+      .env("OPENAPI_ENABLE_RUNTIME_RESPONSE_VALIDATION")
+      .default(false),
+  )
+  .addOption(
+    new Option(
+      "--extract-inline-schemas",
+      "(experimental) Generate names and extract types/schemas for inline schemas",
+    )
+      .env("OPENAPI_EXTRACT_INLINE_SCHEMAS")
+      .default(false),
+  )
+  .addOption(
+    new Option(
+      "--allow-unused-imports",
+      "Keep unused imports. Especially useful if there is a bug in the unused-import elimination.",
+    )
+      .env("OPENAPI_ALLOW_UNUSED_IMPORTS")
+      .default(false),
+  )
+  .addOption(
+    new Option(
+      "--grouping-strategy <value>",
+      "(experimental) Strategy to use for splitting output into separate files. Set to none for a single generated.ts",
+    )
+      .env("OPENAPI_GROUPING_STRATEGY")
+      .choices([
+        "none",
+        "first-tag",
+        "first-slug",
+      ] as const satisfies OperationGroupStrategy[])
+      .default("none" as const)
+      .makeOptionMandatory(),
+  )
+  .showHelpAfterError()
+  .parse()
+
+const config = program.opts()
+
+async function main() {
+  const fsAdaptor = new NodeFsAdaptor()
+  const formatter = await TypescriptFormatter.createNodeFormatter()
+  await generate(config, fsAdaptor, formatter)
+}
+
+main()
+  .then(() => {
+    logger.info("generation complete!")
+    logger.info("elapsed", logger.toJSON())
+
+    process.exit(0)
+  })
+  .catch((err) => {
+    logger.error("unhandled error", err)
+
+    process.exit(1)
+  })

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -1,12 +1,7 @@
-#!/usr/bin/env node
-
-import "source-map-support/register"
-
 import path from "path"
 
-import {Command, Option} from "@commander-js/extra-typings"
-import {NodeFsAdaptor} from "./core/file-system/node-fs-adaptor"
-import {Input, OperationGroupStrategy} from "./core/input"
+import {IFsAdaptor} from "./core/file-system/fs-adaptor"
+import {Input} from "./core/input"
 import {GenericLoader} from "./core/loaders/generic.loader"
 import {loadTsConfigCompilerOptions} from "./core/loaders/tsconfig.loader"
 import {logger} from "./core/logger"
@@ -16,97 +11,30 @@ import {templates} from "./templates"
 import {TypescriptEmitter} from "./typescript/common/typescript-emitter"
 import {TypescriptFormatter} from "./typescript/common/typescript-formatter"
 
-const program = new Command()
-  .addOption(
-    new Option("-i --input <value>", "input file to generate from")
-      .env("OPENAPI_INPUT")
-      .makeOptionMandatory(),
-  )
-  .addOption(
-    new Option(
-      "--input-type <value>",
-      "type of input file. this can be openapi3 or typespec",
-    )
-      .env("OPENAPI_INPUT_TYPE")
-      .choices(["openapi3", "typespec"] as const)
-      .default("openapi3" as const)
-      .makeOptionMandatory(),
-  )
-  .addOption(
-    new Option("-o --output <value>", "directory to output generated code")
-      .env("OPENAPI_OUTPUT")
-      .makeOptionMandatory(),
-  )
-  .addOption(
-    new Option("-t --template <value>", "template to use")
-      .env("OPENAPI_TEMPLATE")
-      .choices([
-        "typescript-koa",
-        "typescript-axios",
-        "typescript-fetch",
-        "typescript-angular",
-      ] as const satisfies Readonly<Array<keyof typeof templates>>)
-      .makeOptionMandatory(),
-  )
-  .addOption(
-    new Option(
-      "-s --schema-builder <value>",
-      "runtime schema parsing library to use",
-    )
-      .env("OPENAPI_SCHEMA_BUILDER")
-      .choices(["zod", "joi"] as const)
-      .default("zod" as const)
-      .makeOptionMandatory(),
-  )
-  .addOption(
-    new Option(
-      "--enable-runtime-response-validation",
-      "(experimental) whether to validate response bodies using the chosen runtime schema library",
-    )
-      .env("OPENAPI_ENABLE_RUNTIME_RESPONSE_VALIDATION")
-      .default(false),
-  )
-  .addOption(
-    new Option(
-      "--extract-inline-schemas",
-      "(experimental) Generate names and extract types/schemas for inline schemas",
-    )
-      .env("OPENAPI_EXTRACT_INLINE_SCHEMAS")
-      .default(false),
-  )
-  .addOption(
-    new Option(
-      "--allow-unused-imports",
-      "Keep unused imports. Especially useful if there is a bug in the unused-import elimination.",
-    )
-      .env("OPENAPI_ALLOW_UNUSED_IMPORTS")
-      .default(false),
-  )
-  .addOption(
-    new Option(
-      "--grouping-strategy <value>",
-      "(experimental) Strategy to use for splitting output into separate files. Set to none for a single generated.ts",
-    )
-      .env("OPENAPI_GROUPING_STRATEGY")
-      .choices([
-        "none",
-        "first-tag",
-        "first-slug",
-      ] as const satisfies OperationGroupStrategy[])
-      .default("none" as const)
-      .makeOptionMandatory(),
-  )
-  .showHelpAfterError()
-  .parse()
+export type Config = {
+  input: string
+  inputType: "openapi3" | "typespec"
+  output: string
+  template:
+    | "typescript-fetch"
+    | "typescript-axios"
+    | "typescript-angular"
+    | "typescript-koa"
+  schemaBuilder: "zod" | "joi"
+  enableRuntimeResponseValidation: boolean
+  extractInlineSchemas: boolean
+  allowUnusedImports: boolean
+  groupingStrategy: "none" | "first-slug" | "first-tag"
+}
 
-const config = program.opts()
-
-async function main() {
+export async function generate(
+  config: Config,
+  fsAdaptor: IFsAdaptor,
+  formatter: TypescriptFormatter,
+) {
   logger.time("program starting")
   logger.info(`running on input file '${config.input}'`)
   logger.time("load files")
-
-  const fsAdaptor = new NodeFsAdaptor()
 
   const compilerOptions = await loadTsConfigCompilerOptions(
     path.join(process.cwd(), config.output),
@@ -129,8 +57,6 @@ async function main() {
 
   const generator = templates[config.template]
 
-  const formatter = await TypescriptFormatter.createNodeFormatter()
-
   const emitter = new TypescriptEmitter(fsAdaptor, formatter, {
     destinationDirectory: config.output,
     allowUnusedImports: config.allowUnusedImports,
@@ -145,16 +71,3 @@ async function main() {
     groupingStrategy: config.groupingStrategy,
   })
 }
-
-main()
-  .then(() => {
-    logger.info("generation complete!")
-    logger.info("elapsed", logger.toJSON())
-
-    process.exit(0)
-  })
-  .catch((err) => {
-    logger.error("unhandled error", err)
-
-    process.exit(1)
-  })

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -43,7 +43,7 @@ async function runSingle(template, input) {
 
   try {
     const result = await runCmd(
-      `node ./packages/openapi-code-generator/dist/index.js ${args.join(" ")}`,
+      `node ./packages/openapi-code-generator/dist/cli.js ${args.join(" ")}`,
     )
     result.forEach((it) => {
       console.info(`[${template} - ${filename}] ${it}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,7 +3035,7 @@ __metadata:
     "@typespec/versioning":
       optional: true
   bin:
-    openapi-code-generator: ./dist/index.js
+    openapi-code-generator: ./dist/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
splits the cli out into a separate file, such that there is a `generate` function that can be called programmatically.