### PR TITLE
feat: add a prettier based formatter

### DIFF
--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -14,7 +14,7 @@ import {logger} from "./core/logger"
 import {OpenapiValidator} from "./core/openapi-validator"
 import {generate} from "./index"
 import {templates} from "./templates"
-import {TypescriptFormatter} from "./typescript/common/typescript-formatter"
+import {TypescriptFormatterBiome} from "./typescript/common/typescript-formatter.biome"
 
 const boolParser = (arg: string): boolean => {
   const TRUTHY_VALUES = ["true", "1", "on"]
@@ -134,7 +134,8 @@ const config = program.opts()
 
 async function main() {
   const fsAdaptor = new NodeFsAdaptor()
-  const formatter = await TypescriptFormatter.createNodeFormatter()
+  // TODO: make switchable with prettier / auto-detect from project?
+  const formatter = await TypescriptFormatterBiome.createNodeFormatter()
   const validator = await OpenapiValidator.create(async (filename: string) => {
     await promptContinue(
       `Found errors validating '${filename}', continue?`,

--- a/packages/openapi-code-generator/src/core/interfaces.ts
+++ b/packages/openapi-code-generator/src/core/interfaces.ts
@@ -1,0 +1,3 @@
+export interface IFormatter {
+  format(filename: string, raw: string): Promise<string>
+}

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -2,6 +2,7 @@ import path from "path"
 
 import {IFsAdaptor} from "./core/file-system/fs-adaptor"
 import {Input} from "./core/input"
+import {IFormatter} from "./core/interfaces"
 import {GenericLoader} from "./core/loaders/generic.loader"
 import {loadTsConfigCompilerOptions} from "./core/loaders/tsconfig.loader"
 import {logger} from "./core/logger"
@@ -9,7 +10,6 @@ import {OpenapiLoader} from "./core/openapi-loader"
 import {OpenapiValidator} from "./core/openapi-validator"
 import {templates} from "./templates"
 import {TypescriptEmitter} from "./typescript/common/typescript-emitter"
-import {TypescriptFormatter} from "./typescript/common/typescript-formatter"
 
 export type Config = {
   input: string
@@ -31,7 +31,7 @@ export type Config = {
 export async function generate(
   config: Config,
   fsAdaptor: IFsAdaptor,
-  formatter: TypescriptFormatter,
+  formatter: IFormatter,
   validator: OpenapiValidator,
 ) {
   logger.time("program starting")

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
@@ -2,7 +2,7 @@ import {Input} from "../../../core/input"
 import {IRModel, MaybeIRModel} from "../../../core/openapi-types-normalized"
 import {OpenApiVersion, unitTestInput} from "../../../test/input.test-utils"
 import {ImportBuilder} from "../import-builder"
-import {TypescriptFormatter} from "../typescript-formatter"
+import {TypescriptFormatterBiome} from "../typescript-formatter.biome"
 import {SchemaBuilderConfig} from "./abstract-schema-builder"
 import {SchemaBuilderType, schemaBuilderFactory} from "./schema-builder"
 
@@ -33,7 +33,7 @@ export function schemaBuilderTestHarness(
     required: boolean,
     config: SchemaBuilderConfig,
   ) {
-    const formatter = await TypescriptFormatter.createNodeFormatter()
+    const formatter = await TypescriptFormatterBiome.createNodeFormatter()
 
     const imports = new ImportBuilder()
 

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -3,7 +3,7 @@ import {CompilerOptions} from "../../core/loaders/tsconfig.loader"
 import {testVersions, unitTestInput} from "../../test/input.test-utils"
 import {ImportBuilder} from "./import-builder"
 import {TypeBuilder, TypeBuilderConfig} from "./type-builder"
-import {TypescriptFormatter} from "./typescript-formatter"
+import {TypescriptFormatterBiome} from "./typescript-formatter.biome"
 
 describe.each(testVersions)(
   "%s - typescript/common/type-builder",
@@ -417,7 +417,7 @@ describe.each(testVersions)(
         compilerOptions?: CompilerOptions
       } = {},
     ) {
-      const formatter = await TypescriptFormatter.createNodeFormatter()
+      const formatter = await TypescriptFormatterBiome.createNodeFormatter()
 
       const {input, file} = await unitTestInput(version)
       const schema = {$ref: `${file}#/${path}`}

--- a/packages/openapi-code-generator/src/typescript/common/typescript-emitter.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-emitter.ts
@@ -1,13 +1,13 @@
 import path from "path"
 import {IFsAdaptor} from "../../core/file-system/fs-adaptor"
+import {IFormatter} from "../../core/interfaces"
 import {logger} from "../../core/logger"
 import {CompilationUnit} from "./compilation-units"
-import {TypescriptFormatter} from "./typescript-formatter"
 
 export class TypescriptEmitter {
   constructor(
     private readonly fsAdaptor: IFsAdaptor,
-    private readonly formatter: TypescriptFormatter,
+    private readonly formatter: IFormatter,
     private readonly config: {
       destinationDirectory: string
       allowUnusedImports: boolean

--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.biome.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.biome.ts
@@ -1,7 +1,8 @@
 import {Biome, Distribution} from "@biomejs/js-api"
+import {IFormatter} from "../../core/interfaces"
 import {logger} from "../../core/logger"
 
-export class TypescriptFormatter {
+export class TypescriptFormatterBiome implements IFormatter {
   private constructor(private readonly biome: Biome) {
     biome.applyConfiguration({
       organizeImports: {
@@ -41,19 +42,19 @@ export class TypescriptFormatter {
     }
   }
 
-  static async createNodeFormatter(): Promise<TypescriptFormatter> {
+  static async createNodeFormatter(): Promise<TypescriptFormatterBiome> {
     const biome = await Biome.create({
       distribution: Distribution.NODE,
     })
 
-    return new TypescriptFormatter(biome)
+    return new TypescriptFormatterBiome(biome)
   }
 
-  static async createWebFormatter(): Promise<TypescriptFormatter> {
+  static async createWebFormatter(): Promise<TypescriptFormatterBiome> {
     const biome = await Biome.create({
       distribution: Distribution.WEB,
     })
 
-    return new TypescriptFormatter(biome)
+    return new TypescriptFormatterBiome(biome)
   }
 }

--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
@@ -1,0 +1,35 @@
+import {IFormatter} from "../../core/interfaces"
+import {logger} from "../../core/logger"
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const prettier = require("prettier/standalone")
+const plugins = [
+  require("prettier/plugins/estree"),
+  require("prettier/plugins/typescript"),
+]
+
+export class TypescriptFormatterPrettier implements IFormatter {
+  private constructor() {}
+
+  async format(filename: string, raw: string): Promise<string> {
+    try {
+      raw = raw
+        .split("\n")
+        .map((it) => it.trim())
+        .join("\n")
+
+      return prettier.format(raw, {
+        semi: false,
+        arrowParens: "always",
+        parser: "typescript",
+        plugins,
+      })
+    } catch (err) {
+      logger.error("failed to format", {err})
+      return raw
+    }
+  }
+
+  static async create(): Promise<TypescriptFormatterPrettier> {
+    return new TypescriptFormatterPrettier()
+  }
+}


### PR DESCRIPTION
for whatever reason `biome` doesn't want to work in the web browser for me using `@biomejs/wasm-web` - so lets add back `prettier` formatting support, and use this in a web setting.

it could be cool to auto-detect whether a project is using `biome` / `prettier` when generating from the cli and adjust the formatter to match in future.