### PR TITLE
fix: decouple validator from readline

### DIFF
--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -7,9 +7,11 @@ import {
   InvalidArgumentError,
   Option,
 } from "@commander-js/extra-typings"
+import {promptContinue} from "./core/cli-utils"
 import {NodeFsAdaptor} from "./core/file-system/node-fs-adaptor"
 import {OperationGroupStrategy} from "./core/input"
 import {logger} from "./core/logger"
+import {OpenapiValidator} from "./core/openapi-validator"
 import {generate} from "./index"
 import {templates} from "./templates"
 import {TypescriptFormatter} from "./typescript/common/typescript-formatter"
@@ -133,7 +135,14 @@ const config = program.opts()
 async function main() {
   const fsAdaptor = new NodeFsAdaptor()
   const formatter = await TypescriptFormatter.createNodeFormatter()
-  await generate(config, fsAdaptor, formatter)
+  const validator = await OpenapiValidator.create(async (filename: string) => {
+    await promptContinue(
+      `Found errors validating '${filename}', continue?`,
+      "yes",
+    )
+  })
+
+  await generate(config, fsAdaptor, formatter, validator)
 }
 
 main()

--- a/packages/openapi-code-generator/src/core/cli-utils.ts
+++ b/packages/openapi-code-generator/src/core/cli-utils.ts
@@ -13,7 +13,7 @@ export async function promptContinue(
   throw new Error("user aborted")
 }
 
-export async function prompt(
+async function prompt(
   question: string,
   defaultValue?: string,
 ): Promise<string> {

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -32,6 +32,7 @@ export async function generate(
   config: Config,
   fsAdaptor: IFsAdaptor,
   formatter: TypescriptFormatter,
+  validator: OpenapiValidator,
 ) {
   logger.time("program starting")
   logger.info(`running on input file '${config.input}'`)
@@ -41,8 +42,6 @@ export async function generate(
     path.join(process.cwd(), config.output),
     fsAdaptor,
   )
-
-  const validator = await OpenapiValidator.create()
 
   const genericLoader = new GenericLoader(fsAdaptor)
 


### PR DESCRIPTION
removes direct dependency on `readline` from the validator, such that it can be used in web