### PR TITLE
feat: support remote specs with authentication

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn lint-staged

--- a/packages/documentation/src/pages/reference/cli-options.mdx
+++ b/packages/documentation/src/pages/reference/cli-options.mdx
@@ -115,6 +115,72 @@ Default: `false` (use `unknown` rather than `any`)
 
 ### Misc
 
+#### `--remote-spec-request-headers` (authenticated remote specifications)
+As environment variable `OPENAPI_REMOTE_SPEC_REQUEST_HEADERS`
+
+Allows providing request headers to use when fetching remote specifications. This allows for running
+generation against remote sources that require authentication.
+
+Common examples include [private github repositories](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api),
+urls secured by an authenticating proxy like [GCP IAP Proxy](https://cloud.google.com/iap/docs/concepts-overview),
+or just generally authenticated servers
+
+
+<Callout type="warning" emoji="⚠️">
+  We strongly recommend using the **environment variable** variant of this option
+  (`OPENAPI_REMOTE_SPEC_REQUEST_HEADERS`), as values for this option will likely include secrets, and it
+  is best to keep these out of your shell history.
+</Callout>
+
+The format of the value is a JSON object keyed by URI, with values being either an object,
+or array of `{name, value}` pairs. As a typescript type:
+```typescript
+type value = {
+  [uri: string]: { name: string, value: string }[] | { name: string, value: string }
+}
+```
+
+For example:
+```json
+{
+  "https://example.com": [
+    {"name": "X-Client-Id", "value": "my-client-id"},
+    {"name": "X-Client-Secret", "value": "some-secret-value"}
+  ],
+  "https://example.org/some/path": {"name": "Proxy-Authorization", "value": "some token"}
+}
+```
+
+A full match on the provided uri is required for the headers to be sent.
+Eg: given a uri of "https://exmaple.com:8080/openapi.yaml" the headers would **not**
+be sent for requests to other ports, resource paths, or protocols, but a less specific
+uri like "https://example.com" will send headers on any (`https`) request to that domain.
+
+<Callout emoji="💡">
+  Why JSON you ask? Simply put it has well defined semantics, and is easy to parse without fear of jumbling the pieces together.
+
+  Unfortunately it is a little annoying to formulate in shell scripts, so here's some examples to get you started
+
+  Using [jq](https://jqlang.github.io/jq/):
+  ```shell
+  jq --null-input --compact-output \
+    --arg domain "https://example.com" \
+    --arg name "authorization" \
+    --arg value "secret value" '{$domain: {$name, $value}}'
+  ```
+
+  Using [nodejs](https://nodejs.org/):
+  ```shell
+  node -p 'JSON.stringify({[process.argv[1]]: {name: process.argv[2], value: process.argv[3]}})' \
+    https://example.com \
+    authorization \
+    'some secret value'
+  ```
+
+  Where typically in either example the values would be coming from shell variables, eg: storing a short-lived
+  access token, etc.
+</Callout>
+
 #### `-h, --help`
 Displays help text for command
 

--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -51,7 +51,8 @@
     "json5": "^2.2.3",
     "lodash": "^4.17.21",
     "source-map-support": "^0.5.21",
-    "tslib": "^2.6.3"
+    "tslib": "^2.6.3",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
     "@typespec/compiler": "^0.58.0",

--- a/packages/openapi-code-generator/src/cli.spec.ts
+++ b/packages/openapi-code-generator/src/cli.spec.ts
@@ -1,0 +1,66 @@
+import {describe, it} from "@jest/globals"
+import {boolParser, remoteSpecRequestHeadersParser} from "./cli"
+
+describe("cli", () => {
+  describe("boolParser", () => {
+    it.each([
+      ["true", true],
+      ["1", true],
+      ["on", true],
+      ["TRUE", true],
+      ["1", true],
+      ["ON", true],
+      ["false", false],
+      ["0", false],
+      ["off", false],
+      ["FALSE", false],
+      ["0", false],
+      ["OFF", false],
+    ])("%s -> %s", (input, expected) => {
+      expect(boolParser(input)).toBe(expected)
+    })
+  })
+
+  describe("remoteSpecRequestHeadersParser", () => {
+    it("accepts a single header", () => {
+      expect(
+        remoteSpecRequestHeadersParser(
+          JSON.stringify({
+            "https://example.com/": {
+              name: "some-header-name",
+              value: "some-header-value",
+            },
+          }),
+        ),
+      ).toEqual({
+        "https://example.com/": [
+          {name: "some-header-name", value: "some-header-value"},
+        ],
+      })
+    })
+
+    it("accepts multiple headers", () => {
+      expect(
+        remoteSpecRequestHeadersParser(
+          JSON.stringify({
+            "https://example.com/": [
+              {
+                name: "some-header-name",
+                value: "some-header-value",
+              },
+              {
+                name: "some-other-header-name",
+                value: "some-other-header-value",
+              },
+            ],
+          }),
+        ),
+      ).toEqual({
+        "https://example.com/": [
+          {name: "some-header-name", value: "some-header-value"},
+          {name: "some-other-header-name", value: "some-other-header-value"},
+        ],
+      })
+    })
+  })
+})

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -8,6 +8,7 @@ import {
   InvalidArgumentError,
   Option,
 } from "@commander-js/extra-typings"
+import {z} from "zod"
 import {promptContinue} from "./core/cli-utils"
 import {NodeFsAdaptor} from "./core/file-system/node-fs-adaptor"
 import type {OperationGroupStrategy} from "./core/input"
@@ -41,15 +42,12 @@ const boolParser = (arg: string): boolean => {
 
 const program = new Command()
   .addOption(
-    new Option("-i --input <value>", "input file to generate from")
+    new Option("-i --input <value>", "input specification to generate from")
       .env("OPENAPI_INPUT")
       .makeOptionMandatory(),
   )
   .addOption(
-    new Option(
-      "--input-type <value>",
-      "type of input file. this can be openapi3 or typespec",
-    )
+    new Option("--input-type <value>", "type of input specification")
       .env("OPENAPI_INPUT_TYPE")
       .choices(["openapi3", "typespec"] as const)
       .default("openapi3" as const)
@@ -74,7 +72,7 @@ const program = new Command()
   .addOption(
     new Option(
       "-s --schema-builder <value>",
-      "runtime schema parsing library to use",
+      "(typescript) runtime schema parsing library to use",
     )
       .env("OPENAPI_SCHEMA_BUILDER")
       .choices(["zod", "joi"] as const)
@@ -84,7 +82,7 @@ const program = new Command()
   .addOption(
     new Option(
       "--ts-allow-any [bool]",
-      "(typescript) whether to use `any` or `unknown` for unspecified types",
+      `(typescript) whether to use "any" or "unknown" for unspecified types`,
     )
       .env("OPENAPI_TS_ALLOW_ANY")
       .argParser(boolParser)
@@ -93,7 +91,7 @@ const program = new Command()
   .addOption(
     new Option(
       "--enable-runtime-response-validation [bool]",
-      "(experimental) whether to validate response bodies using the chosen runtime schema library",
+      "(experimental) (client sdks only) whether to validate response bodies using the chosen runtime schema library",
     )
       .env("OPENAPI_ENABLE_RUNTIME_RESPONSE_VALIDATION")
       .argParser(boolParser)
@@ -111,7 +109,7 @@ const program = new Command()
   .addOption(
     new Option(
       "--allow-unused-imports [bool]",
-      "Keep unused imports. Especially useful if there is a bug in the unused-import elimination.",
+      "Keep unused imports. Primarily useful if a bug occurs in the unused-import elimination.",
     )
       .env("OPENAPI_ALLOW_UNUSED_IMPORTS")
       .argParser(boolParser)
@@ -120,7 +118,10 @@ const program = new Command()
   .addOption(
     new Option(
       "--grouping-strategy <value>",
-      "(experimental) Strategy to use for splitting output into separate files. Set to none for a single generated.ts",
+      `
+    (experimental) Strategy to use for splitting output into separate files.
+
+    Set to none for a single generated.ts`,
     )
       .env("OPENAPI_GROUPING_STRATEGY")
       .choices([
@@ -130,6 +131,49 @@ const program = new Command()
       ] as const satisfies OperationGroupStrategy[])
       .default("none" as const)
       .makeOptionMandatory(),
+  )
+  .addOption(
+    new Option(
+      "--remote-spec-request-headers <value>",
+      `
+    Request headers to use when fetching remote specifications.
+
+    Format is a JSON object keyed by domain name/uri, with values {name, value}[].
+    Eg: '{"https://example.com": [{"name": "Authorization", "value": "some arbitrary value"}]}'.
+
+    Use this if you're generating from a uri that requires authentication.
+
+    A full match on the provided domain/uri is required for the headers to be sent.
+    Eg: given a uri of "https://exmaple.com:8080/openapi.yaml" the headers would not
+    be sent for requests to other ports, resource paths, or protocols, but a less specific
+    uri like "https://example.com" will send headers on any request to that domain.
+
+    Using the environment variable variant is recommended to keep secrets out of your shell history`,
+    )
+      .env("OPENAPI_REMOTE_SPEC_REQUEST_HEADERS")
+      .argParser((value) => {
+        return z
+          .preprocess(
+            (str) =>
+              z
+                .string()
+                .transform((it) => JSON.parse(it))
+                .parse(str),
+            z.record(
+              z.string(),
+              z.preprocess(
+                (it) => (!it || Array.isArray(it) ? it : [it]),
+                z.array(
+                  z.object({
+                    name: z.string(),
+                    value: z.string(),
+                  }),
+                ),
+              ),
+            ),
+          )
+          .parse(value)
+      }),
   )
   .showHelpAfterError()
   .parse()

--- a/packages/openapi-code-generator/src/core/loaders/generic.loader.spec.ts
+++ b/packages/openapi-code-generator/src/core/loaders/generic.loader.spec.ts
@@ -1,0 +1,73 @@
+import {describe} from "@jest/globals"
+import {
+  type GenericLoaderRequestHeaders,
+  headersForRemoteUri,
+} from "./generic.loader"
+
+describe("core/loaders/generic.loader", () => {
+  describe("headersForRemoteUri", () => {
+    const possibleHeaders = {
+      "127.0.0.1": [{name: "Authorization", value: "Bearer bare-ip-address"}],
+      "https://example.com/specific-path.yaml": [
+        {name: "Authorization", value: "Bearer specific-path"},
+      ],
+      "https://example.com:8080": [
+        {name: "Proxy-Authorization", value: "Bearer domain-wide"},
+      ],
+      "https://example.com:8080/specifications": [
+        {name: "Authorization", value: "Bearer sub-path"},
+      ],
+    } satisfies GenericLoaderRequestHeaders
+
+    it("matches a loosely specified host", () => {
+      const actual = headersForRemoteUri(
+        "http://127.0.0.1:8080/openapi.yaml",
+        possibleHeaders,
+      )
+
+      const expected: [string, string][] = [
+        ["authorization", "Bearer bare-ip-address"],
+      ]
+
+      expect(Array.from(actual.entries())).toEqual(expected)
+    })
+
+    it("matches a strictly specified uri", () => {
+      const actual = headersForRemoteUri(
+        "https://example.com/specific-path.yaml",
+        possibleHeaders,
+      )
+
+      const expected: [string, string][] = [
+        ["authorization", "Bearer specific-path"],
+      ]
+
+      expect(Array.from(actual.entries())).toEqual(expected)
+    })
+
+    it("doesn't match other paths from a strictly specified uri", () => {
+      const actual = headersForRemoteUri(
+        "https://example.com/other-path.yaml",
+        possibleHeaders,
+      )
+
+      const expected: [string, string][] = []
+
+      expect(Array.from(actual.entries())).toEqual(expected)
+    })
+
+    it("stacks multiple matches", () => {
+      const actual = headersForRemoteUri(
+        "https://example.com:8080/specifications/some-spec.json",
+        possibleHeaders,
+      )
+
+      const expected: [string, string][] = [
+        ["authorization", "Bearer sub-path"],
+        ["proxy-authorization", "Bearer domain-wide"],
+      ]
+
+      expect(Array.from(actual.entries())).toEqual(expected)
+    })
+  })
+})

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -1,7 +1,10 @@
 import type {IFsAdaptor} from "./core/file-system/fs-adaptor"
 import {Input} from "./core/input"
 import type {IFormatter} from "./core/interfaces"
-import {GenericLoader} from "./core/loaders/generic.loader"
+import {
+  GenericLoader,
+  type GenericLoaderRequestHeaders,
+} from "./core/loaders/generic.loader"
 import type {CompilerOptions} from "./core/loaders/tsconfig.loader"
 import type {TypespecLoader} from "./core/loaders/typespec.loader"
 import {logger} from "./core/logger"
@@ -26,6 +29,7 @@ export type Config = {
   groupingStrategy: "none" | "first-slug" | "first-tag"
   tsAllowAny: boolean
   tsCompilerOptions: CompilerOptions
+  remoteSpecRequestHeaders?: GenericLoaderRequestHeaders | undefined
 }
 
 export async function generate(
@@ -39,7 +43,10 @@ export async function generate(
   logger.info(`running on input file '${config.input}'`)
   logger.time("load files")
 
-  const genericLoader = new GenericLoader(fsAdaptor)
+  const genericLoader = new GenericLoader(
+    fsAdaptor,
+    config.remoteSpecRequestHeaders,
+  )
   const loader = await OpenapiLoader.create(
     {entryPoint: config.input, fileType: config.inputType},
     validator,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,6 +3207,7 @@ __metadata:
     source-map-support: "npm:^0.5.21"
     tslib: "npm:^2.6.3"
     typescript: "npm:~5.5.4"
+    zod: "npm:^3.23.8"
   peerDependencies:
     "@typespec/compiler": ^0.58.0
     "@typespec/http": ^0.58.0


### PR DESCRIPTION
- new cli param `--remote-spec-request-headers` /
  `OPENAPI_REMOTE_SPEC_REQUEST_HEADERS`

- accepts a JSON object like `{[uri: string]: {name: string, value: string} | {name: string, value: string}[]}`
  - I don't _love_ using JSON as a format for this, however at least
    it's standardized and escaping values etc is well understood. By
    using JSON I'm confident that there won't be any edge cases with
    spaces or other separaters that would need handling with a format
    like `<uri>:<name>:<value>`

- main use-case is for generating from remote specs that are behind some
  format of request header based authentication (eg: private github
  repos, GCP IAP proxy, etc)
  - Previously I was having to `curl` these to the local filesystem
    first, which is inconvenient

closes #229