### PR TITLE
feat: include urls from servers array in basePath type

### DIFF
--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -13,8 +13,10 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
@@ -313,7 +313,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "https://api.github.com" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
@@ -25,7 +25,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "{endpoint}/widget" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
@@ -17,7 +17,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "https://management.azure.com" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
@@ -25,7 +25,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "https://{yourOktaDomain}" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
@@ -39,7 +39,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "https://{yourOktaDomain}" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
@@ -8,7 +8,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "https://petstore.swagger.io/v2" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -164,7 +164,7 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ApiClientConfig {
-  basePath: string = ""
+  basePath: "https://api.stripe.com/" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
@@ -309,8 +309,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "https://api.github.com" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -25,8 +25,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "{endpoint}/widget" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/client.ts
@@ -17,8 +17,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "https://management.azure.com" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
@@ -25,8 +25,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "https://{yourOktaDomain}" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
@@ -38,8 +38,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "https://{yourOktaDomain}" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/petstore-expanded.yaml/client.ts
@@ -9,8 +9,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "https://petstore.swagger.io/v2" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
@@ -164,8 +164,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {
+  basePath: "https://api.stripe.com/" | string
+}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
@@ -9,8 +9,10 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
+export interface ApiClientConfig extends AbstractAxiosConfig {}
+
 export class ApiClient extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ApiClientConfig) {
     super(config)
   }
 

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
@@ -315,7 +315,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "https://api.github.com" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -28,7 +28,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "{endpoint}/widget" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
@@ -20,7 +20,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "https://management.azure.com" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
@@ -27,7 +27,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "https://{yourOktaDomain}" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
@@ -41,7 +41,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "https://{yourOktaDomain}" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
@@ -11,7 +11,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "https://petstore.swagger.io/v2" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -167,7 +167,9 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface ApiClientConfig extends AbstractFetchClientConfig {
+  basePath: "https://api.stripe.com/" | string
+}
 
 export class ApiClient extends AbstractFetchClient {
   constructor(config: ApiClientConfig) {

--- a/packages/documentation/src/pages/reference/cli-options.mdx
+++ b/packages/documentation/src/pages/reference/cli-options.mdx
@@ -76,6 +76,14 @@ Default `false`
   Note: this is currently always `true` for server templates, and only applies to the client library templates.
 </Callout>
 
+#### `--enable-typed-base-paths` (client sdks only)
+As environment variable `OPENAPI_ENABLE_TYPED_BASE_PATHS`
+
+Controls whether to generate a union-type of string literals + `string` from the openapi specifications
+array of server urls. Handy for intellisense.
+
+Default: `true`
+
 #### `--extract-inline-schemas` (experimental)
 As environment variable `OPENAPI_EXTRACT_INLINE_SCHEMAS`
 

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -123,6 +123,15 @@ const program = new Command()
   )
   .addOption(
     new Option(
+      "--enable-typed-base-paths",
+      "(client sdks only) whether to produce a union type for the client basePath from the `servers` array",
+    )
+      .env("OPENAPI_ENABLE_TYPED_BASE_PATHS")
+      .argParser(boolParser)
+      .default(true),
+  )
+  .addOption(
+    new Option(
       "--extract-inline-schemas [bool]",
       "(experimental) Generate names and extract types/schemas for inline schemas",
     )

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -47,6 +47,10 @@ export class Input {
     return this.loader.entryPoint.info.title
   }
 
+  servers() {
+    return this.loader.entryPoint.servers?.filter((it) => it.url) ?? []
+  }
+
   allSchemas(): Record<string, IRModel> {
     const allDocuments = this.loader.allDocuments()
 

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -24,6 +24,7 @@ export type Config = {
     | "typescript-koa"
   schemaBuilder: "zod" | "joi"
   enableRuntimeResponseValidation: boolean
+  enableTypedBasePaths: boolean
   extractInlineSchemas: boolean
   allowUnusedImports: boolean
   groupingStrategy: "none" | "first-slug" | "first-tag"
@@ -70,6 +71,7 @@ export async function generate(
     emitter,
     schemaBuilder: config.schemaBuilder,
     enableRuntimeResponseValidation: config.enableRuntimeResponseValidation,
+    enableTypedBasePaths: config.enableTypedBasePaths,
     compilerOptions: config.tsCompilerOptions,
     groupingStrategy: config.groupingStrategy,
     allowAny: config.tsAllowAny,

--- a/packages/openapi-code-generator/src/templates.types.ts
+++ b/packages/openapi-code-generator/src/templates.types.ts
@@ -7,6 +7,7 @@ export interface OpenapiGeneratorConfig {
   input: Input
   emitter: TypescriptEmitter
   enableRuntimeResponseValidation: boolean
+  enableTypedBasePaths: boolean
   groupingStrategy: OperationGroupStrategy
 }
 

--- a/packages/openapi-code-generator/src/typescript/common/client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/client-builder.ts
@@ -5,6 +5,7 @@ import {CompilationUnit, type ICompilable} from "./compilation-units"
 import type {ImportBuilder} from "./import-builder"
 import type {SchemaBuilder} from "./schema-builders/schema-builder"
 import type {TypeBuilder} from "./type-builder"
+import {quotedStringLiteral, union} from "./type-utils"
 
 export abstract class TypescriptClientBuilder implements ICompilable {
   private readonly operations: string[] = []
@@ -18,9 +19,22 @@ export abstract class TypescriptClientBuilder implements ICompilable {
     protected readonly schemaBuilder: SchemaBuilder,
     protected readonly config: {
       enableRuntimeResponseValidation: boolean
-    } = {enableRuntimeResponseValidation: false},
+      enableTypedBasePaths: boolean
+    } = {enableRuntimeResponseValidation: false, enableTypedBasePaths: true},
   ) {
     this.buildImports(imports)
+  }
+
+  basePathType() {
+    const serverUrls = this.input
+      .servers()
+      .map((it) => quotedStringLiteral(it.url))
+
+    if (this.config.enableTypedBasePaths && serverUrls.length > 0) {
+      return union(...serverUrls, "string")
+    }
+
+    return ""
   }
 
   add(operation: IROperation): void {

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/angular-service-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/angular-service-builder.ts
@@ -68,9 +68,11 @@ return this.httpClient.request<any>(
   }
 
   protected buildClient(clientName: string, clientMethods: string[]): string {
+    const basePathType = this.basePathType()
+
     return `
 export class ${clientName}Config {
-  basePath: string = ''
+  basePath: ${basePathType ? basePathType : "string"} = ''
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/typescript-angular.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/typescript-angular.generator.ts
@@ -34,6 +34,7 @@ export async function generateTypescriptAngular(
     rootSchemaBuilder.withImports(imports),
     {
       enableRuntimeResponseValidation: config.enableRuntimeResponseValidation,
+      enableTypedBasePaths: config.enableTypedBasePaths,
     },
   )
 

--- a/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios-client-builder.ts
@@ -1,7 +1,7 @@
 import {TypescriptClientBuilder} from "../common/client-builder"
 import type {ClientOperationBuilder} from "../common/client-operation-builder"
 import type {ImportBuilder} from "../common/import-builder"
-import {union} from "../common/type-utils"
+import {quotedStringLiteral, union} from "../common/type-utils"
 import {asyncMethod, routeToTemplateString} from "../common/typescript-common"
 
 export class TypescriptAxiosClientBuilder extends TypescriptClientBuilder {
@@ -101,10 +101,15 @@ export class TypescriptAxiosClientBuilder extends TypescriptClientBuilder {
   }
 
   protected buildClient(clientName: string, clientMethods: string[]): string {
+    const basePathType = this.basePathType()
+
     return `
+export interface ${clientName}Config extends AbstractAxiosConfig {
+  ${basePathType ? `basePath: ${basePathType}` : ""}
+}
 
 export class ${clientName} extends AbstractAxiosClient {
-  constructor(config: AbstractAxiosConfig) {
+  constructor(config: ${clientName}Config) {
     super(config)
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios.generator.ts
@@ -37,6 +37,7 @@ export async function generateTypescriptAxios(
     rootSchemaBuilder.withImports(imports),
     {
       enableRuntimeResponseValidation: config.enableRuntimeResponseValidation,
+      enableTypedBasePaths: config.enableTypedBasePaths,
     },
   )
 

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
@@ -3,6 +3,7 @@ import type {ClientOperationBuilder} from "../common/client-operation-builder"
 import type {ImportBuilder} from "../common/import-builder"
 import {JoiBuilder} from "../common/schema-builders/joi-schema-builder"
 import {ZodBuilder} from "../common/schema-builders/zod-schema-builder"
+import {quotedStringLiteral, union} from "../common/type-utils"
 import {asyncMethod, routeToTemplateString} from "../common/typescript-common"
 
 export class TypescriptFetchClientBuilder extends TypescriptClientBuilder {
@@ -105,8 +106,12 @@ export class TypescriptFetchClientBuilder extends TypescriptClientBuilder {
   }
 
   protected buildClient(clientName: string, clientMethods: string[]): string {
+    const basePathType = this.basePathType()
+
     return `
-export interface ${clientName}Config extends AbstractFetchClientConfig {}
+export interface ${clientName}Config extends AbstractFetchClientConfig {
+  ${basePathType ? `basePath: ${basePathType}` : ""}
+}
 
 export class ${clientName} extends AbstractFetchClient {
   constructor(config: ${clientName}Config) {

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch.generator.ts
@@ -36,6 +36,7 @@ export async function generateTypescriptFetch(
     rootSchemaBuilder.withImports(imports),
     {
       enableRuntimeResponseValidation: config.enableRuntimeResponseValidation,
+      enableTypedBasePaths: config.enableTypedBasePaths,
     },
   )
 


### PR DESCRIPTION
adds a new `--enable-typed-base-paths` (default true) argument that causes any urls in the servers
array to be added to a union type with `string` for the client SDK `basePath` config types