### PR TITLE
fix: include schemas from all documents in dependency graph

### DIFF
--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
@@ -6,6 +6,11 @@ import { z } from "zod"
 
 export const s_CreateUpdateTodoList = z.object({ name: z.string() })
 
+export const s_Error = z.object({
+  message: z.string().optional(),
+  code: z.coerce.number().optional(),
+})
+
 export const s_Statuses = z.array(z.enum(["incomplete", "complete"]))
 
 export const s_TodoList = z.object({
@@ -15,9 +20,4 @@ export const s_TodoList = z.object({
   incompleteItemCount: z.coerce.number(),
   created: z.string().datetime({ offset: true }),
   updated: z.string().datetime({ offset: true }),
-})
-
-export const s_Error = z.object({
-  message: z.string().optional(),
-  code: z.coerce.number().optional(),
 })

--- a/packages/openapi-code-generator/src/core/dependency-graph.ts
+++ b/packages/openapi-code-generator/src/core/dependency-graph.ts
@@ -106,6 +106,7 @@ export function buildDependencyGraph(
    * Create an object mapping name -> Set(direct dependencies)
    */
   const dependencyGraph = Object.fromEntries(
+    // TODO: this may miss extracted in-line schemas
     Object.entries(input.allSchemas()).map(([name, schema]) => {
       return [
         getNameForRef({$ref: name}),

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -36,6 +36,7 @@ import {
 
 export type OperationGroup = {name: string; operations: IROperation[]}
 export type OperationGroupStrategy = "none" | "first-tag" | "first-slug"
+
 export class Input {
   constructor(
     readonly loader: OpenapiLoader,
@@ -47,7 +48,17 @@ export class Input {
   }
 
   allSchemas(): Record<string, IRModel> {
-    const schemas = this.loader.entryPoint.components?.schemas ?? {}
+    const allDocuments = this.loader.allDocuments()
+
+    const schemas = allDocuments.reduce(
+      (acc, it) => {
+        return Object.assign(acc, it.components?.schemas ?? {})
+      },
+      {} as {
+        [schemaName: string]: Schema | Reference
+      },
+    )
+
     return Object.fromEntries(
       Object.entries(schemas).map(([name, maybeSchema]) => {
         return [name, this.schema(normalizeSchemaObject(maybeSchema))]

--- a/packages/openapi-code-generator/src/core/openapi-loader.ts
+++ b/packages/openapi-code-generator/src/core/openapi-loader.ts
@@ -21,8 +21,7 @@ import type {OpenapiValidator} from "./openapi-validator"
 
 export class OpenapiLoader {
   private readonly virtualLibrary = new Map<string, VirtualDefinition>()
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  private readonly library = new Map<string, any>()
+  private readonly library = new Map<string, OpenapiDocument>()
 
   private constructor(
     private readonly entryPointKey: string,
@@ -48,6 +47,10 @@ export class OpenapiLoader {
     // and the factory function loading the entry point at this key.
     // biome-ignore lint/style/noNonNullAssertion: <explanation>
     return this.library.get(this.entryPointKey)!
+  }
+
+  allDocuments(): OpenapiDocument[] {
+    return Array.from(this.library.values())
   }
 
   paths(maybeRef: Reference | Path): Path {
@@ -81,7 +84,8 @@ export class OpenapiLoader {
   private $ref<T>({$ref}: Reference): T {
     const [key, objPath] = $ref.split("#")
 
-    const obj = key && this.library.get(key)
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    const obj: any = key && this.library.get(key)
 
     if (!obj) {
       throw new Error(`could not load $ref, key not loaded. $ref: '${$ref}'`)


### PR DESCRIPTION
previously schemas loaded from other documents like `$ref: './common.yaml#/components/schemas/FooBar'` were not always correctly considered when building the schema dependency graph.

this meant that you could have schemas output in an ordering that would not build, due to variables not having been initialized.