### PR TITLE
feat: add an interactive playground to the documentation site

### DIFF
--- a/packages/documentation/next.config.mjs
+++ b/packages/documentation/next.config.mjs
@@ -1,4 +1,5 @@
 import nextra from "nextra"
+import NodePolyfillPlugin from "node-polyfill-webpack-plugin"
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -7,6 +8,20 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     unoptimized: true,
+  },
+  webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
+    config.experiments = {...config.experiments, syncWebAssembly: true}
+    config.plugins.push(new NodePolyfillPlugin())
+    config.module.rules.push({
+      test: /node:.+/i,
+      use: "null-loader",
+    })
+    config.module.rules.push({
+      test: /@biomejs\/wasm-nodejs/i,
+      use: "null-loader",
+    })
+
+    return config
   },
   async redirects() {
     return [{source: "/", destination: "/overview/about", permanent: false}]

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
-    "@monaco-editor/react": "^4.6.0",
+    "@monaco-editor/react": "^4.7.0-rc.0",
     "@nahkies/openapi-code-generator": "*",
     "monaco-editor": "^0.52.2",
     "monaco-editor-auto-typings": "^0.4.6",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -18,23 +18,34 @@
   },
   "scripts": {
     "clean": "rm -rf ./.next ./dist",
-    "dev": "next dev",
-    "build": "next build",
-    "lint": "next lint",
+    "dev": "yarn copy-sample-data && next dev",
+    "build": "yarn copy-sample-data && next build",
+    "lint": "yarn run -T lint",
+    "format": "yarn run -T format",
+    "copy-sample-data": "tsx ./scripts/copy-sample-data.ts",
     "publish:gh-pages": "yarn gh-pages -d ./dist -b gh-pages --cname openapi-code-generator.nahkies.co.nz --nojekyll"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
+    "@monaco-editor/react": "^4.6.0",
+    "@nahkies/openapi-code-generator": "*",
+    "monaco-editor": "^0.52.2",
+    "monaco-editor-auto-typings": "^0.4.6",
     "next": "15.1.3",
     "nextra": "^3.3.1",
     "nextra-theme-docs": "^3.3.1",
+    "node-polyfill-webpack-plugin": "^4.1.0",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "react-hook-form": "^7.54.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "gh-pages": "^6.3.0",
+    "null-loader": "^4.0.1",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   }
 }

--- a/packages/documentation/public/samples/.gitignore
+++ b/packages/documentation/public/samples/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/documentation/scripts/copy-sample-data.ts
+++ b/packages/documentation/scripts/copy-sample-data.ts
@@ -1,0 +1,22 @@
+import {copyFile} from "node:fs/promises"
+import {dirname, resolve} from "node:path"
+import {fileURLToPath} from "node:url"
+import {sampleFilenames} from "../src/lib/playground/consts"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+for (const sample of sampleFilenames) {
+  const sourcePath = resolve(
+    __dirname,
+    `../../../integration-tests-definitions/${sample}`,
+  )
+  const destinationPath = resolve(__dirname, `../public/samples/${sample}`)
+
+  try {
+    await copyFile(sourcePath, destinationPath)
+    console.log(`Copied ${sample} to ${destinationPath}`)
+  } catch (error) {
+    console.error(`Failed to copy ${sample}:`, error)
+  }
+}

--- a/packages/documentation/scripts/copy-sample-data.ts
+++ b/packages/documentation/scripts/copy-sample-data.ts
@@ -16,7 +16,8 @@ for (const sample of sampleFilenames) {
   try {
     await copyFile(sourcePath, destinationPath)
     console.log(`Copied ${sample} to ${destinationPath}`)
-  } catch (error) {
-    console.error(`Failed to copy ${sample}:`, error)
+  } catch (err) {
+    console.error(`Failed to copy ${sample}:`, err)
+    throw err
   }
 }

--- a/packages/documentation/src/lib/loading-spinner.module.css
+++ b/packages/documentation/src/lib/loading-spinner.module.css
@@ -1,0 +1,19 @@
+.loader {
+  width: 1rem;
+  height: 1rem;
+  border: 5px solid #363636;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/documentation/src/lib/loading-spinner.tsx
+++ b/packages/documentation/src/lib/loading-spinner.tsx
@@ -1,0 +1,5 @@
+import styles from "./loading-spinner.module.css"
+
+export const LoadingSpinner = () => {
+  return <span className={styles.loader} />
+}

--- a/packages/documentation/src/lib/playground.module.css
+++ b/packages/documentation/src/lib/playground.module.css
@@ -1,0 +1,13 @@
+.editorContainer {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+
+  /*
+  TODO: rendering side-by-side results in weird stuff happening
+        when breakpoints change, stick with the vertical stack for now.
+  @media (min-width: 1536px) {
+    grid-template-columns: 1fr 1fr;
+  }
+   */
+}

--- a/packages/documentation/src/lib/playground.tsx
+++ b/packages/documentation/src/lib/playground.tsx
@@ -50,7 +50,7 @@ const defaultConfig = {
   enableRuntimeResponseValidation: true,
   extractInlineSchemas: true,
   allowUnusedImports: false,
-  groupingStrategy: "none",
+  groupingStrategy: "first-tag",
   tsAllowAny: false,
   tsCompilerOptions: {exactOptionalPropertyTypes: false},
   enableTypedBasePaths: true,

--- a/packages/documentation/src/lib/playground.tsx
+++ b/packages/documentation/src/lib/playground.tsx
@@ -1,0 +1,417 @@
+import {LoadingSpinner} from "@/lib/loading-spinner"
+import {sampleFilenames} from "@/lib/playground/consts"
+import {ControlledSelect} from "@/lib/playground/controls/controlled-select"
+import {loadRuntimeTypes} from "@/lib/playground/load-runtime-types"
+import {createOrUpdateModel, listAvailableModels} from "@/lib/playground/utils"
+import {
+  createWorker,
+  sendMessageToWorker,
+  subscribeToWorkerMessages,
+} from "@/lib/playground/worker/bridge"
+import type {Monad, WorkerResult} from "@/lib/playground/worker/types"
+import {zodResolver} from "@hookform/resolvers/zod"
+import {Editor, type Monaco, useMonaco} from "@monaco-editor/react"
+import {type Config, WebFsAdaptor} from "@nahkies/openapi-code-generator"
+import type {editor} from "monaco-editor"
+import type {AutoTypingsCore} from "monaco-editor-auto-typings/lib/AutoTypingsCore"
+import {getComponents, useThemeConfig} from "nextra-theme-docs"
+import {Callout} from "nextra/components"
+import type React from "react"
+import type {PropsWithChildren} from "react"
+import {useCallback, useEffect, useRef, useState} from "react"
+import {useForm} from "react-hook-form"
+import {z} from "zod"
+import styles from "./playground.module.css"
+import {ConfigForm} from "./playground/config-form"
+
+type IStandaloneCodeEditor = editor.IStandaloneCodeEditor
+
+const fetchSample = async (sample: string) => {
+  try {
+    const res = await fetch(`/samples/${sample}`)
+    const text = await res.text()
+
+    if (res.ok) {
+      return text
+    }
+
+    return `Failed to load sample. ${text}`
+  } catch (err) {
+    return `Failed to load sample. ${err instanceof Error ? err.message : err}`
+  }
+}
+
+const defaultConfig = {
+  input: "/example.yaml",
+  output: "/generated",
+  template: "typescript-fetch",
+  inputType: "openapi3",
+  schemaBuilder: "zod",
+  enableRuntimeResponseValidation: true,
+  extractInlineSchemas: true,
+  allowUnusedImports: false,
+  groupingStrategy: "none",
+  tsAllowAny: false,
+  tsCompilerOptions: {exactOptionalPropertyTypes: false},
+  enableTypedBasePaths: true,
+  filenameConvention: "kebab-case",
+  tsServerImplementationMethod: "type",
+} satisfies Config
+
+const EditorFileSelectorWrapper: React.FC<PropsWithChildren> = ({children}) => {
+  return (
+    <div style={{display: "flex", gap: "0.5rem", margin: "0.5rem 0"}}>
+      {children}
+    </div>
+  )
+}
+
+const EditorControls: React.FC<{editor?: IStandaloneCodeEditor}> = ({
+  editor,
+}) => {
+  const onClickFoldAll = useCallback(() => {
+    editor?.trigger("fold", "editor.foldAll", undefined)
+  }, [editor])
+  const onClickUnFoldAll = useCallback(() => {
+    editor?.trigger("fold", "editor.unfoldAll", undefined)
+  }, [editor])
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        marginTop: "0.5rem",
+        alignItems: "center",
+      }}
+    >
+      <div style={{display: "flex", flexDirection: "row", gap: "1rem"}}>
+        <button type={"button"} onClick={onClickFoldAll}>
+          Fold All
+        </button>
+        <button type={"button"} onClick={onClickUnFoldAll}>
+          Unfold All
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const GenerationResult: React.FC<{result: Monad<WorkerResult> | null}> = ({
+  result,
+}) => {
+  if (!result || result.loading) {
+    return (
+      <Callout type="info" emoji="✅">
+        <p>
+          <strong>Running generation</strong>
+          <br />
+          <LoadingSpinner />
+        </p>
+      </Callout>
+    )
+  }
+
+  if (result.success) {
+    const {elapsed} = result.result
+
+    return (
+      <Callout type="info" emoji="✅">
+        <p>
+          <strong>Generation success</strong>
+          <br />
+          Generation ran in {elapsed}ms
+        </p>
+      </Callout>
+    )
+  }
+
+  if (!result.success) {
+    const err = result.err
+    const cause = result.err.cause
+
+    return (
+      <Callout type="warning" emoji="⚠️">
+        <p>
+          <strong>{err.message}</strong>
+          <br />
+          {cause instanceof Error ? `Details: ${cause.message}` : null}
+        </p>
+      </Callout>
+    )
+  }
+
+  return null
+}
+
+const PlaygroundInner: React.FC<{
+  monaco: Monaco
+  webFsAdaptor: WebFsAdaptor
+  defaultSample: {filename: string; content: string}
+  samples: string[]
+}> = ({monaco, webFsAdaptor, defaultSample, samples}) => {
+  const themeConfig = useThemeConfig()
+
+  const Components = getComponents({
+    isRawLayout: false,
+    components: themeConfig.components,
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  }) as any
+
+  const workerRef = useRef<Worker | null>(null)
+  const [config, setConfig] = useState<Config>(defaultConfig)
+  const [result, setResult] = useState<Monad<WorkerResult> | null>(null)
+  const [inputEditor, setInputEditor] = useState<IStandaloneCodeEditor>()
+  const [outputEditor, setOutputEditor] = useState<IStandaloneCodeEditor>()
+  const [availableModels, setAvailableModels] = useState<string[]>([])
+
+  const inputModel = monaco.editor.getModel(monaco.Uri.file(config.input))
+
+  //region config form
+  const {control, watch} = useForm({
+    resolver: zodResolver(
+      z.object({
+        input: z.string(),
+        output: z.string().optional(),
+      }),
+    ),
+    defaultValues: {
+      input: defaultSample.filename,
+      output: "",
+    },
+  })
+
+  const inputFilename = watch("input")
+  const outputFilename = watch("output")
+  //endregion
+
+  //region create worker
+  useEffect(() => {
+    if (!workerRef.current) {
+      workerRef.current = createWorker()
+    }
+
+    subscribeToWorkerMessages(workerRef.current, async (data) => {
+      if (data.success) {
+        webFsAdaptor.clearFiles((it) => it.includes("/generated/"))
+
+        for (const [key, value] of data.result.files) {
+          await webFsAdaptor.writeFile(key, value)
+          createOrUpdateModel({filename: key, value}, monaco)
+        }
+        // pruneModels(webFsAdaptor, monaco)
+        setAvailableModels(listAvailableModels(webFsAdaptor, monaco))
+      }
+      setResult(data)
+    })
+
+    return () => {
+      if (workerRef.current) {
+        workerRef.current.terminate()
+        workerRef.current = null
+      }
+    }
+  }, [webFsAdaptor, monaco])
+  //endregion
+
+  //region mount input/output editors
+  const onMountInput = useCallback(
+    (e: IStandaloneCodeEditor) => setInputEditor(e),
+    [],
+  )
+  const onMountOutput = useCallback(
+    (e: IStandaloneCodeEditor) => setOutputEditor(e),
+    [],
+  )
+
+  useEffect(() => {
+    if (!inputEditor) {
+      return
+    }
+
+    const inputUri = monaco.Uri.file(config.input)
+    if (!monaco.editor.getModel(inputUri)) {
+      monaco.editor.createModel(defaultSample.content, "yaml", inputUri)
+
+      sendMessageToWorker(workerRef.current, {
+        type: "generate",
+        config,
+        input: defaultSample.content,
+      })
+    }
+
+    const model = monaco.editor.getModel(inputUri)
+    inputEditor.setModel(model)
+
+    if (!model) {
+      return
+    }
+
+    const listener = model.onDidChangeContent(() => {
+      console.info("input changed")
+      const value = model.getValue()
+
+      if (value) {
+        sendMessageToWorker(workerRef.current, {
+          type: "generate",
+          config,
+          input: value,
+        })
+      }
+    })
+
+    return () => {
+      listener.dispose()
+    }
+  }, [monaco, inputEditor, config, defaultSample])
+  //endregion
+
+  //region set input/output model
+  useEffect(() => {
+    const sample = samples.find((it) => it === inputFilename)
+
+    if (!sample || !inputModel || inputModel.isDisposed()) {
+      return
+    }
+    inputModel.setValue("Loading...")
+    fetchSample(sample).then((content) => inputModel.setValue(content))
+  }, [inputFilename, inputModel, samples])
+
+  useEffect(() => {
+    const outputModel =
+      outputFilename && monaco.editor.getModel(monaco.Uri.file(outputFilename))
+
+    if (!outputEditor || !outputModel || outputModel.isDisposed()) {
+      return
+    }
+
+    if (outputEditor.getModel() !== outputModel) {
+      outputEditor.setModel(outputModel)
+    }
+  }, [outputFilename, outputEditor, monaco])
+  //endregion
+
+  //region load typescript definitions
+  useEffect(() => {
+    if (!outputEditor) {
+      return
+    }
+
+    let typings: AutoTypingsCore | undefined
+
+    loadRuntimeTypes(monaco, outputEditor, config.template)
+      .then((it) => {
+        typings = it
+      })
+      .catch((err) => {
+        setResult({
+          success: false,
+          loading: false,
+          err: new Error("Failed to load typescript typings", {cause: err}),
+        })
+      })
+
+    return () => typings?.dispose()
+  }, [config.template, monaco, outputEditor])
+  //endregion
+
+  //region run generation
+  useEffect(() => {
+    const input = inputModel?.getValue()
+    if (input) {
+      sendMessageToWorker(workerRef.current, {
+        type: "generate",
+        config,
+        input,
+      })
+    }
+  }, [config, inputModel])
+  //endregion
+
+  return (
+    <>
+      <Components.h3>Configuration</Components.h3>
+      <ConfigForm config={config} setConfig={setConfig} />
+      {/*TODO: output a copy-paste-able CLI command*/}
+      {/*<Components.code>*/}
+      {/*  yarn openapi-code-generator --template typescript-koa*/}
+      {/*</Components.code>*/}
+      <div className={styles.editorContainer}>
+        <div>
+          <Components.h3>Input Specification</Components.h3>
+          <EditorFileSelectorWrapper>
+            <ControlledSelect
+              label={"Sample Specification"}
+              values={samples}
+              name={"input"}
+              control={control}
+            />
+          </EditorFileSelectorWrapper>
+          <Editor
+            height="30vh"
+            onMount={onMountInput}
+            options={{theme: "vs-dark", minimap: {enabled: false}}}
+          />
+          <EditorControls editor={inputEditor} />
+          <GenerationResult result={result} />
+        </div>
+        <div>
+          <Components.h3>Output</Components.h3>
+          <EditorFileSelectorWrapper>
+            <ControlledSelect
+              label={"Output File"}
+              values={availableModels ?? [""]}
+              name={"output"}
+              control={control}
+            />
+          </EditorFileSelectorWrapper>
+          <Editor
+            height="30vh"
+            defaultLanguage="typescript"
+            options={{
+              theme: "vs-dark",
+              minimap: {enabled: false},
+              domReadOnly: true,
+              readOnly: true,
+            }}
+            onMount={onMountOutput}
+          />
+          <EditorControls editor={outputEditor} />
+        </div>
+      </div>
+    </>
+  )
+}
+
+const PlaygroundWrapper: React.FC = () => {
+  const monaco = useMonaco()
+  const [webFsAdaptor] = useState(new WebFsAdaptor())
+
+  const defaultSampleFilename = sampleFilenames[0]
+
+  const [defaultSample, setDefaultSample] = useState<{
+    filename: string
+    content: string
+  } | null>(null)
+
+  useEffect(() => {
+    fetchSample(defaultSampleFilename).then((content) =>
+      setDefaultSample({filename: defaultSampleFilename, content: content}),
+    )
+  }, [defaultSampleFilename])
+
+  if (!monaco || !defaultSample) {
+    return null
+  }
+
+  return (
+    <PlaygroundInner
+      monaco={monaco}
+      webFsAdaptor={webFsAdaptor}
+      defaultSample={defaultSample}
+      samples={sampleFilenames}
+    />
+  )
+}
+
+export default PlaygroundWrapper

--- a/packages/documentation/src/lib/playground/config-form.module.css
+++ b/packages/documentation/src/lib/playground/config-form.module.css
@@ -1,0 +1,12 @@
+.container {
+  display: grid;
+  grid-gap: 0.5rem;
+  align-items: center;
+  grid-template-columns: 1fr 1fr;
+  max-width: 500px;
+
+  @media (min-width: 1536px) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    max-width: 800px;
+  }
+}

--- a/packages/documentation/src/lib/playground/config-form.tsx
+++ b/packages/documentation/src/lib/playground/config-form.tsx
@@ -1,0 +1,98 @@
+import {ControlledCheckbox} from "@/lib/playground/controls/controlled-checkbox"
+import {ControlledSelect} from "@/lib/playground/controls/controlled-select"
+import {zodResolver} from "@hookform/resolvers/zod"
+import {type Config, configSchema} from "@nahkies/openapi-code-generator"
+import type React from "react"
+import {useEffect} from "react"
+import {useForm} from "react-hook-form"
+import type {z} from "zod"
+import styles from "./config-form.module.css"
+
+const schema = configSchema.pick({
+  template: true,
+  schemaBuilder: true,
+  enableRuntimeResponseValidation: true,
+  enableTypedBasePaths: true,
+  extractInlineSchemas: true,
+  groupingStrategy: true,
+  tsAllowAny: true,
+  tsServerImplementationMethod: true,
+})
+
+type Inputs = z.infer<typeof schema>
+
+export const ConfigForm: React.FC<{
+  config: Config
+  setConfig: (config: Config) => void
+}> = ({config, setConfig}) => {
+  const {control, watch} = useForm<Inputs>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      template: config.template,
+      schemaBuilder: config.schemaBuilder,
+      enableRuntimeResponseValidation: config.enableRuntimeResponseValidation,
+      enableTypedBasePaths: config.enableTypedBasePaths,
+      extractInlineSchemas: config.extractInlineSchemas,
+      groupingStrategy: config.groupingStrategy,
+      tsAllowAny: config.tsAllowAny,
+      tsServerImplementationMethod: config.tsServerImplementationMethod,
+    } as const,
+  })
+
+  useEffect(() => {
+    const {unsubscribe} = watch((value) => {
+      setConfig({...config, ...value})
+    })
+    return () => unsubscribe()
+  }, [watch, config, setConfig])
+
+  return (
+    <div className={styles.container}>
+      <ControlledSelect
+        key={"template"}
+        name={"template"}
+        control={control}
+        label={"--template"}
+        values={schema.shape.template.options}
+      />
+      <ControlledSelect
+        name={"schemaBuilder"}
+        control={control}
+        label={"--schema-builder"}
+        values={schema.shape.schemaBuilder.options}
+      />
+      <ControlledCheckbox
+        label={"--enable-runtime-response-validation"}
+        name={"enableRuntimeResponseValidation"}
+        control={control}
+      />
+      <ControlledCheckbox
+        label={"--enable-typed-base-paths"}
+        name={"enableTypedBasePaths"}
+        control={control}
+      />
+      <ControlledCheckbox
+        label={"--extract-inline-schemas"}
+        name={"extractInlineSchemas"}
+        control={control}
+      />
+      <ControlledCheckbox
+        label={"--ts-allow-any"}
+        name={"tsAllowAny"}
+        control={control}
+      />
+      <ControlledSelect
+        name={"tsServerImplementationMethod"}
+        control={control}
+        label={"--ts-server-implementation-method"}
+        values={schema.shape.tsServerImplementationMethod.options}
+      />
+      <ControlledSelect
+        name={"groupingStrategy"}
+        control={control}
+        label={"--grouping-strategy"}
+        values={schema.shape.groupingStrategy.options}
+      />
+    </div>
+  )
+}

--- a/packages/documentation/src/lib/playground/consts.ts
+++ b/packages/documentation/src/lib/playground/consts.ts
@@ -1,0 +1,10 @@
+// These will be copied into ./public/samples by copy-sample-data.ts
+// to be served statically.
+export const sampleFilenames = [
+  "petstore-expanded.yaml",
+  "okta.oauth.yaml",
+  // todo: relies on additional files, not yet supported.
+  // "todo-lists.yaml",
+  "api.github.com.yaml",
+  "stripe.yaml",
+]

--- a/packages/documentation/src/lib/playground/controls/controlled-checkbox.tsx
+++ b/packages/documentation/src/lib/playground/controls/controlled-checkbox.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import {type UseControllerProps, useController} from "react-hook-form"
+
+export function ControlledCheckbox<
+  Inputs extends Record<string, string | boolean>,
+>(props: {label: string} & UseControllerProps<Inputs>) {
+  const {field} = useController(props)
+
+  return (
+    <>
+      <label htmlFor={field.name}>{props.label}</label>
+      <input
+        id={field.name}
+        type={"checkbox"}
+        checked={field.value as boolean}
+        onChange={field.onChange}
+      />
+    </>
+  )
+}

--- a/packages/documentation/src/lib/playground/controls/controlled-select.tsx
+++ b/packages/documentation/src/lib/playground/controls/controlled-select.tsx
@@ -1,0 +1,35 @@
+import React, {useEffect} from "react"
+import {type UseControllerProps, useController} from "react-hook-form"
+
+export function ControlledSelect<
+  Inputs extends Record<string, string | boolean | undefined>,
+>(props: {label: string; values: string[]} & UseControllerProps<Inputs>) {
+  const {field} = useController(props)
+
+  useEffect(() => {
+    if (
+      field.value !== props.values[0] &&
+      props.values[0] &&
+      !props.values.includes(field.value as string)
+    ) {
+      field.onChange({target: {value: props.values[0]}})
+    }
+  }, [field.value, field.onChange, props.values])
+
+  return (
+    <>
+      <label htmlFor={field.name}>{props.label}</label>
+      <select
+        id={field.name}
+        onChange={field.onChange}
+        value={field.value as string}
+      >
+        {props.values.map((it) => (
+          <option key={it} value={it}>
+            {it}
+          </option>
+        ))}
+      </select>
+    </>
+  )
+}

--- a/packages/documentation/src/lib/playground/load-runtime-types.tsx
+++ b/packages/documentation/src/lib/playground/load-runtime-types.tsx
@@ -1,0 +1,121 @@
+import type {Monaco} from "@monaco-editor/react"
+import type {editor} from "monaco-editor"
+import {
+  AutoTypings,
+  LocalStorageCache,
+} from "monaco-editor-auto-typings/custom-editor"
+
+type IStandaloneCodeEditor = editor.IStandaloneCodeEditor
+
+/**
+ * Hack: the monaco-editor-auto-typings/custom-editor package doesn't handle the "exports" field in package.json
+ * files correctly, and annoyingly even if modified to handle this, the typescript language service doesn't seem
+ * to like it. Let's manually fetch these and map to locations the service will understand.
+ */
+export const loadRuntimeTypes = async (
+  monaco: Monaco,
+  editor: IStandaloneCodeEditor,
+  template:
+    | "typescript-angular"
+    | "typescript-fetch"
+    | "typescript-axios"
+    | "typescript-koa",
+) => {
+  const fileRootPath = "file:///"
+
+  monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    ...monaco.languages.typescript.typescriptDefaults.getCompilerOptions(),
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    target: monaco.languages.typescript.ScriptTarget.ES2020,
+    allowSyntheticDefaultImports: true,
+    esModuleInterop: true,
+    rootDir: fileRootPath,
+  })
+
+  const files = {
+    "typescript-angular": [],
+    "typescript-fetch": [
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-fetch-runtime@latest/package.json",
+        path: "/node_modules/@nahkies/typescript-fetch-runtime/package.json",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-fetch-runtime@latest/dist/main.d.ts",
+        path: "/node_modules/@nahkies/typescript-fetch-runtime/main.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-fetch-runtime@latest/dist/zod.d.ts",
+        path: "/node_modules/@nahkies/typescript-fetch-runtime/zod.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-fetch-runtime@latest/dist/joi.d.ts",
+        path: "/node_modules/@nahkies/typescript-fetch-runtime/joi.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-fetch-runtime@latest/dist/common.d.ts",
+        path: "/node_modules/@nahkies/typescript-fetch-runtime/common.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-fetch-runtime@latest/dist/types.d.ts",
+        path: "/node_modules/@nahkies/typescript-fetch-runtime/types.d.ts",
+      },
+    ],
+    "typescript-axios": [
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-axios-runtime@latest/package.json",
+        path: "/node_modules/@nahkies/typescript-axios-runtime/package.json",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-axios-runtime@latest/dist/main.d.ts",
+        path: "/node_modules/@nahkies/typescript-axios-runtime/main.d.ts",
+      },
+    ],
+    "typescript-koa": [
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-koa-runtime@latest/package.json",
+        path: "/node_modules/@nahkies/typescript-koa-runtime/package.json",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-koa-runtime@latest/dist/server.d.ts",
+        path: "/node_modules/@nahkies/typescript-koa-runtime/server.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-koa-runtime@latest/dist/errors.d.ts",
+        path: "/node_modules/@nahkies/typescript-koa-runtime/errors.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-koa-runtime@latest/dist/zod.d.ts",
+        path: "/node_modules/@nahkies/typescript-koa-runtime/zod.d.ts",
+      },
+      {
+        uri: "https://unpkg.com/@nahkies/typescript-koa-runtime@latest/dist/joi.d.ts",
+        path: "/node_modules/@nahkies/typescript-koa-runtime/joi.d.ts",
+      },
+    ],
+  }
+
+  for (const file of files[template]) {
+    const uri = monaco.Uri.file(file.path)
+    if (!monaco.editor.getModel(uri)) {
+      // TODO: error handling
+      const source = await (await fetch(file.uri)).text()
+      console.info(`createModel for ${uri.path}`)
+      monaco.editor.createModel(source, "typescript", uri)
+      // monaco.languages.typescript.typescriptDefaults.addExtraLib(await source.text(), file.path)
+    }
+  }
+
+  return AutoTypings.create(editor, {
+    monaco,
+    fileRootPath,
+    sourceCache: new LocalStorageCache(),
+    onUpdate: (update) => console.log("progress", update),
+    onError: (error) => console.error(error),
+    dontAdaptEditorOptions: true,
+    preloadPackages: true,
+    shareCache: true,
+    versions: {
+      zod: "3.24.1",
+    },
+  })
+}

--- a/packages/documentation/src/lib/playground/utils.ts
+++ b/packages/documentation/src/lib/playground/utils.ts
@@ -1,0 +1,35 @@
+import type {Monaco} from "@monaco-editor/react"
+import type {WebFsAdaptor} from "@nahkies/openapi-code-generator"
+
+export function createOrUpdateModel(
+  {filename, value}: {filename: string; value: string},
+  monaco: Monaco,
+) {
+  const uri = monaco.Uri.file(filename)
+  const language = filename.endsWith(".ts") ? "typescript" : "yaml"
+
+  if (!monaco.editor.getModel(uri)) {
+    monaco.editor.createModel(value, language, uri)
+  } else {
+    monaco.editor.getModel(uri)?.setValue(value)
+  }
+}
+
+export function pruneModels(fsAdapter: WebFsAdaptor, monaco: Monaco) {
+  for (const model of monaco.editor.getModels()) {
+    if (!fsAdapter.existsSync(model.uri.path)) {
+      model.dispose()
+    }
+  }
+}
+
+export function listAvailableModels(fsAdapter: WebFsAdaptor, monaco: Monaco) {
+  return monaco.editor
+    .getModels()
+    .filter(
+      (it) =>
+        it.uri.path.includes("/generated/") &&
+        fsAdapter.existsSync(it.uri.path),
+    )
+    .map((it) => it.uri.path)
+}

--- a/packages/documentation/src/lib/playground/worker/bridge.ts
+++ b/packages/documentation/src/lib/playground/worker/bridge.ts
@@ -1,0 +1,29 @@
+import type {
+  Monad,
+  WorkerMessage,
+  WorkerResult,
+} from "@/lib/playground/worker/types"
+
+export function createWorker() {
+  return new Worker(new URL("./worker.ts", import.meta.url))
+}
+
+export function sendMessageToWorker(
+  worker: Worker | null,
+  message: WorkerMessage,
+) {
+  worker?.postMessage(message)
+}
+
+export function subscribeToWorkerMessages(
+  worker: Worker,
+  onMessage: (data: Monad<WorkerResult>) => void,
+) {
+  worker.onmessage = (event) => {
+    console.info("received event from worker", event)
+    onMessage(event.data)
+  }
+  worker.onerror = (event) => {
+    console.info("received error event from worker", event)
+  }
+}

--- a/packages/documentation/src/lib/playground/worker/types.ts
+++ b/packages/documentation/src/lib/playground/worker/types.ts
@@ -1,0 +1,9 @@
+import type {Config} from "@nahkies/openapi-code-generator"
+
+export type WorkerMessage = {type: "generate"; config: Config; input: string}
+export type WorkerResult = {files: Map<string, string>; elapsed: number}
+
+export type Monad<T> =
+  | {success: true; loading: false; result: T}
+  | {success: false; loading: false; err: Error}
+  | {success: null; loading: true}

--- a/packages/documentation/src/lib/playground/worker/worker.ts
+++ b/packages/documentation/src/lib/playground/worker/worker.ts
@@ -1,0 +1,154 @@
+import type {
+  Monad,
+  WorkerMessage,
+  WorkerResult,
+} from "@/lib/playground/worker/types"
+import {
+  type Config,
+  OpenapiValidator,
+  TypescriptFormatterPrettier,
+  TypespecLoader,
+  WebFsAdaptor,
+  generate,
+} from "@nahkies/openapi-code-generator"
+import _ from "lodash"
+
+// TODO: move
+export function asyncDebounce<
+  // biome-ignore lint/suspicious/noExplicitAny: generic
+  T extends any[],
+  R,
+  F extends (...args: T) => Promise<R>,
+>(func: F, delayMs: number, opts?: {trailing?: boolean; leading?: boolean}) {
+  const resolves = new Set<(result: R) => void>()
+  const rejects = new Set<(err: Error) => void>()
+
+  const debounced = _.debounce(
+    (args: Parameters<F>) => {
+      func(...args)
+        .then((...res) => {
+          for (const resolve of resolves) {
+            resolve(...res)
+          }
+          resolves.clear()
+          rejects.clear()
+        })
+        .catch((...res) => {
+          for (const reject of rejects) {
+            reject(...res)
+          }
+          resolves.clear()
+          rejects.clear()
+        })
+    },
+    delayMs,
+    opts,
+  )
+
+  return (...args: Parameters<F>): ReturnType<F> =>
+    new Promise((resolve, reject) => {
+      resolves.add(resolve)
+      rejects.add(reject)
+      debounced(args)
+    }) as ReturnType<F>
+}
+
+async function createGenerator() {
+  const webFsAdaptor = new WebFsAdaptor()
+  const formatter = await TypescriptFormatterPrettier.create()
+  const validator = await OpenapiValidator.create()
+  const typespecLoader = await TypespecLoader.create()
+
+  let mostRecentEventTimeStamp: DOMHighResTimeStamp
+
+  const innerGenerate = async (
+    eventTimeStamp: DOMHighResTimeStamp,
+    config: Config,
+    input: string,
+  ) => {
+    const start = Date.now()
+    webFsAdaptor.clearFiles(() => true)
+    await webFsAdaptor.writeFile(config.input, input)
+
+    await generate(config, webFsAdaptor, formatter, validator, typespecLoader)
+
+    const files = new Map(webFsAdaptor.files)
+    files.delete(config.input)
+
+    if (eventTimeStamp === mostRecentEventTimeStamp) {
+      sendMessage({
+        success: true,
+        loading: false,
+        result: {files, elapsed: Date.now() - start},
+      })
+    } else {
+      console.info("ignoring message", {
+        eventTimeStamp,
+        mostRecentEventTimeStamp,
+      })
+    }
+  }
+
+  const debouncedGenerate = asyncDebounce(innerGenerate, 200, {
+    leading: false,
+    trailing: true,
+  })
+
+  return {
+    generate: (
+      timeStamp: DOMHighResTimeStamp,
+      config: Config,
+      input: string,
+    ) => {
+      if (!mostRecentEventTimeStamp || timeStamp > mostRecentEventTimeStamp) {
+        mostRecentEventTimeStamp = timeStamp
+      }
+
+      sendMessage({success: null, loading: true})
+      return debouncedGenerate(timeStamp, config, input)
+    },
+  }
+}
+
+async function createOnMessageHandler(
+  generator: Awaited<ReturnType<typeof createGenerator>>,
+) {
+  return async function onMessage(event: MessageEvent<WorkerMessage>) {
+    try {
+      console.info("Worker: received message", event.data.type)
+
+      const data = event.data
+
+      switch (data.type) {
+        case "generate": {
+          event.lastEventId
+          await generator.generate(event.timeStamp, data.config, data.input)
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error) {
+        sendError(new Error("Failed to generate code", {cause: err}))
+      } else {
+        sendError(new Error("Unknown error", {cause: err}))
+      }
+    }
+  }
+}
+
+async function main() {
+  console.info("Worker: starting worker")
+  const generator = await createGenerator()
+  const onMessage = await createOnMessageHandler(generator)
+  addEventListener("message", onMessage)
+}
+
+main().catch(sendError)
+
+function sendError(err: Error) {
+  sendMessage({success: false, loading: false, err: err})
+}
+
+function sendMessage(message: Monad<WorkerResult>) {
+  console.info("Worker: sending message", message)
+  postMessage(message)
+}

--- a/packages/documentation/src/pages/_meta.tsx
+++ b/packages/documentation/src/pages/_meta.tsx
@@ -11,4 +11,15 @@ export default {
     display: "hidden",
     title: "",
   },
+  docs: {
+    title: "Docs",
+    type: "page",
+    href: "/",
+  },
+  playground: {
+    type: "page",
+    theme: {
+      layout: "full",
+    },
+  },
 }

--- a/packages/documentation/src/pages/overview/about.mdx
+++ b/packages/documentation/src/pages/overview/about.mdx
@@ -10,6 +10,8 @@ Currently, [OpenAPI 3.0](https://swagger.io/specification/v3), [OpenAPI 3.1](htt
 This gives you amazing auto-complete, and compile-time safety. Typescript's expressive type system is used to
 make the generated clients feel idiomatic, and as close to handwritten as possible.
 
+<Callout>Try it out online in our [interactive playground](/playground)!</Callout>
+
 ![Github API Example](/example.png)
 
 <Callout type="info">

--- a/packages/documentation/src/pages/playground.mdx
+++ b/packages/documentation/src/pages/playground.mdx
@@ -1,0 +1,9 @@
+import Playground from "../lib/playground"
+
+# Playground
+Lightweight way to experiment with the different templates and configuration options from the comfort of your browser.
+Some configuration options, such as typespec support are not yet exposed, and performance in-browser is relatively poor for large specifications (eg: the Github API sample).
+
+See the [CLI Reference](/reference/cli-options) for details of each option, or jump over to [quick start](/getting-started/quick-start) to get started locally.
+
+<Playground />

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -31,12 +31,14 @@
     "@azure-tools/typespec-client-generator-core": "^0.49.0",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.14",
+    "@types/prettier": "^3.0.0",
     "@typespec/compiler": "^0.63.0",
     "@typespec/http": "^0.63.0",
     "@typespec/openapi": "^0.63.0",
     "@typespec/openapi3": "^0.63.0",
     "@typespec/rest": "^0.63.0",
     "@typespec/versioning": "^0.63.0",
+    "@typespec/xml": "^0.63.0",
     "typescript": "~5.7.2"
   },
   "dependencies": {

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -17,7 +17,7 @@ import {TypespecLoader} from "./core/loaders/typespec.loader"
 import {logger} from "./core/logger"
 import {OpenapiValidator} from "./core/openapi-validator"
 import type {IdentifierConvention} from "./core/utils"
-import {generate} from "./index"
+import {configSchema, generate} from "./index"
 import type {templates} from "./templates"
 import type {ServerImplementationMethod} from "./templates.types"
 import {TypescriptFormatterBiome} from "./typescript/common/typescript-formatter.biome"
@@ -253,10 +253,10 @@ async function main() {
   )
 
   await generate(
-    {
+    configSchema.parse({
       ...config,
       tsCompilerOptions: compilerOptions,
-    },
+    }),
     fsAdaptor,
     formatter,
     validator,

--- a/packages/openapi-code-generator/src/config.ts
+++ b/packages/openapi-code-generator/src/config.ts
@@ -1,0 +1,72 @@
+import {z} from "zod"
+import type {GenericLoaderRequestHeaders} from "./core/loaders/generic.loader"
+import type {CompilerOptions} from "./core/loaders/tsconfig.loader"
+import {tsconfigSchema} from "./core/schemas/tsconfig.schema"
+import type {IdentifierConvention} from "./core/utils"
+import type {ServerImplementationMethod} from "./templates.types"
+
+export type Config = {
+  input: string
+  inputType: "openapi3" | "typespec"
+  overrideSpecificationTitle?: string | undefined
+  output: string
+  template:
+    | "typescript-fetch"
+    | "typescript-axios"
+    | "typescript-angular"
+    | "typescript-koa"
+  schemaBuilder: "zod" | "joi"
+  enableRuntimeResponseValidation: boolean
+  enableTypedBasePaths: boolean
+  extractInlineSchemas: boolean
+  allowUnusedImports: boolean
+  groupingStrategy: "none" | "first-slug" | "first-tag"
+  filenameConvention: IdentifierConvention
+  tsAllowAny: boolean
+  tsServerImplementationMethod: ServerImplementationMethod
+  tsCompilerOptions: CompilerOptions
+  remoteSpecRequestHeaders?: GenericLoaderRequestHeaders | undefined
+}
+
+const templatesSchema = z.enum([
+  "typescript-koa",
+  "typescript-fetch",
+  "typescript-axios",
+  "typescript-angular",
+])
+
+const schemaBuilderSchema = z.enum(["zod", "joi"])
+
+const groupingStrategySchema = z.enum(["none", "first-slug", "first-tag"])
+
+const tsServerImplementationSchema = z.enum([
+  "interface",
+  "type",
+  "abstract-class",
+])
+
+export const configSchema = z.object({
+  input: z.string(),
+  inputType: z.enum(["openapi3", "typespec"]),
+  overrideSpecificationTitle: z.string().optional(),
+  output: z.string(),
+  template: templatesSchema,
+  schemaBuilder: schemaBuilderSchema,
+  enableRuntimeResponseValidation: z.boolean(),
+  enableTypedBasePaths: z.boolean(),
+  extractInlineSchemas: z.boolean(),
+  allowUnusedImports: z.boolean(),
+  groupingStrategy: groupingStrategySchema,
+  filenameConvention: z.enum([
+    "camel-case",
+    "title-case",
+    "kebab-case",
+    "snake-case",
+  ]),
+  tsAllowAny: z.boolean(),
+  tsServerImplementationMethod: tsServerImplementationSchema,
+  tsCompilerOptions: tsconfigSchema.shape.compilerOptions,
+  remoteSpecRequestHeaders: z
+    .record(z.array(z.object({name: z.string(), value: z.string()})))
+    .optional(),
+})

--- a/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
@@ -7,10 +7,6 @@ import fs from "fs/promises"
 import type {IFsAdaptor} from "./fs-adaptor"
 
 export class NodeFsAdaptor implements IFsAdaptor {
-  clearFiles(filter: (it: string) => boolean) {
-    throw new Error("not implemented for nodejs")
-  }
-
   async readFile(path: string) {
     return await fs.readFile(path, "utf-8")
   }

--- a/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
@@ -1,8 +1,16 @@
-import {existsSync} from "node:fs"
-import fs from "node:fs/promises"
+// TODO: webpack shouldn't be including this file?
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import {existsSync} from "fs"
+
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import fs from "fs/promises"
 import type {IFsAdaptor} from "./fs-adaptor"
 
 export class NodeFsAdaptor implements IFsAdaptor {
+  clearFiles(filter: (it: string) => boolean) {
+    throw new Error("not implemented for nodejs")
+  }
+
   async readFile(path: string) {
     return await fs.readFile(path, "utf-8")
   }

--- a/packages/openapi-code-generator/src/core/file-system/web-fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/web-fs-adaptor.ts
@@ -1,0 +1,33 @@
+import type {IFsAdaptor} from "./fs-adaptor"
+
+export class WebFsAdaptor implements IFsAdaptor {
+  constructor(readonly files = new Map<string, string>()) {}
+
+  clearFiles(filter: (it: string) => boolean) {
+    for (const file of this.files.keys()) {
+      if (filter(file)) {
+        this.files.delete(file)
+      }
+    }
+  }
+
+  async readFile(path: string) {
+    return this.files.get(path) || ""
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content)
+  }
+
+  async exists(path: string) {
+    return this.files.has(path)
+  }
+
+  existsSync(path: string) {
+    return this.files.has(path)
+  }
+
+  async mkDir() {
+    /*noop*/
+  }
+}

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -169,9 +169,7 @@ export class Input {
       const tag = operation.tags[0]
 
       if (!tag) {
-        throw new Error(
-          `cannot group operations by first tag as operationId: '${operation.operationId}' has no tags`,
-        )
+        return "generated"
       }
 
       return tag.toLowerCase()
@@ -185,9 +183,7 @@ export class Input {
       ).replace(/[{}]*/g, "")
 
       if (!slug) {
-        throw new Error(
-          `cannot group operations by first slug as operationId: '${operation.operationId}' has no slugs`,
-        )
+        return "generated"
       }
 
       return slug.toLowerCase()

--- a/packages/openapi-code-generator/src/core/interfaces.ts
+++ b/packages/openapi-code-generator/src/core/interfaces.ts
@@ -1,3 +1,3 @@
 export interface IFormatter {
-  format(filename: string, raw: string): Promise<string>
+  format(filename: string, raw: string): Promise<{result: string; err?: Error}>
 }

--- a/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts
@@ -1,4 +1,5 @@
-import path from "node:path"
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import path from "path"
 import json5 from "json5"
 import ts from "typescript"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"

--- a/packages/openapi-code-generator/src/core/logger.ts
+++ b/packages/openapi-code-generator/src/core/logger.ts
@@ -1,4 +1,5 @@
-import util from "node:util"
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import util from "util"
 
 export type LoggerMeta = Record<string, unknown>
 

--- a/packages/openapi-code-generator/src/core/openapi-loader.ts
+++ b/packages/openapi-code-generator/src/core/openapi-loader.ts
@@ -1,5 +1,7 @@
-import path from "node:path"
-import util from "node:util"
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import path from "path"
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import util from "util"
 
 import * as console from "node:console"
 import {load} from "js-yaml"

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -1,42 +1,22 @@
+import type {Config} from "./config"
 import type {IFsAdaptor} from "./core/file-system/fs-adaptor"
 import {Input} from "./core/input"
 import type {IFormatter} from "./core/interfaces"
-import {
-  GenericLoader,
-  type GenericLoaderRequestHeaders,
-} from "./core/loaders/generic.loader"
-import type {CompilerOptions} from "./core/loaders/tsconfig.loader"
+import {GenericLoader} from "./core/loaders/generic.loader"
 import type {TypespecLoader} from "./core/loaders/typespec.loader"
 import {logger} from "./core/logger"
 import {OpenapiLoader} from "./core/openapi-loader"
 import type {OpenapiValidator} from "./core/openapi-validator"
-import type {IdentifierConvention} from "./core/utils"
 import {templates} from "./templates"
-import type {ServerImplementationMethod} from "./templates.types"
 import {TypescriptEmitter} from "./typescript/common/typescript-emitter"
 
-export type Config = {
-  input: string
-  inputType: "openapi3" | "typespec"
-  overrideSpecificationTitle?: string | undefined
-  output: string
-  template:
-    | "typescript-fetch"
-    | "typescript-axios"
-    | "typescript-angular"
-    | "typescript-koa"
-  schemaBuilder: "zod" | "joi"
-  enableRuntimeResponseValidation: boolean
-  enableTypedBasePaths: boolean
-  extractInlineSchemas: boolean
-  allowUnusedImports: boolean
-  groupingStrategy: "none" | "first-slug" | "first-tag"
-  filenameConvention: IdentifierConvention
-  tsAllowAny: boolean
-  tsServerImplementationMethod: ServerImplementationMethod
-  tsCompilerOptions: CompilerOptions
-  remoteSpecRequestHeaders?: GenericLoaderRequestHeaders | undefined
-}
+export {type Config, configSchema} from "./config"
+export {NodeFsAdaptor} from "./core/file-system/node-fs-adaptor"
+export {WebFsAdaptor} from "./core/file-system/web-fs-adaptor"
+export {TypescriptFormatterPrettier} from "./typescript/common/typescript-formatter.prettier"
+export type {IFormatter} from "./core/interfaces"
+export {OpenapiValidator} from "./core/openapi-validator"
+export {TypespecLoader} from "./core/loaders/typespec.loader"
 
 export async function generate(
   config: Config,

--- a/packages/openapi-code-generator/src/typescript/common/client-servers-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/client-servers-builder.spec.ts
@@ -29,7 +29,7 @@ async function runTest(
   const formatter = await TypescriptFormatterBiome.createNodeFormatter()
 
   return {
-    output: await formatter.format("unit-test.ts", builder.toString()),
+    output: (await formatter.format("unit-test.ts", builder.toString())).result,
     hasServers: builder.hasServers,
     hasOperationServers: builder.hasOperationServers,
     builder,

--- a/packages/openapi-code-generator/src/typescript/common/import-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/import-builder.ts
@@ -1,5 +1,5 @@
-// Note: we can get away with using this in NextJS it seems, but not if using the `node:` prefix
-import path from "node:path"
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import path from "path"
 
 export class ImportBuilder {
   private readonly imports: Record<string, Set<string>> = {}

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
@@ -66,7 +66,7 @@ export function schemaBuilderTestHarness(
           const x = ${schema}
         `,
       )
-    ).trim()
+    ).result.trim()
 
     const schemas = (
       await formatter.format(
@@ -76,7 +76,7 @@ export function schemaBuilderTestHarness(
           includeHeader: false,
         }),
       )
-    ).trim()
+    ).result.trim()
 
     return {
       code,

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -461,10 +461,10 @@ describe.each(testVersions)(
           const x: ${type}
         `,
           )
-        ).trim(),
+        ).result.trim(),
         types: (
           await formatter.format("unit-test.types.ts", builder.toString())
-        ).trim(),
+        ).result.trim(),
       }
     }
   },

--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.biome.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.biome.ts
@@ -28,20 +28,27 @@ export class TypescriptFormatterBiome implements IFormatter {
     })
   }
 
-  async format(filename: string, raw: string): Promise<string> {
+  async format(
+    filename: string,
+    raw: string,
+  ): Promise<{result: string; err?: Error}> {
+    const trimmed = raw
+      .split("\n")
+      .map((it) => it.trim())
+      .join("\n")
+
     try {
-      const trimmed = raw
-        .split("\n")
-        .map((it) => it.trim())
-        .join("\n")
       const formatted = this.biome.formatContent(trimmed, {
         filePath: filename,
       })
 
-      return formatted.content
+      return {result: formatted.content}
     } catch (err) {
       logger.error("failed to format", {err})
-      return raw
+      return {
+        result: trimmed,
+        err: new Error(`failed to format ${filename}`, {cause: err}),
+      }
     }
   }
 

--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
@@ -9,22 +9,30 @@ const plugins = [
 export class TypescriptFormatterPrettier implements IFormatter {
   private constructor() {}
 
-  async format(filename: string, raw: string): Promise<string> {
-    try {
-      const trimmed = raw
-        .split("\n")
-        .map((it) => it.trim())
-        .join("\n")
+  async format(
+    filename: string,
+    raw: string,
+  ): Promise<{result: string; err?: Error}> {
+    const trimmed = raw
+      .split("\n")
+      .map((it) => it.trim())
+      .join("\n")
 
-      return prettier.format(trimmed, {
+    try {
+      const formatted = await prettier.format(trimmed, {
         semi: false,
         arrowParens: "always",
         parser: "typescript",
         plugins,
       })
+
+      return {result: formatted}
     } catch (err) {
       logger.error("failed to format", {err})
-      return raw
+      return {
+        result: trimmed,
+        err: new Error(`failed to format ${filename}`, {cause: err}),
+      }
     }
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.spec.ts
@@ -102,10 +102,12 @@ describe("typescript/typescript-koa", () => {
         tags: [],
       })
 
-      return formatter.format(
-        "unit-test.ts",
-        serverRouterBuilder.implementationExport("UnitTestImplementation"),
-      )
+      return (
+        await formatter.format(
+          "unit-test.ts",
+          serverRouterBuilder.implementationExport("UnitTestImplementation"),
+        )
+      ).result
     }
   })
 })

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -1,4 +1,5 @@
-import path from "node:path"
+// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
+import path from "path"
 import type {Input} from "../../core/input"
 import type {
   IRModelObject,

--- a/scripts/assert-clean-working-directory.sh
+++ b/scripts/assert-clean-working-directory.sh
@@ -4,5 +4,6 @@ set -e
 
 if [ -n "$(git status --porcelain=v1)" ]; then
   echo "Uncommitted changes to repo found!"
+  git status --porcelain=v1
   exit 1
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,16 +3732,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monaco-editor/react@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@monaco-editor/react@npm:4.6.0"
+"@monaco-editor/react@npm:^4.7.0-rc.0":
+  version: 4.7.0-rc.0
+  resolution: "@monaco-editor/react@npm:4.7.0-rc.0"
   dependencies:
     "@monaco-editor/loader": "npm:^1.4.0"
   peerDependencies:
     monaco-editor: ">= 0.25.0 < 1"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/e32724ebcc2fc81e91169d69eff8533e15a595c13156ec57965238a0f0afa67e2ed2abbf735a57cfaae15430bbc905b016b644bf7383a82d607501d557a6dd82
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/2018430b8517de846aba84ba8b5c70ce8826e96b58568e16231e3d0ce6d95e170b27bd08534273b2e579aee252cd9ea1b85d64a06503c7bb7613ffe65aff6b88
   languageName: node
   linkType: hard
 
@@ -3792,7 +3792,7 @@ __metadata:
   resolution: "@nahkies/openapi-code-generator-documentation@workspace:packages/documentation"
   dependencies:
     "@hookform/resolvers": "npm:^3.9.1"
-    "@monaco-editor/react": "npm:^4.6.0"
+    "@monaco-editor/react": "npm:^4.7.0-rc.0"
     "@nahkies/openapi-code-generator": "npm:*"
     "@types/node": "npm:^22.10.5"
     "@types/react": "npm:^19.0.2"
@@ -10131,7 +10131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
+"dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
   dependencies:
@@ -11544,25 +11544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4":
-  version: 1.2.6
-  resolution: "get-intrinsic@npm:1.2.6"
-  dependencies:
-    call-bind-apply-helpers: "npm:^1.0.1"
-    dunder-proto: "npm:^1.0.0"
-    es-define-property: "npm:^1.0.1"
-    es-errors: "npm:^1.3.0"
-    es-object-atoms: "npm:^1.0.0"
-    function-bind: "npm:^1.1.2"
-    gopd: "npm:^1.2.0"
-    has-symbols: "npm:^1.1.0"
-    hasown: "npm:^2.0.2"
-    math-intrinsics: "npm:^1.0.0"
-  checksum: 10/a1ffae6d7893a6fa0f4d1472adbc85095edd6b3b0943ead97c3738539cecb19d422ff4d48009eed8c3c27ad678c2b1e38a83b1a1e96b691d13ed8ecefca1068d
-  languageName: node
-  linkType: hard
-
-"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6":
   version: 1.2.7
   resolution: "get-intrinsic@npm:1.2.7"
   dependencies:
@@ -14951,7 +14933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"math-intrinsics@npm:^1.0.0, math-intrinsics@npm:^1.1.0":
+"math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10/11df2eda46d092a6035479632e1ec865b8134bdfc4bd9e571a656f4191525404f13a283a515938c3a8de934dbfd9c09674d9da9fa831e6eb7e22b50b197d2edd
@@ -21017,9 +20999,9 @@ __metadata:
   linkType: hard
 
 "type-fest@npm:^4.27.0":
-  version: 4.30.2
-  resolution: "type-fest@npm:4.30.2"
-  checksum: 10/c5168b159c366e4fd5b74c7f7b786bed9248c03f67e6e07d52dd5d51354447468fa7c92b9f2142c7fe9279814031f783959370242c3520de848931b65ddb48bb
+  version: 4.31.0
+  resolution: "type-fest@npm:4.31.0"
+  checksum: 10/e7e849845bf33e1237c3ff0d5ed00a251a807e3321ffe75278dd56a7d3c385badfe09180057c2d0b93cf7429432b8e7061b6ccf4cc468720d8f69073d2b1bed2
   languageName: node
   linkType: hard
 
@@ -22175,12 +22157,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.3.2, yaml@npm:^2.6.0, yaml@npm:~2.6.1":
-  version: 2.6.1
-  resolution: "yaml@npm:2.6.1"
+"yaml@npm:^2.3.2, yaml@npm:^2.6.0":
+  version: 2.7.0
+  resolution: "yaml@npm:2.7.0"
   bin:
     yaml: bin.mjs
-  checksum: 10/cf412f03a33886db0a3aac70bb4165588f4c5b3c6f8fc91520b71491e5537800b6c2c73ed52015617f6e191eb4644c73c92973960a1999779c62a200ee4c231d
+  checksum: 10/c8c314c62fbd49244a6a51b06482f6d495b37ab10fa685fcafa1bbaae7841b7233ee7d12cab087bcca5a0b28adc92868b6e437322276430c28d00f1c1732eeec
   languageName: node
   linkType: hard
 
@@ -22190,6 +22172,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10/0eecb679db75ea6a989ad97715a9fa5d946972945aa6aa7d2175bca66c213b5564502ccb1cdd04b1bf816ee38b5c43e4e2fda3ff6f5e09da24dabb51ae92c57d
+  languageName: node
+  linkType: hard
+
+"yaml@npm:~2.6.1":
+  version: 2.6.1
+  resolution: "yaml@npm:2.6.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/cf412f03a33886db0a3aac70bb4165588f4c5b3c6f8fc91520b71491e5537800b6c2c73ed52015617f6e191eb4644c73c92973960a1999779c62a200ee4c231d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,6 +2066,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/aix-ppc64@npm:0.23.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/aix-ppc64@npm:0.24.0"
@@ -2076,6 +2083,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm64@npm:0.23.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2094,6 +2108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-arm@npm:0.23.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/android-arm@npm:0.24.0"
@@ -2104,6 +2125,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/android-x64@npm:0.23.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -2122,6 +2150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-arm64@npm:0.23.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/darwin-arm64@npm:0.24.0"
@@ -2132,6 +2167,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/darwin-x64@npm:0.23.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -2150,6 +2192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.23.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/freebsd-arm64@npm:0.24.0"
@@ -2160,6 +2209,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/freebsd-x64@npm:0.23.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -2178,6 +2234,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm64@npm:0.23.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/linux-arm64@npm:0.24.0"
@@ -2188,6 +2251,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-arm@npm:0.23.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -2206,6 +2276,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ia32@npm:0.23.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/linux-ia32@npm:0.24.0"
@@ -2216,6 +2293,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-loong64@npm:0.23.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -2234,6 +2318,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-mips64el@npm:0.23.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/linux-mips64el@npm:0.24.0"
@@ -2244,6 +2335,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-ppc64@npm:0.23.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -2262,6 +2360,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-riscv64@npm:0.23.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/linux-riscv64@npm:0.24.0"
@@ -2272,6 +2377,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-s390x@npm:0.23.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -2290,6 +2402,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/linux-x64@npm:0.23.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/linux-x64@npm:0.24.0"
@@ -2304,10 +2423,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/netbsd-x64@npm:0.23.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/netbsd-x64@npm:0.24.0"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.23.1"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2321,6 +2454,13 @@ __metadata:
 "@esbuild/openbsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/openbsd-x64@npm:0.21.5"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/openbsd-x64@npm:0.23.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -2339,6 +2479,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/sunos-x64@npm:0.23.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/sunos-x64@npm:0.24.0"
@@ -2349,6 +2496,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-arm64@npm:0.21.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-arm64@npm:0.23.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -2367,6 +2521,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-ia32@npm:0.23.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.24.0":
   version: 0.24.0
   resolution: "@esbuild/win32-ia32@npm:0.24.0"
@@ -2377,6 +2538,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.23.1":
+  version: 0.23.1
+  resolution: "@esbuild/win32-x64@npm:0.23.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2484,6 +2652,15 @@ __metadata:
     react: ^18 || ^19 || ^19.0.0-rc
     react-dom: ^18 || ^19 || ^19.0.0-rc
   checksum: 10/baaa65f2cadf87d6ef5a15de5c8e532b79f491258166af6f3fe7b05a9196de4db9f3414b62192b4588c610786acb6623e3d775fc23d9001f6b31d13c4a5854c1
+  languageName: node
+  linkType: hard
+
+"@hookform/resolvers@npm:^3.9.1":
+  version: 3.9.1
+  resolution: "@hookform/resolvers@npm:3.9.1"
+  peerDependencies:
+    react-hook-form: ^7.0.0
+  checksum: 10/4e7a24f79ead48db5c869c17b5f47412a7d628939f743bdc1248ea3a291b1a9dd777cd02f84326e91d258283a6351566f13bca5cb30f996e5a9db7ee490b5cc5
   languageName: node
   linkType: hard
 
@@ -3544,6 +3721,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@monaco-editor/loader@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@monaco-editor/loader@npm:1.4.0"
+  dependencies:
+    state-local: "npm:^1.0.6"
+  peerDependencies:
+    monaco-editor: ">= 0.21.0 < 1"
+  checksum: 10/32ad01de015fc187450aa1cc0aa763af167664b6a61efcb9e1523a0f51ca5d0b35ba11ed95889edd6d774dfe98f196ef58f1607243abcbdd3d6d743f82ba8285
+  languageName: node
+  linkType: hard
+
+"@monaco-editor/react@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@monaco-editor/react@npm:4.6.0"
+  dependencies:
+    "@monaco-editor/loader": "npm:^1.4.0"
+  peerDependencies:
+    monaco-editor: ">= 0.25.0 < 1"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/e32724ebcc2fc81e91169d69eff8533e15a595c13156ec57965238a0f0afa67e2ed2abbf735a57cfaae15430bbc905b016b644bf7383a82d607501d557a6dd82
+  languageName: node
+  linkType: hard
+
 "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.3":
   version: 3.0.3
   resolution: "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.3"
@@ -3590,15 +3791,24 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nahkies/openapi-code-generator-documentation@workspace:packages/documentation"
   dependencies:
+    "@hookform/resolvers": "npm:^3.9.1"
+    "@monaco-editor/react": "npm:^4.6.0"
+    "@nahkies/openapi-code-generator": "npm:*"
     "@types/node": "npm:^22.10.5"
     "@types/react": "npm:^19.0.2"
     "@types/react-dom": "npm:^19.0.2"
     gh-pages: "npm:^6.3.0"
+    monaco-editor: "npm:^0.52.2"
+    monaco-editor-auto-typings: "npm:^0.4.6"
     next: "npm:15.1.3"
     nextra: "npm:^3.3.1"
     nextra-theme-docs: "npm:^3.3.1"
+    node-polyfill-webpack-plugin: "npm:^4.1.0"
+    null-loader: "npm:^4.0.1"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"
+    react-hook-form: "npm:^7.54.2"
+    tsx: "npm:^4.19.2"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
@@ -3617,12 +3827,14 @@ __metadata:
     "@commander-js/extra-typings": "npm:^12.1.0"
     "@types/js-yaml": "npm:^4.0.9"
     "@types/lodash": "npm:^4.17.14"
+    "@types/prettier": "npm:^3.0.0"
     "@typespec/compiler": "npm:^0.63.0"
     "@typespec/http": "npm:^0.63.0"
     "@typespec/openapi": "npm:^0.63.0"
     "@typespec/openapi3": "npm:^0.63.0"
     "@typespec/rest": "npm:^0.63.0"
     "@typespec/versioning": "npm:^0.63.0"
+    "@typespec/xml": "npm:^0.63.0"
     ajv: "npm:^8.17.1"
     ajv-draft-04: "npm:^1.0.0"
     ajv-formats: "npm:^3.0.1"
@@ -6500,6 +6712,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prettier@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/prettier@npm:3.0.0"
+  dependencies:
+    prettier: "npm:*"
+  checksum: 10/a2a512d304e5bcf78f38089dc88ad19215e6ab871d435a17aef3ce538a63b07c0e359c18db23989dc1ed9fff96d99eee1f680416080184df5c7e0e3bf767e165
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*, @types/qs@npm:^6.9.17":
   version: 6.9.17
   resolution: "@types/qs@npm:6.9.17"
@@ -6727,6 +6948,15 @@ __metadata:
   peerDependencies:
     "@typespec/compiler": ~0.63.0
   checksum: 10/341a2451cb6d5ac6c1db6dce8df38f0ca67650f5121d77a1f980ec2d80ad0f54d1c9d0132b5f943141e2975e03c2527e6b677834f990b6acdcd9237462a68ae7
+  languageName: node
+  linkType: hard
+
+"@typespec/xml@npm:^0.63.0":
+  version: 0.63.0
+  resolution: "@typespec/xml@npm:0.63.0"
+  peerDependencies:
+    "@typespec/compiler": ~0.63.0
+  checksum: 10/954ec3e74622a856982d6601f07d824e1bd89382e3514f0cca321c8a1cc3e1b98fd19b01be3372391029fd0994fdd16e2e9d0c77ef325ecff1da84e5a5a4db68
   languageName: node
   linkType: hard
 
@@ -7296,6 +7526,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asn1.js@npm:^4.10.1":
+  version: 4.10.1
+  resolution: "asn1.js@npm:4.10.1"
+  dependencies:
+    bn.js: "npm:^4.0.0"
+    inherits: "npm:^2.0.1"
+    minimalistic-assert: "npm:^1.0.0"
+  checksum: 10/5a02104b9ba167917c786a3fdac9840a057d29e6b609250e6af924d0529ead1a32417da13eec809cadea8f991eb67782196f3df427c5b4f30eaf22044fc64fda
+  languageName: node
+  linkType: hard
+
+"assert@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "assert@npm:2.1.0"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    is-nan: "npm:^1.3.2"
+    object-is: "npm:^1.1.5"
+    object.assign: "npm:^4.1.4"
+    util: "npm:^0.12.5"
+  checksum: 10/6b9d813c8eef1c0ac13feac5553972e4bd180ae16000d4eb5c0ded2489188737c75a5aacefc97a985008b37502f62fe1bad34da1a7481a54bbfabec3964c8aa7
+  languageName: node
+  linkType: hard
+
 "astring@npm:^1.8.0":
   version: 1.9.0
   resolution: "astring@npm:1.9.0"
@@ -7343,6 +7597,15 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: 10/d3c4b562fc4af2393623a0207cc336f5b9f94c4264ae1c316376904c279702ce2b12dc3f27205f491195d1e29bb52ffc269970ceb0f271f035fadee128a273f7
+  languageName: node
+  linkType: hard
+
+"available-typed-arrays@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "available-typed-arrays@npm:1.0.7"
+  dependencies:
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10/6c9da3a66caddd83c875010a1ca8ef11eac02ba15fb592dc9418b2b5e7b77b645fa7729380a92d9835c2f05f2ca1b6251f39b993e0feb3f1517c74fa1af02cab
   languageName: node
   linkType: hard
 
@@ -7590,6 +7853,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
+  version: 4.12.1
+  resolution: "bn.js@npm:4.12.1"
+  checksum: 10/07f22df8880b423c4890648e95791319898b96712b6ebc5d6b1082b34074f09dedb8601e717d67f905ce29bb1a5313f9a2b1a2015a679e42c9eed94392c0d379
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "bn.js@npm:5.2.1"
+  checksum: 10/7a7e8764d7a6e9708b8b9841b2b3d6019cc154d2fc23716d0efecfe1e16921b7533c6f7361fb05471eab47986c4aa310c270f88e3507172104632ac8df2cfd84
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:1.20.3, body-parser@npm:^1.19.0":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
@@ -7655,6 +7932,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brorand@npm:^1.0.1, brorand@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "brorand@npm:1.1.0"
+  checksum: 10/8a05c9f3c4b46572dec6ef71012b1946db6cae8c7bb60ccd4b7dd5a84655db49fe043ecc6272e7ef1f69dc53d6730b9e2a3a03a8310509a3d797a618cbee52be
+  languageName: node
+  linkType: hard
+
+"browser-resolve@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "browser-resolve@npm:2.0.0"
+  dependencies:
+    resolve: "npm:^1.17.0"
+  checksum: 10/ad5314db3429a903b07d6445137588665c4677d6276298bb08f0623f05cb107762b73c78f03b4f954a712bd1ebaf98e349b9d98e423123a42804924327a5acd4
+  languageName: node
+  linkType: hard
+
+"browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "browserify-aes@npm:1.2.0"
+  dependencies:
+    buffer-xor: "npm:^1.0.3"
+    cipher-base: "npm:^1.0.0"
+    create-hash: "npm:^1.1.0"
+    evp_bytestokey: "npm:^1.0.3"
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10/2813058f74e083a00450b11ea9d5d1f072de7bf0133f5d122d4ff7b849bece56d52b9c51ad0db0fad21c0bc4e8272fd5196114bbe7b94a9b7feb0f9fbb33a3bf
+  languageName: node
+  linkType: hard
+
+"browserify-cipher@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "browserify-cipher@npm:1.0.1"
+  dependencies:
+    browserify-aes: "npm:^1.0.4"
+    browserify-des: "npm:^1.0.0"
+    evp_bytestokey: "npm:^1.0.0"
+  checksum: 10/2d8500acf1ee535e6bebe808f7a20e4c3a9e2ed1a6885fff1facbfd201ac013ef030422bec65ca9ece8ffe82b03ca580421463f9c45af6c8415fd629f4118c13
+  languageName: node
+  linkType: hard
+
+"browserify-des@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "browserify-des@npm:1.0.2"
+  dependencies:
+    cipher-base: "npm:^1.0.1"
+    des.js: "npm:^1.0.0"
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.1.2"
+  checksum: 10/2fd9018e598b1b25e002abaf656d46d8e0f2ee2666ff18852d37e5c3d0e47701d6824256b060fac395420d56a0c49c2b0d40a194e6fbd837bfdd893e7eb5ade4
+  languageName: node
+  linkType: hard
+
+"browserify-rsa@npm:^4.0.0, browserify-rsa@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "browserify-rsa@npm:4.1.1"
+  dependencies:
+    bn.js: "npm:^5.2.1"
+    randombytes: "npm:^2.1.0"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/62ae0da60e49e8d5dd3b0922119b6edee94ebfa3a184211c804024b3a75f9dab31a1d124cc0545ed050e273f0325c2fd7aba6a51e44ba6f726fceae3210ddade
+  languageName: node
+  linkType: hard
+
+"browserify-sign@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "browserify-sign@npm:4.2.3"
+  dependencies:
+    bn.js: "npm:^5.2.1"
+    browserify-rsa: "npm:^4.1.0"
+    create-hash: "npm:^1.2.0"
+    create-hmac: "npm:^1.1.7"
+    elliptic: "npm:^6.5.5"
+    hash-base: "npm:~3.0"
+    inherits: "npm:^2.0.4"
+    parse-asn1: "npm:^5.1.7"
+    readable-stream: "npm:^2.3.8"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/403a8061d229ae31266670345b4a7c00051266761d2c9bbeb68b1a9bcb05f68143b16110cf23a171a5d6716396a1f41296282b3e73eeec0a1871c77f0ff4ee6b
+  languageName: node
+  linkType: hard
+
+"browserify-zlib@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "browserify-zlib@npm:0.2.0"
+  dependencies:
+    pako: "npm:~1.0.5"
+  checksum: 10/852e72effdc00bf8acc6d167d835179eda9e5bd13721ae5d0a2d132dc542f33e73bead2959eb43a2f181a9c495bc2ae2bdb4ec37c4e37ff61a0277741cbaaa7a
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.21.5, browserslist@npm:^4.23.0, browserslist@npm:^4.23.3, browserslist@npm:^4.24.0, browserslist@npm:^4.24.2":
   version: 4.24.3
   resolution: "browserslist@npm:4.24.3"
@@ -7685,13 +8053,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.5.0":
+"buffer-xor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "buffer-xor@npm:1.0.3"
+  checksum: 10/4a63d48b5117c7eda896d81cd3582d9707329b07c97a14b0ece2edc6e64220ea7ea17c94b295e8c2cb7b9f8291e2b079f9096be8ac14be238420a43e06ec66e2
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^5.5.0, buffer@npm:^5.7.1":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10/997434d3c6e3b39e0be479a80288875f71cd1c07d75a3855e6f08ef848a3c966023f79534e22e415ff3a5112708ce06127277ab20e527146d55c84566405c7c6
+  languageName: node
+  linkType: hard
+
+"builtin-status-codes@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "builtin-status-codes@npm:3.0.0"
+  checksum: 10/1119429cf4b0d57bf76b248ad6f529167d343156ebbcc4d4e4ad600484f6bc63002595cbb61b67ad03ce55cd1d3c4711c03bbf198bf24653b8392420482f3773
   languageName: node
   linkType: hard
 
@@ -7777,13 +8159,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind-apply-helpers@npm:^1.0.1":
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1":
   version: 1.0.1
   resolution: "call-bind-apply-helpers@npm:1.0.1"
   dependencies:
     es-errors: "npm:^1.3.0"
     function-bind: "npm:^1.1.2"
   checksum: 10/6e30c621170e45f1fd6735e84d02ee8e02a3ab95cb109499d5308cbe5d1e84d0cd0e10b48cc43c76aa61450ae1b03a7f89c37c10fc0de8d4998b42aab0f268cc
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.7, call-bind@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "call-bind@npm:1.0.8"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10/659b03c79bbfccf0cde3a79e7d52570724d7290209823e1ca5088f94b52192dc1836b82a324d0144612f816abb2f1734447438e38d9dafe0b3f82c2a1b9e3bce
   languageName: node
   linkType: hard
 
@@ -8022,6 +8416,16 @@ __metadata:
   version: 4.1.0
   resolution: "ci-info@npm:4.1.0"
   checksum: 10/546628efd04e37da3182a58b6995a3313deb86ec7c8112e22ffb644317a61296b89bbfa128219e5bfcce43d9613a434ed89907ed8e752db947f7291e0405125f
+  languageName: node
+  linkType: hard
+
+"cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
+  version: 1.0.6
+  resolution: "cipher-base@npm:1.0.6"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/faf232deff2351448ea23d265eb8723e035ebbb454baca45fb60c1bd71056ede8b153bef1b221e067f13e6b9288ebb83bb6ae2d5dd4cec285411f9fc22ec1f5b
   languageName: node
   linkType: hard
 
@@ -8482,10 +8886,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"console-browserify@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "console-browserify@npm:1.2.0"
+  checksum: 10/4f16c471fa84909af6ae00527ce8d19dd9ed587eab85923c145cadfbc35414139f87e7bdd61746138e22cd9df45c2a1ca060370998c2c39f801d4a778105bac5
+  languageName: node
+  linkType: hard
+
 "console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 10/27b5fa302bc8e9ae9e98c03c66d76ca289ad0c61ce2fe20ab288d288bee875d217512d2edb2363fc83165e88f1c405180cf3f5413a46e51b4fe1a004840c6cdb
+  languageName: node
+  linkType: hard
+
+"constants-browserify@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "constants-browserify@npm:1.0.0"
+  checksum: 10/49ef0babd907616dddde6905b80fe44ad5948e1eaaf6cf65d5f23a8c60c029ff63a1198c364665be1d6b2cb183d7e12921f33049cc126734ade84a3cfdbc83f6
   languageName: node
   linkType: hard
 
@@ -8729,6 +9147,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-ecdh@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "create-ecdh@npm:4.0.4"
+  dependencies:
+    bn.js: "npm:^4.1.0"
+    elliptic: "npm:^6.5.3"
+  checksum: 10/0dd7fca9711d09e152375b79acf1e3f306d1a25ba87b8ff14c2fd8e68b83aafe0a7dd6c4e540c9ffbdd227a5fa1ad9b81eca1f233c38bb47770597ba247e614b
+  languageName: node
+  linkType: hard
+
+"create-hash@npm:^1.1.0, create-hash@npm:^1.1.2, create-hash@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "create-hash@npm:1.2.0"
+  dependencies:
+    cipher-base: "npm:^1.0.1"
+    inherits: "npm:^2.0.1"
+    md5.js: "npm:^1.3.4"
+    ripemd160: "npm:^2.0.1"
+    sha.js: "npm:^2.4.0"
+  checksum: 10/3cfef32043b47a8999602af9bcd74966db6971dd3eb828d1a479f3a44d7f58e38c1caf34aa21a01941cc8d9e1a841738a732f200f00ea155f8a8835133d2e7bc
+  languageName: node
+  linkType: hard
+
+"create-hmac@npm:^1.1.4, create-hmac@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "create-hmac@npm:1.1.7"
+  dependencies:
+    cipher-base: "npm:^1.0.3"
+    create-hash: "npm:^1.1.0"
+    inherits: "npm:^2.0.1"
+    ripemd160: "npm:^2.0.0"
+    safe-buffer: "npm:^5.0.1"
+    sha.js: "npm:^2.4.8"
+  checksum: 10/2b26769f87e99ef72150bf99d1439d69272b2e510e23a2b8daf4e93e2412f4842504237d726044fa797cb20ee0ec8bee78d414b11f2d7ca93299185c93df0dae
+  languageName: node
+  linkType: hard
+
+"create-require@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: 10/a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -8737,6 +9199,26 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10/0d52657d7ae36eb130999dffff1168ec348687b48dd38e2ff59992ed916c88d328cf1d07ff4a4a10bc78de5e1c23f04b306d569e42f7a2293915c081e4dfee86
+  languageName: node
+  linkType: hard
+
+"crypto-browserify@npm:^3.11.0":
+  version: 3.12.1
+  resolution: "crypto-browserify@npm:3.12.1"
+  dependencies:
+    browserify-cipher: "npm:^1.0.1"
+    browserify-sign: "npm:^4.2.3"
+    create-ecdh: "npm:^4.0.4"
+    create-hash: "npm:^1.2.0"
+    create-hmac: "npm:^1.1.7"
+    diffie-hellman: "npm:^5.0.3"
+    hash-base: "npm:~3.0.4"
+    inherits: "npm:^2.0.4"
+    pbkdf2: "npm:^3.1.2"
+    public-encrypt: "npm:^4.0.3"
+    randombytes: "npm:^2.1.0"
+    randomfill: "npm:^1.0.4"
+  checksum: 10/13da0b5f61b3e8e68fcbebf0394f2b2b4d35a0d0ba6ab762720c13391d3697ea42735260a26328a6a3d872be7d4cb5abe98a7a8f88bc93da7ba59b993331b409
   languageName: node
   linkType: hard
 
@@ -9338,6 +9820,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.0.1"
+  checksum: 10/abdcb2505d80a53524ba871273e5da75e77e52af9e15b3aa65d8aad82b8a3a424dad7aee2cc0b71470ac7acf501e08defac362e8b6a73cdb4309f028061df4ae
+  languageName: node
+  linkType: hard
+
 "define-lazy-prop@npm:^2.0.0":
   version: 2.0.0
   resolution: "define-lazy-prop@npm:2.0.0"
@@ -9349,6 +9842,17 @@ __metadata:
   version: 3.0.0
   resolution: "define-lazy-prop@npm:3.0.0"
   checksum: 10/f28421cf9ee86eecaf5f3b8fe875f13d7009c2625e97645bfff7a2a49aca678270b86c39f9c32939e5ca7ab96b551377ed4139558c795e076774287ad3af1aa4
+  languageName: node
+  linkType: hard
+
+"define-properties@npm:^1.1.3, define-properties@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
+  dependencies:
+    define-data-property: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.0"
+    object-keys: "npm:^1.1.1"
+  checksum: 10/b4ccd00597dd46cb2d4a379398f5b19fca84a16f3374e2249201992f36b30f6835949a9429669ee6b41b6e837205a163eadd745e472069e70dfc10f03e5fcc12
   languageName: node
   linkType: hard
 
@@ -9400,6 +9904,16 @@ __metadata:
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10/6ff05a7561f33603df87c45e389c9ac0a95e3c056be3da1a0c4702149e3a7f6fe5ffbb294478687ba51a9e95f3a60e8b6b9005993acd79c292c7d15f71964b6b
+  languageName: node
+  linkType: hard
+
+"des.js@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "des.js@npm:1.1.0"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    minimalistic-assert: "npm:^1.0.0"
+  checksum: 10/d35fc82b5a0b2127b12699212e90b54ddd8134e0cf8d27a8c30507ed3572aa574ab71800cbb473769128a52dcf21acc3271c5c359508a5aa772e990df3b1a698
   languageName: node
   linkType: hard
 
@@ -9494,6 +10008,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diffie-hellman@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "diffie-hellman@npm:5.0.3"
+  dependencies:
+    bn.js: "npm:^4.1.0"
+    miller-rabin: "npm:^4.0.0"
+    randombytes: "npm:^2.0.0"
+  checksum: 10/2ff28231f93b27a4903461432d2de831df02e3568ea7633d5d7b6167eb73077f823b2bca26de6ba4f5c7ecd10a3df5aa94d376d136ab6209948c03cc4e4ac1fe
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -9532,6 +10057,13 @@ __metadata:
     domhandler: "npm:^5.0.2"
     entities: "npm:^4.2.0"
   checksum: 10/e3bf9027a64450bca0a72297ecdc1e3abb7a2912268a9f3f5d33a2e29c1e2c3502c6e9f860fc6625940bfe0cfb57a44953262b9e94df76872fdfb8151097eeb3
+  languageName: node
+  linkType: hard
+
+"domain-browser@npm:4.22.0":
+  version: 4.22.0
+  resolution: "domain-browser@npm:4.22.0"
+  checksum: 10/3ffbaf0cae8da717698d472ca85ab52f96c538fe1fe85e5eb3351d4e7af52423ce096b8a0c51bb318e1c9ccf9c2e94b3b0f68e5923ad0aa0c623a32b641ed11c
   languageName: node
   linkType: hard
 
@@ -9599,7 +10131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dunder-proto@npm:^1.0.1":
+"dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
   dependencies:
@@ -9662,6 +10194,21 @@ __metadata:
   version: 1.5.76
   resolution: "electron-to-chromium@npm:1.5.76"
   checksum: 10/2e8ead6caf746385a8789ced87da8ed98629b3c6bcf19e50e1feb51c2cc5b501fd068c2fa9eefd6c513fb4f07c44d2bd7ead432c083c3798107dc920a3cda1d8
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.3, elliptic@npm:^6.5.5":
+  version: 6.6.1
+  resolution: "elliptic@npm:6.6.1"
+  dependencies:
+    bn.js: "npm:^4.11.9"
+    brorand: "npm:^1.1.0"
+    hash.js: "npm:^1.0.0"
+    hmac-drbg: "npm:^1.0.1"
+    inherits: "npm:^2.0.4"
+    minimalistic-assert: "npm:^1.0.1"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10/dc678c9febd89a219c4008ba3a9abb82237be853d9fd171cd602c8fb5ec39927e65c6b5e7a1b2a4ea82ee8e0ded72275e7932bb2da04a5790c2638b818e4e1c5
   languageName: node
   linkType: hard
 
@@ -9859,7 +10406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-define-property@npm:^1.0.1":
+"es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
   version: 1.0.1
   resolution: "es-define-property@npm:1.0.1"
   checksum: 10/f8dc9e660d90919f11084db0a893128f3592b781ce967e4fccfb8f3106cb83e400a4032c559184ec52ee1dbd4b01e7776c7cd0b3327b1961b1a4a7008920fe78
@@ -10085,6 +10632,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.23.0":
+  version: 0.23.1
+  resolution: "esbuild@npm:0.23.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.23.1"
+    "@esbuild/android-arm": "npm:0.23.1"
+    "@esbuild/android-arm64": "npm:0.23.1"
+    "@esbuild/android-x64": "npm:0.23.1"
+    "@esbuild/darwin-arm64": "npm:0.23.1"
+    "@esbuild/darwin-x64": "npm:0.23.1"
+    "@esbuild/freebsd-arm64": "npm:0.23.1"
+    "@esbuild/freebsd-x64": "npm:0.23.1"
+    "@esbuild/linux-arm": "npm:0.23.1"
+    "@esbuild/linux-arm64": "npm:0.23.1"
+    "@esbuild/linux-ia32": "npm:0.23.1"
+    "@esbuild/linux-loong64": "npm:0.23.1"
+    "@esbuild/linux-mips64el": "npm:0.23.1"
+    "@esbuild/linux-ppc64": "npm:0.23.1"
+    "@esbuild/linux-riscv64": "npm:0.23.1"
+    "@esbuild/linux-s390x": "npm:0.23.1"
+    "@esbuild/linux-x64": "npm:0.23.1"
+    "@esbuild/netbsd-x64": "npm:0.23.1"
+    "@esbuild/openbsd-arm64": "npm:0.23.1"
+    "@esbuild/openbsd-x64": "npm:0.23.1"
+    "@esbuild/sunos-x64": "npm:0.23.1"
+    "@esbuild/win32-arm64": "npm:0.23.1"
+    "@esbuild/win32-ia32": "npm:0.23.1"
+    "@esbuild/win32-x64": "npm:0.23.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/f55fbd0bfb0f86ce67a6d2c6f6780729d536c330999ecb9f5a38d578fb9fda820acbbc67d6d1d377eed8fed50fc38f14ff9cb014f86dafab94269a7fb2177018
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -10291,10 +10921,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.2.0":
+"events@npm:^3.0.0, events@npm:^3.2.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10/a3d47e285e28d324d7180f1e493961a2bbb4cad6412090e4dec114f4db1f5b560c7696ee8e758f55e23913ede856e3689cd3aa9ae13c56b5d8314cd3b3ddd1be
+  languageName: node
+  linkType: hard
+
+"evp_bytestokey@npm:^1.0.0, evp_bytestokey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "evp_bytestokey@npm:1.0.3"
+  dependencies:
+    md5.js: "npm:^1.3.4"
+    node-gyp: "npm:latest"
+    safe-buffer: "npm:^5.1.1"
+  checksum: 10/ad4e1577f1a6b721c7800dcc7c733fe01f6c310732bb5bf2240245c2a5b45a38518b91d8be2c610611623160b9d1c0e91f1ce96d639f8b53e8894625cf20fa45
   languageName: node
   linkType: hard
 
@@ -10663,6 +11304,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: "npm:^6.0.0"
+    path-exists: "npm:^4.0.0"
+  checksum: 10/07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^6.3.0":
   version: 6.3.0
   resolution: "find-up@npm:6.3.0"
@@ -10703,6 +11354,15 @@ __metadata:
     debug:
       optional: true
   checksum: 10/e3ab42d1097e90d28b913903841e6779eb969b62a64706a3eb983e894a5db000fbd89296f45f08885a0e54cd558ef62e81be1165da9be25a6c44920da10f424c
+  languageName: node
+  linkType: hard
+
+"for-each@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "for-each@npm:0.3.3"
+  dependencies:
+    is-callable: "npm:^1.1.3"
+  checksum: 10/fdac0cde1be35610bd635ae958422e8ce0cc1313e8d32ea6d34cfda7b60850940c1fd07c36456ad76bd9c24aef6ff5e03b02beb58c83af5ef6c968a64eada676
   languageName: node
   linkType: hard
 
@@ -10884,6 +11544,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.4":
+  version: 1.2.6
+  resolution: "get-intrinsic@npm:1.2.6"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    dunder-proto: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    function-bind: "npm:^1.1.2"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.0.0"
+  checksum: 10/a1ffae6d7893a6fa0f4d1472adbc85095edd6b3b0943ead97c3738539cecb19d422ff4d48009eed8c3c27ad678c2b1e38a83b1a1e96b691d13ed8ecefca1068d
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6":
   version: 1.2.7
   resolution: "get-intrinsic@npm:1.2.7"
@@ -10958,6 +11636,15 @@ __metadata:
   version: 8.0.1
   resolution: "get-stream@npm:8.0.1"
   checksum: 10/dde5511e2e65a48e9af80fea64aff11b4921b14b6e874c6f8294c50975095af08f41bfb0b680c887f28b566dd6ec2cb2f960f9d36a323359be324ce98b766e9e
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.8.1
+  resolution: "get-tsconfig@npm:4.8.1"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10/3fb5a8ad57b9633eaea085d81661e9e5c9f78b35d8f8689eaf8b8b45a2a3ebf3b3422266d4d7df765e308cc1e6231648d114803ab3d018332e29916f2c1de036
   languageName: node
   linkType: hard
 
@@ -11158,7 +11845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gopd@npm:^1.2.0":
+"gopd@npm:^1.0.1, gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
   checksum: 10/94e296d69f92dc1c0768fcfeecfb3855582ab59a7c75e969d5f96ce50c3d201fd86d5a2857c22565764d5bb8a816c7b1e58f133ec318cd56274da36c5e3fb1a1
@@ -11268,6 +11955,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+  checksum: 10/2d8c9ab8cebb572e3362f7d06139a4592105983d4317e68f7adba320fe6ddfc8874581e0971e899e633fd5f72e262830edce36d5a0bc863dad17ad20572484b2
+  languageName: node
+  linkType: hard
+
 "has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
@@ -11288,6 +11984,37 @@ __metadata:
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 10/041b4293ad6bf391e21c5d85ed03f412506d6623786b801c4ab39e4e6ca54993f13201bceb544d92963f9e0024e6e7fbf0cb1d84c9d6b31cb9c79c8c990d13d8
+  languageName: node
+  linkType: hard
+
+"hash-base@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "hash-base@npm:3.1.0"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.6.0"
+    safe-buffer: "npm:^5.2.0"
+  checksum: 10/26b7e97ac3de13cb23fc3145e7e3450b0530274a9562144fc2bf5c1e2983afd0e09ed7cc3b20974ba66039fad316db463da80eb452e7373e780cbee9a0d2f2dc
+  languageName: node
+  linkType: hard
+
+"hash-base@npm:~3.0, hash-base@npm:~3.0.4":
+  version: 3.0.5
+  resolution: "hash-base@npm:3.0.5"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/6a82675a5de2ea9347501bbe655a2334950c7ec972fd9810ae9529e06aeab8f7e8ef68fc2112e5e6f0745561a7e05326efca42ad59bb5fd116537f5f8b0a216d
+  languageName: node
+  linkType: hard
+
+"hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
+  version: 1.1.7
+  resolution: "hash.js@npm:1.1.7"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    minimalistic-assert: "npm:^1.0.1"
+  checksum: 10/0c89ee4006606a40f92df5cc3c263342e7fea68110f3e9ef032bd2083650430505db01b6b7926953489517d4027535e4fdc7f970412893d3031c361d3ec8f4b3
   languageName: node
   linkType: hard
 
@@ -11523,6 +12250,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hmac-drbg@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "hmac-drbg@npm:1.0.1"
+  dependencies:
+    hash.js: "npm:^1.0.3"
+    minimalistic-assert: "npm:^1.0.0"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10/0298a1445b8029a69b713d918ecaa84a1d9f614f5857e0c6e1ca517abfa1357216987b2ee08cc6cc73ba82a6c6ddf2ff11b9717a653530ef03be599d4699b836
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -11724,6 +12462,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"https-browserify@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "https-browserify@npm:1.0.0"
+  checksum: 10/2d707c457319e1320adf0e7556174c190865fb345b6a183f033cee440f73221dbe7fa3f0adcffb1e6b0664726256bd44771a82e50fe6c66976c10b237100536a
+  languageName: node
+  linkType: hard
+
 "https-proxy-agent@npm:7.0.5":
   version: 7.0.5
   resolution: "https-proxy-agent@npm:7.0.5"
@@ -11914,7 +12659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
@@ -12049,6 +12794,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arguments@npm:^1.0.4":
+  version: 1.2.0
+  resolution: "is-arguments@npm:1.2.0"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/471a8ef631b8ee8829c43a8ab05c081700c0e25180c73d19f3bf819c1a8448c426a9e8e601f278973eca68966384b16ceb78b8c63af795b099cd199ea5afc457
+  languageName: node
+  linkType: hard
+
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
@@ -12076,6 +12831,13 @@ __metadata:
   version: 1.1.6
   resolution: "is-buffer@npm:1.1.6"
   checksum: 10/f63da109e74bbe8947036ed529d43e4ae0c5fcd0909921dce4917ad3ea212c6a87c29f525ba1d17c0858c18331cf1046d4fc69ef59ed26896b25c8288a627133
+  languageName: node
+  linkType: hard
+
+"is-callable@npm:^1.1.3":
+  version: 1.2.7
+  resolution: "is-callable@npm:1.2.7"
+  checksum: 10/48a9297fb92c99e9df48706241a189da362bff3003354aea4048bd5f7b2eb0d823cd16d0a383cece3d76166ba16d85d9659165ac6fcce1ac12e6c649d66dbdb9
   languageName: node
   linkType: hard
 
@@ -12230,6 +12992,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-nan@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "is-nan@npm:1.3.2"
+  dependencies:
+    call-bind: "npm:^1.0.0"
+    define-properties: "npm:^1.1.3"
+  checksum: 10/1f784d3472c09bc2e47acba7ffd4f6c93b0394479aa613311dc1d70f1bfa72eb0846c81350967722c959ba65811bae222204d6c65856fdce68f31986140c7b0e
+  languageName: node
+  linkType: hard
+
 "is-network-error@npm:^1.0.0":
   version: 1.1.0
   resolution: "is-network-error@npm:1.1.0"
@@ -12355,6 +13127,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-typed-array@npm:^1.1.3":
+  version: 1.1.15
+  resolution: "is-typed-array@npm:1.1.15"
+  dependencies:
+    which-typed-array: "npm:^1.1.16"
+  checksum: 10/e8cf60b9ea85667097a6ad68c209c9722cfe8c8edf04d6218366469e51944c5cc25bae45ffb845c23f811d262e4314d3b0168748eb16711aa34d12724cdf0735
+  languageName: node
+  linkType: hard
+
 "is-unicode-supported@npm:^0.1.0":
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
@@ -12437,6 +13218,13 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: 10/db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
+  languageName: node
+  linkType: hard
+
+"isomorphic-timers-promises@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "isomorphic-timers-promises@npm:1.0.1"
+  checksum: 10/2dabe397039081dbf30039f295333a7f9888b072dd0afa3aa7d8ba8f812a6db5efcbda0861a4be43ecfec207d56314ecf27150187b8d0f924a93103fa93eac73
   languageName: node
   linkType: hard
 
@@ -13872,6 +14660,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"locate-path@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "locate-path@npm:6.0.0"
+  dependencies:
+    p-locate: "npm:^5.0.0"
+  checksum: 10/72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^7.1.0":
   version: 7.2.0
   resolution: "locate-path@npm:7.2.0"
@@ -14154,7 +14951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"math-intrinsics@npm:^1.1.0":
+"math-intrinsics@npm:^1.0.0, math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10/11df2eda46d092a6035479632e1ec865b8134bdfc4bd9e571a656f4191525404f13a283a515938c3a8de934dbfd9c09674d9da9fa831e6eb7e22b50b197d2edd
@@ -14177,6 +14974,17 @@ __metadata:
     mj-context-menu: "npm:^0.6.1"
     speech-rule-engine: "npm:^4.0.6"
   checksum: 10/1091a1773f736c00723ce4db35f9f0f04f4e54b8af51cf1b916ea0e1f90411e64521970f9ec5f760a7b490956f54cf2a5ddda2a2d762eddf65d6cd63494c4f8c
+  languageName: node
+  linkType: hard
+
+"md5.js@npm:^1.3.4":
+  version: 1.3.5
+  resolution: "md5.js@npm:1.3.5"
+  dependencies:
+    hash-base: "npm:^3.0.0"
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.1.2"
+  checksum: 10/098494d885684bcc4f92294b18ba61b7bd353c23147fbc4688c75b45cb8590f5a95fd4584d742415dcc52487f7a1ef6ea611cfa1543b0dc4492fe026357f3f0c
   languageName: node
   linkType: hard
 
@@ -15009,6 +15817,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"miller-rabin@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "miller-rabin@npm:4.0.1"
+  dependencies:
+    bn.js: "npm:^4.0.0"
+    brorand: "npm:^1.0.1"
+  bin:
+    miller-rabin: bin/miller-rabin
+  checksum: 10/2a38ba9d1e878d94ee8a8ab3505b40e8d44fb9700a7716570fe4c8ca7e20d49b69aea579106580618c877cc6ff969eff71705042fafb47573736bf89404417bc
+  languageName: node
+  linkType: hard
+
 "mime-db@npm:1.52.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
@@ -15090,10 +15910,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimalistic-assert@npm:^1.0.0":
+"minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
   version: 1.0.1
   resolution: "minimalistic-assert@npm:1.0.1"
   checksum: 10/cc7974a9268fbf130fb055aff76700d7e2d8be5f761fb5c60318d0ed010d839ab3661a533ad29a5d37653133385204c503bfac995aaa4236f4e847461ea32ba7
+  languageName: node
+  linkType: hard
+
+"minimalistic-crypto-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "minimalistic-crypto-utils@npm:1.0.1"
+  checksum: 10/6e8a0422b30039406efd4c440829ea8f988845db02a3299f372fceba56ffa94994a9c0f2fd70c17f9969eedfbd72f34b5070ead9656a34d3f71c0bd72583a0ed
   languageName: node
   linkType: hard
 
@@ -15347,6 +16174,22 @@ __metadata:
   version: 1.0.1
   resolution: "modify-values@npm:1.0.1"
   checksum: 10/16fa93f7ddb2540a8e82c99738ae4ed0e8e8cae57c96e13a0db9d68dfad074fd2eec542929b62ebbb18b357bbb3e4680b92d3a4099baa7aeb32360cb1c8f0247
+  languageName: node
+  linkType: hard
+
+"monaco-editor-auto-typings@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "monaco-editor-auto-typings@npm:0.4.6"
+  peerDependencies:
+    monaco-editor: "*"
+  checksum: 10/626deb04bded81e6778604203a159de888b3d93015c9dffe7f0856213f39733687e822263248dde6204957e231ea452876ad86319222d11ca15a4903f90dd32e
+  languageName: node
+  linkType: hard
+
+"monaco-editor@npm:^0.52.2":
+  version: 0.52.2
+  resolution: "monaco-editor@npm:0.52.2"
+  checksum: 10/0d4962d69ffa0a8df040faa9c582cef1893fa3fb617feca8f1425c5e670e74c2856104b9a2b01cbda0103a5e5f92f58843206bc9a0e070471c0c1270d7f52a96
   languageName: node
   linkType: hard
 
@@ -15796,10 +16639,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-polyfill-webpack-plugin@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "node-polyfill-webpack-plugin@npm:4.1.0"
+  dependencies:
+    node-stdlib-browser: "npm:^1.3.0"
+    type-fest: "npm:^4.27.0"
+  peerDependencies:
+    webpack: ">=5"
+  checksum: 10/e6d76301e2fc081bf64d85a6451a7320e4c4a415fb1cd19bf27ef0cb6ae472de9cca449af4d5948890b84de0859217369dd66085db5fcecfe02af15de03767d7
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.19":
   version: 2.0.19
   resolution: "node-releases@npm:2.0.19"
   checksum: 10/c2b33b4f0c40445aee56141f13ca692fa6805db88510e5bbb3baadb2da13e1293b738e638e15e4a8eb668bb9e97debb08e7a35409b477b5cc18f171d35a83045
+  languageName: node
+  linkType: hard
+
+"node-stdlib-browser@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "node-stdlib-browser@npm:1.3.0"
+  dependencies:
+    assert: "npm:^2.0.0"
+    browser-resolve: "npm:^2.0.0"
+    browserify-zlib: "npm:^0.2.0"
+    buffer: "npm:^5.7.1"
+    console-browserify: "npm:^1.1.0"
+    constants-browserify: "npm:^1.0.0"
+    create-require: "npm:^1.1.1"
+    crypto-browserify: "npm:^3.11.0"
+    domain-browser: "npm:4.22.0"
+    events: "npm:^3.0.0"
+    https-browserify: "npm:^1.0.0"
+    isomorphic-timers-promises: "npm:^1.0.1"
+    os-browserify: "npm:^0.3.0"
+    path-browserify: "npm:^1.0.1"
+    pkg-dir: "npm:^5.0.0"
+    process: "npm:^0.11.10"
+    punycode: "npm:^1.4.1"
+    querystring-es3: "npm:^0.2.1"
+    readable-stream: "npm:^3.6.0"
+    stream-browserify: "npm:^3.0.0"
+    stream-http: "npm:^3.2.0"
+    string_decoder: "npm:^1.0.0"
+    timers-browserify: "npm:^2.0.4"
+    tty-browserify: "npm:0.0.1"
+    url: "npm:^0.11.4"
+    util: "npm:^0.12.4"
+    vm-browserify: "npm:^1.0.1"
+  checksum: 10/b35ea38004466d3df228b7e7b58a64b00c5a8282a4ba6c14a327623c7551ff97471a87d4ab5c1ad4fa8d7f6d766d3e5a388ff72abf50fa8dfac12ee237ba053c
   languageName: node
   linkType: hard
 
@@ -16091,6 +16981,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"null-loader@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "null-loader@npm:4.0.1"
+  dependencies:
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 10/eeb4c4dd2f8f41e46f5665e4500359109e95ec1028a178a60e0161984906572da7dd87644bcc3cb29f0125d77e2b2508fb4f3813cfb1c6604a15865beb4b987b
+  languageName: node
+  linkType: hard
+
 "nx@npm:>=17.1.2 < 21":
   version: 20.3.0
   resolution: "nx@npm:20.3.0"
@@ -16186,6 +17088,37 @@ __metadata:
   version: 1.13.3
   resolution: "object-inspect@npm:1.13.3"
   checksum: 10/14cb973d8381c69e14d7f1c8c75044eb4caf04c6dabcf40ca5c2ce42dc2073ae0bb2a9939eeca142b0c05215afaa1cd5534adb7c8879c32cba2576e045ed8368
+  languageName: node
+  linkType: hard
+
+"object-is@npm:^1.1.5":
+  version: 1.1.6
+  resolution: "object-is@npm:1.1.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+  checksum: 10/4f6f544773a595da21c69a7531e0e1d6250670f4e09c55f47eb02c516035cfcb1b46ceb744edfd3ecb362309dbccb6d7f88e43bf42e4d4595ac10a329061053a
+  languageName: node
+  linkType: hard
+
+"object-keys@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "object-keys@npm:1.1.1"
+  checksum: 10/3d81d02674115973df0b7117628ea4110d56042e5326413e4b4313f0bcdf7dd78d4a3acef2c831463fa3796a66762c49daef306f4a0ea1af44877d7086d73bde
+  languageName: node
+  linkType: hard
+
+"object.assign@npm:^4.1.4":
+  version: 4.1.7
+  resolution: "object.assign@npm:4.1.7"
+  dependencies:
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.3"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.0.0"
+    has-symbols: "npm:^1.1.0"
+    object-keys: "npm:^1.1.1"
+  checksum: 10/3fe28cdd779f2a728a9a66bd688679ba231a2b16646cd1e46b528fe7c947494387dda4bc189eff3417f3717ef4f0a8f2439347cf9a9aa3cef722fbfd9f615587
   languageName: node
   linkType: hard
 
@@ -16375,6 +17308,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"os-browserify@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "os-browserify@npm:0.3.0"
+  checksum: 10/16e37ba3c0e6a4c63443c7b55799ce4066d59104143cb637ecb9fce586d5da319cdca786ba1c867abbe3890d2cbf37953f2d51eea85e20dd6c4570d6c54bfebf
+  languageName: node
+  linkType: hard
+
 "os-tmpdir@npm:~1.0.2":
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
@@ -16407,7 +17347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.1.0":
+"p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
@@ -16449,6 +17389,15 @@ __metadata:
   dependencies:
     p-limit: "npm:^2.2.0"
   checksum: 10/513bd14a455f5da4ebfcb819ef706c54adb09097703de6aeaa5d26fe5ea16df92b48d1ac45e01e3944ce1e6aa2a66f7f8894742b8c9d6e276e16cd2049a2b870
+  languageName: node
+  linkType: hard
+
+"p-locate@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "p-locate@npm:5.0.0"
+  dependencies:
+    p-limit: "npm:^3.0.2"
+  checksum: 10/1623088f36cf1cbca58e9b61c4e62bf0c60a07af5ae1ca99a720837356b5b6c5ba3eb1b2127e47a06865fee59dd0453cad7cc844cda9d5a62ac1a5a51b7c86d3
   languageName: node
   linkType: hard
 
@@ -16619,12 +17568,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:~1.0.5":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 10/1ad07210e894472685564c4d39a08717e84c2a68a70d3c1d9e657d32394ef1670e22972a433cbfe48976cb98b154ba06855dcd3fcfba77f60f1777634bec48c0
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
   dependencies:
     callsites: "npm:^3.0.0"
   checksum: 10/6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
+  languageName: node
+  linkType: hard
+
+"parse-asn1@npm:^5.0.0, parse-asn1@npm:^5.1.7":
+  version: 5.1.7
+  resolution: "parse-asn1@npm:5.1.7"
+  dependencies:
+    asn1.js: "npm:^4.10.1"
+    browserify-aes: "npm:^1.2.0"
+    evp_bytestokey: "npm:^1.0.3"
+    hash-base: "npm:~3.0"
+    pbkdf2: "npm:^3.1.2"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10/f82c079f4d9a4d33159c7682f9c516680f4d659fde8060697a6b3c1be4795976e826d53a1e5751a81ddc800e9c6d6fa4629b59f6d1f3241ac8447a00c89a67d3
   languageName: node
   linkType: hard
 
@@ -16758,6 +17728,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-browserify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "path-browserify@npm:1.0.1"
+  checksum: 10/7e7368a5207e7c6b9051ef045711d0dc3c2b6203e96057e408e6e74d09f383061010d2be95cb8593fe6258a767c3e9fc6b2bfc7ce8d48ae8c3d9f6994cca9ad8
+  languageName: node
+  linkType: hard
+
 "path-data-parser@npm:0.1.0, path-data-parser@npm:^0.1.0":
   version: 0.1.0
   resolution: "path-data-parser@npm:0.1.0"
@@ -16868,6 +17845,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pbkdf2@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "pbkdf2@npm:3.1.2"
+  dependencies:
+    create-hash: "npm:^1.1.2"
+    create-hmac: "npm:^1.1.4"
+    ripemd160: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+    sha.js: "npm:^2.4.8"
+  checksum: 10/40bdf30df1c9bb1ae41ec50c11e480cf0d36484b7c7933bf55e4451d1d0e3f09589df70935c56e7fccc5702779a0d7b842d012be8c08a187b44eb24d55bb9460
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1, picocolors@npm:~1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -16954,6 +17944,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg-dir@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pkg-dir@npm:5.0.0"
+  dependencies:
+    find-up: "npm:^5.0.0"
+  checksum: 10/b167bb8dac7bbf22b1d5e30ec223e6b064b84b63010c9d49384619a36734caf95ed23ad23d4f9bd975e8e8082b60a83395f43a89bb192df53a7c25a38ecb57d9
+  languageName: node
+  linkType: hard
+
 "pkg-dir@npm:^7.0.0":
   version: 7.0.0
   resolution: "pkg-dir@npm:7.0.0"
@@ -16995,6 +17994,13 @@ __metadata:
     path-data-parser: "npm:0.1.0"
     points-on-curve: "npm:0.2.0"
   checksum: 10/8b3f42feb24433b4a3e0b1c1f951340f06f523b26ed4d87446829f500f1468ad1484a6bf7fedf076ff4b492ae6b1daa7ffc07c7a8f7c00f4d072f17f79fe9ed0
+  languageName: node
+  linkType: hard
+
+"possible-typed-array-names@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "possible-typed-array-names@npm:1.0.0"
+  checksum: 10/8ed3e96dfeea1c5880c1f4c9cb707e5fb26e8be22f14f82ef92df20fd2004e635c62ba47fbe8f2bb63bfd80dac1474be2fb39798da8c2feba2815435d1f749af
   languageName: node
   linkType: hard
 
@@ -17118,7 +18124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.4.2":
+"prettier@npm:*, prettier@npm:^3.4.2":
   version: 3.4.2
   resolution: "prettier@npm:3.4.2"
   bin:
@@ -17176,6 +18182,13 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 10/1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: 10/dbaa7e8d1d5cf375c36963ff43116772a989ef2bb47c9bdee20f38fd8fc061119cf38140631cf90c781aca4d3f0f0d2c834711952b728953f04fd7d238f59f5b
   languageName: node
   linkType: hard
 
@@ -17274,6 +18287,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"public-encrypt@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "public-encrypt@npm:4.0.3"
+  dependencies:
+    bn.js: "npm:^4.1.0"
+    browserify-rsa: "npm:^4.0.0"
+    create-hash: "npm:^1.1.0"
+    parse-asn1: "npm:^5.0.0"
+    randombytes: "npm:^2.0.1"
+    safe-buffer: "npm:^5.1.2"
+  checksum: 10/059d64da8ba9ea0733377d23b57b6cbe5be663c8eb187b9c051eec85f799ff95c4e194eb3a69db07cc1f73a2a63519e67716ae9b8630e13e7149840d0abe044d
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^1.4.1":
   version: 1.4.1
   resolution: "punycode@npm:1.4.1"
@@ -17311,12 +18338,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.11.0, qs@npm:^6.13.1, qs@npm:^6.5.2":
+"qs@npm:^6.11.0, qs@npm:^6.12.3, qs@npm:^6.13.1, qs@npm:^6.5.2":
   version: 6.13.1
   resolution: "qs@npm:6.13.1"
   dependencies:
     side-channel: "npm:^1.0.6"
   checksum: 10/53cf5fdc5f342a9ffd3968f20c8c61624924cf928d86fff525240620faba8ca5cfd6c3f12718cc755561bfc3dc9721bc8924e38f53d8925b03940f0b8a902212
+  languageName: node
+  linkType: hard
+
+"querystring-es3@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "querystring-es3@npm:0.2.1"
+  checksum: 10/c99fccfe1a9c4c25ea6194fa7a559fdb83d2628f118f898af6f0ac02c4ffcd7e0576997bb80e7dfa892d193988b60e23d4968122426351819f87051862af991c
   languageName: node
   linkType: hard
 
@@ -17345,12 +18379,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
+"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
   dependencies:
     safe-buffer: "npm:^5.1.0"
   checksum: 10/4efd1ad3d88db77c2d16588dc54c2b52fd2461e70fe5724611f38d283857094fe09040fa2c9776366803c3152cf133171b452ef717592b65631ce5dc3a2bdafc
+  languageName: node
+  linkType: hard
+
+"randomfill@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "randomfill@npm:1.0.4"
+  dependencies:
+    randombytes: "npm:^2.0.5"
+    safe-buffer: "npm:^5.1.0"
+  checksum: 10/33734bb578a868d29ee1b8555e21a36711db084065d94e019a6d03caa67debef8d6a1bfd06a2b597e32901ddc761ab483a85393f0d9a75838f1912461d4dbfc7
   languageName: node
   linkType: hard
 
@@ -17381,6 +18425,15 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
   checksum: 10/aa64a2f1991042f516260e8b0eca0ae777b6c8f1aa2b5ae096e80bbb6ac9b005aef2bca697969841d34f7e1819556263476bdfea36c35092e8d9aefde3de2d9a
+  languageName: node
+  linkType: hard
+
+"react-hook-form@npm:^7.54.2":
+  version: 7.54.2
+  resolution: "react-hook-form@npm:7.54.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18 || ^19
+  checksum: 10/b156d15b6246c76d0275e5722d9056014693e014d0e3dec06e44bf2672ee549aaba4366de5144d18c4cab29e631f3b2b84269d4fd5727ca17aad9b970fde6960
   languageName: node
   linkType: hard
 
@@ -17478,7 +18531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.1, readable-stream@npm:^2.2.2, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.1, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.8, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -17493,7 +18546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+"readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -17931,6 +18984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10/0763150adf303040c304009231314d1e84c6e5ebfa2d82b7d94e96a6e82bacd1dcc0b58ae257315f3c8adb89a91d8d0f12928241cba2df1680fbe6f60bf99b0e
+  languageName: node
+  linkType: hard
+
 "resolve-url-loader@npm:5.0.0":
   version: 5.0.0
   resolution: "resolve-url-loader@npm:5.0.0"
@@ -17964,7 +19024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.20.0":
+"resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.20.0":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -17990,7 +19050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -18126,6 +19186,16 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10/f3b8ce81eecbde4628b07bdf9e2fa8b684e0caea4999acb1e3b0402c695cd41f28cd075609a808e61ce2672f528ca079f675ab1d8e8d5f86d56643a03e0b8d2e
+  languageName: node
+  linkType: hard
+
+"ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "ripemd160@npm:2.0.2"
+  dependencies:
+    hash-base: "npm:^3.0.0"
+    inherits: "npm:^2.0.1"
+  checksum: 10/006accc40578ee2beae382757c4ce2908a826b27e2b079efdcd2959ee544ddf210b7b5d7d5e80467807604244e7388427330f5c6d4cd61e6edaddc5773ccc393
   languageName: node
   linkType: hard
 
@@ -18328,7 +19398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
@@ -18417,7 +19487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.2.0":
+"schema-utils@npm:^3.0.0, schema-utils@npm:^3.2.0":
   version: 3.3.0
   resolution: "schema-utils@npm:3.3.0"
   dependencies:
@@ -18567,12 +19637,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-function-length@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "set-function-length@npm:1.2.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.4"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: 10/505d62b8e088468917ca4e3f8f39d0e29f9a563b97dbebf92f4bd2c3172ccfb3c5b8e4566d5fcd00784a00433900e7cb8fbc404e2dbd8c3818ba05bb9d4a8a6d
+  languageName: node
+  linkType: hard
+
 "set-getter@npm:^0.1.0":
   version: 0.1.1
   resolution: "set-getter@npm:0.1.1"
   dependencies:
     to-object-path: "npm:^0.3.0"
   checksum: 10/04bc8ffff286d7b36a3adc675d2858db3d6768f0290dce98ca5d481d5361936f4fa1e2570833de3511424adf534fc9e48f4b420163906b0d6ca45f38074f5108
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.4":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 10/76e3f5d7f4b581b6100ff819761f04a984fa3f3990e72a6554b57188ded53efce2d3d6c0932c10f810b7c59414f85e2ab3c11521877d1dea1ce0b56dc906f485
   languageName: node
   linkType: hard
 
@@ -18587,6 +19678,18 @@ __metadata:
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10/fde1630422502fbbc19e6844346778f99d449986b2f9cdcceb8326730d2f3d9964dbcb03c02aaadaefffecd0f2c063315ebea8b3ad895914bf1afc1747fc172e
+  languageName: node
+  linkType: hard
+
+"sha.js@npm:^2.4.0, sha.js@npm:^2.4.8":
+  version: 2.4.11
+  resolution: "sha.js@npm:2.4.11"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  bin:
+    sha.js: ./bin.js
+  checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
   languageName: node
   linkType: hard
 
@@ -19123,6 +20226,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"state-local@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "state-local@npm:1.0.7"
+  checksum: 10/1d956043e270861d40a639ff3457938cf61dbc7e25209d21b55060d8dfaf74742b8a1e525ed6fcb0c2d89b7d3e305bb8589bf27392012889456b3ad82a4b7d0a
+  languageName: node
+  linkType: hard
+
 "statuses@npm:2.0.1":
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
@@ -19134,6 +20244,28 @@ __metadata:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10/c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
+  languageName: node
+  linkType: hard
+
+"stream-browserify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "stream-browserify@npm:3.0.0"
+  dependencies:
+    inherits: "npm:~2.0.4"
+    readable-stream: "npm:^3.5.0"
+  checksum: 10/05a3cd0a0ce2d568dbdeb69914557c26a1b0a9d871839666b692eae42b96189756a3ed685affc90dab64ff588a8524c8aec6d85072c07905a1f0d941ea68f956
+  languageName: node
+  linkType: hard
+
+"stream-http@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "stream-http@npm:3.2.0"
+  dependencies:
+    builtin-status-codes: "npm:^3.0.0"
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.6.0"
+    xtend: "npm:^4.0.2"
+  checksum: 10/4f85738cbc6de70ecf0a04bc38b6092b4d91dd5317d3d93c88a84c48e63b82a8724ab5fd591df9f587b5139fe439d1748e4e3db3cb09c2b1e23649cb9d89859e
   languageName: node
   linkType: hard
 
@@ -19205,7 +20337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.0.0, string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -19600,6 +20732,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"timers-browserify@npm:^2.0.4":
+  version: 2.0.12
+  resolution: "timers-browserify@npm:2.0.12"
+  dependencies:
+    setimmediate: "npm:^1.0.4"
+  checksum: 10/ec37ae299066bef6c464dcac29c7adafba1999e7227a9bdc4e105a459bee0f0b27234a46bfd7ab4041da79619e06a58433472867a913d01c26f8a203f87cee70
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^0.3.0":
   version: 0.3.2
   resolution: "tinyexec@npm:0.3.2"
@@ -19769,6 +20910,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsx@npm:^4.19.2":
+  version: 4.19.2
+  resolution: "tsx@npm:4.19.2"
+  dependencies:
+    esbuild: "npm:~0.23.0"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10/4c5610ed1fb2f80d766681f8ac7827e1e8118dfe354c18f74800691f3ef1e9ed676a29842ab818806bcf8613cdc97c6af84b5645e768ddb7f4b0527b9100deda
+  languageName: node
+  linkType: hard
+
+"tty-browserify@npm:0.0.1":
+  version: 0.0.1
+  resolution: "tty-browserify@npm:0.0.1"
+  checksum: 10/93b745d43fa5a7d2b948fa23be8d313576d1d884b48acd957c07710bac1c0d8ac34c0556ad4c57c73d36e11741763ef66b3fb4fb97b06b7e4d525315a3cd45f5
+  languageName: node
+  linkType: hard
+
 "tuf-js@npm:^2.2.1":
   version: 2.2.1
   resolution: "tuf-js@npm:2.2.1"
@@ -19849,6 +21013,13 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10/fd4a91bfb706aeeb0d326ebd2e9a8ea5263979e5dec8d16c3e469a5bd3a946e014a062ef76c02e3086d3d1c7209a56a20a4caafd0e9f9a5c2ab975084ea3d388
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.27.0":
+  version: 4.30.2
+  resolution: "type-fest@npm:4.30.2"
+  checksum: 10/c5168b159c366e4fd5b74c7f7b786bed9248c03f67e6e07d52dd5d51354447468fa7c92b9f2142c7fe9279814031f783959370242c3520de848931b65ddb48bb
   languageName: node
   linkType: hard
 
@@ -20279,10 +21450,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url@npm:^0.11.4":
+  version: 0.11.4
+  resolution: "url@npm:0.11.4"
+  dependencies:
+    punycode: "npm:^1.4.1"
+    qs: "npm:^6.12.3"
+  checksum: 10/e787d070f0756518b982a4653ef6cdf4d9030d8691eee2d483344faf2b530b71d302287fa63b292299455fea5075c502a5ad5f920cb790e95605847f957a65e4
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10/474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"util@npm:^0.12.4, util@npm:^0.12.5":
+  version: 0.12.5
+  resolution: "util@npm:0.12.5"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    is-arguments: "npm:^1.0.4"
+    is-generator-function: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.3"
+    which-typed-array: "npm:^1.1.2"
+  checksum: 10/61a10de7753353dd4d744c917f74cdd7d21b8b46379c1e48e1c4fd8e83f8190e6bd9978fc4e5102ab6a10ebda6019d1b36572fa4a325e175ec8b789a121f6147
   languageName: node
   linkType: hard
 
@@ -20432,6 +21626,13 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10/719c4dea896e9547958643354003c8c9ea98e5367196d98f5f46cffb3ec963fead3ea5853f5af941c79bbfb73583dec19bbb0d28d2f644b95d7f59c55e22919d
+  languageName: node
+  linkType: hard
+
+"vm-browserify@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "vm-browserify@npm:1.1.2"
+  checksum: 10/ad5b17c9f7a9d9f1ed0e24c897782ab7a587c1fd40f370152482e1af154c7cf0b0bacc45c5ae76a44289881e083ae4ae127808fdff864aa9b562192aae8b5c3b
   languageName: node
   linkType: hard
 
@@ -20717,6 +21918,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.2":
+  version: 1.1.18
+  resolution: "which-typed-array@npm:1.1.18"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.3"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.2.0"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10/11eed801b2bd08cdbaecb17aff381e0fb03526532f61acc06e6c7b9370e08062c33763a51f27825f13fdf34aabd0df6104007f4e8f96e6eaef7db0ce17a26d6e
+  languageName: node
+  linkType: hard
+
 "which@npm:^1.2.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
@@ -20925,7 +22140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:~4.0.1":
+"xtend@npm:^4.0.2, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 10/ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
@@ -20960,12 +22175,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.3.2, yaml@npm:^2.6.0":
-  version: 2.7.0
-  resolution: "yaml@npm:2.7.0"
+"yaml@npm:^2.3.2, yaml@npm:^2.6.0, yaml@npm:~2.6.1":
+  version: 2.6.1
+  resolution: "yaml@npm:2.6.1"
   bin:
     yaml: bin.mjs
-  checksum: 10/c8c314c62fbd49244a6a51b06482f6d495b37ab10fa685fcafa1bbaae7841b7233ee7d12cab087bcca5a0b28adc92868b6e437322276430c28d00f1c1732eeec
+  checksum: 10/cf412f03a33886db0a3aac70bb4165588f4c5b3c6f8fc91520b71491e5537800b6c2c73ed52015617f6e191eb4644c73c92973960a1999779c62a200ee4c231d
   languageName: node
   linkType: hard
 
@@ -20975,15 +22190,6 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10/0eecb679db75ea6a989ad97715a9fa5d946972945aa6aa7d2175bca66c213b5564502ccb1cdd04b1bf816ee38b5c43e4e2fda3ff6f5e09da24dabb51ae92c57d
-  languageName: node
-  linkType: hard
-
-"yaml@npm:~2.6.1":
-  version: 2.6.1
-  resolution: "yaml@npm:2.6.1"
-  bin:
-    yaml: bin.mjs
-  checksum: 10/cf412f03a33886db0a3aac70bb4165588f4c5b3c6f8fc91520b71491e5537800b6c2c73ed52015617f6e191eb4644c73c92973960a1999779c62a200ee4c231d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Oh boy was this more of a pain than I expected. 

Creates an interactive playground similar to the typespec or typescript ones, based on https://github.com/microsoft/monaco-editor

The actual code generation is off-loaded to a web worker, which actually made the react side of things much simpler and easier to reason about, and reduces blocking on the UI thread/main event loop.

Prettier is used instead of Biome due to difficulties getting the WASM to load correctly in the browser / with nextjs. Unfortunately Prettier hits a maximum recursion limit when formatting some of the larger files (in firefox at least), so it would be good to revisit this and try and get Biome working.

When loading the larger files, the performance of the editor gets a bit shaky. I'm unsure if there is a way to offload more of the editor to web workers to reduce strain on the UI thread.

**Demo Video**
https://github.com/user-attachments/assets/5b34f63e-9eaf-4e27-88e9-5a6a0bf5b9fe

