### PR TITLE
feat!: parse/validate request headers

### DIFF
--- a/e2e/openapi.yaml
+++ b/e2e/openapi.yaml
@@ -70,7 +70,14 @@ components:
           schema:
             type: object
             properties:
-              headers:
+              rawHeaders:
+                additionalProperties:
+                  anyOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+              typedHeaders:
                 additionalProperties:
                   anyOf:
                     - type: string

--- a/e2e/openapi.yaml
+++ b/e2e/openapi.yaml
@@ -22,6 +22,10 @@ paths:
           in: header
           schema:
             type: string
+        - name: number-header
+          in: header
+          schema:
+            type: number
         - name: Authorization
           in: header
           schema:
@@ -71,19 +75,9 @@ components:
             type: object
             properties:
               rawHeaders:
-                additionalProperties:
-                  anyOf:
-                    - type: string
-                    - type: array
-                      items:
-                        type: string
+                additionalProperties: true
               typedHeaders:
-                additionalProperties:
-                  anyOf:
-                    - type: string
-                    - type: array
-                      items:
-                        type: string
+                additionalProperties: true
 
   schemas:
     RandomNumber:

--- a/e2e/openapi.yaml
+++ b/e2e/openapi.yaml
@@ -18,11 +18,11 @@ paths:
       tags:
         - headers
       parameters:
-        - name: route-level-header
+        - name: Route-Level-Header
           in: header
           schema:
             type: string
-        - name: number-header
+        - name: Number-Header
           in: header
           schema:
             type: number

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -39,6 +39,7 @@ export class ApiClient extends AbstractAxiosClient {
   async getHeadersRequest(
     p: {
       routeLevelHeader?: string
+      numberHeader?: number
       authorization?: string
     } = {},
     timeout?: number,
@@ -48,6 +49,7 @@ export class ApiClient extends AbstractAxiosClient {
     const headers = this._headers(
       {
         "route-level-header": p["routeLevelHeader"],
+        "number-header": p["numberHeader"],
         Authorization: p["authorization"],
       },
       opts.headers,

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -48,8 +48,8 @@ export class ApiClient extends AbstractAxiosClient {
     const url = `/headers/request`
     const headers = this._headers(
       {
-        "route-level-header": p["routeLevelHeader"],
-        "number-header": p["numberHeader"],
+        "Route-Level-Header": p["routeLevelHeader"],
+        "Number-Header": p["numberHeader"],
         Authorization: p["authorization"],
       },
       opts.headers,

--- a/e2e/src/generated/client/axios/models.ts
+++ b/e2e/src/generated/client/axios/models.ts
@@ -12,13 +12,19 @@ export type t_RandomNumber = {
 }
 
 export type t_getHeadersRequestJson200Response = {
-  headers?: {
+  rawHeaders?: {
+    [key: string]: (string | string[]) | undefined
+  }
+  typedHeaders?: {
     [key: string]: (string | string[]) | undefined
   }
 }
 
 export type t_getHeadersUndeclaredJson200Response = {
-  headers?: {
+  rawHeaders?: {
+    [key: string]: (string | string[]) | undefined
+  }
+  typedHeaders?: {
     [key: string]: (string | string[]) | undefined
   }
 }

--- a/e2e/src/generated/client/axios/models.ts
+++ b/e2e/src/generated/client/axios/models.ts
@@ -12,19 +12,11 @@ export type t_RandomNumber = {
 }
 
 export type t_getHeadersRequestJson200Response = {
-  rawHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
-  typedHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
+  rawHeaders?: unknown
+  typedHeaders?: unknown
 }
 
 export type t_getHeadersUndeclaredJson200Response = {
-  rawHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
-  typedHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
+  rawHeaders?: unknown
+  typedHeaders?: unknown
 }

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -45,8 +45,8 @@ export class ApiClient extends AbstractFetchClient {
     const url = this.basePath + `/headers/request`
     const headers = this._headers(
       {
-        "route-level-header": p["routeLevelHeader"],
-        "number-header": p["numberHeader"],
+        "Route-Level-Header": p["routeLevelHeader"],
+        "Number-Header": p["numberHeader"],
         Authorization: p["authorization"],
       },
       opts.headers,

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -36,6 +36,7 @@ export class ApiClient extends AbstractFetchClient {
   async getHeadersRequest(
     p: {
       routeLevelHeader?: string
+      numberHeader?: number
       authorization?: string
     } = {},
     timeout?: number,
@@ -45,6 +46,7 @@ export class ApiClient extends AbstractFetchClient {
     const headers = this._headers(
       {
         "route-level-header": p["routeLevelHeader"],
+        "number-header": p["numberHeader"],
         Authorization: p["authorization"],
       },
       opts.headers,

--- a/e2e/src/generated/client/fetch/models.ts
+++ b/e2e/src/generated/client/fetch/models.ts
@@ -12,13 +12,19 @@ export type t_RandomNumber = {
 }
 
 export type t_getHeadersRequestJson200Response = {
-  headers?: {
+  rawHeaders?: {
+    [key: string]: (string | string[]) | undefined
+  }
+  typedHeaders?: {
     [key: string]: (string | string[]) | undefined
   }
 }
 
 export type t_getHeadersUndeclaredJson200Response = {
-  headers?: {
+  rawHeaders?: {
+    [key: string]: (string | string[]) | undefined
+  }
+  typedHeaders?: {
     [key: string]: (string | string[]) | undefined
   }
 }

--- a/e2e/src/generated/client/fetch/models.ts
+++ b/e2e/src/generated/client/fetch/models.ts
@@ -12,19 +12,11 @@ export type t_RandomNumber = {
 }
 
 export type t_getHeadersRequestJson200Response = {
-  rawHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
-  typedHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
+  rawHeaders?: unknown
+  typedHeaders?: unknown
 }
 
 export type t_getHeadersUndeclaredJson200Response = {
-  rawHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
-  typedHeaders?: {
-    [key: string]: (string | string[]) | undefined
-  }
+  rawHeaders?: unknown
+  typedHeaders?: unknown
 }

--- a/e2e/src/generated/models.ts
+++ b/e2e/src/generated/models.ts
@@ -15,33 +15,18 @@ export type t_RandomNumber = {
 
 export type t_GetHeadersRequestHeaderSchema = {
   authorization?: string | undefined
+  "number-header"?: number | undefined
   "route-level-header"?: string | undefined
 }
 
 export type t_getHeadersRequestJson200Response = {
-  rawHeaders?:
-    | {
-        [key: string]: (string | string[]) | undefined
-      }
-    | undefined
-  typedHeaders?:
-    | {
-        [key: string]: (string | string[]) | undefined
-      }
-    | undefined
+  rawHeaders?: unknown | undefined
+  typedHeaders?: unknown | undefined
 }
 
 export type t_getHeadersUndeclaredJson200Response = {
-  rawHeaders?:
-    | {
-        [key: string]: (string | string[]) | undefined
-      }
-    | undefined
-  typedHeaders?:
-    | {
-        [key: string]: (string | string[]) | undefined
-      }
-    | undefined
+  rawHeaders?: unknown | undefined
+  typedHeaders?: unknown | undefined
 }
 
 export type t_GetValidationNumbersRandomNumberQuerySchema = {

--- a/e2e/src/generated/models.ts
+++ b/e2e/src/generated/models.ts
@@ -13,8 +13,18 @@ export type t_RandomNumber = {
   result?: number | undefined
 }
 
+export type t_GetHeadersRequestHeaderSchema = {
+  authorization?: string | undefined
+  "route-level-header"?: string | undefined
+}
+
 export type t_getHeadersRequestJson200Response = {
-  headers?:
+  rawHeaders?:
+    | {
+        [key: string]: (string | string[]) | undefined
+      }
+    | undefined
+  typedHeaders?:
     | {
         [key: string]: (string | string[]) | undefined
       }
@@ -22,7 +32,12 @@ export type t_getHeadersRequestJson200Response = {
 }
 
 export type t_getHeadersUndeclaredJson200Response = {
-  headers?:
+  rawHeaders?:
+    | {
+        [key: string]: (string | string[]) | undefined
+      }
+    | undefined
+  typedHeaders?:
     | {
         [key: string]: (string | string[]) | undefined
       }

--- a/e2e/src/generated/routes/headers.ts
+++ b/e2e/src/generated/routes/headers.ts
@@ -107,6 +107,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const getHeadersRequestHeaderSchema = z.object({
     "route-level-header": z.string().optional(),
+    "number-header": z.coerce.number().optional(),
     authorization: z.string().optional(),
   })
 

--- a/e2e/src/generated/routes/headers.ts
+++ b/e2e/src/generated/routes/headers.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import {
+  t_GetHeadersRequestHeaderSchema,
   t_getHeadersRequestJson200Response,
   t_getHeadersUndeclaredJson200Response,
 } from "../models"
@@ -11,7 +12,10 @@ import {
   s_getHeadersUndeclaredJson200Response,
 } from "../schemas"
 import KoaRouter, { RouterContext } from "@koa/router"
-import { KoaRuntimeError } from "@nahkies/typescript-koa-runtime/errors"
+import {
+  KoaRuntimeError,
+  RequestInputType,
+} from "@nahkies/typescript-koa-runtime/errors"
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
@@ -20,15 +24,17 @@ import {
 } from "@nahkies/typescript-koa-runtime/server"
 import {
   Params,
+  parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
+import { z } from "zod"
 
 export type GetHeadersUndeclaredResponder = {
   with200(): KoaRuntimeResponse<t_getHeadersUndeclaredJson200Response>
 } & KoaRuntimeResponder
 
 export type GetHeadersUndeclared = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: GetHeadersUndeclaredResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -41,7 +47,7 @@ export type GetHeadersRequestResponder = {
 } & KoaRuntimeResponder
 
 export type GetHeadersRequest = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, t_GetHeadersRequestHeaderSchema>,
   respond: GetHeadersRequestResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -70,6 +76,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -98,6 +105,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
+  const getHeadersRequestHeaderSchema = z.object({
+    "route-level-header": z.string().optional(),
+    authorization: z.string().optional(),
+  })
+
   const getHeadersRequestResponseValidator = responseValidationFactory(
     [["200", s_getHeadersRequestJson200Response]],
     undefined,
@@ -108,6 +120,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: parseRequestInput(
+        getHeadersRequestHeaderSchema,
+        Reflect.get(ctx.request, "headers"),
+        RequestInputType.RequestHeader,
+      ),
     }
 
     const responder = {

--- a/e2e/src/generated/routes/validation.ts
+++ b/e2e/src/generated/routes/validation.ts
@@ -30,7 +30,12 @@ export type GetValidationNumbersRandomNumberResponder = {
 } & KoaRuntimeResponder
 
 export type GetValidationNumbersRandomNumber = (
-  params: Params<void, t_GetValidationNumbersRandomNumberQuerySchema, void>,
+  params: Params<
+    void,
+    t_GetValidationNumbersRandomNumberQuerySchema,
+    void,
+    void
+  >,
   respond: GetValidationNumbersRandomNumberResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_RandomNumber>>
@@ -68,6 +73,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {

--- a/e2e/src/generated/schemas.ts
+++ b/e2e/src/generated/schemas.ts
@@ -16,11 +16,11 @@ export const s_RandomNumber = z.object({
 })
 
 export const s_getHeadersUndeclaredJson200Response = z.object({
-  rawHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
-  typedHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  rawHeaders: z.unknown().optional(),
+  typedHeaders: z.unknown().optional(),
 })
 
 export const s_getHeadersRequestJson200Response = z.object({
-  rawHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
-  typedHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  rawHeaders: z.unknown().optional(),
+  typedHeaders: z.unknown().optional(),
 })

--- a/e2e/src/generated/schemas.ts
+++ b/e2e/src/generated/schemas.ts
@@ -16,9 +16,11 @@ export const s_RandomNumber = z.object({
 })
 
 export const s_getHeadersUndeclaredJson200Response = z.object({
-  headers: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  rawHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  typedHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
 })
 
 export const s_getHeadersRequestJson200Response = z.object({
-  headers: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  rawHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  typedHeaders: z.record(z.union([z.string(), z.array(z.string())])).optional(),
 })

--- a/e2e/src/index.fetch.spec.ts
+++ b/e2e/src/index.fetch.spec.ts
@@ -157,6 +157,24 @@ describe("e2e - typescript-fetch client", () => {
         }),
       })
     })
+
+    it("rejects headers of the wrong type", async () => {
+      const res = await client.getHeadersRequest(
+        // @ts-expect-error testing validation
+        {numberHeader: "i'm not a number"},
+      )
+
+      expect(res.status).toBe(400)
+
+      const body = await res.json()
+
+      expect(body).toEqual({
+        cause: {
+          message: "Request validation failed parsing request header",
+        },
+        message: "Request validation failed parsing request header",
+      })
+    })
   })
 
   describe("GET /validation/numbers/random-number", () => {

--- a/e2e/src/index.fetch.spec.ts
+++ b/e2e/src/index.fetch.spec.ts
@@ -32,7 +32,8 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: undefined,
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer default-header",
         }),
       })
@@ -47,7 +48,8 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: undefined,
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer default-header",
           "some-random-header": "arbitrary-header",
         }),
@@ -64,7 +66,10 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: {
+          authorization: "Bearer default-header",
+        },
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer default-header",
         }),
       })
@@ -80,7 +85,11 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: {
+          authorization: "Bearer default-header",
+          "route-level-header": "route-header",
+        },
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer default-header",
           "route-level-header": "route-header",
         }),
@@ -97,7 +106,10 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: {
+          authorization: "Bearer override",
+        },
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer override",
         }),
       })
@@ -113,7 +125,10 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: {
+          authorization: "Bearer config",
+        },
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer config",
         }),
       })
@@ -131,29 +146,14 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        headers: expect.objectContaining({
+        typedHeaders: {
+          authorization: "Bearer default-header",
+          "route-level-header": "route-header",
+        },
+        rawHeaders: expect.objectContaining({
           authorization: "Bearer default-header",
           "route-level-header": "route-header",
           "some-random-header": "arbitrary-header",
-        }),
-      })
-    })
-
-    it("provides route level header with default headers, and arbitrary extra headers", async () => {
-      const res = await client.getHeadersRequest(
-        {routeLevelHeader: "route-header"},
-        undefined,
-        {headers: {authorization: "Bearer override"}},
-      )
-
-      expect(res.status).toBe(200)
-
-      const body = await res.json()
-
-      expect(body).toEqual({
-        headers: expect.objectContaining({
-          authorization: "Bearer override",
-          "route-level-header": "route-header",
         }),
       })
     })

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -1,10 +1,29 @@
 import Router from "@koa/router"
+import {KoaRuntimeError} from "@nahkies/typescript-koa-runtime/errors"
 import {bootstrap} from "./generated"
 import {createHeadersRouter} from "./routes/headers"
 import {createValidationRouter} from "./routes/validation"
 
 function createRouter() {
   const router = new Router()
+
+  router.use(async (ctx, next) => {
+    try {
+      await next()
+    } catch (err) {
+      if (KoaRuntimeError.isKoaError(err)) {
+        ctx.status = 400
+        ctx.body = {
+          message: err.message,
+          cause: {
+            message: err.message,
+          },
+        }
+      } else {
+        throw err
+      }
+    }
+  })
 
   const headersRouter = createHeadersRouter()
   const validationRouter = createValidationRouter()

--- a/e2e/src/routes/headers.ts
+++ b/e2e/src/routes/headers.ts
@@ -9,12 +9,9 @@ const getHeadersUndeclared: GetHeadersUndeclared = async (
   respond,
   ctx,
 ) => {
-  return (
-    respond
-      .with200()
-      // biome-ignore lint/suspicious/noExplicitAny: passing through headers to prove none were parsed
-      .body({typedHeaders: headers as unknown as any, rawHeaders: ctx.headers})
-  )
+  return respond
+    .with200()
+    .body({typedHeaders: headers, rawHeaders: ctx.headers})
 }
 
 const getHeadersRequest: GetHeadersRequest = async (

--- a/e2e/src/routes/headers.ts
+++ b/e2e/src/routes/headers.ts
@@ -1,12 +1,35 @@
-import {type GetHeadersRequest, createRouter} from "../generated/routes/headers"
+import {
+  type GetHeadersRequest,
+  type GetHeadersUndeclared,
+  createRouter,
+} from "../generated/routes/headers"
 
-const getHeadersRequest: GetHeadersRequest = async (_, respond, ctx) => {
-  return respond.with200().body({headers: ctx.headers})
+const getHeadersUndeclared: GetHeadersUndeclared = async (
+  {headers},
+  respond,
+  ctx,
+) => {
+  return (
+    respond
+      .with200()
+      // biome-ignore lint/suspicious/noExplicitAny: passing through headers to prove none were parsed
+      .body({typedHeaders: headers as unknown as any, rawHeaders: ctx.headers})
+  )
+}
+
+const getHeadersRequest: GetHeadersRequest = async (
+  {headers},
+  respond,
+  ctx,
+) => {
+  return respond
+    .with200()
+    .body({typedHeaders: headers, rawHeaders: ctx.headers})
 }
 
 export function createHeadersRouter() {
   return createRouter({
-    getHeadersUndeclared: getHeadersRequest,
+    getHeadersUndeclared,
     getHeadersRequest,
   })
 }

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -1982,7 +1982,7 @@ export type MetaRootResponder = {
 } & KoaRuntimeResponder
 
 export type MetaRoot = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: MetaRootResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_root>>
@@ -1997,6 +1997,7 @@ export type SecurityAdvisoriesListGlobalAdvisories = (
   params: Params<
     void,
     t_SecurityAdvisoriesListGlobalAdvisoriesQuerySchema,
+    void,
     void
   >,
   respond: SecurityAdvisoriesListGlobalAdvisoriesResponder,
@@ -2014,7 +2015,12 @@ export type SecurityAdvisoriesGetGlobalAdvisoryResponder = {
 } & KoaRuntimeResponder
 
 export type SecurityAdvisoriesGetGlobalAdvisory = (
-  params: Params<t_SecurityAdvisoriesGetGlobalAdvisoryParamSchema, void, void>,
+  params: Params<
+    t_SecurityAdvisoriesGetGlobalAdvisoryParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: SecurityAdvisoriesGetGlobalAdvisoryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2028,7 +2034,7 @@ export type AppsGetAuthenticatedResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetAuthenticated = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: AppsGetAuthenticatedResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_integration>>
@@ -2048,7 +2054,7 @@ export type AppsCreateFromManifestResponder = {
 } & KoaRuntimeResponder
 
 export type AppsCreateFromManifest = (
-  params: Params<t_AppsCreateFromManifestParamSchema, void, void>,
+  params: Params<t_AppsCreateFromManifestParamSchema, void, void, void>,
   respond: AppsCreateFromManifestResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2072,7 +2078,7 @@ export type AppsGetWebhookConfigForAppResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetWebhookConfigForApp = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: AppsGetWebhookConfigForAppResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_webhook_config>>
@@ -2082,7 +2088,7 @@ export type AppsUpdateWebhookConfigForAppResponder = {
 } & KoaRuntimeResponder
 
 export type AppsUpdateWebhookConfigForApp = (
-  params: Params<void, void, t_AppsUpdateWebhookConfigForAppBodySchema>,
+  params: Params<void, void, t_AppsUpdateWebhookConfigForAppBodySchema, void>,
   respond: AppsUpdateWebhookConfigForAppResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_webhook_config>>
@@ -2094,7 +2100,7 @@ export type AppsListWebhookDeliveriesResponder = {
 } & KoaRuntimeResponder
 
 export type AppsListWebhookDeliveries = (
-  params: Params<void, t_AppsListWebhookDeliveriesQuerySchema, void>,
+  params: Params<void, t_AppsListWebhookDeliveriesQuerySchema, void, void>,
   respond: AppsListWebhookDeliveriesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2111,7 +2117,7 @@ export type AppsGetWebhookDeliveryResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetWebhookDelivery = (
-  params: Params<t_AppsGetWebhookDeliveryParamSchema, void, void>,
+  params: Params<t_AppsGetWebhookDeliveryParamSchema, void, void, void>,
   respond: AppsGetWebhookDeliveryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2130,7 +2136,7 @@ export type AppsRedeliverWebhookDeliveryResponder = {
 } & KoaRuntimeResponder
 
 export type AppsRedeliverWebhookDelivery = (
-  params: Params<t_AppsRedeliverWebhookDeliveryParamSchema, void, void>,
+  params: Params<t_AppsRedeliverWebhookDeliveryParamSchema, void, void, void>,
   respond: AppsRedeliverWebhookDeliveryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2155,6 +2161,7 @@ export type AppsListInstallationRequestsForAuthenticatedApp = (
   params: Params<
     void,
     t_AppsListInstallationRequestsForAuthenticatedAppQuerySchema,
+    void,
     void
   >,
   respond: AppsListInstallationRequestsForAuthenticatedAppResponder,
@@ -2171,7 +2178,7 @@ export type AppsListInstallationsResponder = {
 } & KoaRuntimeResponder
 
 export type AppsListInstallations = (
-  params: Params<void, t_AppsListInstallationsQuerySchema, void>,
+  params: Params<void, t_AppsListInstallationsQuerySchema, void, void>,
   respond: AppsListInstallationsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_installation[]>>
@@ -2182,7 +2189,7 @@ export type AppsGetInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetInstallation = (
-  params: Params<t_AppsGetInstallationParamSchema, void, void>,
+  params: Params<t_AppsGetInstallationParamSchema, void, void, void>,
   respond: AppsGetInstallationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2197,7 +2204,7 @@ export type AppsDeleteInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsDeleteInstallation = (
-  params: Params<t_AppsDeleteInstallationParamSchema, void, void>,
+  params: Params<t_AppsDeleteInstallationParamSchema, void, void, void>,
   respond: AppsDeleteInstallationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2218,7 +2225,8 @@ export type AppsCreateInstallationAccessToken = (
   params: Params<
     t_AppsCreateInstallationAccessTokenParamSchema,
     void,
-    t_AppsCreateInstallationAccessTokenBodySchema | undefined
+    t_AppsCreateInstallationAccessTokenBodySchema | undefined,
+    void
   >,
   respond: AppsCreateInstallationAccessTokenResponder,
   ctx: RouterContext,
@@ -2237,7 +2245,7 @@ export type AppsSuspendInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsSuspendInstallation = (
-  params: Params<t_AppsSuspendInstallationParamSchema, void, void>,
+  params: Params<t_AppsSuspendInstallationParamSchema, void, void, void>,
   respond: AppsSuspendInstallationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2252,7 +2260,7 @@ export type AppsUnsuspendInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsUnsuspendInstallation = (
-  params: Params<t_AppsUnsuspendInstallationParamSchema, void, void>,
+  params: Params<t_AppsUnsuspendInstallationParamSchema, void, void, void>,
   respond: AppsUnsuspendInstallationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2270,7 +2278,8 @@ export type AppsDeleteAuthorization = (
   params: Params<
     t_AppsDeleteAuthorizationParamSchema,
     void,
-    t_AppsDeleteAuthorizationBodySchema
+    t_AppsDeleteAuthorizationBodySchema,
+    void
   >,
   respond: AppsDeleteAuthorizationResponder,
   ctx: RouterContext,
@@ -2287,7 +2296,12 @@ export type AppsCheckTokenResponder = {
 } & KoaRuntimeResponder
 
 export type AppsCheckToken = (
-  params: Params<t_AppsCheckTokenParamSchema, void, t_AppsCheckTokenBodySchema>,
+  params: Params<
+    t_AppsCheckTokenParamSchema,
+    void,
+    t_AppsCheckTokenBodySchema,
+    void
+  >,
   respond: AppsCheckTokenResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2303,7 +2317,12 @@ export type AppsResetTokenResponder = {
 } & KoaRuntimeResponder
 
 export type AppsResetToken = (
-  params: Params<t_AppsResetTokenParamSchema, void, t_AppsResetTokenBodySchema>,
+  params: Params<
+    t_AppsResetTokenParamSchema,
+    void,
+    t_AppsResetTokenBodySchema,
+    void
+  >,
   respond: AppsResetTokenResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2321,7 +2340,8 @@ export type AppsDeleteToken = (
   params: Params<
     t_AppsDeleteTokenParamSchema,
     void,
-    t_AppsDeleteTokenBodySchema
+    t_AppsDeleteTokenBodySchema,
+    void
   >,
   respond: AppsDeleteTokenResponder,
   ctx: RouterContext,
@@ -2340,7 +2360,12 @@ export type AppsScopeTokenResponder = {
 } & KoaRuntimeResponder
 
 export type AppsScopeToken = (
-  params: Params<t_AppsScopeTokenParamSchema, void, t_AppsScopeTokenBodySchema>,
+  params: Params<
+    t_AppsScopeTokenParamSchema,
+    void,
+    t_AppsScopeTokenBodySchema,
+    void
+  >,
   respond: AppsScopeTokenResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2359,7 +2384,7 @@ export type AppsGetBySlugResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetBySlug = (
-  params: Params<t_AppsGetBySlugParamSchema, void, void>,
+  params: Params<t_AppsGetBySlugParamSchema, void, void, void>,
   respond: AppsGetBySlugResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2375,7 +2400,7 @@ export type ClassroomGetAnAssignmentResponder = {
 } & KoaRuntimeResponder
 
 export type ClassroomGetAnAssignment = (
-  params: Params<t_ClassroomGetAnAssignmentParamSchema, void, void>,
+  params: Params<t_ClassroomGetAnAssignmentParamSchema, void, void, void>,
   respond: ClassroomGetAnAssignmentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2392,6 +2417,7 @@ export type ClassroomListAcceptedAssigmentsForAnAssignment = (
   params: Params<
     t_ClassroomListAcceptedAssigmentsForAnAssignmentParamSchema,
     t_ClassroomListAcceptedAssigmentsForAnAssignmentQuerySchema,
+    void,
     void
   >,
   respond: ClassroomListAcceptedAssigmentsForAnAssignmentResponder,
@@ -2406,7 +2432,7 @@ export type ClassroomGetAssignmentGradesResponder = {
 } & KoaRuntimeResponder
 
 export type ClassroomGetAssignmentGrades = (
-  params: Params<t_ClassroomGetAssignmentGradesParamSchema, void, void>,
+  params: Params<t_ClassroomGetAssignmentGradesParamSchema, void, void, void>,
   respond: ClassroomGetAssignmentGradesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2420,7 +2446,7 @@ export type ClassroomListClassroomsResponder = {
 } & KoaRuntimeResponder
 
 export type ClassroomListClassrooms = (
-  params: Params<void, t_ClassroomListClassroomsQuerySchema, void>,
+  params: Params<void, t_ClassroomListClassroomsQuerySchema, void, void>,
   respond: ClassroomListClassroomsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_simple_classroom[]>>
@@ -2431,7 +2457,7 @@ export type ClassroomGetAClassroomResponder = {
 } & KoaRuntimeResponder
 
 export type ClassroomGetAClassroom = (
-  params: Params<t_ClassroomGetAClassroomParamSchema, void, void>,
+  params: Params<t_ClassroomGetAClassroomParamSchema, void, void, void>,
   respond: ClassroomGetAClassroomResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2448,6 +2474,7 @@ export type ClassroomListAssignmentsForAClassroom = (
   params: Params<
     t_ClassroomListAssignmentsForAClassroomParamSchema,
     t_ClassroomListAssignmentsForAClassroomQuerySchema,
+    void,
     void
   >,
   respond: ClassroomListAssignmentsForAClassroomResponder,
@@ -2462,7 +2489,7 @@ export type CodesOfConductGetAllCodesOfConductResponder = {
 } & KoaRuntimeResponder
 
 export type CodesOfConductGetAllCodesOfConduct = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: CodesOfConductGetAllCodesOfConductResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2478,7 +2505,7 @@ export type CodesOfConductGetConductCodeResponder = {
 } & KoaRuntimeResponder
 
 export type CodesOfConductGetConductCode = (
-  params: Params<t_CodesOfConductGetConductCodeParamSchema, void, void>,
+  params: Params<t_CodesOfConductGetConductCodeParamSchema, void, void, void>,
   respond: CodesOfConductGetConductCodeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2496,7 +2523,7 @@ export type EmojisGetResponder = {
 } & KoaRuntimeResponder
 
 export type EmojisGet = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: EmojisGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2525,6 +2552,7 @@ export type CopilotListCopilotSeatsForEnterprise = (
   params: Params<
     t_CopilotListCopilotSeatsForEnterpriseParamSchema,
     t_CopilotListCopilotSeatsForEnterpriseQuerySchema,
+    void,
     void
   >,
   respond: CopilotListCopilotSeatsForEnterpriseResponder,
@@ -2556,6 +2584,7 @@ export type CopilotUsageMetricsForEnterprise = (
   params: Params<
     t_CopilotUsageMetricsForEnterpriseParamSchema,
     t_CopilotUsageMetricsForEnterpriseQuerySchema,
+    void,
     void
   >,
   respond: CopilotUsageMetricsForEnterpriseResponder,
@@ -2581,6 +2610,7 @@ export type DependabotListAlertsForEnterprise = (
   params: Params<
     t_DependabotListAlertsForEnterpriseParamSchema,
     t_DependabotListAlertsForEnterpriseQuerySchema,
+    void,
     void
   >,
   respond: DependabotListAlertsForEnterpriseResponder,
@@ -2608,6 +2638,7 @@ export type SecretScanningListAlertsForEnterprise = (
   params: Params<
     t_SecretScanningListAlertsForEnterpriseParamSchema,
     t_SecretScanningListAlertsForEnterpriseQuerySchema,
+    void,
     void
   >,
   respond: SecretScanningListAlertsForEnterpriseResponder,
@@ -2638,6 +2669,7 @@ export type CopilotUsageMetricsForEnterpriseTeam = (
   params: Params<
     t_CopilotUsageMetricsForEnterpriseTeamParamSchema,
     t_CopilotUsageMetricsForEnterpriseTeamQuerySchema,
+    void,
     void
   >,
   respond: CopilotUsageMetricsForEnterpriseTeamResponder,
@@ -2663,7 +2695,7 @@ export type ActivityListPublicEventsResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityListPublicEvents = (
-  params: Params<void, t_ActivityListPublicEventsQuerySchema, void>,
+  params: Params<void, t_ActivityListPublicEventsQuerySchema, void, void>,
   respond: ActivityListPublicEventsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2686,7 +2718,7 @@ export type ActivityGetFeedsResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityGetFeeds = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: ActivityGetFeedsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_feed>>
@@ -2698,7 +2730,7 @@ export type GistsListResponder = {
 } & KoaRuntimeResponder
 
 export type GistsList = (
-  params: Params<void, t_GistsListQuerySchema, void>,
+  params: Params<void, t_GistsListQuerySchema, void, void>,
   respond: GistsListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2717,7 +2749,7 @@ export type GistsCreateResponder = {
 } & KoaRuntimeResponder
 
 export type GistsCreate = (
-  params: Params<void, void, t_GistsCreateBodySchema>,
+  params: Params<void, void, t_GistsCreateBodySchema, void>,
   respond: GistsCreateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2737,7 +2769,7 @@ export type GistsListPublicResponder = {
 } & KoaRuntimeResponder
 
 export type GistsListPublic = (
-  params: Params<void, t_GistsListPublicQuerySchema, void>,
+  params: Params<void, t_GistsListPublicQuerySchema, void, void>,
   respond: GistsListPublicResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2756,7 +2788,7 @@ export type GistsListStarredResponder = {
 } & KoaRuntimeResponder
 
 export type GistsListStarred = (
-  params: Params<void, t_GistsListStarredQuerySchema, void>,
+  params: Params<void, t_GistsListStarredQuerySchema, void, void>,
   respond: GistsListStarredResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2783,7 +2815,7 @@ export type GistsGetResponder = {
 } & KoaRuntimeResponder
 
 export type GistsGet = (
-  params: Params<t_GistsGetParamSchema, void, void>,
+  params: Params<t_GistsGetParamSchema, void, void, void>,
   respond: GistsGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2812,7 +2844,7 @@ export type GistsUpdateResponder = {
 } & KoaRuntimeResponder
 
 export type GistsUpdate = (
-  params: Params<t_GistsUpdateParamSchema, void, t_GistsUpdateBodySchema>,
+  params: Params<t_GistsUpdateParamSchema, void, t_GistsUpdateBodySchema, void>,
   respond: GistsUpdateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2830,7 +2862,7 @@ export type GistsDeleteResponder = {
 } & KoaRuntimeResponder
 
 export type GistsDelete = (
-  params: Params<t_GistsDeleteParamSchema, void, void>,
+  params: Params<t_GistsDeleteParamSchema, void, void, void>,
   respond: GistsDeleteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2852,6 +2884,7 @@ export type GistsListComments = (
   params: Params<
     t_GistsListCommentsParamSchema,
     t_GistsListCommentsQuerySchema,
+    void,
     void
   >,
   respond: GistsListCommentsResponder,
@@ -2875,7 +2908,8 @@ export type GistsCreateComment = (
   params: Params<
     t_GistsCreateCommentParamSchema,
     void,
-    t_GistsCreateCommentBodySchema
+    t_GistsCreateCommentBodySchema,
+    void
   >,
   respond: GistsCreateCommentResponder,
   ctx: RouterContext,
@@ -2903,7 +2937,7 @@ export type GistsGetCommentResponder = {
 } & KoaRuntimeResponder
 
 export type GistsGetComment = (
-  params: Params<t_GistsGetCommentParamSchema, void, void>,
+  params: Params<t_GistsGetCommentParamSchema, void, void, void>,
   respond: GistsGetCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2934,7 +2968,8 @@ export type GistsUpdateComment = (
   params: Params<
     t_GistsUpdateCommentParamSchema,
     void,
-    t_GistsUpdateCommentBodySchema
+    t_GistsUpdateCommentBodySchema,
+    void
   >,
   respond: GistsUpdateCommentResponder,
   ctx: RouterContext,
@@ -2952,7 +2987,7 @@ export type GistsDeleteCommentResponder = {
 } & KoaRuntimeResponder
 
 export type GistsDeleteComment = (
-  params: Params<t_GistsDeleteCommentParamSchema, void, void>,
+  params: Params<t_GistsDeleteCommentParamSchema, void, void, void>,
   respond: GistsDeleteCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2974,6 +3009,7 @@ export type GistsListCommits = (
   params: Params<
     t_GistsListCommitsParamSchema,
     t_GistsListCommitsQuerySchema,
+    void,
     void
   >,
   respond: GistsListCommitsResponder,
@@ -2997,6 +3033,7 @@ export type GistsListForks = (
   params: Params<
     t_GistsListForksParamSchema,
     t_GistsListForksQuerySchema,
+    void,
     void
   >,
   respond: GistsListForksResponder,
@@ -3018,7 +3055,7 @@ export type GistsForkResponder = {
 } & KoaRuntimeResponder
 
 export type GistsFork = (
-  params: Params<t_GistsForkParamSchema, void, void>,
+  params: Params<t_GistsForkParamSchema, void, void, void>,
   respond: GistsForkResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3038,7 +3075,7 @@ export type GistsCheckIsStarredResponder = {
 } & KoaRuntimeResponder
 
 export type GistsCheckIsStarred = (
-  params: Params<t_GistsCheckIsStarredParamSchema, void, void>,
+  params: Params<t_GistsCheckIsStarredParamSchema, void, void, void>,
   respond: GistsCheckIsStarredResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3057,7 +3094,7 @@ export type GistsStarResponder = {
 } & KoaRuntimeResponder
 
 export type GistsStar = (
-  params: Params<t_GistsStarParamSchema, void, void>,
+  params: Params<t_GistsStarParamSchema, void, void, void>,
   respond: GistsStarResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3076,7 +3113,7 @@ export type GistsUnstarResponder = {
 } & KoaRuntimeResponder
 
 export type GistsUnstar = (
-  params: Params<t_GistsUnstarParamSchema, void, void>,
+  params: Params<t_GistsUnstarParamSchema, void, void, void>,
   respond: GistsUnstarResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3095,7 +3132,7 @@ export type GistsGetRevisionResponder = {
 } & KoaRuntimeResponder
 
 export type GistsGetRevision = (
-  params: Params<t_GistsGetRevisionParamSchema, void, void>,
+  params: Params<t_GistsGetRevisionParamSchema, void, void, void>,
   respond: GistsGetRevisionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3112,7 +3149,7 @@ export type GitignoreGetAllTemplatesResponder = {
 } & KoaRuntimeResponder
 
 export type GitignoreGetAllTemplates = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: GitignoreGetAllTemplatesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3125,7 +3162,7 @@ export type GitignoreGetTemplateResponder = {
 } & KoaRuntimeResponder
 
 export type GitignoreGetTemplate = (
-  params: Params<t_GitignoreGetTemplateParamSchema, void, void>,
+  params: Params<t_GitignoreGetTemplateParamSchema, void, void, void>,
   respond: GitignoreGetTemplateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3149,6 +3186,7 @@ export type AppsListReposAccessibleToInstallation = (
   params: Params<
     void,
     t_AppsListReposAccessibleToInstallationQuerySchema,
+    void,
     void
   >,
   respond: AppsListReposAccessibleToInstallationResponder,
@@ -3173,7 +3211,7 @@ export type AppsRevokeInstallationAccessTokenResponder = {
 } & KoaRuntimeResponder
 
 export type AppsRevokeInstallationAccessToken = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: AppsRevokeInstallationAccessTokenResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -3186,7 +3224,7 @@ export type IssuesListResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesList = (
-  params: Params<void, t_IssuesListQuerySchema, void>,
+  params: Params<void, t_IssuesListQuerySchema, void, void>,
   respond: IssuesListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3203,7 +3241,7 @@ export type LicensesGetAllCommonlyUsedResponder = {
 } & KoaRuntimeResponder
 
 export type LicensesGetAllCommonlyUsed = (
-  params: Params<void, t_LicensesGetAllCommonlyUsedQuerySchema, void>,
+  params: Params<void, t_LicensesGetAllCommonlyUsedQuerySchema, void, void>,
   respond: LicensesGetAllCommonlyUsedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3220,7 +3258,7 @@ export type LicensesGetResponder = {
 } & KoaRuntimeResponder
 
 export type LicensesGet = (
-  params: Params<t_LicensesGetParamSchema, void, void>,
+  params: Params<t_LicensesGetParamSchema, void, void, void>,
   respond: LicensesGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3237,7 +3275,7 @@ export type MarkdownRenderResponder = {
 } & KoaRuntimeResponder
 
 export type MarkdownRender = (
-  params: Params<void, void, t_MarkdownRenderBodySchema>,
+  params: Params<void, void, t_MarkdownRenderBodySchema, void>,
   respond: MarkdownRenderResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3250,7 +3288,7 @@ export type MarkdownRenderRawResponder = {
 } & KoaRuntimeResponder
 
 export type MarkdownRenderRaw = (
-  params: Params<void, void, t_MarkdownRenderRawBodySchema | undefined>,
+  params: Params<void, void, t_MarkdownRenderRawBodySchema | undefined, void>,
   respond: MarkdownRenderRawResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3264,7 +3302,12 @@ export type AppsGetSubscriptionPlanForAccountResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetSubscriptionPlanForAccount = (
-  params: Params<t_AppsGetSubscriptionPlanForAccountParamSchema, void, void>,
+  params: Params<
+    t_AppsGetSubscriptionPlanForAccountParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: AppsGetSubscriptionPlanForAccountResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3281,7 +3324,7 @@ export type AppsListPlansResponder = {
 } & KoaRuntimeResponder
 
 export type AppsListPlans = (
-  params: Params<void, t_AppsListPlansQuerySchema, void>,
+  params: Params<void, t_AppsListPlansQuerySchema, void, void>,
   respond: AppsListPlansResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3302,6 +3345,7 @@ export type AppsListAccountsForPlan = (
   params: Params<
     t_AppsListAccountsForPlanParamSchema,
     t_AppsListAccountsForPlanQuerySchema,
+    void,
     void
   >,
   respond: AppsListAccountsForPlanResponder,
@@ -3324,6 +3368,7 @@ export type AppsGetSubscriptionPlanForAccountStubbed = (
   params: Params<
     t_AppsGetSubscriptionPlanForAccountStubbedParamSchema,
     void,
+    void,
     void
   >,
   respond: AppsGetSubscriptionPlanForAccountStubbedResponder,
@@ -3341,7 +3386,7 @@ export type AppsListPlansStubbedResponder = {
 } & KoaRuntimeResponder
 
 export type AppsListPlansStubbed = (
-  params: Params<void, t_AppsListPlansStubbedQuerySchema, void>,
+  params: Params<void, t_AppsListPlansStubbedQuerySchema, void, void>,
   respond: AppsListPlansStubbedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3359,6 +3404,7 @@ export type AppsListAccountsForPlanStubbed = (
   params: Params<
     t_AppsListAccountsForPlanStubbedParamSchema,
     t_AppsListAccountsForPlanStubbedQuerySchema,
+    void,
     void
   >,
   respond: AppsListAccountsForPlanStubbedResponder,
@@ -3375,7 +3421,7 @@ export type MetaGetResponder = {
 } & KoaRuntimeResponder
 
 export type MetaGet = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: MetaGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3396,6 +3442,7 @@ export type ActivityListPublicEventsForRepoNetwork = (
   params: Params<
     t_ActivityListPublicEventsForRepoNetworkParamSchema,
     t_ActivityListPublicEventsForRepoNetworkQuerySchema,
+    void,
     void
   >,
   respond: ActivityListPublicEventsForRepoNetworkResponder,
@@ -3421,6 +3468,7 @@ export type ActivityListNotificationsForAuthenticatedUser = (
   params: Params<
     void,
     t_ActivityListNotificationsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListNotificationsForAuthenticatedUserResponder,
@@ -3448,7 +3496,8 @@ export type ActivityMarkNotificationsAsRead = (
   params: Params<
     void,
     void,
-    t_ActivityMarkNotificationsAsReadBodySchema | undefined
+    t_ActivityMarkNotificationsAsReadBodySchema | undefined,
+    void
   >,
   respond: ActivityMarkNotificationsAsReadResponder,
   ctx: RouterContext,
@@ -3474,7 +3523,7 @@ export type ActivityGetThreadResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityGetThread = (
-  params: Params<t_ActivityGetThreadParamSchema, void, void>,
+  params: Params<t_ActivityGetThreadParamSchema, void, void, void>,
   respond: ActivityGetThreadResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3492,7 +3541,7 @@ export type ActivityMarkThreadAsReadResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityMarkThreadAsRead = (
-  params: Params<t_ActivityMarkThreadAsReadParamSchema, void, void>,
+  params: Params<t_ActivityMarkThreadAsReadParamSchema, void, void, void>,
   respond: ActivityMarkThreadAsReadResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3507,7 +3556,7 @@ export type ActivityMarkThreadAsDoneResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityMarkThreadAsDone = (
-  params: Params<t_ActivityMarkThreadAsDoneParamSchema, void, void>,
+  params: Params<t_ActivityMarkThreadAsDoneParamSchema, void, void, void>,
   respond: ActivityMarkThreadAsDoneResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -3522,6 +3571,7 @@ export type ActivityGetThreadSubscriptionForAuthenticatedUserResponder = {
 export type ActivityGetThreadSubscriptionForAuthenticatedUser = (
   params: Params<
     t_ActivityGetThreadSubscriptionForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -3546,7 +3596,8 @@ export type ActivitySetThreadSubscription = (
   params: Params<
     t_ActivitySetThreadSubscriptionParamSchema,
     void,
-    t_ActivitySetThreadSubscriptionBodySchema | undefined
+    t_ActivitySetThreadSubscriptionBodySchema | undefined,
+    void
   >,
   respond: ActivitySetThreadSubscriptionResponder,
   ctx: RouterContext,
@@ -3566,7 +3617,12 @@ export type ActivityDeleteThreadSubscriptionResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityDeleteThreadSubscription = (
-  params: Params<t_ActivityDeleteThreadSubscriptionParamSchema, void, void>,
+  params: Params<
+    t_ActivityDeleteThreadSubscriptionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActivityDeleteThreadSubscriptionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3582,7 +3638,7 @@ export type MetaGetOctocatResponder = {
 } & KoaRuntimeResponder
 
 export type MetaGetOctocat = (
-  params: Params<void, t_MetaGetOctocatQuerySchema, void>,
+  params: Params<void, t_MetaGetOctocatQuerySchema, void, void>,
   respond: MetaGetOctocatResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, string>>
@@ -3593,7 +3649,7 @@ export type OrgsListResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsList = (
-  params: Params<void, t_OrgsListQuerySchema, void>,
+  params: Params<void, t_OrgsListQuerySchema, void, void>,
   respond: OrgsListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3608,7 +3664,7 @@ export type OrgsGetResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGet = (
-  params: Params<t_OrgsGetParamSchema, void, void>,
+  params: Params<t_OrgsGetParamSchema, void, void, void>,
   respond: OrgsGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3627,7 +3683,8 @@ export type OrgsUpdate = (
   params: Params<
     t_OrgsUpdateParamSchema,
     void,
-    t_OrgsUpdateBodySchema | undefined
+    t_OrgsUpdateBodySchema | undefined,
+    void
   >,
   respond: OrgsUpdateResponder,
   ctx: RouterContext,
@@ -3647,7 +3704,7 @@ export type OrgsDeleteResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsDelete = (
-  params: Params<t_OrgsDeleteParamSchema, void, void>,
+  params: Params<t_OrgsDeleteParamSchema, void, void, void>,
   respond: OrgsDeleteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3667,7 +3724,12 @@ export type ActionsGetActionsCacheUsageForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetActionsCacheUsageForOrg = (
-  params: Params<t_ActionsGetActionsCacheUsageForOrgParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetActionsCacheUsageForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetActionsCacheUsageForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3686,6 +3748,7 @@ export type ActionsGetActionsCacheUsageByRepoForOrg = (
   params: Params<
     t_ActionsGetActionsCacheUsageByRepoForOrgParamSchema,
     t_ActionsGetActionsCacheUsageByRepoForOrgQuerySchema,
+    void,
     void
   >,
   respond: ActionsGetActionsCacheUsageByRepoForOrgResponder,
@@ -3706,7 +3769,12 @@ export type OidcGetOidcCustomSubTemplateForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type OidcGetOidcCustomSubTemplateForOrg = (
-  params: Params<t_OidcGetOidcCustomSubTemplateForOrgParamSchema, void, void>,
+  params: Params<
+    t_OidcGetOidcCustomSubTemplateForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: OidcGetOidcCustomSubTemplateForOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_oidc_custom_sub>>
@@ -3721,7 +3789,8 @@ export type OidcUpdateOidcCustomSubTemplateForOrg = (
   params: Params<
     t_OidcUpdateOidcCustomSubTemplateForOrgParamSchema,
     void,
-    t_OidcUpdateOidcCustomSubTemplateForOrgBodySchema
+    t_OidcUpdateOidcCustomSubTemplateForOrgBodySchema,
+    void
   >,
   respond: OidcUpdateOidcCustomSubTemplateForOrgResponder,
   ctx: RouterContext,
@@ -3740,6 +3809,7 @@ export type ActionsGetGithubActionsPermissionsOrganization = (
   params: Params<
     t_ActionsGetGithubActionsPermissionsOrganizationParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsGetGithubActionsPermissionsOrganizationResponder,
@@ -3757,7 +3827,8 @@ export type ActionsSetGithubActionsPermissionsOrganization = (
   params: Params<
     t_ActionsSetGithubActionsPermissionsOrganizationParamSchema,
     void,
-    t_ActionsSetGithubActionsPermissionsOrganizationBodySchema
+    t_ActionsSetGithubActionsPermissionsOrganizationBodySchema,
+    void
   >,
   respond: ActionsSetGithubActionsPermissionsOrganizationResponder,
   ctx: RouterContext,
@@ -3775,6 +3846,7 @@ export type ActionsListSelectedRepositoriesEnabledGithubActionsOrganization = (
   params: Params<
     t_ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema,
     t_ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationQuerySchema,
+    void,
     void
   >,
   respond: ActionsListSelectedRepositoriesEnabledGithubActionsOrganizationResponder,
@@ -3799,7 +3871,8 @@ export type ActionsSetSelectedRepositoriesEnabledGithubActionsOrganization = (
   params: Params<
     t_ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema,
     void,
-    t_ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationBodySchema
+    t_ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationBodySchema,
+    void
   >,
   respond: ActionsSetSelectedRepositoriesEnabledGithubActionsOrganizationResponder,
   ctx: RouterContext,
@@ -3813,6 +3886,7 @@ export type ActionsEnableSelectedRepositoryGithubActionsOrganizationResponder =
 export type ActionsEnableSelectedRepositoryGithubActionsOrganization = (
   params: Params<
     t_ActionsEnableSelectedRepositoryGithubActionsOrganizationParamSchema,
+    void,
     void,
     void
   >,
@@ -3829,6 +3903,7 @@ export type ActionsDisableSelectedRepositoryGithubActionsOrganization = (
   params: Params<
     t_ActionsDisableSelectedRepositoryGithubActionsOrganizationParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsDisableSelectedRepositoryGithubActionsOrganizationResponder,
@@ -3840,7 +3915,12 @@ export type ActionsGetAllowedActionsOrganizationResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetAllowedActionsOrganization = (
-  params: Params<t_ActionsGetAllowedActionsOrganizationParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetAllowedActionsOrganizationParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetAllowedActionsOrganizationResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_selected_actions>>
@@ -3853,7 +3933,8 @@ export type ActionsSetAllowedActionsOrganization = (
   params: Params<
     t_ActionsSetAllowedActionsOrganizationParamSchema,
     void,
-    t_ActionsSetAllowedActionsOrganizationBodySchema | undefined
+    t_ActionsSetAllowedActionsOrganizationBodySchema | undefined,
+    void
   >,
   respond: ActionsSetAllowedActionsOrganizationResponder,
   ctx: RouterContext,
@@ -3867,6 +3948,7 @@ export type ActionsGetGithubActionsDefaultWorkflowPermissionsOrganizationRespond
 export type ActionsGetGithubActionsDefaultWorkflowPermissionsOrganization = (
   params: Params<
     t_ActionsGetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema,
+    void,
     void,
     void
   >,
@@ -3887,7 +3969,8 @@ export type ActionsSetGithubActionsDefaultWorkflowPermissionsOrganization = (
     t_ActionsSetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema,
     void,
     | t_ActionsSetGithubActionsDefaultWorkflowPermissionsOrganizationBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: ActionsSetGithubActionsDefaultWorkflowPermissionsOrganizationResponder,
   ctx: RouterContext,
@@ -3904,6 +3987,7 @@ export type ActionsListSelfHostedRunnersForOrg = (
   params: Params<
     t_ActionsListSelfHostedRunnersForOrgParamSchema,
     t_ActionsListSelfHostedRunnersForOrgQuerySchema,
+    void,
     void
   >,
   respond: ActionsListSelfHostedRunnersForOrgResponder,
@@ -3924,7 +4008,12 @@ export type ActionsListRunnerApplicationsForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsListRunnerApplicationsForOrg = (
-  params: Params<t_ActionsListRunnerApplicationsForOrgParamSchema, void, void>,
+  params: Params<
+    t_ActionsListRunnerApplicationsForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsListRunnerApplicationsForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3944,7 +4033,8 @@ export type ActionsGenerateRunnerJitconfigForOrg = (
   params: Params<
     t_ActionsGenerateRunnerJitconfigForOrgParamSchema,
     void,
-    t_ActionsGenerateRunnerJitconfigForOrgBodySchema
+    t_ActionsGenerateRunnerJitconfigForOrgBodySchema,
+    void
   >,
   respond: ActionsGenerateRunnerJitconfigForOrgResponder,
   ctx: RouterContext,
@@ -3966,7 +4056,12 @@ export type ActionsCreateRegistrationTokenForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsCreateRegistrationTokenForOrg = (
-  params: Params<t_ActionsCreateRegistrationTokenForOrgParamSchema, void, void>,
+  params: Params<
+    t_ActionsCreateRegistrationTokenForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsCreateRegistrationTokenForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3978,7 +4073,7 @@ export type ActionsCreateRemoveTokenForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsCreateRemoveTokenForOrg = (
-  params: Params<t_ActionsCreateRemoveTokenForOrgParamSchema, void, void>,
+  params: Params<t_ActionsCreateRemoveTokenForOrgParamSchema, void, void, void>,
   respond: ActionsCreateRemoveTokenForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3990,7 +4085,12 @@ export type ActionsGetSelfHostedRunnerForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetSelfHostedRunnerForOrg = (
-  params: Params<t_ActionsGetSelfHostedRunnerForOrgParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetSelfHostedRunnerForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetSelfHostedRunnerForOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_runner>>
@@ -4000,7 +4100,12 @@ export type ActionsDeleteSelfHostedRunnerFromOrgResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteSelfHostedRunnerFromOrg = (
-  params: Params<t_ActionsDeleteSelfHostedRunnerFromOrgParamSchema, void, void>,
+  params: Params<
+    t_ActionsDeleteSelfHostedRunnerFromOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsDeleteSelfHostedRunnerFromOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -4016,6 +4121,7 @@ export type ActionsListLabelsForSelfHostedRunnerForOrgResponder = {
 export type ActionsListLabelsForSelfHostedRunnerForOrg = (
   params: Params<
     t_ActionsListLabelsForSelfHostedRunnerForOrgParamSchema,
+    void,
     void,
     void
   >,
@@ -4046,7 +4152,8 @@ export type ActionsAddCustomLabelsToSelfHostedRunnerForOrg = (
   params: Params<
     t_ActionsAddCustomLabelsToSelfHostedRunnerForOrgParamSchema,
     void,
-    t_ActionsAddCustomLabelsToSelfHostedRunnerForOrgBodySchema
+    t_ActionsAddCustomLabelsToSelfHostedRunnerForOrgBodySchema,
+    void
   >,
   respond: ActionsAddCustomLabelsToSelfHostedRunnerForOrgResponder,
   ctx: RouterContext,
@@ -4076,7 +4183,8 @@ export type ActionsSetCustomLabelsForSelfHostedRunnerForOrg = (
   params: Params<
     t_ActionsSetCustomLabelsForSelfHostedRunnerForOrgParamSchema,
     void,
-    t_ActionsSetCustomLabelsForSelfHostedRunnerForOrgBodySchema
+    t_ActionsSetCustomLabelsForSelfHostedRunnerForOrgBodySchema,
+    void
   >,
   respond: ActionsSetCustomLabelsForSelfHostedRunnerForOrgResponder,
   ctx: RouterContext,
@@ -4104,6 +4212,7 @@ export type ActionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgResponder = {
 export type ActionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrg = (
   params: Params<
     t_ActionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgParamSchema,
+    void,
     void,
     void
   >,
@@ -4134,6 +4243,7 @@ export type ActionsRemoveCustomLabelFromSelfHostedRunnerForOrg = (
   params: Params<
     t_ActionsRemoveCustomLabelFromSelfHostedRunnerForOrgParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsRemoveCustomLabelFromSelfHostedRunnerForOrgResponder,
@@ -4162,6 +4272,7 @@ export type ActionsListOrgSecrets = (
   params: Params<
     t_ActionsListOrgSecretsParamSchema,
     t_ActionsListOrgSecretsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListOrgSecretsResponder,
@@ -4182,7 +4293,7 @@ export type ActionsGetOrgPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetOrgPublicKey = (
-  params: Params<t_ActionsGetOrgPublicKeyParamSchema, void, void>,
+  params: Params<t_ActionsGetOrgPublicKeyParamSchema, void, void, void>,
   respond: ActionsGetOrgPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_public_key>>
@@ -4192,7 +4303,7 @@ export type ActionsGetOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetOrgSecret = (
-  params: Params<t_ActionsGetOrgSecretParamSchema, void, void>,
+  params: Params<t_ActionsGetOrgSecretParamSchema, void, void, void>,
   respond: ActionsGetOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4208,7 +4319,8 @@ export type ActionsCreateOrUpdateOrgSecret = (
   params: Params<
     t_ActionsCreateOrUpdateOrgSecretParamSchema,
     void,
-    t_ActionsCreateOrUpdateOrgSecretBodySchema
+    t_ActionsCreateOrUpdateOrgSecretBodySchema,
+    void
   >,
   respond: ActionsCreateOrUpdateOrgSecretResponder,
   ctx: RouterContext,
@@ -4223,7 +4335,7 @@ export type ActionsDeleteOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteOrgSecret = (
-  params: Params<t_ActionsDeleteOrgSecretParamSchema, void, void>,
+  params: Params<t_ActionsDeleteOrgSecretParamSchema, void, void, void>,
   respond: ActionsDeleteOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -4239,6 +4351,7 @@ export type ActionsListSelectedReposForOrgSecret = (
   params: Params<
     t_ActionsListSelectedReposForOrgSecretParamSchema,
     t_ActionsListSelectedReposForOrgSecretQuerySchema,
+    void,
     void
   >,
   respond: ActionsListSelectedReposForOrgSecretResponder,
@@ -4262,7 +4375,8 @@ export type ActionsSetSelectedReposForOrgSecret = (
   params: Params<
     t_ActionsSetSelectedReposForOrgSecretParamSchema,
     void,
-    t_ActionsSetSelectedReposForOrgSecretBodySchema
+    t_ActionsSetSelectedReposForOrgSecretBodySchema,
+    void
   >,
   respond: ActionsSetSelectedReposForOrgSecretResponder,
   ctx: RouterContext,
@@ -4274,7 +4388,12 @@ export type ActionsAddSelectedRepoToOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsAddSelectedRepoToOrgSecret = (
-  params: Params<t_ActionsAddSelectedRepoToOrgSecretParamSchema, void, void>,
+  params: Params<
+    t_ActionsAddSelectedRepoToOrgSecretParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsAddSelectedRepoToOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4289,6 +4408,7 @@ export type ActionsRemoveSelectedRepoFromOrgSecretResponder = {
 export type ActionsRemoveSelectedRepoFromOrgSecret = (
   params: Params<
     t_ActionsRemoveSelectedRepoFromOrgSecretParamSchema,
+    void,
     void,
     void
   >,
@@ -4309,6 +4429,7 @@ export type ActionsListOrgVariables = (
   params: Params<
     t_ActionsListOrgVariablesParamSchema,
     t_ActionsListOrgVariablesQuerySchema,
+    void,
     void
   >,
   respond: ActionsListOrgVariablesResponder,
@@ -4332,7 +4453,8 @@ export type ActionsCreateOrgVariable = (
   params: Params<
     t_ActionsCreateOrgVariableParamSchema,
     void,
-    t_ActionsCreateOrgVariableBodySchema
+    t_ActionsCreateOrgVariableBodySchema,
+    void
   >,
   respond: ActionsCreateOrgVariableResponder,
   ctx: RouterContext,
@@ -4343,7 +4465,7 @@ export type ActionsGetOrgVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetOrgVariable = (
-  params: Params<t_ActionsGetOrgVariableParamSchema, void, void>,
+  params: Params<t_ActionsGetOrgVariableParamSchema, void, void, void>,
   respond: ActionsGetOrgVariableResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4358,7 +4480,8 @@ export type ActionsUpdateOrgVariable = (
   params: Params<
     t_ActionsUpdateOrgVariableParamSchema,
     void,
-    t_ActionsUpdateOrgVariableBodySchema
+    t_ActionsUpdateOrgVariableBodySchema,
+    void
   >,
   respond: ActionsUpdateOrgVariableResponder,
   ctx: RouterContext,
@@ -4369,7 +4492,7 @@ export type ActionsDeleteOrgVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteOrgVariable = (
-  params: Params<t_ActionsDeleteOrgVariableParamSchema, void, void>,
+  params: Params<t_ActionsDeleteOrgVariableParamSchema, void, void, void>,
   respond: ActionsDeleteOrgVariableResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -4386,6 +4509,7 @@ export type ActionsListSelectedReposForOrgVariable = (
   params: Params<
     t_ActionsListSelectedReposForOrgVariableParamSchema,
     t_ActionsListSelectedReposForOrgVariableQuerySchema,
+    void,
     void
   >,
   respond: ActionsListSelectedReposForOrgVariableResponder,
@@ -4411,7 +4535,8 @@ export type ActionsSetSelectedReposForOrgVariable = (
   params: Params<
     t_ActionsSetSelectedReposForOrgVariableParamSchema,
     void,
-    t_ActionsSetSelectedReposForOrgVariableBodySchema
+    t_ActionsSetSelectedReposForOrgVariableBodySchema,
+    void
   >,
   respond: ActionsSetSelectedReposForOrgVariableResponder,
   ctx: RouterContext,
@@ -4425,7 +4550,12 @@ export type ActionsAddSelectedRepoToOrgVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsAddSelectedRepoToOrgVariable = (
-  params: Params<t_ActionsAddSelectedRepoToOrgVariableParamSchema, void, void>,
+  params: Params<
+    t_ActionsAddSelectedRepoToOrgVariableParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsAddSelectedRepoToOrgVariableResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4440,6 +4570,7 @@ export type ActionsRemoveSelectedRepoFromOrgVariableResponder = {
 export type ActionsRemoveSelectedRepoFromOrgVariable = (
   params: Params<
     t_ActionsRemoveSelectedRepoFromOrgVariableParamSchema,
+    void,
     void,
     void
   >,
@@ -4470,6 +4601,7 @@ export type OrgsListAttestations = (
   params: Params<
     t_OrgsListAttestationsParamSchema,
     t_OrgsListAttestationsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListAttestationsResponder,
@@ -4503,6 +4635,7 @@ export type OrgsListBlockedUsers = (
   params: Params<
     t_OrgsListBlockedUsersParamSchema,
     t_OrgsListBlockedUsersQuerySchema,
+    void,
     void
   >,
   respond: OrgsListBlockedUsersResponder,
@@ -4515,7 +4648,7 @@ export type OrgsCheckBlockedUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsCheckBlockedUser = (
-  params: Params<t_OrgsCheckBlockedUserParamSchema, void, void>,
+  params: Params<t_OrgsCheckBlockedUserParamSchema, void, void, void>,
   respond: OrgsCheckBlockedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4530,7 +4663,7 @@ export type OrgsBlockUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsBlockUser = (
-  params: Params<t_OrgsBlockUserParamSchema, void, void>,
+  params: Params<t_OrgsBlockUserParamSchema, void, void, void>,
   respond: OrgsBlockUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4544,7 +4677,7 @@ export type OrgsUnblockUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsUnblockUser = (
-  params: Params<t_OrgsUnblockUserParamSchema, void, void>,
+  params: Params<t_OrgsUnblockUserParamSchema, void, void, void>,
   respond: OrgsUnblockUserResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -4563,6 +4696,7 @@ export type CodeScanningListAlertsForOrg = (
   params: Params<
     t_CodeScanningListAlertsForOrgParamSchema,
     t_CodeScanningListAlertsForOrgQuerySchema,
+    void,
     void
   >,
   respond: CodeScanningListAlertsForOrgResponder,
@@ -4591,6 +4725,7 @@ export type CodeSecurityGetConfigurationsForOrg = (
   params: Params<
     t_CodeSecurityGetConfigurationsForOrgParamSchema,
     t_CodeSecurityGetConfigurationsForOrgQuerySchema,
+    void,
     void
   >,
   respond: CodeSecurityGetConfigurationsForOrgResponder,
@@ -4610,7 +4745,8 @@ export type CodeSecurityCreateConfiguration = (
   params: Params<
     t_CodeSecurityCreateConfigurationParamSchema,
     void,
-    t_CodeSecurityCreateConfigurationBodySchema
+    t_CodeSecurityCreateConfigurationBodySchema,
+    void
   >,
   respond: CodeSecurityCreateConfigurationResponder,
   ctx: RouterContext,
@@ -4626,7 +4762,12 @@ export type CodeSecurityGetDefaultConfigurationsResponder = {
 } & KoaRuntimeResponder
 
 export type CodeSecurityGetDefaultConfigurations = (
-  params: Params<t_CodeSecurityGetDefaultConfigurationsParamSchema, void, void>,
+  params: Params<
+    t_CodeSecurityGetDefaultConfigurationsParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodeSecurityGetDefaultConfigurationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4649,7 +4790,8 @@ export type CodeSecurityDetachConfiguration = (
   params: Params<
     t_CodeSecurityDetachConfigurationParamSchema,
     void,
-    t_CodeSecurityDetachConfigurationBodySchema
+    t_CodeSecurityDetachConfigurationBodySchema,
+    void
   >,
   respond: CodeSecurityDetachConfigurationResponder,
   ctx: RouterContext,
@@ -4670,7 +4812,7 @@ export type CodeSecurityGetConfigurationResponder = {
 } & KoaRuntimeResponder
 
 export type CodeSecurityGetConfiguration = (
-  params: Params<t_CodeSecurityGetConfigurationParamSchema, void, void>,
+  params: Params<t_CodeSecurityGetConfigurationParamSchema, void, void, void>,
   respond: CodeSecurityGetConfigurationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4690,7 +4832,8 @@ export type CodeSecurityUpdateConfiguration = (
   params: Params<
     t_CodeSecurityUpdateConfigurationParamSchema,
     void,
-    t_CodeSecurityUpdateConfigurationBodySchema
+    t_CodeSecurityUpdateConfigurationBodySchema,
+    void
   >,
   respond: CodeSecurityUpdateConfigurationResponder,
   ctx: RouterContext,
@@ -4709,7 +4852,12 @@ export type CodeSecurityDeleteConfigurationResponder = {
 } & KoaRuntimeResponder
 
 export type CodeSecurityDeleteConfiguration = (
-  params: Params<t_CodeSecurityDeleteConfigurationParamSchema, void, void>,
+  params: Params<
+    t_CodeSecurityDeleteConfigurationParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodeSecurityDeleteConfigurationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4731,7 +4879,8 @@ export type CodeSecurityAttachConfiguration = (
   params: Params<
     t_CodeSecurityAttachConfigurationParamSchema,
     void,
-    t_CodeSecurityAttachConfigurationBodySchema
+    t_CodeSecurityAttachConfigurationBodySchema,
+    void
   >,
   respond: CodeSecurityAttachConfigurationResponder,
   ctx: RouterContext,
@@ -4758,7 +4907,8 @@ export type CodeSecuritySetConfigurationAsDefault = (
   params: Params<
     t_CodeSecuritySetConfigurationAsDefaultParamSchema,
     void,
-    t_CodeSecuritySetConfigurationAsDefaultBodySchema
+    t_CodeSecuritySetConfigurationAsDefaultBodySchema,
+    void
   >,
   respond: CodeSecuritySetConfigurationAsDefaultResponder,
   ctx: RouterContext,
@@ -4789,6 +4939,7 @@ export type CodeSecurityGetRepositoriesForConfiguration = (
   params: Params<
     t_CodeSecurityGetRepositoriesForConfigurationParamSchema,
     t_CodeSecurityGetRepositoriesForConfigurationQuerySchema,
+    void,
     void
   >,
   respond: CodeSecurityGetRepositoriesForConfigurationResponder,
@@ -4816,6 +4967,7 @@ export type CodespacesListInOrganization = (
   params: Params<
     t_CodespacesListInOrganizationParamSchema,
     t_CodespacesListInOrganizationQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListInOrganizationResponder,
@@ -4849,7 +5001,8 @@ export type CodespacesSetCodespacesAccess = (
   params: Params<
     t_CodespacesSetCodespacesAccessParamSchema,
     void,
-    t_CodespacesSetCodespacesAccessBodySchema
+    t_CodespacesSetCodespacesAccessBodySchema,
+    void
   >,
   respond: CodespacesSetCodespacesAccessResponder,
   ctx: RouterContext,
@@ -4876,7 +5029,8 @@ export type CodespacesSetCodespacesAccessUsers = (
   params: Params<
     t_CodespacesSetCodespacesAccessUsersParamSchema,
     void,
-    t_CodespacesSetCodespacesAccessUsersBodySchema
+    t_CodespacesSetCodespacesAccessUsersBodySchema,
+    void
   >,
   respond: CodespacesSetCodespacesAccessUsersResponder,
   ctx: RouterContext,
@@ -4903,7 +5057,8 @@ export type CodespacesDeleteCodespacesAccessUsers = (
   params: Params<
     t_CodespacesDeleteCodespacesAccessUsersParamSchema,
     void,
-    t_CodespacesDeleteCodespacesAccessUsersBodySchema
+    t_CodespacesDeleteCodespacesAccessUsersBodySchema,
+    void
   >,
   respond: CodespacesDeleteCodespacesAccessUsersResponder,
   ctx: RouterContext,
@@ -4928,6 +5083,7 @@ export type CodespacesListOrgSecrets = (
   params: Params<
     t_CodespacesListOrgSecretsParamSchema,
     t_CodespacesListOrgSecretsQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListOrgSecretsResponder,
@@ -4948,7 +5104,7 @@ export type CodespacesGetOrgPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesGetOrgPublicKey = (
-  params: Params<t_CodespacesGetOrgPublicKeyParamSchema, void, void>,
+  params: Params<t_CodespacesGetOrgPublicKeyParamSchema, void, void, void>,
   respond: CodespacesGetOrgPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4960,7 +5116,7 @@ export type CodespacesGetOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesGetOrgSecret = (
-  params: Params<t_CodespacesGetOrgSecretParamSchema, void, void>,
+  params: Params<t_CodespacesGetOrgSecretParamSchema, void, void, void>,
   respond: CodespacesGetOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4978,7 +5134,8 @@ export type CodespacesCreateOrUpdateOrgSecret = (
   params: Params<
     t_CodespacesCreateOrUpdateOrgSecretParamSchema,
     void,
-    t_CodespacesCreateOrUpdateOrgSecretBodySchema
+    t_CodespacesCreateOrUpdateOrgSecretBodySchema,
+    void
   >,
   respond: CodespacesCreateOrUpdateOrgSecretResponder,
   ctx: RouterContext,
@@ -4996,7 +5153,7 @@ export type CodespacesDeleteOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesDeleteOrgSecret = (
-  params: Params<t_CodespacesDeleteOrgSecretParamSchema, void, void>,
+  params: Params<t_CodespacesDeleteOrgSecretParamSchema, void, void, void>,
   respond: CodespacesDeleteOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5017,6 +5174,7 @@ export type CodespacesListSelectedReposForOrgSecret = (
   params: Params<
     t_CodespacesListSelectedReposForOrgSecretParamSchema,
     t_CodespacesListSelectedReposForOrgSecretQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListSelectedReposForOrgSecretResponder,
@@ -5043,7 +5201,8 @@ export type CodespacesSetSelectedReposForOrgSecret = (
   params: Params<
     t_CodespacesSetSelectedReposForOrgSecretParamSchema,
     void,
-    t_CodespacesSetSelectedReposForOrgSecretBodySchema
+    t_CodespacesSetSelectedReposForOrgSecretBodySchema,
+    void
   >,
   respond: CodespacesSetSelectedReposForOrgSecretResponder,
   ctx: RouterContext,
@@ -5062,7 +5221,12 @@ export type CodespacesAddSelectedRepoToOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesAddSelectedRepoToOrgSecret = (
-  params: Params<t_CodespacesAddSelectedRepoToOrgSecretParamSchema, void, void>,
+  params: Params<
+    t_CodespacesAddSelectedRepoToOrgSecretParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesAddSelectedRepoToOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5083,6 +5247,7 @@ export type CodespacesRemoveSelectedRepoFromOrgSecretResponder = {
 export type CodespacesRemoveSelectedRepoFromOrgSecret = (
   params: Params<
     t_CodespacesRemoveSelectedRepoFromOrgSecretParamSchema,
+    void,
     void,
     void
   >,
@@ -5106,7 +5271,12 @@ export type CopilotGetCopilotOrganizationDetailsResponder = {
 } & KoaRuntimeResponder
 
 export type CopilotGetCopilotOrganizationDetails = (
-  params: Params<t_CopilotGetCopilotOrganizationDetailsParamSchema, void, void>,
+  params: Params<
+    t_CopilotGetCopilotOrganizationDetailsParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CopilotGetCopilotOrganizationDetailsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5134,6 +5304,7 @@ export type CopilotListCopilotSeats = (
   params: Params<
     t_CopilotListCopilotSeatsParamSchema,
     t_CopilotListCopilotSeatsQuerySchema,
+    void,
     void
   >,
   respond: CopilotListCopilotSeatsResponder,
@@ -5168,7 +5339,8 @@ export type CopilotAddCopilotSeatsForTeams = (
   params: Params<
     t_CopilotAddCopilotSeatsForTeamsParamSchema,
     void,
-    t_CopilotAddCopilotSeatsForTeamsBodySchema
+    t_CopilotAddCopilotSeatsForTeamsBodySchema,
+    void
   >,
   respond: CopilotAddCopilotSeatsForTeamsResponder,
   ctx: RouterContext,
@@ -5202,7 +5374,8 @@ export type CopilotCancelCopilotSeatAssignmentForTeams = (
   params: Params<
     t_CopilotCancelCopilotSeatAssignmentForTeamsParamSchema,
     void,
-    t_CopilotCancelCopilotSeatAssignmentForTeamsBodySchema
+    t_CopilotCancelCopilotSeatAssignmentForTeamsBodySchema,
+    void
   >,
   respond: CopilotCancelCopilotSeatAssignmentForTeamsResponder,
   ctx: RouterContext,
@@ -5236,7 +5409,8 @@ export type CopilotAddCopilotSeatsForUsers = (
   params: Params<
     t_CopilotAddCopilotSeatsForUsersParamSchema,
     void,
-    t_CopilotAddCopilotSeatsForUsersBodySchema
+    t_CopilotAddCopilotSeatsForUsersBodySchema,
+    void
   >,
   respond: CopilotAddCopilotSeatsForUsersResponder,
   ctx: RouterContext,
@@ -5270,7 +5444,8 @@ export type CopilotCancelCopilotSeatAssignmentForUsers = (
   params: Params<
     t_CopilotCancelCopilotSeatAssignmentForUsersParamSchema,
     void,
-    t_CopilotCancelCopilotSeatAssignmentForUsersBodySchema
+    t_CopilotCancelCopilotSeatAssignmentForUsersBodySchema,
+    void
   >,
   respond: CopilotCancelCopilotSeatAssignmentForUsersResponder,
   ctx: RouterContext,
@@ -5301,6 +5476,7 @@ export type CopilotUsageMetricsForOrg = (
   params: Params<
     t_CopilotUsageMetricsForOrgParamSchema,
     t_CopilotUsageMetricsForOrgQuerySchema,
+    void,
     void
   >,
   respond: CopilotUsageMetricsForOrgResponder,
@@ -5327,6 +5503,7 @@ export type DependabotListAlertsForOrg = (
   params: Params<
     t_DependabotListAlertsForOrgParamSchema,
     t_DependabotListAlertsForOrgQuerySchema,
+    void,
     void
   >,
   respond: DependabotListAlertsForOrgResponder,
@@ -5352,6 +5529,7 @@ export type DependabotListOrgSecrets = (
   params: Params<
     t_DependabotListOrgSecretsParamSchema,
     t_DependabotListOrgSecretsQuerySchema,
+    void,
     void
   >,
   respond: DependabotListOrgSecretsResponder,
@@ -5372,7 +5550,7 @@ export type DependabotGetOrgPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotGetOrgPublicKey = (
-  params: Params<t_DependabotGetOrgPublicKeyParamSchema, void, void>,
+  params: Params<t_DependabotGetOrgPublicKeyParamSchema, void, void, void>,
   respond: DependabotGetOrgPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5384,7 +5562,7 @@ export type DependabotGetOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotGetOrgSecret = (
-  params: Params<t_DependabotGetOrgSecretParamSchema, void, void>,
+  params: Params<t_DependabotGetOrgSecretParamSchema, void, void, void>,
   respond: DependabotGetOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5400,7 +5578,8 @@ export type DependabotCreateOrUpdateOrgSecret = (
   params: Params<
     t_DependabotCreateOrUpdateOrgSecretParamSchema,
     void,
-    t_DependabotCreateOrUpdateOrgSecretBodySchema
+    t_DependabotCreateOrUpdateOrgSecretBodySchema,
+    void
   >,
   respond: DependabotCreateOrUpdateOrgSecretResponder,
   ctx: RouterContext,
@@ -5415,7 +5594,7 @@ export type DependabotDeleteOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotDeleteOrgSecret = (
-  params: Params<t_DependabotDeleteOrgSecretParamSchema, void, void>,
+  params: Params<t_DependabotDeleteOrgSecretParamSchema, void, void, void>,
   respond: DependabotDeleteOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -5431,6 +5610,7 @@ export type DependabotListSelectedReposForOrgSecret = (
   params: Params<
     t_DependabotListSelectedReposForOrgSecretParamSchema,
     t_DependabotListSelectedReposForOrgSecretQuerySchema,
+    void,
     void
   >,
   respond: DependabotListSelectedReposForOrgSecretResponder,
@@ -5454,7 +5634,8 @@ export type DependabotSetSelectedReposForOrgSecret = (
   params: Params<
     t_DependabotSetSelectedReposForOrgSecretParamSchema,
     void,
-    t_DependabotSetSelectedReposForOrgSecretBodySchema
+    t_DependabotSetSelectedReposForOrgSecretBodySchema,
+    void
   >,
   respond: DependabotSetSelectedReposForOrgSecretResponder,
   ctx: RouterContext,
@@ -5466,7 +5647,12 @@ export type DependabotAddSelectedRepoToOrgSecretResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotAddSelectedRepoToOrgSecret = (
-  params: Params<t_DependabotAddSelectedRepoToOrgSecretParamSchema, void, void>,
+  params: Params<
+    t_DependabotAddSelectedRepoToOrgSecretParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: DependabotAddSelectedRepoToOrgSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5481,6 +5667,7 @@ export type DependabotRemoveSelectedRepoFromOrgSecretResponder = {
 export type DependabotRemoveSelectedRepoFromOrgSecret = (
   params: Params<
     t_DependabotRemoveSelectedRepoFromOrgSecretParamSchema,
+    void,
     void,
     void
   >,
@@ -5501,6 +5688,7 @@ export type PackagesListDockerMigrationConflictingPackagesForOrganization = (
   params: Params<
     t_PackagesListDockerMigrationConflictingPackagesForOrganizationParamSchema,
     void,
+    void,
     void
   >,
   respond: PackagesListDockerMigrationConflictingPackagesForOrganizationResponder,
@@ -5520,6 +5708,7 @@ export type ActivityListPublicOrgEvents = (
   params: Params<
     t_ActivityListPublicOrgEventsParamSchema,
     t_ActivityListPublicOrgEventsQuerySchema,
+    void,
     void
   >,
   respond: ActivityListPublicOrgEventsResponder,
@@ -5535,6 +5724,7 @@ export type OrgsListFailedInvitations = (
   params: Params<
     t_OrgsListFailedInvitationsParamSchema,
     t_OrgsListFailedInvitationsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListFailedInvitationsResponder,
@@ -5554,6 +5744,7 @@ export type OrgsListWebhooks = (
   params: Params<
     t_OrgsListWebhooksParamSchema,
     t_OrgsListWebhooksQuerySchema,
+    void,
     void
   >,
   respond: OrgsListWebhooksResponder,
@@ -5574,7 +5765,8 @@ export type OrgsCreateWebhook = (
   params: Params<
     t_OrgsCreateWebhookParamSchema,
     void,
-    t_OrgsCreateWebhookBodySchema
+    t_OrgsCreateWebhookBodySchema,
+    void
   >,
   respond: OrgsCreateWebhookResponder,
   ctx: RouterContext,
@@ -5591,7 +5783,7 @@ export type OrgsGetWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetWebhook = (
-  params: Params<t_OrgsGetWebhookParamSchema, void, void>,
+  params: Params<t_OrgsGetWebhookParamSchema, void, void, void>,
   respond: OrgsGetWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5610,7 +5802,8 @@ export type OrgsUpdateWebhook = (
   params: Params<
     t_OrgsUpdateWebhookParamSchema,
     void,
-    t_OrgsUpdateWebhookBodySchema | undefined
+    t_OrgsUpdateWebhookBodySchema | undefined,
+    void
   >,
   respond: OrgsUpdateWebhookResponder,
   ctx: RouterContext,
@@ -5627,7 +5820,7 @@ export type OrgsDeleteWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsDeleteWebhook = (
-  params: Params<t_OrgsDeleteWebhookParamSchema, void, void>,
+  params: Params<t_OrgsDeleteWebhookParamSchema, void, void, void>,
   respond: OrgsDeleteWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5641,7 +5834,7 @@ export type OrgsGetWebhookConfigForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetWebhookConfigForOrg = (
-  params: Params<t_OrgsGetWebhookConfigForOrgParamSchema, void, void>,
+  params: Params<t_OrgsGetWebhookConfigForOrgParamSchema, void, void, void>,
   respond: OrgsGetWebhookConfigForOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_webhook_config>>
@@ -5654,7 +5847,8 @@ export type OrgsUpdateWebhookConfigForOrg = (
   params: Params<
     t_OrgsUpdateWebhookConfigForOrgParamSchema,
     void,
-    t_OrgsUpdateWebhookConfigForOrgBodySchema | undefined
+    t_OrgsUpdateWebhookConfigForOrgBodySchema | undefined,
+    void
   >,
   respond: OrgsUpdateWebhookConfigForOrgResponder,
   ctx: RouterContext,
@@ -5670,6 +5864,7 @@ export type OrgsListWebhookDeliveries = (
   params: Params<
     t_OrgsListWebhookDeliveriesParamSchema,
     t_OrgsListWebhookDeliveriesQuerySchema,
+    void,
     void
   >,
   respond: OrgsListWebhookDeliveriesResponder,
@@ -5688,7 +5883,7 @@ export type OrgsGetWebhookDeliveryResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetWebhookDelivery = (
-  params: Params<t_OrgsGetWebhookDeliveryParamSchema, void, void>,
+  params: Params<t_OrgsGetWebhookDeliveryParamSchema, void, void, void>,
   respond: OrgsGetWebhookDeliveryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5707,7 +5902,7 @@ export type OrgsRedeliverWebhookDeliveryResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRedeliverWebhookDelivery = (
-  params: Params<t_OrgsRedeliverWebhookDeliveryParamSchema, void, void>,
+  params: Params<t_OrgsRedeliverWebhookDeliveryParamSchema, void, void, void>,
   respond: OrgsRedeliverWebhookDeliveryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5728,7 +5923,7 @@ export type OrgsPingWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsPingWebhook = (
-  params: Params<t_OrgsPingWebhookParamSchema, void, void>,
+  params: Params<t_OrgsPingWebhookParamSchema, void, void, void>,
   respond: OrgsPingWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5742,7 +5937,7 @@ export type AppsGetOrgInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetOrgInstallation = (
-  params: Params<t_AppsGetOrgInstallationParamSchema, void, void>,
+  params: Params<t_AppsGetOrgInstallationParamSchema, void, void, void>,
   respond: AppsGetOrgInstallationResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_installation>>
@@ -5758,6 +5953,7 @@ export type OrgsListAppInstallations = (
   params: Params<
     t_OrgsListAppInstallationsParamSchema,
     t_OrgsListAppInstallationsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListAppInstallationsResponder,
@@ -5778,7 +5974,12 @@ export type InteractionsGetRestrictionsForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type InteractionsGetRestrictionsForOrg = (
-  params: Params<t_InteractionsGetRestrictionsForOrgParamSchema, void, void>,
+  params: Params<
+    t_InteractionsGetRestrictionsForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: InteractionsGetRestrictionsForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5795,7 +5996,8 @@ export type InteractionsSetRestrictionsForOrg = (
   params: Params<
     t_InteractionsSetRestrictionsForOrgParamSchema,
     void,
-    t_InteractionsSetRestrictionsForOrgBodySchema
+    t_InteractionsSetRestrictionsForOrgBodySchema,
+    void
   >,
   respond: InteractionsSetRestrictionsForOrgResponder,
   ctx: RouterContext,
@@ -5810,7 +6012,12 @@ export type InteractionsRemoveRestrictionsForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type InteractionsRemoveRestrictionsForOrg = (
-  params: Params<t_InteractionsRemoveRestrictionsForOrgParamSchema, void, void>,
+  params: Params<
+    t_InteractionsRemoveRestrictionsForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: InteractionsRemoveRestrictionsForOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -5824,6 +6031,7 @@ export type OrgsListPendingInvitations = (
   params: Params<
     t_OrgsListPendingInvitationsParamSchema,
     t_OrgsListPendingInvitationsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListPendingInvitationsResponder,
@@ -5844,7 +6052,8 @@ export type OrgsCreateInvitation = (
   params: Params<
     t_OrgsCreateInvitationParamSchema,
     void,
-    t_OrgsCreateInvitationBodySchema | undefined
+    t_OrgsCreateInvitationBodySchema | undefined,
+    void
   >,
   respond: OrgsCreateInvitationResponder,
   ctx: RouterContext,
@@ -5862,7 +6071,7 @@ export type OrgsCancelInvitationResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsCancelInvitation = (
-  params: Params<t_OrgsCancelInvitationParamSchema, void, void>,
+  params: Params<t_OrgsCancelInvitationParamSchema, void, void, void>,
   respond: OrgsCancelInvitationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5881,6 +6090,7 @@ export type OrgsListInvitationTeams = (
   params: Params<
     t_OrgsListInvitationTeamsParamSchema,
     t_OrgsListInvitationTeamsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListInvitationTeamsResponder,
@@ -5900,6 +6110,7 @@ export type IssuesListForOrg = (
   params: Params<
     t_IssuesListForOrgParamSchema,
     t_IssuesListForOrgQuerySchema,
+    void,
     void
   >,
   respond: IssuesListForOrgResponder,
@@ -5919,6 +6130,7 @@ export type OrgsListMembers = (
   params: Params<
     t_OrgsListMembersParamSchema,
     t_OrgsListMembersQuerySchema,
+    void,
     void
   >,
   respond: OrgsListMembersResponder,
@@ -5936,7 +6148,7 @@ export type OrgsCheckMembershipForUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsCheckMembershipForUser = (
-  params: Params<t_OrgsCheckMembershipForUserParamSchema, void, void>,
+  params: Params<t_OrgsCheckMembershipForUserParamSchema, void, void, void>,
   respond: OrgsCheckMembershipForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5952,7 +6164,7 @@ export type OrgsRemoveMemberResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRemoveMember = (
-  params: Params<t_OrgsRemoveMemberParamSchema, void, void>,
+  params: Params<t_OrgsRemoveMemberParamSchema, void, void, void>,
   respond: OrgsRemoveMemberResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5977,6 +6189,7 @@ export type CodespacesGetCodespacesForUserInOrg = (
   params: Params<
     t_CodespacesGetCodespacesForUserInOrgParamSchema,
     t_CodespacesGetCodespacesForUserInOrgQuerySchema,
+    void,
     void
   >,
   respond: CodespacesGetCodespacesForUserInOrgResponder,
@@ -6009,7 +6222,12 @@ export type CodespacesDeleteFromOrganizationResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesDeleteFromOrganization = (
-  params: Params<t_CodespacesDeleteFromOrganizationParamSchema, void, void>,
+  params: Params<
+    t_CodespacesDeleteFromOrganizationParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesDeleteFromOrganizationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6037,7 +6255,7 @@ export type CodespacesStopInOrganizationResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesStopInOrganization = (
-  params: Params<t_CodespacesStopInOrganizationParamSchema, void, void>,
+  params: Params<t_CodespacesStopInOrganizationParamSchema, void, void, void>,
   respond: CodespacesStopInOrganizationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6060,7 +6278,12 @@ export type CopilotGetCopilotSeatDetailsForUserResponder = {
 } & KoaRuntimeResponder
 
 export type CopilotGetCopilotSeatDetailsForUser = (
-  params: Params<t_CopilotGetCopilotSeatDetailsForUserParamSchema, void, void>,
+  params: Params<
+    t_CopilotGetCopilotSeatDetailsForUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CopilotGetCopilotSeatDetailsForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6080,7 +6303,7 @@ export type OrgsGetMembershipForUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetMembershipForUser = (
-  params: Params<t_OrgsGetMembershipForUserParamSchema, void, void>,
+  params: Params<t_OrgsGetMembershipForUserParamSchema, void, void, void>,
   respond: OrgsGetMembershipForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6100,7 +6323,8 @@ export type OrgsSetMembershipForUser = (
   params: Params<
     t_OrgsSetMembershipForUserParamSchema,
     void,
-    t_OrgsSetMembershipForUserBodySchema | undefined
+    t_OrgsSetMembershipForUserBodySchema | undefined,
+    void
   >,
   respond: OrgsSetMembershipForUserResponder,
   ctx: RouterContext,
@@ -6118,7 +6342,7 @@ export type OrgsRemoveMembershipForUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRemoveMembershipForUser = (
-  params: Params<t_OrgsRemoveMembershipForUserParamSchema, void, void>,
+  params: Params<t_OrgsRemoveMembershipForUserParamSchema, void, void, void>,
   respond: OrgsRemoveMembershipForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6136,6 +6360,7 @@ export type MigrationsListForOrg = (
   params: Params<
     t_MigrationsListForOrgParamSchema,
     t_MigrationsListForOrgQuerySchema,
+    void,
     void
   >,
   respond: MigrationsListForOrgResponder,
@@ -6152,7 +6377,8 @@ export type MigrationsStartForOrg = (
   params: Params<
     t_MigrationsStartForOrgParamSchema,
     void,
-    t_MigrationsStartForOrgBodySchema
+    t_MigrationsStartForOrgBodySchema,
+    void
   >,
   respond: MigrationsStartForOrgResponder,
   ctx: RouterContext,
@@ -6172,6 +6398,7 @@ export type MigrationsGetStatusForOrg = (
   params: Params<
     t_MigrationsGetStatusForOrgParamSchema,
     t_MigrationsGetStatusForOrgQuerySchema,
+    void,
     void
   >,
   respond: MigrationsGetStatusForOrgResponder,
@@ -6188,7 +6415,12 @@ export type MigrationsDownloadArchiveForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsDownloadArchiveForOrg = (
-  params: Params<t_MigrationsDownloadArchiveForOrgParamSchema, void, void>,
+  params: Params<
+    t_MigrationsDownloadArchiveForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: MigrationsDownloadArchiveForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6203,7 +6435,7 @@ export type MigrationsDeleteArchiveForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsDeleteArchiveForOrg = (
-  params: Params<t_MigrationsDeleteArchiveForOrgParamSchema, void, void>,
+  params: Params<t_MigrationsDeleteArchiveForOrgParamSchema, void, void, void>,
   respond: MigrationsDeleteArchiveForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6218,7 +6450,7 @@ export type MigrationsUnlockRepoForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsUnlockRepoForOrg = (
-  params: Params<t_MigrationsUnlockRepoForOrgParamSchema, void, void>,
+  params: Params<t_MigrationsUnlockRepoForOrgParamSchema, void, void, void>,
   respond: MigrationsUnlockRepoForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6236,6 +6468,7 @@ export type MigrationsListReposForOrg = (
   params: Params<
     t_MigrationsListReposForOrgParamSchema,
     t_MigrationsListReposForOrgQuerySchema,
+    void,
     void
   >,
   respond: MigrationsListReposForOrgResponder,
@@ -6256,7 +6489,7 @@ export type OrgsListOrgRolesResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsListOrgRoles = (
-  params: Params<t_OrgsListOrgRolesParamSchema, void, void>,
+  params: Params<t_OrgsListOrgRolesParamSchema, void, void, void>,
   respond: OrgsListOrgRolesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6277,7 +6510,7 @@ export type OrgsRevokeAllOrgRolesTeamResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRevokeAllOrgRolesTeam = (
-  params: Params<t_OrgsRevokeAllOrgRolesTeamParamSchema, void, void>,
+  params: Params<t_OrgsRevokeAllOrgRolesTeamParamSchema, void, void, void>,
   respond: OrgsRevokeAllOrgRolesTeamResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -6289,7 +6522,7 @@ export type OrgsAssignTeamToOrgRoleResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsAssignTeamToOrgRole = (
-  params: Params<t_OrgsAssignTeamToOrgRoleParamSchema, void, void>,
+  params: Params<t_OrgsAssignTeamToOrgRoleParamSchema, void, void, void>,
   respond: OrgsAssignTeamToOrgRoleResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6304,7 +6537,7 @@ export type OrgsRevokeOrgRoleTeamResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRevokeOrgRoleTeam = (
-  params: Params<t_OrgsRevokeOrgRoleTeamParamSchema, void, void>,
+  params: Params<t_OrgsRevokeOrgRoleTeamParamSchema, void, void, void>,
   respond: OrgsRevokeOrgRoleTeamResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -6314,7 +6547,7 @@ export type OrgsRevokeAllOrgRolesUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRevokeAllOrgRolesUser = (
-  params: Params<t_OrgsRevokeAllOrgRolesUserParamSchema, void, void>,
+  params: Params<t_OrgsRevokeAllOrgRolesUserParamSchema, void, void, void>,
   respond: OrgsRevokeAllOrgRolesUserResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -6326,7 +6559,7 @@ export type OrgsAssignUserToOrgRoleResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsAssignUserToOrgRole = (
-  params: Params<t_OrgsAssignUserToOrgRoleParamSchema, void, void>,
+  params: Params<t_OrgsAssignUserToOrgRoleParamSchema, void, void, void>,
   respond: OrgsAssignUserToOrgRoleResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6341,7 +6574,7 @@ export type OrgsRevokeOrgRoleUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRevokeOrgRoleUser = (
-  params: Params<t_OrgsRevokeOrgRoleUserParamSchema, void, void>,
+  params: Params<t_OrgsRevokeOrgRoleUserParamSchema, void, void, void>,
   respond: OrgsRevokeOrgRoleUserResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -6353,7 +6586,7 @@ export type OrgsGetOrgRoleResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetOrgRole = (
-  params: Params<t_OrgsGetOrgRoleParamSchema, void, void>,
+  params: Params<t_OrgsGetOrgRoleParamSchema, void, void, void>,
   respond: OrgsGetOrgRoleResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6373,6 +6606,7 @@ export type OrgsListOrgRoleTeams = (
   params: Params<
     t_OrgsListOrgRoleTeamsParamSchema,
     t_OrgsListOrgRoleTeamsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListOrgRoleTeamsResponder,
@@ -6394,6 +6628,7 @@ export type OrgsListOrgRoleUsers = (
   params: Params<
     t_OrgsListOrgRoleUsersParamSchema,
     t_OrgsListOrgRoleUsersQuerySchema,
+    void,
     void
   >,
   respond: OrgsListOrgRoleUsersResponder,
@@ -6413,6 +6648,7 @@ export type OrgsListOutsideCollaborators = (
   params: Params<
     t_OrgsListOutsideCollaboratorsParamSchema,
     t_OrgsListOutsideCollaboratorsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListOutsideCollaboratorsResponder,
@@ -6430,7 +6666,8 @@ export type OrgsConvertMemberToOutsideCollaborator = (
   params: Params<
     t_OrgsConvertMemberToOutsideCollaboratorParamSchema,
     void,
-    t_OrgsConvertMemberToOutsideCollaboratorBodySchema | undefined
+    t_OrgsConvertMemberToOutsideCollaboratorBodySchema | undefined,
+    void
   >,
   respond: OrgsConvertMemberToOutsideCollaboratorResponder,
   ctx: RouterContext,
@@ -6451,7 +6688,7 @@ export type OrgsRemoveOutsideCollaboratorResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRemoveOutsideCollaborator = (
-  params: Params<t_OrgsRemoveOutsideCollaboratorParamSchema, void, void>,
+  params: Params<t_OrgsRemoveOutsideCollaboratorParamSchema, void, void, void>,
   respond: OrgsRemoveOutsideCollaboratorResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6477,6 +6714,7 @@ export type PackagesListPackagesForOrganization = (
   params: Params<
     t_PackagesListPackagesForOrganizationParamSchema,
     t_PackagesListPackagesForOrganizationQuerySchema,
+    void,
     void
   >,
   respond: PackagesListPackagesForOrganizationResponder,
@@ -6494,7 +6732,12 @@ export type PackagesGetPackageForOrganizationResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesGetPackageForOrganization = (
-  params: Params<t_PackagesGetPackageForOrganizationParamSchema, void, void>,
+  params: Params<
+    t_PackagesGetPackageForOrganizationParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: PackagesGetPackageForOrganizationResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_package>>
@@ -6507,7 +6750,7 @@ export type PackagesDeletePackageForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesDeletePackageForOrg = (
-  params: Params<t_PackagesDeletePackageForOrgParamSchema, void, void>,
+  params: Params<t_PackagesDeletePackageForOrgParamSchema, void, void, void>,
   respond: PackagesDeletePackageForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6529,6 +6772,7 @@ export type PackagesRestorePackageForOrg = (
   params: Params<
     t_PackagesRestorePackageForOrgParamSchema,
     t_PackagesRestorePackageForOrgQuerySchema,
+    void,
     void
   >,
   respond: PackagesRestorePackageForOrgResponder,
@@ -6552,6 +6796,7 @@ export type PackagesGetAllPackageVersionsForPackageOwnedByOrg = (
   params: Params<
     t_PackagesGetAllPackageVersionsForPackageOwnedByOrgParamSchema,
     t_PackagesGetAllPackageVersionsForPackageOwnedByOrgQuerySchema,
+    void,
     void
   >,
   respond: PackagesGetAllPackageVersionsForPackageOwnedByOrgResponder,
@@ -6572,6 +6817,7 @@ export type PackagesGetPackageVersionForOrganization = (
   params: Params<
     t_PackagesGetPackageVersionForOrganizationParamSchema,
     void,
+    void,
     void
   >,
   respond: PackagesGetPackageVersionForOrganizationResponder,
@@ -6586,7 +6832,12 @@ export type PackagesDeletePackageVersionForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesDeletePackageVersionForOrg = (
-  params: Params<t_PackagesDeletePackageVersionForOrgParamSchema, void, void>,
+  params: Params<
+    t_PackagesDeletePackageVersionForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: PackagesDeletePackageVersionForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6605,7 +6856,12 @@ export type PackagesRestorePackageVersionForOrgResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesRestorePackageVersionForOrg = (
-  params: Params<t_PackagesRestorePackageVersionForOrgParamSchema, void, void>,
+  params: Params<
+    t_PackagesRestorePackageVersionForOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: PackagesRestorePackageVersionForOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6630,6 +6886,7 @@ export type OrgsListPatGrantRequests = (
   params: Params<
     t_OrgsListPatGrantRequestsParamSchema,
     t_OrgsListPatGrantRequestsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListPatGrantRequestsResponder,
@@ -6657,7 +6914,8 @@ export type OrgsReviewPatGrantRequestsInBulk = (
   params: Params<
     t_OrgsReviewPatGrantRequestsInBulkParamSchema,
     void,
-    t_OrgsReviewPatGrantRequestsInBulkBodySchema
+    t_OrgsReviewPatGrantRequestsInBulkBodySchema,
+    void
   >,
   respond: OrgsReviewPatGrantRequestsInBulkResponder,
   ctx: RouterContext,
@@ -6687,7 +6945,8 @@ export type OrgsReviewPatGrantRequest = (
   params: Params<
     t_OrgsReviewPatGrantRequestParamSchema,
     void,
-    t_OrgsReviewPatGrantRequestBodySchema
+    t_OrgsReviewPatGrantRequestBodySchema,
+    void
   >,
   respond: OrgsReviewPatGrantRequestResponder,
   ctx: RouterContext,
@@ -6711,6 +6970,7 @@ export type OrgsListPatGrantRequestRepositories = (
   params: Params<
     t_OrgsListPatGrantRequestRepositoriesParamSchema,
     t_OrgsListPatGrantRequestRepositoriesQuerySchema,
+    void,
     void
   >,
   respond: OrgsListPatGrantRequestRepositoriesResponder,
@@ -6735,6 +6995,7 @@ export type OrgsListPatGrants = (
   params: Params<
     t_OrgsListPatGrantsParamSchema,
     t_OrgsListPatGrantsQuerySchema,
+    void,
     void
   >,
   respond: OrgsListPatGrantsResponder,
@@ -6762,7 +7023,8 @@ export type OrgsUpdatePatAccesses = (
   params: Params<
     t_OrgsUpdatePatAccessesParamSchema,
     void,
-    t_OrgsUpdatePatAccessesBodySchema
+    t_OrgsUpdatePatAccessesBodySchema,
+    void
   >,
   respond: OrgsUpdatePatAccessesResponder,
   ctx: RouterContext,
@@ -6792,7 +7054,8 @@ export type OrgsUpdatePatAccess = (
   params: Params<
     t_OrgsUpdatePatAccessParamSchema,
     void,
-    t_OrgsUpdatePatAccessBodySchema
+    t_OrgsUpdatePatAccessBodySchema,
+    void
   >,
   respond: OrgsUpdatePatAccessResponder,
   ctx: RouterContext,
@@ -6816,6 +7079,7 @@ export type OrgsListPatGrantRepositories = (
   params: Params<
     t_OrgsListPatGrantRepositoriesParamSchema,
     t_OrgsListPatGrantRepositoriesQuerySchema,
+    void,
     void
   >,
   respond: OrgsListPatGrantRepositoriesResponder,
@@ -6837,6 +7101,7 @@ export type ProjectsListForOrg = (
   params: Params<
     t_ProjectsListForOrgParamSchema,
     t_ProjectsListForOrgQuerySchema,
+    void,
     void
   >,
   respond: ProjectsListForOrgResponder,
@@ -6860,7 +7125,8 @@ export type ProjectsCreateForOrg = (
   params: Params<
     t_ProjectsCreateForOrgParamSchema,
     void,
-    t_ProjectsCreateForOrgBodySchema
+    t_ProjectsCreateForOrgBodySchema,
+    void
   >,
   respond: ProjectsCreateForOrgResponder,
   ctx: RouterContext,
@@ -6881,7 +7147,7 @@ export type OrgsGetAllCustomPropertiesResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetAllCustomProperties = (
-  params: Params<t_OrgsGetAllCustomPropertiesParamSchema, void, void>,
+  params: Params<t_OrgsGetAllCustomPropertiesParamSchema, void, void, void>,
   respond: OrgsGetAllCustomPropertiesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6901,7 +7167,8 @@ export type OrgsCreateOrUpdateCustomProperties = (
   params: Params<
     t_OrgsCreateOrUpdateCustomPropertiesParamSchema,
     void,
-    t_OrgsCreateOrUpdateCustomPropertiesBodySchema
+    t_OrgsCreateOrUpdateCustomPropertiesBodySchema,
+    void
   >,
   respond: OrgsCreateOrUpdateCustomPropertiesResponder,
   ctx: RouterContext,
@@ -6919,7 +7186,7 @@ export type OrgsGetCustomPropertyResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsGetCustomProperty = (
-  params: Params<t_OrgsGetCustomPropertyParamSchema, void, void>,
+  params: Params<t_OrgsGetCustomPropertyParamSchema, void, void, void>,
   respond: OrgsGetCustomPropertyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6939,7 +7206,8 @@ export type OrgsCreateOrUpdateCustomProperty = (
   params: Params<
     t_OrgsCreateOrUpdateCustomPropertyParamSchema,
     void,
-    t_OrgsCreateOrUpdateCustomPropertyBodySchema
+    t_OrgsCreateOrUpdateCustomPropertyBodySchema,
+    void
   >,
   respond: OrgsCreateOrUpdateCustomPropertyResponder,
   ctx: RouterContext,
@@ -6957,7 +7225,7 @@ export type OrgsRemoveCustomPropertyResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRemoveCustomProperty = (
-  params: Params<t_OrgsRemoveCustomPropertyParamSchema, void, void>,
+  params: Params<t_OrgsRemoveCustomPropertyParamSchema, void, void, void>,
   respond: OrgsRemoveCustomPropertyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6977,6 +7245,7 @@ export type OrgsListCustomPropertiesValuesForRepos = (
   params: Params<
     t_OrgsListCustomPropertiesValuesForReposParamSchema,
     t_OrgsListCustomPropertiesValuesForReposQuerySchema,
+    void,
     void
   >,
   respond: OrgsListCustomPropertiesValuesForReposResponder,
@@ -6999,7 +7268,8 @@ export type OrgsCreateOrUpdateCustomPropertiesValuesForRepos = (
   params: Params<
     t_OrgsCreateOrUpdateCustomPropertiesValuesForReposParamSchema,
     void,
-    t_OrgsCreateOrUpdateCustomPropertiesValuesForReposBodySchema
+    t_OrgsCreateOrUpdateCustomPropertiesValuesForReposBodySchema,
+    void
   >,
   respond: OrgsCreateOrUpdateCustomPropertiesValuesForReposResponder,
   ctx: RouterContext,
@@ -7019,6 +7289,7 @@ export type OrgsListPublicMembers = (
   params: Params<
     t_OrgsListPublicMembersParamSchema,
     t_OrgsListPublicMembersQuerySchema,
+    void,
     void
   >,
   respond: OrgsListPublicMembersResponder,
@@ -7031,7 +7302,12 @@ export type OrgsCheckPublicMembershipForUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsCheckPublicMembershipForUser = (
-  params: Params<t_OrgsCheckPublicMembershipForUserParamSchema, void, void>,
+  params: Params<
+    t_OrgsCheckPublicMembershipForUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: OrgsCheckPublicMembershipForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7046,6 +7322,7 @@ export type OrgsSetPublicMembershipForAuthenticatedUserResponder = {
 export type OrgsSetPublicMembershipForAuthenticatedUser = (
   params: Params<
     t_OrgsSetPublicMembershipForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -7065,6 +7342,7 @@ export type OrgsRemovePublicMembershipForAuthenticatedUser = (
   params: Params<
     t_OrgsRemovePublicMembershipForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: OrgsRemovePublicMembershipForAuthenticatedUserResponder,
@@ -7079,6 +7357,7 @@ export type ReposListForOrg = (
   params: Params<
     t_ReposListForOrgParamSchema,
     t_ReposListForOrgQuerySchema,
+    void,
     void
   >,
   respond: ReposListForOrgResponder,
@@ -7097,7 +7376,8 @@ export type ReposCreateInOrg = (
   params: Params<
     t_ReposCreateInOrgParamSchema,
     void,
-    t_ReposCreateInOrgBodySchema
+    t_ReposCreateInOrgBodySchema,
+    void
   >,
   respond: ReposCreateInOrgResponder,
   ctx: RouterContext,
@@ -7118,6 +7398,7 @@ export type ReposGetOrgRulesets = (
   params: Params<
     t_ReposGetOrgRulesetsParamSchema,
     t_ReposGetOrgRulesetsQuerySchema,
+    void,
     void
   >,
   respond: ReposGetOrgRulesetsResponder,
@@ -7139,7 +7420,8 @@ export type ReposCreateOrgRuleset = (
   params: Params<
     t_ReposCreateOrgRulesetParamSchema,
     void,
-    t_ReposCreateOrgRulesetBodySchema
+    t_ReposCreateOrgRulesetBodySchema,
+    void
   >,
   respond: ReposCreateOrgRulesetResponder,
   ctx: RouterContext,
@@ -7160,6 +7442,7 @@ export type ReposGetOrgRuleSuites = (
   params: Params<
     t_ReposGetOrgRuleSuitesParamSchema,
     t_ReposGetOrgRuleSuitesQuerySchema,
+    void,
     void
   >,
   respond: ReposGetOrgRuleSuitesResponder,
@@ -7178,7 +7461,7 @@ export type ReposGetOrgRuleSuiteResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetOrgRuleSuite = (
-  params: Params<t_ReposGetOrgRuleSuiteParamSchema, void, void>,
+  params: Params<t_ReposGetOrgRuleSuiteParamSchema, void, void, void>,
   respond: ReposGetOrgRuleSuiteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7195,7 +7478,7 @@ export type ReposGetOrgRulesetResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetOrgRuleset = (
-  params: Params<t_ReposGetOrgRulesetParamSchema, void, void>,
+  params: Params<t_ReposGetOrgRulesetParamSchema, void, void, void>,
   respond: ReposGetOrgRulesetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7215,7 +7498,8 @@ export type ReposUpdateOrgRuleset = (
   params: Params<
     t_ReposUpdateOrgRulesetParamSchema,
     void,
-    t_ReposUpdateOrgRulesetBodySchema | undefined
+    t_ReposUpdateOrgRulesetBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateOrgRulesetResponder,
   ctx: RouterContext,
@@ -7233,7 +7517,7 @@ export type ReposDeleteOrgRulesetResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteOrgRuleset = (
-  params: Params<t_ReposDeleteOrgRulesetParamSchema, void, void>,
+  params: Params<t_ReposDeleteOrgRulesetParamSchema, void, void, void>,
   respond: ReposDeleteOrgRulesetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7257,6 +7541,7 @@ export type SecretScanningListAlertsForOrg = (
   params: Params<
     t_SecretScanningListAlertsForOrgParamSchema,
     t_SecretScanningListAlertsForOrgQuerySchema,
+    void,
     void
   >,
   respond: SecretScanningListAlertsForOrgResponder,
@@ -7285,6 +7570,7 @@ export type SecurityAdvisoriesListOrgRepositoryAdvisories = (
   params: Params<
     t_SecurityAdvisoriesListOrgRepositoryAdvisoriesParamSchema,
     t_SecurityAdvisoriesListOrgRepositoryAdvisoriesQuerySchema,
+    void,
     void
   >,
   respond: SecurityAdvisoriesListOrgRepositoryAdvisoriesResponder,
@@ -7301,7 +7587,7 @@ export type OrgsListSecurityManagerTeamsResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsListSecurityManagerTeams = (
-  params: Params<t_OrgsListSecurityManagerTeamsParamSchema, void, void>,
+  params: Params<t_OrgsListSecurityManagerTeamsParamSchema, void, void, void>,
   respond: OrgsListSecurityManagerTeamsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_team_simple[]>>
@@ -7311,7 +7597,7 @@ export type OrgsAddSecurityManagerTeamResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsAddSecurityManagerTeam = (
-  params: Params<t_OrgsAddSecurityManagerTeamParamSchema, void, void>,
+  params: Params<t_OrgsAddSecurityManagerTeamParamSchema, void, void, void>,
   respond: OrgsAddSecurityManagerTeamResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7321,7 +7607,7 @@ export type OrgsRemoveSecurityManagerTeamResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsRemoveSecurityManagerTeam = (
-  params: Params<t_OrgsRemoveSecurityManagerTeamParamSchema, void, void>,
+  params: Params<t_OrgsRemoveSecurityManagerTeamParamSchema, void, void, void>,
   respond: OrgsRemoveSecurityManagerTeamResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7331,7 +7617,12 @@ export type BillingGetGithubActionsBillingOrgResponder = {
 } & KoaRuntimeResponder
 
 export type BillingGetGithubActionsBillingOrg = (
-  params: Params<t_BillingGetGithubActionsBillingOrgParamSchema, void, void>,
+  params: Params<
+    t_BillingGetGithubActionsBillingOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: BillingGetGithubActionsBillingOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7343,7 +7634,12 @@ export type BillingGetGithubPackagesBillingOrgResponder = {
 } & KoaRuntimeResponder
 
 export type BillingGetGithubPackagesBillingOrg = (
-  params: Params<t_BillingGetGithubPackagesBillingOrgParamSchema, void, void>,
+  params: Params<
+    t_BillingGetGithubPackagesBillingOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: BillingGetGithubPackagesBillingOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7355,7 +7651,12 @@ export type BillingGetSharedStorageBillingOrgResponder = {
 } & KoaRuntimeResponder
 
 export type BillingGetSharedStorageBillingOrg = (
-  params: Params<t_BillingGetSharedStorageBillingOrgParamSchema, void, void>,
+  params: Params<
+    t_BillingGetSharedStorageBillingOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: BillingGetSharedStorageBillingOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7374,6 +7675,7 @@ export type CopilotUsageMetricsForTeam = (
   params: Params<
     t_CopilotUsageMetricsForTeamParamSchema,
     t_CopilotUsageMetricsForTeamQuerySchema,
+    void,
     void
   >,
   respond: CopilotUsageMetricsForTeamResponder,
@@ -7393,7 +7695,7 @@ export type TeamsListResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsList = (
-  params: Params<t_TeamsListParamSchema, t_TeamsListQuerySchema, void>,
+  params: Params<t_TeamsListParamSchema, t_TeamsListQuerySchema, void, void>,
   respond: TeamsListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7409,7 +7711,7 @@ export type TeamsCreateResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsCreate = (
-  params: Params<t_TeamsCreateParamSchema, void, t_TeamsCreateBodySchema>,
+  params: Params<t_TeamsCreateParamSchema, void, t_TeamsCreateBodySchema, void>,
   respond: TeamsCreateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7425,7 +7727,7 @@ export type TeamsGetByNameResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetByName = (
-  params: Params<t_TeamsGetByNameParamSchema, void, void>,
+  params: Params<t_TeamsGetByNameParamSchema, void, void, void>,
   respond: TeamsGetByNameResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7446,7 +7748,8 @@ export type TeamsUpdateInOrg = (
   params: Params<
     t_TeamsUpdateInOrgParamSchema,
     void,
-    t_TeamsUpdateInOrgBodySchema | undefined
+    t_TeamsUpdateInOrgBodySchema | undefined,
+    void
   >,
   respond: TeamsUpdateInOrgResponder,
   ctx: RouterContext,
@@ -7464,7 +7767,7 @@ export type TeamsDeleteInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsDeleteInOrg = (
-  params: Params<t_TeamsDeleteInOrgParamSchema, void, void>,
+  params: Params<t_TeamsDeleteInOrgParamSchema, void, void, void>,
   respond: TeamsDeleteInOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7477,6 +7780,7 @@ export type TeamsListDiscussionsInOrg = (
   params: Params<
     t_TeamsListDiscussionsInOrgParamSchema,
     t_TeamsListDiscussionsInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListDiscussionsInOrgResponder,
@@ -7491,7 +7795,8 @@ export type TeamsCreateDiscussionInOrg = (
   params: Params<
     t_TeamsCreateDiscussionInOrgParamSchema,
     void,
-    t_TeamsCreateDiscussionInOrgBodySchema
+    t_TeamsCreateDiscussionInOrgBodySchema,
+    void
   >,
   respond: TeamsCreateDiscussionInOrgResponder,
   ctx: RouterContext,
@@ -7502,7 +7807,7 @@ export type TeamsGetDiscussionInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetDiscussionInOrg = (
-  params: Params<t_TeamsGetDiscussionInOrgParamSchema, void, void>,
+  params: Params<t_TeamsGetDiscussionInOrgParamSchema, void, void, void>,
   respond: TeamsGetDiscussionInOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_team_discussion>>
@@ -7515,7 +7820,8 @@ export type TeamsUpdateDiscussionInOrg = (
   params: Params<
     t_TeamsUpdateDiscussionInOrgParamSchema,
     void,
-    t_TeamsUpdateDiscussionInOrgBodySchema | undefined
+    t_TeamsUpdateDiscussionInOrgBodySchema | undefined,
+    void
   >,
   respond: TeamsUpdateDiscussionInOrgResponder,
   ctx: RouterContext,
@@ -7526,7 +7832,7 @@ export type TeamsDeleteDiscussionInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsDeleteDiscussionInOrg = (
-  params: Params<t_TeamsDeleteDiscussionInOrgParamSchema, void, void>,
+  params: Params<t_TeamsDeleteDiscussionInOrgParamSchema, void, void, void>,
   respond: TeamsDeleteDiscussionInOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7539,6 +7845,7 @@ export type TeamsListDiscussionCommentsInOrg = (
   params: Params<
     t_TeamsListDiscussionCommentsInOrgParamSchema,
     t_TeamsListDiscussionCommentsInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListDiscussionCommentsInOrgResponder,
@@ -7555,7 +7862,8 @@ export type TeamsCreateDiscussionCommentInOrg = (
   params: Params<
     t_TeamsCreateDiscussionCommentInOrgParamSchema,
     void,
-    t_TeamsCreateDiscussionCommentInOrgBodySchema
+    t_TeamsCreateDiscussionCommentInOrgBodySchema,
+    void
   >,
   respond: TeamsCreateDiscussionCommentInOrgResponder,
   ctx: RouterContext,
@@ -7568,7 +7876,7 @@ export type TeamsGetDiscussionCommentInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetDiscussionCommentInOrg = (
-  params: Params<t_TeamsGetDiscussionCommentInOrgParamSchema, void, void>,
+  params: Params<t_TeamsGetDiscussionCommentInOrgParamSchema, void, void, void>,
   respond: TeamsGetDiscussionCommentInOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7583,7 +7891,8 @@ export type TeamsUpdateDiscussionCommentInOrg = (
   params: Params<
     t_TeamsUpdateDiscussionCommentInOrgParamSchema,
     void,
-    t_TeamsUpdateDiscussionCommentInOrgBodySchema
+    t_TeamsUpdateDiscussionCommentInOrgBodySchema,
+    void
   >,
   respond: TeamsUpdateDiscussionCommentInOrgResponder,
   ctx: RouterContext,
@@ -7596,7 +7905,12 @@ export type TeamsDeleteDiscussionCommentInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsDeleteDiscussionCommentInOrg = (
-  params: Params<t_TeamsDeleteDiscussionCommentInOrgParamSchema, void, void>,
+  params: Params<
+    t_TeamsDeleteDiscussionCommentInOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsDeleteDiscussionCommentInOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7609,6 +7923,7 @@ export type ReactionsListForTeamDiscussionCommentInOrg = (
   params: Params<
     t_ReactionsListForTeamDiscussionCommentInOrgParamSchema,
     t_ReactionsListForTeamDiscussionCommentInOrgQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForTeamDiscussionCommentInOrgResponder,
@@ -7624,7 +7939,8 @@ export type ReactionsCreateForTeamDiscussionCommentInOrg = (
   params: Params<
     t_ReactionsCreateForTeamDiscussionCommentInOrgParamSchema,
     void,
-    t_ReactionsCreateForTeamDiscussionCommentInOrgBodySchema
+    t_ReactionsCreateForTeamDiscussionCommentInOrgBodySchema,
+    void
   >,
   respond: ReactionsCreateForTeamDiscussionCommentInOrgResponder,
   ctx: RouterContext,
@@ -7642,6 +7958,7 @@ export type ReactionsDeleteForTeamDiscussionComment = (
   params: Params<
     t_ReactionsDeleteForTeamDiscussionCommentParamSchema,
     void,
+    void,
     void
   >,
   respond: ReactionsDeleteForTeamDiscussionCommentResponder,
@@ -7656,6 +7973,7 @@ export type ReactionsListForTeamDiscussionInOrg = (
   params: Params<
     t_ReactionsListForTeamDiscussionInOrgParamSchema,
     t_ReactionsListForTeamDiscussionInOrgQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForTeamDiscussionInOrgResponder,
@@ -7671,7 +7989,8 @@ export type ReactionsCreateForTeamDiscussionInOrg = (
   params: Params<
     t_ReactionsCreateForTeamDiscussionInOrgParamSchema,
     void,
-    t_ReactionsCreateForTeamDiscussionInOrgBodySchema
+    t_ReactionsCreateForTeamDiscussionInOrgBodySchema,
+    void
   >,
   respond: ReactionsCreateForTeamDiscussionInOrgResponder,
   ctx: RouterContext,
@@ -7686,7 +8005,12 @@ export type ReactionsDeleteForTeamDiscussionResponder = {
 } & KoaRuntimeResponder
 
 export type ReactionsDeleteForTeamDiscussion = (
-  params: Params<t_ReactionsDeleteForTeamDiscussionParamSchema, void, void>,
+  params: Params<
+    t_ReactionsDeleteForTeamDiscussionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReactionsDeleteForTeamDiscussionResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7699,6 +8023,7 @@ export type TeamsListPendingInvitationsInOrg = (
   params: Params<
     t_TeamsListPendingInvitationsInOrgParamSchema,
     t_TeamsListPendingInvitationsInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListPendingInvitationsInOrgResponder,
@@ -7715,6 +8040,7 @@ export type TeamsListMembersInOrg = (
   params: Params<
     t_TeamsListMembersInOrgParamSchema,
     t_TeamsListMembersInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListMembersInOrgResponder,
@@ -7727,7 +8053,7 @@ export type TeamsGetMembershipForUserInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetMembershipForUserInOrg = (
-  params: Params<t_TeamsGetMembershipForUserInOrgParamSchema, void, void>,
+  params: Params<t_TeamsGetMembershipForUserInOrgParamSchema, void, void, void>,
   respond: TeamsGetMembershipForUserInOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7746,7 +8072,8 @@ export type TeamsAddOrUpdateMembershipForUserInOrg = (
   params: Params<
     t_TeamsAddOrUpdateMembershipForUserInOrgParamSchema,
     void,
-    t_TeamsAddOrUpdateMembershipForUserInOrgBodySchema | undefined
+    t_TeamsAddOrUpdateMembershipForUserInOrgBodySchema | undefined,
+    void
   >,
   respond: TeamsAddOrUpdateMembershipForUserInOrgResponder,
   ctx: RouterContext,
@@ -7763,7 +8090,12 @@ export type TeamsRemoveMembershipForUserInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveMembershipForUserInOrg = (
-  params: Params<t_TeamsRemoveMembershipForUserInOrgParamSchema, void, void>,
+  params: Params<
+    t_TeamsRemoveMembershipForUserInOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsRemoveMembershipForUserInOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7778,6 +8110,7 @@ export type TeamsListProjectsInOrg = (
   params: Params<
     t_TeamsListProjectsInOrgParamSchema,
     t_TeamsListProjectsInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListProjectsInOrgResponder,
@@ -7790,7 +8123,12 @@ export type TeamsCheckPermissionsForProjectInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsCheckPermissionsForProjectInOrg = (
-  params: Params<t_TeamsCheckPermissionsForProjectInOrgParamSchema, void, void>,
+  params: Params<
+    t_TeamsCheckPermissionsForProjectInOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsCheckPermissionsForProjectInOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7811,7 +8149,8 @@ export type TeamsAddOrUpdateProjectPermissionsInOrg = (
   params: Params<
     t_TeamsAddOrUpdateProjectPermissionsInOrgParamSchema,
     void,
-    t_TeamsAddOrUpdateProjectPermissionsInOrgBodySchema | undefined
+    t_TeamsAddOrUpdateProjectPermissionsInOrgBodySchema | undefined,
+    void
   >,
   respond: TeamsAddOrUpdateProjectPermissionsInOrgResponder,
   ctx: RouterContext,
@@ -7832,7 +8171,7 @@ export type TeamsRemoveProjectInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveProjectInOrg = (
-  params: Params<t_TeamsRemoveProjectInOrgParamSchema, void, void>,
+  params: Params<t_TeamsRemoveProjectInOrgParamSchema, void, void, void>,
   respond: TeamsRemoveProjectInOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7845,6 +8184,7 @@ export type TeamsListReposInOrg = (
   params: Params<
     t_TeamsListReposInOrgParamSchema,
     t_TeamsListReposInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListReposInOrgResponder,
@@ -7860,7 +8200,12 @@ export type TeamsCheckPermissionsForRepoInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsCheckPermissionsForRepoInOrg = (
-  params: Params<t_TeamsCheckPermissionsForRepoInOrgParamSchema, void, void>,
+  params: Params<
+    t_TeamsCheckPermissionsForRepoInOrgParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsCheckPermissionsForRepoInOrgResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7878,7 +8223,8 @@ export type TeamsAddOrUpdateRepoPermissionsInOrg = (
   params: Params<
     t_TeamsAddOrUpdateRepoPermissionsInOrgParamSchema,
     void,
-    t_TeamsAddOrUpdateRepoPermissionsInOrgBodySchema | undefined
+    t_TeamsAddOrUpdateRepoPermissionsInOrgBodySchema | undefined,
+    void
   >,
   respond: TeamsAddOrUpdateRepoPermissionsInOrgResponder,
   ctx: RouterContext,
@@ -7889,7 +8235,7 @@ export type TeamsRemoveRepoInOrgResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveRepoInOrg = (
-  params: Params<t_TeamsRemoveRepoInOrgParamSchema, void, void>,
+  params: Params<t_TeamsRemoveRepoInOrgParamSchema, void, void, void>,
   respond: TeamsRemoveRepoInOrgResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -7902,6 +8248,7 @@ export type TeamsListChildInOrg = (
   params: Params<
     t_TeamsListChildInOrgParamSchema,
     t_TeamsListChildInOrgQuerySchema,
+    void,
     void
   >,
   respond: TeamsListChildInOrgResponder,
@@ -7917,7 +8264,8 @@ export type OrgsEnableOrDisableSecurityProductOnAllOrgRepos = (
   params: Params<
     t_OrgsEnableOrDisableSecurityProductOnAllOrgReposParamSchema,
     void,
-    t_OrgsEnableOrDisableSecurityProductOnAllOrgReposBodySchema | undefined
+    t_OrgsEnableOrDisableSecurityProductOnAllOrgReposBodySchema | undefined,
+    void
   >,
   respond: OrgsEnableOrDisableSecurityProductOnAllOrgReposResponder,
   ctx: RouterContext,
@@ -7934,7 +8282,7 @@ export type ProjectsGetCardResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsGetCard = (
-  params: Params<t_ProjectsGetCardParamSchema, void, void>,
+  params: Params<t_ProjectsGetCardParamSchema, void, void, void>,
   respond: ProjectsGetCardResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7959,7 +8307,8 @@ export type ProjectsUpdateCard = (
   params: Params<
     t_ProjectsUpdateCardParamSchema,
     void,
-    t_ProjectsUpdateCardBodySchema | undefined
+    t_ProjectsUpdateCardBodySchema | undefined,
+    void
   >,
   respond: ProjectsUpdateCardResponder,
   ctx: RouterContext,
@@ -7986,7 +8335,7 @@ export type ProjectsDeleteCardResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsDeleteCard = (
-  params: Params<t_ProjectsDeleteCardParamSchema, void, void>,
+  params: Params<t_ProjectsDeleteCardParamSchema, void, void, void>,
   respond: ProjectsDeleteCardResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8035,7 +8384,8 @@ export type ProjectsMoveCard = (
   params: Params<
     t_ProjectsMoveCardParamSchema,
     void,
-    t_ProjectsMoveCardBodySchema
+    t_ProjectsMoveCardBodySchema,
+    void
   >,
   respond: ProjectsMoveCardResponder,
   ctx: RouterContext,
@@ -8081,7 +8431,7 @@ export type ProjectsGetColumnResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsGetColumn = (
-  params: Params<t_ProjectsGetColumnParamSchema, void, void>,
+  params: Params<t_ProjectsGetColumnParamSchema, void, void, void>,
   respond: ProjectsGetColumnResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8104,7 +8454,8 @@ export type ProjectsUpdateColumn = (
   params: Params<
     t_ProjectsUpdateColumnParamSchema,
     void,
-    t_ProjectsUpdateColumnBodySchema
+    t_ProjectsUpdateColumnBodySchema,
+    void
   >,
   respond: ProjectsUpdateColumnResponder,
   ctx: RouterContext,
@@ -8124,7 +8475,7 @@ export type ProjectsDeleteColumnResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsDeleteColumn = (
-  params: Params<t_ProjectsDeleteColumnParamSchema, void, void>,
+  params: Params<t_ProjectsDeleteColumnParamSchema, void, void, void>,
   respond: ProjectsDeleteColumnResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8146,6 +8497,7 @@ export type ProjectsListCards = (
   params: Params<
     t_ProjectsListCardsParamSchema,
     t_ProjectsListCardsQuerySchema,
+    void,
     void
   >,
   respond: ProjectsListCardsResponder,
@@ -8179,7 +8531,8 @@ export type ProjectsCreateCard = (
   params: Params<
     t_ProjectsCreateCardParamSchema,
     void,
-    t_ProjectsCreateCardBodySchema
+    t_ProjectsCreateCardBodySchema,
+    void
   >,
   respond: ProjectsCreateCardResponder,
   ctx: RouterContext,
@@ -8216,7 +8569,8 @@ export type ProjectsMoveColumn = (
   params: Params<
     t_ProjectsMoveColumnParamSchema,
     void,
-    t_ProjectsMoveColumnBodySchema
+    t_ProjectsMoveColumnBodySchema,
+    void
   >,
   respond: ProjectsMoveColumnResponder,
   ctx: RouterContext,
@@ -8237,7 +8591,7 @@ export type ProjectsGetResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsGet = (
-  params: Params<t_ProjectsGetParamSchema, void, void>,
+  params: Params<t_ProjectsGetParamSchema, void, void, void>,
   respond: ProjectsGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8266,7 +8620,8 @@ export type ProjectsUpdate = (
   params: Params<
     t_ProjectsUpdateParamSchema,
     void,
-    t_ProjectsUpdateBodySchema | undefined
+    t_ProjectsUpdateBodySchema | undefined,
+    void
   >,
   respond: ProjectsUpdateResponder,
   ctx: RouterContext,
@@ -8302,7 +8657,7 @@ export type ProjectsDeleteResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsDelete = (
-  params: Params<t_ProjectsDeleteParamSchema, void, void>,
+  params: Params<t_ProjectsDeleteParamSchema, void, void, void>,
   respond: ProjectsDeleteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8335,6 +8690,7 @@ export type ProjectsListCollaborators = (
   params: Params<
     t_ProjectsListCollaboratorsParamSchema,
     t_ProjectsListCollaboratorsQuerySchema,
+    void,
     void
   >,
   respond: ProjectsListCollaboratorsResponder,
@@ -8362,7 +8718,8 @@ export type ProjectsAddCollaborator = (
   params: Params<
     t_ProjectsAddCollaboratorParamSchema,
     void,
-    t_ProjectsAddCollaboratorBodySchema | undefined
+    t_ProjectsAddCollaboratorBodySchema | undefined,
+    void
   >,
   respond: ProjectsAddCollaboratorResponder,
   ctx: RouterContext,
@@ -8386,7 +8743,7 @@ export type ProjectsRemoveCollaboratorResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsRemoveCollaborator = (
-  params: Params<t_ProjectsRemoveCollaboratorParamSchema, void, void>,
+  params: Params<t_ProjectsRemoveCollaboratorParamSchema, void, void, void>,
   respond: ProjectsRemoveCollaboratorResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8409,7 +8766,7 @@ export type ProjectsGetPermissionForUserResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsGetPermissionForUser = (
-  params: Params<t_ProjectsGetPermissionForUserParamSchema, void, void>,
+  params: Params<t_ProjectsGetPermissionForUserParamSchema, void, void, void>,
   respond: ProjectsGetPermissionForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8433,6 +8790,7 @@ export type ProjectsListColumns = (
   params: Params<
     t_ProjectsListColumnsParamSchema,
     t_ProjectsListColumnsQuerySchema,
+    void,
     void
   >,
   respond: ProjectsListColumnsResponder,
@@ -8457,7 +8815,8 @@ export type ProjectsCreateColumn = (
   params: Params<
     t_ProjectsCreateColumnParamSchema,
     void,
-    t_ProjectsCreateColumnBodySchema
+    t_ProjectsCreateColumnBodySchema,
+    void
   >,
   respond: ProjectsCreateColumnResponder,
   ctx: RouterContext,
@@ -8477,7 +8836,7 @@ export type RateLimitGetResponder = {
 } & KoaRuntimeResponder
 
 export type RateLimitGet = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: RateLimitGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8495,7 +8854,7 @@ export type ReposGetResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGet = (
-  params: Params<t_ReposGetParamSchema, void, void>,
+  params: Params<t_ReposGetParamSchema, void, void, void>,
   respond: ReposGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8518,7 +8877,8 @@ export type ReposUpdate = (
   params: Params<
     t_ReposUpdateParamSchema,
     void,
-    t_ReposUpdateBodySchema | undefined
+    t_ReposUpdateBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateResponder,
   ctx: RouterContext,
@@ -8542,7 +8902,7 @@ export type ReposDeleteResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDelete = (
-  params: Params<t_ReposDeleteParamSchema, void, void>,
+  params: Params<t_ReposDeleteParamSchema, void, void, void>,
   respond: ReposDeleteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8570,6 +8930,7 @@ export type ActionsListArtifactsForRepo = (
   params: Params<
     t_ActionsListArtifactsForRepoParamSchema,
     t_ActionsListArtifactsForRepoQuerySchema,
+    void,
     void
   >,
   respond: ActionsListArtifactsForRepoResponder,
@@ -8590,7 +8951,7 @@ export type ActionsGetArtifactResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetArtifact = (
-  params: Params<t_ActionsGetArtifactParamSchema, void, void>,
+  params: Params<t_ActionsGetArtifactParamSchema, void, void, void>,
   respond: ActionsGetArtifactResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_artifact>>
@@ -8600,7 +8961,7 @@ export type ActionsDeleteArtifactResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteArtifact = (
-  params: Params<t_ActionsDeleteArtifactParamSchema, void, void>,
+  params: Params<t_ActionsDeleteArtifactParamSchema, void, void, void>,
   respond: ActionsDeleteArtifactResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -8611,7 +8972,7 @@ export type ActionsDownloadArtifactResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDownloadArtifact = (
-  params: Params<t_ActionsDownloadArtifactParamSchema, void, void>,
+  params: Params<t_ActionsDownloadArtifactParamSchema, void, void, void>,
   respond: ActionsDownloadArtifactResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8625,7 +8986,7 @@ export type ActionsGetActionsCacheUsageResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetActionsCacheUsage = (
-  params: Params<t_ActionsGetActionsCacheUsageParamSchema, void, void>,
+  params: Params<t_ActionsGetActionsCacheUsageParamSchema, void, void, void>,
   respond: ActionsGetActionsCacheUsageResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8641,6 +9002,7 @@ export type ActionsGetActionsCacheList = (
   params: Params<
     t_ActionsGetActionsCacheListParamSchema,
     t_ActionsGetActionsCacheListQuerySchema,
+    void,
     void
   >,
   respond: ActionsGetActionsCacheListResponder,
@@ -8655,6 +9017,7 @@ export type ActionsDeleteActionsCacheByKey = (
   params: Params<
     t_ActionsDeleteActionsCacheByKeyParamSchema,
     t_ActionsDeleteActionsCacheByKeyQuerySchema,
+    void,
     void
   >,
   respond: ActionsDeleteActionsCacheByKeyResponder,
@@ -8666,7 +9029,7 @@ export type ActionsDeleteActionsCacheByIdResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteActionsCacheById = (
-  params: Params<t_ActionsDeleteActionsCacheByIdParamSchema, void, void>,
+  params: Params<t_ActionsDeleteActionsCacheByIdParamSchema, void, void, void>,
   respond: ActionsDeleteActionsCacheByIdResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -8676,7 +9039,7 @@ export type ActionsGetJobForWorkflowRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetJobForWorkflowRun = (
-  params: Params<t_ActionsGetJobForWorkflowRunParamSchema, void, void>,
+  params: Params<t_ActionsGetJobForWorkflowRunParamSchema, void, void, void>,
   respond: ActionsGetJobForWorkflowRunResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_job>>
@@ -8686,7 +9049,12 @@ export type ActionsDownloadJobLogsForWorkflowRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDownloadJobLogsForWorkflowRun = (
-  params: Params<t_ActionsDownloadJobLogsForWorkflowRunParamSchema, void, void>,
+  params: Params<
+    t_ActionsDownloadJobLogsForWorkflowRunParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsDownloadJobLogsForWorkflowRunResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<302, void>>
@@ -8700,7 +9068,8 @@ export type ActionsReRunJobForWorkflowRun = (
   params: Params<
     t_ActionsReRunJobForWorkflowRunParamSchema,
     void,
-    t_ActionsReRunJobForWorkflowRunBodySchema | undefined
+    t_ActionsReRunJobForWorkflowRunBodySchema | undefined,
+    void
   >,
   respond: ActionsReRunJobForWorkflowRunResponder,
   ctx: RouterContext,
@@ -8717,7 +9086,12 @@ export type ActionsGetCustomOidcSubClaimForRepoResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetCustomOidcSubClaimForRepo = (
-  params: Params<t_ActionsGetCustomOidcSubClaimForRepoParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetCustomOidcSubClaimForRepoParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetCustomOidcSubClaimForRepoResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8738,7 +9112,8 @@ export type ActionsSetCustomOidcSubClaimForRepo = (
   params: Params<
     t_ActionsSetCustomOidcSubClaimForRepoParamSchema,
     void,
-    t_ActionsSetCustomOidcSubClaimForRepoBodySchema
+    t_ActionsSetCustomOidcSubClaimForRepoBodySchema,
+    void
   >,
   respond: ActionsSetCustomOidcSubClaimForRepoResponder,
   ctx: RouterContext,
@@ -8761,6 +9136,7 @@ export type ActionsListRepoOrganizationSecrets = (
   params: Params<
     t_ActionsListRepoOrganizationSecretsParamSchema,
     t_ActionsListRepoOrganizationSecretsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListRepoOrganizationSecretsResponder,
@@ -8787,6 +9163,7 @@ export type ActionsListRepoOrganizationVariables = (
   params: Params<
     t_ActionsListRepoOrganizationVariablesParamSchema,
     t_ActionsListRepoOrganizationVariablesQuerySchema,
+    void,
     void
   >,
   respond: ActionsListRepoOrganizationVariablesResponder,
@@ -8810,6 +9187,7 @@ export type ActionsGetGithubActionsPermissionsRepository = (
   params: Params<
     t_ActionsGetGithubActionsPermissionsRepositoryParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsGetGithubActionsPermissionsRepositoryResponder,
@@ -8826,7 +9204,8 @@ export type ActionsSetGithubActionsPermissionsRepository = (
   params: Params<
     t_ActionsSetGithubActionsPermissionsRepositoryParamSchema,
     void,
-    t_ActionsSetGithubActionsPermissionsRepositoryBodySchema
+    t_ActionsSetGithubActionsPermissionsRepositoryBodySchema,
+    void
   >,
   respond: ActionsSetGithubActionsPermissionsRepositoryResponder,
   ctx: RouterContext,
@@ -8837,7 +9216,12 @@ export type ActionsGetWorkflowAccessToRepositoryResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetWorkflowAccessToRepository = (
-  params: Params<t_ActionsGetWorkflowAccessToRepositoryParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetWorkflowAccessToRepositoryParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetWorkflowAccessToRepositoryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8853,7 +9237,8 @@ export type ActionsSetWorkflowAccessToRepository = (
   params: Params<
     t_ActionsSetWorkflowAccessToRepositoryParamSchema,
     void,
-    t_ActionsSetWorkflowAccessToRepositoryBodySchema
+    t_ActionsSetWorkflowAccessToRepositoryBodySchema,
+    void
   >,
   respond: ActionsSetWorkflowAccessToRepositoryResponder,
   ctx: RouterContext,
@@ -8864,7 +9249,12 @@ export type ActionsGetAllowedActionsRepositoryResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetAllowedActionsRepository = (
-  params: Params<t_ActionsGetAllowedActionsRepositoryParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetAllowedActionsRepositoryParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetAllowedActionsRepositoryResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_selected_actions>>
@@ -8877,7 +9267,8 @@ export type ActionsSetAllowedActionsRepository = (
   params: Params<
     t_ActionsSetAllowedActionsRepositoryParamSchema,
     void,
-    t_ActionsSetAllowedActionsRepositoryBodySchema | undefined
+    t_ActionsSetAllowedActionsRepositoryBodySchema | undefined,
+    void
   >,
   respond: ActionsSetAllowedActionsRepositoryResponder,
   ctx: RouterContext,
@@ -8891,6 +9282,7 @@ export type ActionsGetGithubActionsDefaultWorkflowPermissionsRepositoryResponder
 export type ActionsGetGithubActionsDefaultWorkflowPermissionsRepository = (
   params: Params<
     t_ActionsGetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema,
+    void,
     void,
     void
   >,
@@ -8911,7 +9303,8 @@ export type ActionsSetGithubActionsDefaultWorkflowPermissionsRepository = (
   params: Params<
     t_ActionsSetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema,
     void,
-    t_ActionsSetGithubActionsDefaultWorkflowPermissionsRepositoryBodySchema
+    t_ActionsSetGithubActionsDefaultWorkflowPermissionsRepositoryBodySchema,
+    void
   >,
   respond: ActionsSetGithubActionsDefaultWorkflowPermissionsRepositoryResponder,
   ctx: RouterContext,
@@ -8930,6 +9323,7 @@ export type ActionsListSelfHostedRunnersForRepo = (
   params: Params<
     t_ActionsListSelfHostedRunnersForRepoParamSchema,
     t_ActionsListSelfHostedRunnersForRepoQuerySchema,
+    void,
     void
   >,
   respond: ActionsListSelfHostedRunnersForRepoResponder,
@@ -8950,7 +9344,12 @@ export type ActionsListRunnerApplicationsForRepoResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsListRunnerApplicationsForRepo = (
-  params: Params<t_ActionsListRunnerApplicationsForRepoParamSchema, void, void>,
+  params: Params<
+    t_ActionsListRunnerApplicationsForRepoParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsListRunnerApplicationsForRepoResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8970,7 +9369,8 @@ export type ActionsGenerateRunnerJitconfigForRepo = (
   params: Params<
     t_ActionsGenerateRunnerJitconfigForRepoParamSchema,
     void,
-    t_ActionsGenerateRunnerJitconfigForRepoBodySchema
+    t_ActionsGenerateRunnerJitconfigForRepoBodySchema,
+    void
   >,
   respond: ActionsGenerateRunnerJitconfigForRepoResponder,
   ctx: RouterContext,
@@ -8995,6 +9395,7 @@ export type ActionsCreateRegistrationTokenForRepo = (
   params: Params<
     t_ActionsCreateRegistrationTokenForRepoParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsCreateRegistrationTokenForRepoResponder,
@@ -9008,7 +9409,12 @@ export type ActionsCreateRemoveTokenForRepoResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsCreateRemoveTokenForRepo = (
-  params: Params<t_ActionsCreateRemoveTokenForRepoParamSchema, void, void>,
+  params: Params<
+    t_ActionsCreateRemoveTokenForRepoParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsCreateRemoveTokenForRepoResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9020,7 +9426,12 @@ export type ActionsGetSelfHostedRunnerForRepoResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetSelfHostedRunnerForRepo = (
-  params: Params<t_ActionsGetSelfHostedRunnerForRepoParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetSelfHostedRunnerForRepoParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetSelfHostedRunnerForRepoResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_runner>>
@@ -9032,6 +9443,7 @@ export type ActionsDeleteSelfHostedRunnerFromRepoResponder = {
 export type ActionsDeleteSelfHostedRunnerFromRepo = (
   params: Params<
     t_ActionsDeleteSelfHostedRunnerFromRepoParamSchema,
+    void,
     void,
     void
   >,
@@ -9050,6 +9462,7 @@ export type ActionsListLabelsForSelfHostedRunnerForRepoResponder = {
 export type ActionsListLabelsForSelfHostedRunnerForRepo = (
   params: Params<
     t_ActionsListLabelsForSelfHostedRunnerForRepoParamSchema,
+    void,
     void,
     void
   >,
@@ -9080,7 +9493,8 @@ export type ActionsAddCustomLabelsToSelfHostedRunnerForRepo = (
   params: Params<
     t_ActionsAddCustomLabelsToSelfHostedRunnerForRepoParamSchema,
     void,
-    t_ActionsAddCustomLabelsToSelfHostedRunnerForRepoBodySchema
+    t_ActionsAddCustomLabelsToSelfHostedRunnerForRepoBodySchema,
+    void
   >,
   respond: ActionsAddCustomLabelsToSelfHostedRunnerForRepoResponder,
   ctx: RouterContext,
@@ -9110,7 +9524,8 @@ export type ActionsSetCustomLabelsForSelfHostedRunnerForRepo = (
   params: Params<
     t_ActionsSetCustomLabelsForSelfHostedRunnerForRepoParamSchema,
     void,
-    t_ActionsSetCustomLabelsForSelfHostedRunnerForRepoBodySchema
+    t_ActionsSetCustomLabelsForSelfHostedRunnerForRepoBodySchema,
+    void
   >,
   respond: ActionsSetCustomLabelsForSelfHostedRunnerForRepoResponder,
   ctx: RouterContext,
@@ -9138,6 +9553,7 @@ export type ActionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepoResponder = {
 export type ActionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepo = (
   params: Params<
     t_ActionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepoParamSchema,
+    void,
     void,
     void
   >,
@@ -9168,6 +9584,7 @@ export type ActionsRemoveCustomLabelFromSelfHostedRunnerForRepo = (
   params: Params<
     t_ActionsRemoveCustomLabelFromSelfHostedRunnerForRepoParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsRemoveCustomLabelFromSelfHostedRunnerForRepoResponder,
@@ -9196,6 +9613,7 @@ export type ActionsListWorkflowRunsForRepo = (
   params: Params<
     t_ActionsListWorkflowRunsForRepoParamSchema,
     t_ActionsListWorkflowRunsForRepoQuerySchema,
+    void,
     void
   >,
   respond: ActionsListWorkflowRunsForRepoResponder,
@@ -9219,6 +9637,7 @@ export type ActionsGetWorkflowRun = (
   params: Params<
     t_ActionsGetWorkflowRunParamSchema,
     t_ActionsGetWorkflowRunQuerySchema,
+    void,
     void
   >,
   respond: ActionsGetWorkflowRunResponder,
@@ -9230,7 +9649,7 @@ export type ActionsDeleteWorkflowRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteWorkflowRun = (
-  params: Params<t_ActionsDeleteWorkflowRunParamSchema, void, void>,
+  params: Params<t_ActionsDeleteWorkflowRunParamSchema, void, void, void>,
   respond: ActionsDeleteWorkflowRunResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9240,7 +9659,7 @@ export type ActionsGetReviewsForRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetReviewsForRun = (
-  params: Params<t_ActionsGetReviewsForRunParamSchema, void, void>,
+  params: Params<t_ActionsGetReviewsForRunParamSchema, void, void, void>,
   respond: ActionsGetReviewsForRunResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9254,7 +9673,7 @@ export type ActionsApproveWorkflowRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsApproveWorkflowRun = (
-  params: Params<t_ActionsApproveWorkflowRunParamSchema, void, void>,
+  params: Params<t_ActionsApproveWorkflowRunParamSchema, void, void, void>,
   respond: ActionsApproveWorkflowRunResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9275,6 +9694,7 @@ export type ActionsListWorkflowRunArtifacts = (
   params: Params<
     t_ActionsListWorkflowRunArtifactsParamSchema,
     t_ActionsListWorkflowRunArtifactsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListWorkflowRunArtifactsResponder,
@@ -9298,6 +9718,7 @@ export type ActionsGetWorkflowRunAttempt = (
   params: Params<
     t_ActionsGetWorkflowRunAttemptParamSchema,
     t_ActionsGetWorkflowRunAttemptQuerySchema,
+    void,
     void
   >,
   respond: ActionsGetWorkflowRunAttemptResponder,
@@ -9316,6 +9737,7 @@ export type ActionsListJobsForWorkflowRunAttempt = (
   params: Params<
     t_ActionsListJobsForWorkflowRunAttemptParamSchema,
     t_ActionsListJobsForWorkflowRunAttemptQuerySchema,
+    void,
     void
   >,
   respond: ActionsListJobsForWorkflowRunAttemptResponder,
@@ -9340,6 +9762,7 @@ export type ActionsDownloadWorkflowRunAttemptLogs = (
   params: Params<
     t_ActionsDownloadWorkflowRunAttemptLogsParamSchema,
     void,
+    void,
     void
   >,
   respond: ActionsDownloadWorkflowRunAttemptLogsResponder,
@@ -9352,7 +9775,7 @@ export type ActionsCancelWorkflowRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsCancelWorkflowRun = (
-  params: Params<t_ActionsCancelWorkflowRunParamSchema, void, void>,
+  params: Params<t_ActionsCancelWorkflowRunParamSchema, void, void, void>,
   respond: ActionsCancelWorkflowRunResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9369,7 +9792,8 @@ export type ActionsReviewCustomGatesForRun = (
   params: Params<
     t_ActionsReviewCustomGatesForRunParamSchema,
     void,
-    t_ActionsReviewCustomGatesForRunBodySchema
+    t_ActionsReviewCustomGatesForRunBodySchema,
+    void
   >,
   respond: ActionsReviewCustomGatesForRunResponder,
   ctx: RouterContext,
@@ -9381,7 +9805,7 @@ export type ActionsForceCancelWorkflowRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsForceCancelWorkflowRun = (
-  params: Params<t_ActionsForceCancelWorkflowRunParamSchema, void, void>,
+  params: Params<t_ActionsForceCancelWorkflowRunParamSchema, void, void, void>,
   respond: ActionsForceCancelWorkflowRunResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9401,6 +9825,7 @@ export type ActionsListJobsForWorkflowRun = (
   params: Params<
     t_ActionsListJobsForWorkflowRunParamSchema,
     t_ActionsListJobsForWorkflowRunQuerySchema,
+    void,
     void
   >,
   respond: ActionsListJobsForWorkflowRunResponder,
@@ -9421,7 +9846,7 @@ export type ActionsDownloadWorkflowRunLogsResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDownloadWorkflowRunLogs = (
-  params: Params<t_ActionsDownloadWorkflowRunLogsParamSchema, void, void>,
+  params: Params<t_ActionsDownloadWorkflowRunLogsParamSchema, void, void, void>,
   respond: ActionsDownloadWorkflowRunLogsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<302, void>>
@@ -9433,7 +9858,7 @@ export type ActionsDeleteWorkflowRunLogsResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteWorkflowRunLogs = (
-  params: Params<t_ActionsDeleteWorkflowRunLogsParamSchema, void, void>,
+  params: Params<t_ActionsDeleteWorkflowRunLogsParamSchema, void, void, void>,
   respond: ActionsDeleteWorkflowRunLogsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9448,7 +9873,12 @@ export type ActionsGetPendingDeploymentsForRunResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetPendingDeploymentsForRun = (
-  params: Params<t_ActionsGetPendingDeploymentsForRunParamSchema, void, void>,
+  params: Params<
+    t_ActionsGetPendingDeploymentsForRunParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsGetPendingDeploymentsForRunResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9463,7 +9893,8 @@ export type ActionsReviewPendingDeploymentsForRun = (
   params: Params<
     t_ActionsReviewPendingDeploymentsForRunParamSchema,
     void,
-    t_ActionsReviewPendingDeploymentsForRunBodySchema
+    t_ActionsReviewPendingDeploymentsForRunBodySchema,
+    void
   >,
   respond: ActionsReviewPendingDeploymentsForRunResponder,
   ctx: RouterContext,
@@ -9477,7 +9908,8 @@ export type ActionsReRunWorkflow = (
   params: Params<
     t_ActionsReRunWorkflowParamSchema,
     void,
-    t_ActionsReRunWorkflowBodySchema | undefined
+    t_ActionsReRunWorkflowBodySchema | undefined,
+    void
   >,
   respond: ActionsReRunWorkflowResponder,
   ctx: RouterContext,
@@ -9491,7 +9923,8 @@ export type ActionsReRunWorkflowFailedJobs = (
   params: Params<
     t_ActionsReRunWorkflowFailedJobsParamSchema,
     void,
-    t_ActionsReRunWorkflowFailedJobsBodySchema | undefined
+    t_ActionsReRunWorkflowFailedJobsBodySchema | undefined,
+    void
   >,
   respond: ActionsReRunWorkflowFailedJobsResponder,
   ctx: RouterContext,
@@ -9502,7 +9935,7 @@ export type ActionsGetWorkflowRunUsageResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetWorkflowRunUsage = (
-  params: Params<t_ActionsGetWorkflowRunUsageParamSchema, void, void>,
+  params: Params<t_ActionsGetWorkflowRunUsageParamSchema, void, void, void>,
   respond: ActionsGetWorkflowRunUsageResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_workflow_run_usage>>
@@ -9518,6 +9951,7 @@ export type ActionsListRepoSecrets = (
   params: Params<
     t_ActionsListRepoSecretsParamSchema,
     t_ActionsListRepoSecretsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListRepoSecretsResponder,
@@ -9538,7 +9972,7 @@ export type ActionsGetRepoPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetRepoPublicKey = (
-  params: Params<t_ActionsGetRepoPublicKeyParamSchema, void, void>,
+  params: Params<t_ActionsGetRepoPublicKeyParamSchema, void, void, void>,
   respond: ActionsGetRepoPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_public_key>>
@@ -9548,7 +9982,7 @@ export type ActionsGetRepoSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetRepoSecret = (
-  params: Params<t_ActionsGetRepoSecretParamSchema, void, void>,
+  params: Params<t_ActionsGetRepoSecretParamSchema, void, void, void>,
   respond: ActionsGetRepoSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_secret>>
@@ -9562,7 +9996,8 @@ export type ActionsCreateOrUpdateRepoSecret = (
   params: Params<
     t_ActionsCreateOrUpdateRepoSecretParamSchema,
     void,
-    t_ActionsCreateOrUpdateRepoSecretBodySchema
+    t_ActionsCreateOrUpdateRepoSecretBodySchema,
+    void
   >,
   respond: ActionsCreateOrUpdateRepoSecretResponder,
   ctx: RouterContext,
@@ -9577,7 +10012,7 @@ export type ActionsDeleteRepoSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteRepoSecret = (
-  params: Params<t_ActionsDeleteRepoSecretParamSchema, void, void>,
+  params: Params<t_ActionsDeleteRepoSecretParamSchema, void, void, void>,
   respond: ActionsDeleteRepoSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9593,6 +10028,7 @@ export type ActionsListRepoVariables = (
   params: Params<
     t_ActionsListRepoVariablesParamSchema,
     t_ActionsListRepoVariablesQuerySchema,
+    void,
     void
   >,
   respond: ActionsListRepoVariablesResponder,
@@ -9616,7 +10052,8 @@ export type ActionsCreateRepoVariable = (
   params: Params<
     t_ActionsCreateRepoVariableParamSchema,
     void,
-    t_ActionsCreateRepoVariableBodySchema
+    t_ActionsCreateRepoVariableBodySchema,
+    void
   >,
   respond: ActionsCreateRepoVariableResponder,
   ctx: RouterContext,
@@ -9627,7 +10064,7 @@ export type ActionsGetRepoVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetRepoVariable = (
-  params: Params<t_ActionsGetRepoVariableParamSchema, void, void>,
+  params: Params<t_ActionsGetRepoVariableParamSchema, void, void, void>,
   respond: ActionsGetRepoVariableResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_variable>>
@@ -9640,7 +10077,8 @@ export type ActionsUpdateRepoVariable = (
   params: Params<
     t_ActionsUpdateRepoVariableParamSchema,
     void,
-    t_ActionsUpdateRepoVariableBodySchema
+    t_ActionsUpdateRepoVariableBodySchema,
+    void
   >,
   respond: ActionsUpdateRepoVariableResponder,
   ctx: RouterContext,
@@ -9651,7 +10089,7 @@ export type ActionsDeleteRepoVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteRepoVariable = (
-  params: Params<t_ActionsDeleteRepoVariableParamSchema, void, void>,
+  params: Params<t_ActionsDeleteRepoVariableParamSchema, void, void, void>,
   respond: ActionsDeleteRepoVariableResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9667,6 +10105,7 @@ export type ActionsListRepoWorkflows = (
   params: Params<
     t_ActionsListRepoWorkflowsParamSchema,
     t_ActionsListRepoWorkflowsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListRepoWorkflowsResponder,
@@ -9687,7 +10126,7 @@ export type ActionsGetWorkflowResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetWorkflow = (
-  params: Params<t_ActionsGetWorkflowParamSchema, void, void>,
+  params: Params<t_ActionsGetWorkflowParamSchema, void, void, void>,
   respond: ActionsGetWorkflowResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_workflow>>
@@ -9697,7 +10136,7 @@ export type ActionsDisableWorkflowResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDisableWorkflow = (
-  params: Params<t_ActionsDisableWorkflowParamSchema, void, void>,
+  params: Params<t_ActionsDisableWorkflowParamSchema, void, void, void>,
   respond: ActionsDisableWorkflowResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9710,7 +10149,8 @@ export type ActionsCreateWorkflowDispatch = (
   params: Params<
     t_ActionsCreateWorkflowDispatchParamSchema,
     void,
-    t_ActionsCreateWorkflowDispatchBodySchema
+    t_ActionsCreateWorkflowDispatchBodySchema,
+    void
   >,
   respond: ActionsCreateWorkflowDispatchResponder,
   ctx: RouterContext,
@@ -9721,7 +10161,7 @@ export type ActionsEnableWorkflowResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsEnableWorkflow = (
-  params: Params<t_ActionsEnableWorkflowParamSchema, void, void>,
+  params: Params<t_ActionsEnableWorkflowParamSchema, void, void, void>,
   respond: ActionsEnableWorkflowResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9737,6 +10177,7 @@ export type ActionsListWorkflowRuns = (
   params: Params<
     t_ActionsListWorkflowRunsParamSchema,
     t_ActionsListWorkflowRunsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListWorkflowRunsResponder,
@@ -9757,7 +10198,7 @@ export type ActionsGetWorkflowUsageResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetWorkflowUsage = (
-  params: Params<t_ActionsGetWorkflowUsageParamSchema, void, void>,
+  params: Params<t_ActionsGetWorkflowUsageParamSchema, void, void, void>,
   respond: ActionsGetWorkflowUsageResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_workflow_usage>>
@@ -9771,6 +10212,7 @@ export type ReposListActivities = (
   params: Params<
     t_ReposListActivitiesParamSchema,
     t_ReposListActivitiesQuerySchema,
+    void,
     void
   >,
   respond: ReposListActivitiesResponder,
@@ -9790,6 +10232,7 @@ export type IssuesListAssignees = (
   params: Params<
     t_IssuesListAssigneesParamSchema,
     t_IssuesListAssigneesQuerySchema,
+    void,
     void
   >,
   respond: IssuesListAssigneesResponder,
@@ -9806,7 +10249,7 @@ export type IssuesCheckUserCanBeAssignedResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesCheckUserCanBeAssigned = (
-  params: Params<t_IssuesCheckUserCanBeAssignedParamSchema, void, void>,
+  params: Params<t_IssuesCheckUserCanBeAssignedParamSchema, void, void, void>,
   respond: IssuesCheckUserCanBeAssignedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9827,7 +10270,8 @@ export type ReposCreateAttestation = (
   params: Params<
     t_ReposCreateAttestationParamSchema,
     void,
-    t_ReposCreateAttestationBodySchema
+    t_ReposCreateAttestationBodySchema,
+    void
   >,
   respond: ReposCreateAttestationResponder,
   ctx: RouterContext,
@@ -9864,6 +10308,7 @@ export type ReposListAttestations = (
   params: Params<
     t_ReposListAttestationsParamSchema,
     t_ReposListAttestationsQuerySchema,
+    void,
     void
   >,
   respond: ReposListAttestationsResponder,
@@ -9894,7 +10339,7 @@ export type ReposListAutolinksResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListAutolinks = (
-  params: Params<t_ReposListAutolinksParamSchema, void, void>,
+  params: Params<t_ReposListAutolinksParamSchema, void, void, void>,
   respond: ReposListAutolinksResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_autolink[]>>
@@ -9908,7 +10353,8 @@ export type ReposCreateAutolink = (
   params: Params<
     t_ReposCreateAutolinkParamSchema,
     void,
-    t_ReposCreateAutolinkBodySchema
+    t_ReposCreateAutolinkBodySchema,
+    void
   >,
   respond: ReposCreateAutolinkResponder,
   ctx: RouterContext,
@@ -9924,7 +10370,7 @@ export type ReposGetAutolinkResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetAutolink = (
-  params: Params<t_ReposGetAutolinkParamSchema, void, void>,
+  params: Params<t_ReposGetAutolinkParamSchema, void, void, void>,
   respond: ReposGetAutolinkResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9939,7 +10385,7 @@ export type ReposDeleteAutolinkResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteAutolink = (
-  params: Params<t_ReposDeleteAutolinkParamSchema, void, void>,
+  params: Params<t_ReposDeleteAutolinkParamSchema, void, void, void>,
   respond: ReposDeleteAutolinkResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9954,7 +10400,12 @@ export type ReposCheckAutomatedSecurityFixesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposCheckAutomatedSecurityFixes = (
-  params: Params<t_ReposCheckAutomatedSecurityFixesParamSchema, void, void>,
+  params: Params<
+    t_ReposCheckAutomatedSecurityFixesParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposCheckAutomatedSecurityFixesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9968,7 +10419,12 @@ export type ReposEnableAutomatedSecurityFixesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposEnableAutomatedSecurityFixes = (
-  params: Params<t_ReposEnableAutomatedSecurityFixesParamSchema, void, void>,
+  params: Params<
+    t_ReposEnableAutomatedSecurityFixesParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposEnableAutomatedSecurityFixesResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9978,7 +10434,12 @@ export type ReposDisableAutomatedSecurityFixesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDisableAutomatedSecurityFixes = (
-  params: Params<t_ReposDisableAutomatedSecurityFixesParamSchema, void, void>,
+  params: Params<
+    t_ReposDisableAutomatedSecurityFixesParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposDisableAutomatedSecurityFixesResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -9992,6 +10453,7 @@ export type ReposListBranches = (
   params: Params<
     t_ReposListBranchesParamSchema,
     t_ReposListBranchesQuerySchema,
+    void,
     void
   >,
   respond: ReposListBranchesResponder,
@@ -10009,7 +10471,7 @@ export type ReposGetBranchResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetBranch = (
-  params: Params<t_ReposGetBranchParamSchema, void, void>,
+  params: Params<t_ReposGetBranchParamSchema, void, void, void>,
   respond: ReposGetBranchResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10025,7 +10487,7 @@ export type ReposGetBranchProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetBranchProtection = (
-  params: Params<t_ReposGetBranchProtectionParamSchema, void, void>,
+  params: Params<t_ReposGetBranchProtectionParamSchema, void, void, void>,
   respond: ReposGetBranchProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10045,7 +10507,8 @@ export type ReposUpdateBranchProtection = (
   params: Params<
     t_ReposUpdateBranchProtectionParamSchema,
     void,
-    t_ReposUpdateBranchProtectionBodySchema
+    t_ReposUpdateBranchProtectionBodySchema,
+    void
   >,
   respond: ReposUpdateBranchProtectionResponder,
   ctx: RouterContext,
@@ -10063,7 +10526,7 @@ export type ReposDeleteBranchProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteBranchProtection = (
-  params: Params<t_ReposDeleteBranchProtectionParamSchema, void, void>,
+  params: Params<t_ReposDeleteBranchProtectionParamSchema, void, void, void>,
   respond: ReposDeleteBranchProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10077,7 +10540,7 @@ export type ReposGetAdminBranchProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetAdminBranchProtection = (
-  params: Params<t_ReposGetAdminBranchProtectionParamSchema, void, void>,
+  params: Params<t_ReposGetAdminBranchProtectionParamSchema, void, void, void>,
   respond: ReposGetAdminBranchProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10089,7 +10552,7 @@ export type ReposSetAdminBranchProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposSetAdminBranchProtection = (
-  params: Params<t_ReposSetAdminBranchProtectionParamSchema, void, void>,
+  params: Params<t_ReposSetAdminBranchProtectionParamSchema, void, void, void>,
   respond: ReposSetAdminBranchProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10102,7 +10565,12 @@ export type ReposDeleteAdminBranchProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteAdminBranchProtection = (
-  params: Params<t_ReposDeleteAdminBranchProtectionParamSchema, void, void>,
+  params: Params<
+    t_ReposDeleteAdminBranchProtectionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposDeleteAdminBranchProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10116,7 +10584,12 @@ export type ReposGetPullRequestReviewProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetPullRequestReviewProtection = (
-  params: Params<t_ReposGetPullRequestReviewProtectionParamSchema, void, void>,
+  params: Params<
+    t_ReposGetPullRequestReviewProtectionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposGetPullRequestReviewProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10133,7 +10606,8 @@ export type ReposUpdatePullRequestReviewProtection = (
   params: Params<
     t_ReposUpdatePullRequestReviewProtectionParamSchema,
     void,
-    t_ReposUpdatePullRequestReviewProtectionBodySchema | undefined
+    t_ReposUpdatePullRequestReviewProtectionBodySchema | undefined,
+    void
   >,
   respond: ReposUpdatePullRequestReviewProtectionResponder,
   ctx: RouterContext,
@@ -10152,6 +10626,7 @@ export type ReposDeletePullRequestReviewProtection = (
   params: Params<
     t_ReposDeletePullRequestReviewProtectionParamSchema,
     void,
+    void,
     void
   >,
   respond: ReposDeletePullRequestReviewProtectionResponder,
@@ -10168,7 +10643,12 @@ export type ReposGetCommitSignatureProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCommitSignatureProtection = (
-  params: Params<t_ReposGetCommitSignatureProtectionParamSchema, void, void>,
+  params: Params<
+    t_ReposGetCommitSignatureProtectionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposGetCommitSignatureProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10183,7 +10663,12 @@ export type ReposCreateCommitSignatureProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposCreateCommitSignatureProtection = (
-  params: Params<t_ReposCreateCommitSignatureProtectionParamSchema, void, void>,
+  params: Params<
+    t_ReposCreateCommitSignatureProtectionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposCreateCommitSignatureProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10198,7 +10683,12 @@ export type ReposDeleteCommitSignatureProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteCommitSignatureProtection = (
-  params: Params<t_ReposDeleteCommitSignatureProtectionParamSchema, void, void>,
+  params: Params<
+    t_ReposDeleteCommitSignatureProtectionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposDeleteCommitSignatureProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10213,7 +10703,7 @@ export type ReposGetStatusChecksProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetStatusChecksProtection = (
-  params: Params<t_ReposGetStatusChecksProtectionParamSchema, void, void>,
+  params: Params<t_ReposGetStatusChecksProtectionParamSchema, void, void, void>,
   respond: ReposGetStatusChecksProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10232,7 +10722,8 @@ export type ReposUpdateStatusCheckProtection = (
   params: Params<
     t_ReposUpdateStatusCheckProtectionParamSchema,
     void,
-    t_ReposUpdateStatusCheckProtectionBodySchema | undefined
+    t_ReposUpdateStatusCheckProtectionBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateStatusCheckProtectionResponder,
   ctx: RouterContext,
@@ -10248,7 +10739,12 @@ export type ReposRemoveStatusCheckProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposRemoveStatusCheckProtection = (
-  params: Params<t_ReposRemoveStatusCheckProtectionParamSchema, void, void>,
+  params: Params<
+    t_ReposRemoveStatusCheckProtectionParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposRemoveStatusCheckProtectionResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -10259,7 +10755,7 @@ export type ReposGetAllStatusCheckContextsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetAllStatusCheckContexts = (
-  params: Params<t_ReposGetAllStatusCheckContextsParamSchema, void, void>,
+  params: Params<t_ReposGetAllStatusCheckContextsParamSchema, void, void, void>,
   respond: ReposGetAllStatusCheckContextsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10279,7 +10775,8 @@ export type ReposAddStatusCheckContexts = (
   params: Params<
     t_ReposAddStatusCheckContextsParamSchema,
     void,
-    t_ReposAddStatusCheckContextsBodySchema | undefined
+    t_ReposAddStatusCheckContextsBodySchema | undefined,
+    void
   >,
   respond: ReposAddStatusCheckContextsResponder,
   ctx: RouterContext,
@@ -10301,7 +10798,8 @@ export type ReposSetStatusCheckContexts = (
   params: Params<
     t_ReposSetStatusCheckContextsParamSchema,
     void,
-    t_ReposSetStatusCheckContextsBodySchema | undefined
+    t_ReposSetStatusCheckContextsBodySchema | undefined,
+    void
   >,
   respond: ReposSetStatusCheckContextsResponder,
   ctx: RouterContext,
@@ -10322,7 +10820,8 @@ export type ReposRemoveStatusCheckContexts = (
   params: Params<
     t_ReposRemoveStatusCheckContextsParamSchema,
     void,
-    t_ReposRemoveStatusCheckContextsBodySchema
+    t_ReposRemoveStatusCheckContextsBodySchema,
+    void
   >,
   respond: ReposRemoveStatusCheckContextsResponder,
   ctx: RouterContext,
@@ -10339,7 +10838,7 @@ export type ReposGetAccessRestrictionsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetAccessRestrictions = (
-  params: Params<t_ReposGetAccessRestrictionsParamSchema, void, void>,
+  params: Params<t_ReposGetAccessRestrictionsParamSchema, void, void, void>,
   respond: ReposGetAccessRestrictionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10353,7 +10852,7 @@ export type ReposDeleteAccessRestrictionsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteAccessRestrictions = (
-  params: Params<t_ReposDeleteAccessRestrictionsParamSchema, void, void>,
+  params: Params<t_ReposDeleteAccessRestrictionsParamSchema, void, void, void>,
   respond: ReposDeleteAccessRestrictionsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -10366,6 +10865,7 @@ export type ReposGetAppsWithAccessToProtectedBranchResponder = {
 export type ReposGetAppsWithAccessToProtectedBranch = (
   params: Params<
     t_ReposGetAppsWithAccessToProtectedBranchParamSchema,
+    void,
     void,
     void
   >,
@@ -10386,7 +10886,8 @@ export type ReposAddAppAccessRestrictions = (
   params: Params<
     t_ReposAddAppAccessRestrictionsParamSchema,
     void,
-    t_ReposAddAppAccessRestrictionsBodySchema | undefined
+    t_ReposAddAppAccessRestrictionsBodySchema | undefined,
+    void
   >,
   respond: ReposAddAppAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10405,7 +10906,8 @@ export type ReposSetAppAccessRestrictions = (
   params: Params<
     t_ReposSetAppAccessRestrictionsParamSchema,
     void,
-    t_ReposSetAppAccessRestrictionsBodySchema | undefined
+    t_ReposSetAppAccessRestrictionsBodySchema | undefined,
+    void
   >,
   respond: ReposSetAppAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10424,7 +10926,8 @@ export type ReposRemoveAppAccessRestrictions = (
   params: Params<
     t_ReposRemoveAppAccessRestrictionsParamSchema,
     void,
-    t_ReposRemoveAppAccessRestrictionsBodySchema
+    t_ReposRemoveAppAccessRestrictionsBodySchema,
+    void
   >,
   respond: ReposRemoveAppAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10442,6 +10945,7 @@ export type ReposGetTeamsWithAccessToProtectedBranchResponder = {
 export type ReposGetTeamsWithAccessToProtectedBranch = (
   params: Params<
     t_ReposGetTeamsWithAccessToProtectedBranchParamSchema,
+    void,
     void,
     void
   >,
@@ -10462,7 +10966,8 @@ export type ReposAddTeamAccessRestrictions = (
   params: Params<
     t_ReposAddTeamAccessRestrictionsParamSchema,
     void,
-    t_ReposAddTeamAccessRestrictionsBodySchema | undefined
+    t_ReposAddTeamAccessRestrictionsBodySchema | undefined,
+    void
   >,
   respond: ReposAddTeamAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10481,7 +10986,8 @@ export type ReposSetTeamAccessRestrictions = (
   params: Params<
     t_ReposSetTeamAccessRestrictionsParamSchema,
     void,
-    t_ReposSetTeamAccessRestrictionsBodySchema | undefined
+    t_ReposSetTeamAccessRestrictionsBodySchema | undefined,
+    void
   >,
   respond: ReposSetTeamAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10500,7 +11006,8 @@ export type ReposRemoveTeamAccessRestrictions = (
   params: Params<
     t_ReposRemoveTeamAccessRestrictionsParamSchema,
     void,
-    t_ReposRemoveTeamAccessRestrictionsBodySchema
+    t_ReposRemoveTeamAccessRestrictionsBodySchema,
+    void
   >,
   respond: ReposRemoveTeamAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10518,6 +11025,7 @@ export type ReposGetUsersWithAccessToProtectedBranchResponder = {
 export type ReposGetUsersWithAccessToProtectedBranch = (
   params: Params<
     t_ReposGetUsersWithAccessToProtectedBranchParamSchema,
+    void,
     void,
     void
   >,
@@ -10538,7 +11046,8 @@ export type ReposAddUserAccessRestrictions = (
   params: Params<
     t_ReposAddUserAccessRestrictionsParamSchema,
     void,
-    t_ReposAddUserAccessRestrictionsBodySchema | undefined
+    t_ReposAddUserAccessRestrictionsBodySchema | undefined,
+    void
   >,
   respond: ReposAddUserAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10557,7 +11066,8 @@ export type ReposSetUserAccessRestrictions = (
   params: Params<
     t_ReposSetUserAccessRestrictionsParamSchema,
     void,
-    t_ReposSetUserAccessRestrictionsBodySchema | undefined
+    t_ReposSetUserAccessRestrictionsBodySchema | undefined,
+    void
   >,
   respond: ReposSetUserAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10576,7 +11086,8 @@ export type ReposRemoveUserAccessRestrictions = (
   params: Params<
     t_ReposRemoveUserAccessRestrictionsParamSchema,
     void,
-    t_ReposRemoveUserAccessRestrictionsBodySchema
+    t_ReposRemoveUserAccessRestrictionsBodySchema,
+    void
   >,
   respond: ReposRemoveUserAccessRestrictionsResponder,
   ctx: RouterContext,
@@ -10597,7 +11108,8 @@ export type ReposRenameBranch = (
   params: Params<
     t_ReposRenameBranchParamSchema,
     void,
-    t_ReposRenameBranchBodySchema
+    t_ReposRenameBranchBodySchema,
+    void
   >,
   respond: ReposRenameBranchResponder,
   ctx: RouterContext,
@@ -10614,7 +11126,12 @@ export type ChecksCreateResponder = {
 } & KoaRuntimeResponder
 
 export type ChecksCreate = (
-  params: Params<t_ChecksCreateParamSchema, void, t_ChecksCreateBodySchema>,
+  params: Params<
+    t_ChecksCreateParamSchema,
+    void,
+    t_ChecksCreateBodySchema,
+    void
+  >,
   respond: ChecksCreateResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<201, t_check_run>>
@@ -10624,7 +11141,7 @@ export type ChecksGetResponder = {
 } & KoaRuntimeResponder
 
 export type ChecksGet = (
-  params: Params<t_ChecksGetParamSchema, void, void>,
+  params: Params<t_ChecksGetParamSchema, void, void, void>,
   respond: ChecksGetResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_check_run>>
@@ -10634,7 +11151,12 @@ export type ChecksUpdateResponder = {
 } & KoaRuntimeResponder
 
 export type ChecksUpdate = (
-  params: Params<t_ChecksUpdateParamSchema, void, t_ChecksUpdateBodySchema>,
+  params: Params<
+    t_ChecksUpdateParamSchema,
+    void,
+    t_ChecksUpdateBodySchema,
+    void
+  >,
   respond: ChecksUpdateResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_check_run>>
@@ -10647,6 +11169,7 @@ export type ChecksListAnnotations = (
   params: Params<
     t_ChecksListAnnotationsParamSchema,
     t_ChecksListAnnotationsQuerySchema,
+    void,
     void
   >,
   respond: ChecksListAnnotationsResponder,
@@ -10661,7 +11184,7 @@ export type ChecksRerequestRunResponder = {
 } & KoaRuntimeResponder
 
 export type ChecksRerequestRun = (
-  params: Params<t_ChecksRerequestRunParamSchema, void, void>,
+  params: Params<t_ChecksRerequestRunParamSchema, void, void, void>,
   respond: ChecksRerequestRunResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10681,7 +11204,8 @@ export type ChecksCreateSuite = (
   params: Params<
     t_ChecksCreateSuiteParamSchema,
     void,
-    t_ChecksCreateSuiteBodySchema
+    t_ChecksCreateSuiteBodySchema,
+    void
   >,
   respond: ChecksCreateSuiteResponder,
   ctx: RouterContext,
@@ -10699,7 +11223,8 @@ export type ChecksSetSuitesPreferences = (
   params: Params<
     t_ChecksSetSuitesPreferencesParamSchema,
     void,
-    t_ChecksSetSuitesPreferencesBodySchema
+    t_ChecksSetSuitesPreferencesBodySchema,
+    void
   >,
   respond: ChecksSetSuitesPreferencesResponder,
   ctx: RouterContext,
@@ -10712,7 +11237,7 @@ export type ChecksGetSuiteResponder = {
 } & KoaRuntimeResponder
 
 export type ChecksGetSuite = (
-  params: Params<t_ChecksGetSuiteParamSchema, void, void>,
+  params: Params<t_ChecksGetSuiteParamSchema, void, void, void>,
   respond: ChecksGetSuiteResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_check_suite>>
@@ -10728,6 +11253,7 @@ export type ChecksListForSuite = (
   params: Params<
     t_ChecksListForSuiteParamSchema,
     t_ChecksListForSuiteQuerySchema,
+    void,
     void
   >,
   respond: ChecksListForSuiteResponder,
@@ -10748,7 +11274,7 @@ export type ChecksRerequestSuiteResponder = {
 } & KoaRuntimeResponder
 
 export type ChecksRerequestSuite = (
-  params: Params<t_ChecksRerequestSuiteParamSchema, void, void>,
+  params: Params<t_ChecksRerequestSuiteParamSchema, void, void, void>,
   respond: ChecksRerequestSuiteResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<201, t_empty_object>>
@@ -10769,6 +11295,7 @@ export type CodeScanningListAlertsForRepo = (
   params: Params<
     t_CodeScanningListAlertsForRepoParamSchema,
     t_CodeScanningListAlertsForRepoQuerySchema,
+    void,
     void
   >,
   respond: CodeScanningListAlertsForRepoResponder,
@@ -10802,7 +11329,7 @@ export type CodeScanningGetAlertResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningGetAlert = (
-  params: Params<t_CodeScanningGetAlertParamSchema, void, void>,
+  params: Params<t_CodeScanningGetAlertParamSchema, void, void, void>,
   respond: CodeScanningGetAlertResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10836,7 +11363,8 @@ export type CodeScanningUpdateAlert = (
   params: Params<
     t_CodeScanningUpdateAlertParamSchema,
     void,
-    t_CodeScanningUpdateAlertBodySchema
+    t_CodeScanningUpdateAlertBodySchema,
+    void
   >,
   respond: CodeScanningUpdateAlertResponder,
   ctx: RouterContext,
@@ -10870,6 +11398,7 @@ export type CodeScanningListAlertInstances = (
   params: Params<
     t_CodeScanningListAlertInstancesParamSchema,
     t_CodeScanningListAlertInstancesQuerySchema,
+    void,
     void
   >,
   respond: CodeScanningListAlertInstancesResponder,
@@ -10904,6 +11433,7 @@ export type CodeScanningListRecentAnalyses = (
   params: Params<
     t_CodeScanningListRecentAnalysesParamSchema,
     t_CodeScanningListRecentAnalysesQuerySchema,
+    void,
     void
   >,
   respond: CodeScanningListRecentAnalysesResponder,
@@ -10937,7 +11467,7 @@ export type CodeScanningGetAnalysisResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningGetAnalysis = (
-  params: Params<t_CodeScanningGetAnalysisParamSchema, void, void>,
+  params: Params<t_CodeScanningGetAnalysisParamSchema, void, void, void>,
   respond: CodeScanningGetAnalysisResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10976,6 +11506,7 @@ export type CodeScanningDeleteAnalysis = (
   params: Params<
     t_CodeScanningDeleteAnalysisParamSchema,
     t_CodeScanningDeleteAnalysisQuerySchema,
+    void,
     void
   >,
   respond: CodeScanningDeleteAnalysisResponder,
@@ -11008,7 +11539,12 @@ export type CodeScanningListCodeqlDatabasesResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningListCodeqlDatabases = (
-  params: Params<t_CodeScanningListCodeqlDatabasesParamSchema, void, void>,
+  params: Params<
+    t_CodeScanningListCodeqlDatabasesParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodeScanningListCodeqlDatabasesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11039,7 +11575,7 @@ export type CodeScanningGetCodeqlDatabaseResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningGetCodeqlDatabase = (
-  params: Params<t_CodeScanningGetCodeqlDatabaseParamSchema, void, void>,
+  params: Params<t_CodeScanningGetCodeqlDatabaseParamSchema, void, void, void>,
   respond: CodeScanningGetCodeqlDatabaseResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11073,7 +11609,8 @@ export type CodeScanningCreateVariantAnalysis = (
   params: Params<
     t_CodeScanningCreateVariantAnalysisParamSchema,
     void,
-    t_CodeScanningCreateVariantAnalysisBodySchema
+    t_CodeScanningCreateVariantAnalysisBodySchema,
+    void
   >,
   respond: CodeScanningCreateVariantAnalysisResponder,
   ctx: RouterContext,
@@ -11103,7 +11640,7 @@ export type CodeScanningGetVariantAnalysisResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningGetVariantAnalysis = (
-  params: Params<t_CodeScanningGetVariantAnalysisParamSchema, void, void>,
+  params: Params<t_CodeScanningGetVariantAnalysisParamSchema, void, void, void>,
   respond: CodeScanningGetVariantAnalysisResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11133,6 +11670,7 @@ export type CodeScanningGetVariantAnalysisRepoTaskResponder = {
 export type CodeScanningGetVariantAnalysisRepoTask = (
   params: Params<
     t_CodeScanningGetVariantAnalysisRepoTaskParamSchema,
+    void,
     void,
     void
   >,
@@ -11164,7 +11702,7 @@ export type CodeScanningGetDefaultSetupResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningGetDefaultSetup = (
-  params: Params<t_CodeScanningGetDefaultSetupParamSchema, void, void>,
+  params: Params<t_CodeScanningGetDefaultSetupParamSchema, void, void, void>,
   respond: CodeScanningGetDefaultSetupResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11199,7 +11737,8 @@ export type CodeScanningUpdateDefaultSetup = (
   params: Params<
     t_CodeScanningUpdateDefaultSetupParamSchema,
     void,
-    t_CodeScanningUpdateDefaultSetupBodySchema
+    t_CodeScanningUpdateDefaultSetupBodySchema,
+    void
   >,
   respond: CodeScanningUpdateDefaultSetupResponder,
   ctx: RouterContext,
@@ -11237,7 +11776,8 @@ export type CodeScanningUploadSarif = (
   params: Params<
     t_CodeScanningUploadSarifParamSchema,
     void,
-    t_CodeScanningUploadSarifBodySchema
+    t_CodeScanningUploadSarifBodySchema,
+    void
   >,
   respond: CodeScanningUploadSarifResponder,
   ctx: RouterContext,
@@ -11270,7 +11810,7 @@ export type CodeScanningGetSarifResponder = {
 } & KoaRuntimeResponder
 
 export type CodeScanningGetSarif = (
-  params: Params<t_CodeScanningGetSarifParamSchema, void, void>,
+  params: Params<t_CodeScanningGetSarifParamSchema, void, void, void>,
   respond: CodeScanningGetSarifResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11300,6 +11840,7 @@ export type CodeSecurityGetConfigurationForRepository = (
   params: Params<
     t_CodeSecurityGetConfigurationForRepositoryParamSchema,
     void,
+    void,
     void
   >,
   respond: CodeSecurityGetConfigurationForRepositoryResponder,
@@ -11322,6 +11863,7 @@ export type ReposCodeownersErrors = (
   params: Params<
     t_ReposCodeownersErrorsParamSchema,
     t_ReposCodeownersErrorsQuerySchema,
+    void,
     void
   >,
   respond: ReposCodeownersErrorsResponder,
@@ -11347,6 +11889,7 @@ export type CodespacesListInRepositoryForAuthenticatedUser = (
   params: Params<
     t_CodespacesListInRepositoryForAuthenticatedUserParamSchema,
     t_CodespacesListInRepositoryForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListInRepositoryForAuthenticatedUserResponder,
@@ -11384,7 +11927,8 @@ export type CodespacesCreateWithRepoForAuthenticatedUser = (
   params: Params<
     t_CodespacesCreateWithRepoForAuthenticatedUserParamSchema,
     void,
-    t_CodespacesCreateWithRepoForAuthenticatedUserBodySchema
+    t_CodespacesCreateWithRepoForAuthenticatedUserBodySchema,
+    void
   >,
   respond: CodespacesCreateWithRepoForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -11427,6 +11971,7 @@ export type CodespacesListDevcontainersInRepositoryForAuthenticatedUser = (
   params: Params<
     t_CodespacesListDevcontainersInRepositoryForAuthenticatedUserParamSchema,
     t_CodespacesListDevcontainersInRepositoryForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListDevcontainersInRepositoryForAuthenticatedUserResponder,
@@ -11467,6 +12012,7 @@ export type CodespacesRepoMachinesForAuthenticatedUser = (
   params: Params<
     t_CodespacesRepoMachinesForAuthenticatedUserParamSchema,
     t_CodespacesRepoMachinesForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: CodespacesRepoMachinesForAuthenticatedUserResponder,
@@ -11504,6 +12050,7 @@ export type CodespacesPreFlightWithRepoForAuthenticatedUser = (
   params: Params<
     t_CodespacesPreFlightWithRepoForAuthenticatedUserParamSchema,
     t_CodespacesPreFlightWithRepoForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: CodespacesPreFlightWithRepoForAuthenticatedUserResponder,
@@ -11542,6 +12089,7 @@ export type CodespacesCheckPermissionsForDevcontainer = (
   params: Params<
     t_CodespacesCheckPermissionsForDevcontainerParamSchema,
     t_CodespacesCheckPermissionsForDevcontainerQuerySchema,
+    void,
     void
   >,
   respond: CodespacesCheckPermissionsForDevcontainerResponder,
@@ -11574,6 +12122,7 @@ export type CodespacesListRepoSecrets = (
   params: Params<
     t_CodespacesListRepoSecretsParamSchema,
     t_CodespacesListRepoSecretsQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListRepoSecretsResponder,
@@ -11594,7 +12143,7 @@ export type CodespacesGetRepoPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesGetRepoPublicKey = (
-  params: Params<t_CodespacesGetRepoPublicKeyParamSchema, void, void>,
+  params: Params<t_CodespacesGetRepoPublicKeyParamSchema, void, void, void>,
   respond: CodespacesGetRepoPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11606,7 +12155,7 @@ export type CodespacesGetRepoSecretResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesGetRepoSecret = (
-  params: Params<t_CodespacesGetRepoSecretParamSchema, void, void>,
+  params: Params<t_CodespacesGetRepoSecretParamSchema, void, void, void>,
   respond: CodespacesGetRepoSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11622,7 +12171,8 @@ export type CodespacesCreateOrUpdateRepoSecret = (
   params: Params<
     t_CodespacesCreateOrUpdateRepoSecretParamSchema,
     void,
-    t_CodespacesCreateOrUpdateRepoSecretBodySchema
+    t_CodespacesCreateOrUpdateRepoSecretBodySchema,
+    void
   >,
   respond: CodespacesCreateOrUpdateRepoSecretResponder,
   ctx: RouterContext,
@@ -11637,7 +12187,7 @@ export type CodespacesDeleteRepoSecretResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesDeleteRepoSecret = (
-  params: Params<t_CodespacesDeleteRepoSecretParamSchema, void, void>,
+  params: Params<t_CodespacesDeleteRepoSecretParamSchema, void, void, void>,
   respond: CodespacesDeleteRepoSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -11651,6 +12201,7 @@ export type ReposListCollaborators = (
   params: Params<
     t_ReposListCollaboratorsParamSchema,
     t_ReposListCollaboratorsQuerySchema,
+    void,
     void
   >,
   respond: ReposListCollaboratorsResponder,
@@ -11667,7 +12218,7 @@ export type ReposCheckCollaboratorResponder = {
 } & KoaRuntimeResponder
 
 export type ReposCheckCollaborator = (
-  params: Params<t_ReposCheckCollaboratorParamSchema, void, void>,
+  params: Params<t_ReposCheckCollaboratorParamSchema, void, void, void>,
   respond: ReposCheckCollaboratorResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11685,7 +12236,8 @@ export type ReposAddCollaborator = (
   params: Params<
     t_ReposAddCollaboratorParamSchema,
     void,
-    t_ReposAddCollaboratorBodySchema | undefined
+    t_ReposAddCollaboratorBodySchema | undefined,
+    void
   >,
   respond: ReposAddCollaboratorResponder,
   ctx: RouterContext,
@@ -11704,7 +12256,7 @@ export type ReposRemoveCollaboratorResponder = {
 } & KoaRuntimeResponder
 
 export type ReposRemoveCollaborator = (
-  params: Params<t_ReposRemoveCollaboratorParamSchema, void, void>,
+  params: Params<t_ReposRemoveCollaboratorParamSchema, void, void, void>,
   respond: ReposRemoveCollaboratorResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11720,7 +12272,12 @@ export type ReposGetCollaboratorPermissionLevelResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCollaboratorPermissionLevel = (
-  params: Params<t_ReposGetCollaboratorPermissionLevelParamSchema, void, void>,
+  params: Params<
+    t_ReposGetCollaboratorPermissionLevelParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposGetCollaboratorPermissionLevelResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11737,6 +12294,7 @@ export type ReposListCommitCommentsForRepo = (
   params: Params<
     t_ReposListCommitCommentsForRepoParamSchema,
     t_ReposListCommitCommentsForRepoQuerySchema,
+    void,
     void
   >,
   respond: ReposListCommitCommentsForRepoResponder,
@@ -11749,7 +12307,7 @@ export type ReposGetCommitCommentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCommitComment = (
-  params: Params<t_ReposGetCommitCommentParamSchema, void, void>,
+  params: Params<t_ReposGetCommitCommentParamSchema, void, void, void>,
   respond: ReposGetCommitCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11767,7 +12325,8 @@ export type ReposUpdateCommitComment = (
   params: Params<
     t_ReposUpdateCommitCommentParamSchema,
     void,
-    t_ReposUpdateCommitCommentBodySchema
+    t_ReposUpdateCommitCommentBodySchema,
+    void
   >,
   respond: ReposUpdateCommitCommentResponder,
   ctx: RouterContext,
@@ -11783,7 +12342,7 @@ export type ReposDeleteCommitCommentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteCommitComment = (
-  params: Params<t_ReposDeleteCommitCommentParamSchema, void, void>,
+  params: Params<t_ReposDeleteCommitCommentParamSchema, void, void, void>,
   respond: ReposDeleteCommitCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11801,6 +12360,7 @@ export type ReactionsListForCommitComment = (
   params: Params<
     t_ReactionsListForCommitCommentParamSchema,
     t_ReactionsListForCommitCommentQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForCommitCommentResponder,
@@ -11821,7 +12381,8 @@ export type ReactionsCreateForCommitComment = (
   params: Params<
     t_ReactionsCreateForCommitCommentParamSchema,
     void,
-    t_ReactionsCreateForCommitCommentBodySchema
+    t_ReactionsCreateForCommitCommentBodySchema,
+    void
   >,
   respond: ReactionsCreateForCommitCommentResponder,
   ctx: RouterContext,
@@ -11837,7 +12398,12 @@ export type ReactionsDeleteForCommitCommentResponder = {
 } & KoaRuntimeResponder
 
 export type ReactionsDeleteForCommitComment = (
-  params: Params<t_ReactionsDeleteForCommitCommentParamSchema, void, void>,
+  params: Params<
+    t_ReactionsDeleteForCommitCommentParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReactionsDeleteForCommitCommentResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -11854,6 +12420,7 @@ export type ReposListCommits = (
   params: Params<
     t_ReposListCommitsParamSchema,
     t_ReposListCommitsQuerySchema,
+    void,
     void
   >,
   respond: ReposListCommitsResponder,
@@ -11874,7 +12441,7 @@ export type ReposListBranchesForHeadCommitResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListBranchesForHeadCommit = (
-  params: Params<t_ReposListBranchesForHeadCommitParamSchema, void, void>,
+  params: Params<t_ReposListBranchesForHeadCommitParamSchema, void, void, void>,
   respond: ReposListBranchesForHeadCommitResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11892,6 +12459,7 @@ export type ReposListCommentsForCommit = (
   params: Params<
     t_ReposListCommentsForCommitParamSchema,
     t_ReposListCommentsForCommitQuerySchema,
+    void,
     void
   >,
   respond: ReposListCommentsForCommitResponder,
@@ -11908,7 +12476,8 @@ export type ReposCreateCommitComment = (
   params: Params<
     t_ReposCreateCommitCommentParamSchema,
     void,
-    t_ReposCreateCommitCommentBodySchema
+    t_ReposCreateCommitCommentBodySchema,
+    void
   >,
   respond: ReposCreateCommitCommentResponder,
   ctx: RouterContext,
@@ -11928,6 +12497,7 @@ export type ReposListPullRequestsAssociatedWithCommit = (
   params: Params<
     t_ReposListPullRequestsAssociatedWithCommitParamSchema,
     t_ReposListPullRequestsAssociatedWithCommitQuerySchema,
+    void,
     void
   >,
   respond: ReposListPullRequestsAssociatedWithCommitResponder,
@@ -11955,6 +12525,7 @@ export type ReposGetCommit = (
   params: Params<
     t_ReposGetCommitParamSchema,
     t_ReposGetCommitQuerySchema,
+    void,
     void
   >,
   respond: ReposGetCommitResponder,
@@ -11987,6 +12558,7 @@ export type ChecksListForRef = (
   params: Params<
     t_ChecksListForRefParamSchema,
     t_ChecksListForRefQuerySchema,
+    void,
     void
   >,
   respond: ChecksListForRefResponder,
@@ -12013,6 +12585,7 @@ export type ChecksListSuitesForRef = (
   params: Params<
     t_ChecksListSuitesForRefParamSchema,
     t_ChecksListSuitesForRefQuerySchema,
+    void,
     void
   >,
   respond: ChecksListSuitesForRefResponder,
@@ -12037,6 +12610,7 @@ export type ReposGetCombinedStatusForRef = (
   params: Params<
     t_ReposGetCombinedStatusForRefParamSchema,
     t_ReposGetCombinedStatusForRefQuerySchema,
+    void,
     void
   >,
   respond: ReposGetCombinedStatusForRefResponder,
@@ -12056,6 +12630,7 @@ export type ReposListCommitStatusesForRef = (
   params: Params<
     t_ReposListCommitStatusesForRefParamSchema,
     t_ReposListCommitStatusesForRefQuerySchema,
+    void,
     void
   >,
   respond: ReposListCommitStatusesForRefResponder,
@@ -12071,7 +12646,12 @@ export type ReposGetCommunityProfileMetricsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCommunityProfileMetrics = (
-  params: Params<t_ReposGetCommunityProfileMetricsParamSchema, void, void>,
+  params: Params<
+    t_ReposGetCommunityProfileMetricsParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposGetCommunityProfileMetricsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_community_profile>>
@@ -12091,6 +12671,7 @@ export type ReposCompareCommits = (
   params: Params<
     t_ReposCompareCommitsParamSchema,
     t_ReposCompareCommitsQuerySchema,
+    void,
     void
   >,
   respond: ReposCompareCommitsResponder,
@@ -12127,6 +12708,7 @@ export type ReposGetContent = (
   params: Params<
     t_ReposGetContentParamSchema,
     t_ReposGetContentQuerySchema,
+    void,
     void
   >,
   respond: ReposGetContentResponder,
@@ -12160,7 +12742,8 @@ export type ReposCreateOrUpdateFileContents = (
   params: Params<
     t_ReposCreateOrUpdateFileContentsParamSchema,
     void,
-    t_ReposCreateOrUpdateFileContentsBodySchema
+    t_ReposCreateOrUpdateFileContentsBodySchema,
+    void
   >,
   respond: ReposCreateOrUpdateFileContentsResponder,
   ctx: RouterContext,
@@ -12189,7 +12772,8 @@ export type ReposDeleteFile = (
   params: Params<
     t_ReposDeleteFileParamSchema,
     void,
-    t_ReposDeleteFileBodySchema
+    t_ReposDeleteFileBodySchema,
+    void
   >,
   respond: ReposDeleteFileResponder,
   ctx: RouterContext,
@@ -12220,6 +12804,7 @@ export type ReposListContributors = (
   params: Params<
     t_ReposListContributorsParamSchema,
     t_ReposListContributorsQuerySchema,
+    void,
     void
   >,
   respond: ReposListContributorsResponder,
@@ -12245,6 +12830,7 @@ export type DependabotListAlertsForRepo = (
   params: Params<
     t_DependabotListAlertsForRepoParamSchema,
     t_DependabotListAlertsForRepoQuerySchema,
+    void,
     void
   >,
   respond: DependabotListAlertsForRepoResponder,
@@ -12267,7 +12853,7 @@ export type DependabotGetAlertResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotGetAlert = (
-  params: Params<t_DependabotGetAlertParamSchema, void, void>,
+  params: Params<t_DependabotGetAlertParamSchema, void, void, void>,
   respond: DependabotGetAlertResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12291,7 +12877,8 @@ export type DependabotUpdateAlert = (
   params: Params<
     t_DependabotUpdateAlertParamSchema,
     void,
-    t_DependabotUpdateAlertBodySchema
+    t_DependabotUpdateAlertBodySchema,
+    void
   >,
   respond: DependabotUpdateAlertResponder,
   ctx: RouterContext,
@@ -12316,6 +12903,7 @@ export type DependabotListRepoSecrets = (
   params: Params<
     t_DependabotListRepoSecretsParamSchema,
     t_DependabotListRepoSecretsQuerySchema,
+    void,
     void
   >,
   respond: DependabotListRepoSecretsResponder,
@@ -12336,7 +12924,7 @@ export type DependabotGetRepoPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotGetRepoPublicKey = (
-  params: Params<t_DependabotGetRepoPublicKeyParamSchema, void, void>,
+  params: Params<t_DependabotGetRepoPublicKeyParamSchema, void, void, void>,
   respond: DependabotGetRepoPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12348,7 +12936,7 @@ export type DependabotGetRepoSecretResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotGetRepoSecret = (
-  params: Params<t_DependabotGetRepoSecretParamSchema, void, void>,
+  params: Params<t_DependabotGetRepoSecretParamSchema, void, void, void>,
   respond: DependabotGetRepoSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_dependabot_secret>>
@@ -12362,7 +12950,8 @@ export type DependabotCreateOrUpdateRepoSecret = (
   params: Params<
     t_DependabotCreateOrUpdateRepoSecretParamSchema,
     void,
-    t_DependabotCreateOrUpdateRepoSecretBodySchema
+    t_DependabotCreateOrUpdateRepoSecretBodySchema,
+    void
   >,
   respond: DependabotCreateOrUpdateRepoSecretResponder,
   ctx: RouterContext,
@@ -12377,7 +12966,7 @@ export type DependabotDeleteRepoSecretResponder = {
 } & KoaRuntimeResponder
 
 export type DependabotDeleteRepoSecret = (
-  params: Params<t_DependabotDeleteRepoSecretParamSchema, void, void>,
+  params: Params<t_DependabotDeleteRepoSecretParamSchema, void, void, void>,
   respond: DependabotDeleteRepoSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -12392,6 +12981,7 @@ export type DependencyGraphDiffRange = (
   params: Params<
     t_DependencyGraphDiffRangeParamSchema,
     t_DependencyGraphDiffRangeQuerySchema,
+    void,
     void
   >,
   respond: DependencyGraphDiffRangeResponder,
@@ -12410,7 +13000,7 @@ export type DependencyGraphExportSbomResponder = {
 } & KoaRuntimeResponder
 
 export type DependencyGraphExportSbom = (
-  params: Params<t_DependencyGraphExportSbomParamSchema, void, void>,
+  params: Params<t_DependencyGraphExportSbomParamSchema, void, void, void>,
   respond: DependencyGraphExportSbomResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12433,7 +13023,8 @@ export type DependencyGraphCreateRepositorySnapshot = (
   params: Params<
     t_DependencyGraphCreateRepositorySnapshotParamSchema,
     void,
-    t_DependencyGraphCreateRepositorySnapshotBodySchema
+    t_DependencyGraphCreateRepositorySnapshotBodySchema,
+    void
   >,
   respond: DependencyGraphCreateRepositorySnapshotResponder,
   ctx: RouterContext,
@@ -12458,6 +13049,7 @@ export type ReposListDeployments = (
   params: Params<
     t_ReposListDeploymentsParamSchema,
     t_ReposListDeploymentsQuerySchema,
+    void,
     void
   >,
   respond: ReposListDeploymentsResponder,
@@ -12477,7 +13069,8 @@ export type ReposCreateDeployment = (
   params: Params<
     t_ReposCreateDeploymentParamSchema,
     void,
-    t_ReposCreateDeploymentBodySchema
+    t_ReposCreateDeploymentBodySchema,
+    void
   >,
   respond: ReposCreateDeploymentResponder,
   ctx: RouterContext,
@@ -12500,7 +13093,7 @@ export type ReposGetDeploymentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetDeployment = (
-  params: Params<t_ReposGetDeploymentParamSchema, void, void>,
+  params: Params<t_ReposGetDeploymentParamSchema, void, void, void>,
   respond: ReposGetDeploymentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12516,7 +13109,7 @@ export type ReposDeleteDeploymentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteDeployment = (
-  params: Params<t_ReposDeleteDeploymentParamSchema, void, void>,
+  params: Params<t_ReposDeleteDeploymentParamSchema, void, void, void>,
   respond: ReposDeleteDeploymentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12535,6 +13128,7 @@ export type ReposListDeploymentStatuses = (
   params: Params<
     t_ReposListDeploymentStatusesParamSchema,
     t_ReposListDeploymentStatusesQuerySchema,
+    void,
     void
   >,
   respond: ReposListDeploymentStatusesResponder,
@@ -12554,7 +13148,8 @@ export type ReposCreateDeploymentStatus = (
   params: Params<
     t_ReposCreateDeploymentStatusParamSchema,
     void,
-    t_ReposCreateDeploymentStatusBodySchema
+    t_ReposCreateDeploymentStatusBodySchema,
+    void
   >,
   respond: ReposCreateDeploymentStatusResponder,
   ctx: RouterContext,
@@ -12570,7 +13165,7 @@ export type ReposGetDeploymentStatusResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetDeploymentStatus = (
-  params: Params<t_ReposGetDeploymentStatusParamSchema, void, void>,
+  params: Params<t_ReposGetDeploymentStatusParamSchema, void, void, void>,
   respond: ReposGetDeploymentStatusResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12589,7 +13184,8 @@ export type ReposCreateDispatchEvent = (
   params: Params<
     t_ReposCreateDispatchEventParamSchema,
     void,
-    t_ReposCreateDispatchEventBodySchema
+    t_ReposCreateDispatchEventBodySchema,
+    void
   >,
   respond: ReposCreateDispatchEventResponder,
   ctx: RouterContext,
@@ -12611,6 +13207,7 @@ export type ReposGetAllEnvironments = (
   params: Params<
     t_ReposGetAllEnvironmentsParamSchema,
     t_ReposGetAllEnvironmentsQuerySchema,
+    void,
     void
   >,
   respond: ReposGetAllEnvironmentsResponder,
@@ -12631,7 +13228,7 @@ export type ReposGetEnvironmentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetEnvironment = (
-  params: Params<t_ReposGetEnvironmentParamSchema, void, void>,
+  params: Params<t_ReposGetEnvironmentParamSchema, void, void, void>,
   respond: ReposGetEnvironmentResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_environment>>
@@ -12645,7 +13242,8 @@ export type ReposCreateOrUpdateEnvironment = (
   params: Params<
     t_ReposCreateOrUpdateEnvironmentParamSchema,
     void,
-    t_ReposCreateOrUpdateEnvironmentBodySchema | undefined
+    t_ReposCreateOrUpdateEnvironmentBodySchema | undefined,
+    void
   >,
   respond: ReposCreateOrUpdateEnvironmentResponder,
   ctx: RouterContext,
@@ -12660,7 +13258,7 @@ export type ReposDeleteAnEnvironmentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteAnEnvironment = (
-  params: Params<t_ReposDeleteAnEnvironmentParamSchema, void, void>,
+  params: Params<t_ReposDeleteAnEnvironmentParamSchema, void, void, void>,
   respond: ReposDeleteAnEnvironmentResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -12676,6 +13274,7 @@ export type ReposListDeploymentBranchPolicies = (
   params: Params<
     t_ReposListDeploymentBranchPoliciesParamSchema,
     t_ReposListDeploymentBranchPoliciesQuerySchema,
+    void,
     void
   >,
   respond: ReposListDeploymentBranchPoliciesResponder,
@@ -12701,7 +13300,8 @@ export type ReposCreateDeploymentBranchPolicy = (
   params: Params<
     t_ReposCreateDeploymentBranchPolicyParamSchema,
     void,
-    t_ReposCreateDeploymentBranchPolicyBodySchema
+    t_ReposCreateDeploymentBranchPolicyBodySchema,
+    void
   >,
   respond: ReposCreateDeploymentBranchPolicyResponder,
   ctx: RouterContext,
@@ -12717,7 +13317,7 @@ export type ReposGetDeploymentBranchPolicyResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetDeploymentBranchPolicy = (
-  params: Params<t_ReposGetDeploymentBranchPolicyParamSchema, void, void>,
+  params: Params<t_ReposGetDeploymentBranchPolicyParamSchema, void, void, void>,
   respond: ReposGetDeploymentBranchPolicyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12732,7 +13332,8 @@ export type ReposUpdateDeploymentBranchPolicy = (
   params: Params<
     t_ReposUpdateDeploymentBranchPolicyParamSchema,
     void,
-    t_ReposUpdateDeploymentBranchPolicyBodySchema
+    t_ReposUpdateDeploymentBranchPolicyBodySchema,
+    void
   >,
   respond: ReposUpdateDeploymentBranchPolicyResponder,
   ctx: RouterContext,
@@ -12745,7 +13346,12 @@ export type ReposDeleteDeploymentBranchPolicyResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteDeploymentBranchPolicy = (
-  params: Params<t_ReposDeleteDeploymentBranchPolicyParamSchema, void, void>,
+  params: Params<
+    t_ReposDeleteDeploymentBranchPolicyParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposDeleteDeploymentBranchPolicyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -12758,7 +13364,12 @@ export type ReposGetAllDeploymentProtectionRulesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetAllDeploymentProtectionRules = (
-  params: Params<t_ReposGetAllDeploymentProtectionRulesParamSchema, void, void>,
+  params: Params<
+    t_ReposGetAllDeploymentProtectionRulesParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposGetAllDeploymentProtectionRulesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12780,7 +13391,8 @@ export type ReposCreateDeploymentProtectionRule = (
   params: Params<
     t_ReposCreateDeploymentProtectionRuleParamSchema,
     void,
-    t_ReposCreateDeploymentProtectionRuleBodySchema
+    t_ReposCreateDeploymentProtectionRuleBodySchema,
+    void
   >,
   respond: ReposCreateDeploymentProtectionRuleResponder,
   ctx: RouterContext,
@@ -12799,6 +13411,7 @@ export type ReposListCustomDeploymentRuleIntegrations = (
   params: Params<
     t_ReposListCustomDeploymentRuleIntegrationsParamSchema,
     t_ReposListCustomDeploymentRuleIntegrationsQuerySchema,
+    void,
     void
   >,
   respond: ReposListCustomDeploymentRuleIntegrationsResponder,
@@ -12822,6 +13435,7 @@ export type ReposGetCustomDeploymentProtectionRule = (
   params: Params<
     t_ReposGetCustomDeploymentProtectionRuleParamSchema,
     void,
+    void,
     void
   >,
   respond: ReposGetCustomDeploymentProtectionRuleResponder,
@@ -12835,7 +13449,12 @@ export type ReposDisableDeploymentProtectionRuleResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDisableDeploymentProtectionRule = (
-  params: Params<t_ReposDisableDeploymentProtectionRuleParamSchema, void, void>,
+  params: Params<
+    t_ReposDisableDeploymentProtectionRuleParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposDisableDeploymentProtectionRuleResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -12851,6 +13470,7 @@ export type ActionsListEnvironmentSecrets = (
   params: Params<
     t_ActionsListEnvironmentSecretsParamSchema,
     t_ActionsListEnvironmentSecretsQuerySchema,
+    void,
     void
   >,
   respond: ActionsListEnvironmentSecretsResponder,
@@ -12871,7 +13491,7 @@ export type ActionsGetEnvironmentPublicKeyResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetEnvironmentPublicKey = (
-  params: Params<t_ActionsGetEnvironmentPublicKeyParamSchema, void, void>,
+  params: Params<t_ActionsGetEnvironmentPublicKeyParamSchema, void, void, void>,
   respond: ActionsGetEnvironmentPublicKeyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_public_key>>
@@ -12881,7 +13501,7 @@ export type ActionsGetEnvironmentSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetEnvironmentSecret = (
-  params: Params<t_ActionsGetEnvironmentSecretParamSchema, void, void>,
+  params: Params<t_ActionsGetEnvironmentSecretParamSchema, void, void, void>,
   respond: ActionsGetEnvironmentSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_secret>>
@@ -12895,7 +13515,8 @@ export type ActionsCreateOrUpdateEnvironmentSecret = (
   params: Params<
     t_ActionsCreateOrUpdateEnvironmentSecretParamSchema,
     void,
-    t_ActionsCreateOrUpdateEnvironmentSecretBodySchema
+    t_ActionsCreateOrUpdateEnvironmentSecretBodySchema,
+    void
   >,
   respond: ActionsCreateOrUpdateEnvironmentSecretResponder,
   ctx: RouterContext,
@@ -12910,7 +13531,7 @@ export type ActionsDeleteEnvironmentSecretResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteEnvironmentSecret = (
-  params: Params<t_ActionsDeleteEnvironmentSecretParamSchema, void, void>,
+  params: Params<t_ActionsDeleteEnvironmentSecretParamSchema, void, void, void>,
   respond: ActionsDeleteEnvironmentSecretResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -12926,6 +13547,7 @@ export type ActionsListEnvironmentVariables = (
   params: Params<
     t_ActionsListEnvironmentVariablesParamSchema,
     t_ActionsListEnvironmentVariablesQuerySchema,
+    void,
     void
   >,
   respond: ActionsListEnvironmentVariablesResponder,
@@ -12949,7 +13571,8 @@ export type ActionsCreateEnvironmentVariable = (
   params: Params<
     t_ActionsCreateEnvironmentVariableParamSchema,
     void,
-    t_ActionsCreateEnvironmentVariableBodySchema
+    t_ActionsCreateEnvironmentVariableBodySchema,
+    void
   >,
   respond: ActionsCreateEnvironmentVariableResponder,
   ctx: RouterContext,
@@ -12960,7 +13583,7 @@ export type ActionsGetEnvironmentVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsGetEnvironmentVariable = (
-  params: Params<t_ActionsGetEnvironmentVariableParamSchema, void, void>,
+  params: Params<t_ActionsGetEnvironmentVariableParamSchema, void, void, void>,
   respond: ActionsGetEnvironmentVariableResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_actions_variable>>
@@ -12973,7 +13596,8 @@ export type ActionsUpdateEnvironmentVariable = (
   params: Params<
     t_ActionsUpdateEnvironmentVariableParamSchema,
     void,
-    t_ActionsUpdateEnvironmentVariableBodySchema
+    t_ActionsUpdateEnvironmentVariableBodySchema,
+    void
   >,
   respond: ActionsUpdateEnvironmentVariableResponder,
   ctx: RouterContext,
@@ -12984,7 +13608,12 @@ export type ActionsDeleteEnvironmentVariableResponder = {
 } & KoaRuntimeResponder
 
 export type ActionsDeleteEnvironmentVariable = (
-  params: Params<t_ActionsDeleteEnvironmentVariableParamSchema, void, void>,
+  params: Params<
+    t_ActionsDeleteEnvironmentVariableParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActionsDeleteEnvironmentVariableResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -12997,6 +13626,7 @@ export type ActivityListRepoEvents = (
   params: Params<
     t_ActivityListRepoEventsParamSchema,
     t_ActivityListRepoEventsQuerySchema,
+    void,
     void
   >,
   respond: ActivityListRepoEventsResponder,
@@ -13012,6 +13642,7 @@ export type ReposListForks = (
   params: Params<
     t_ReposListForksParamSchema,
     t_ReposListForksQuerySchema,
+    void,
     void
   >,
   respond: ReposListForksResponder,
@@ -13034,7 +13665,8 @@ export type ReposCreateFork = (
   params: Params<
     t_ReposCreateForkParamSchema,
     void,
-    t_ReposCreateForkBodySchema | undefined
+    t_ReposCreateForkBodySchema | undefined,
+    void
   >,
   respond: ReposCreateForkResponder,
   ctx: RouterContext,
@@ -13058,7 +13690,12 @@ export type GitCreateBlobResponder = {
 } & KoaRuntimeResponder
 
 export type GitCreateBlob = (
-  params: Params<t_GitCreateBlobParamSchema, void, t_GitCreateBlobBodySchema>,
+  params: Params<
+    t_GitCreateBlobParamSchema,
+    void,
+    t_GitCreateBlobBodySchema,
+    void
+  >,
   respond: GitCreateBlobResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13079,7 +13716,7 @@ export type GitGetBlobResponder = {
 } & KoaRuntimeResponder
 
 export type GitGetBlob = (
-  params: Params<t_GitGetBlobParamSchema, void, void>,
+  params: Params<t_GitGetBlobParamSchema, void, void, void>,
   respond: GitGetBlobResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13102,7 +13739,8 @@ export type GitCreateCommit = (
   params: Params<
     t_GitCreateCommitParamSchema,
     void,
-    t_GitCreateCommitBodySchema
+    t_GitCreateCommitBodySchema,
+    void
   >,
   respond: GitCreateCommitResponder,
   ctx: RouterContext,
@@ -13121,7 +13759,7 @@ export type GitGetCommitResponder = {
 } & KoaRuntimeResponder
 
 export type GitGetCommit = (
-  params: Params<t_GitGetCommitParamSchema, void, void>,
+  params: Params<t_GitGetCommitParamSchema, void, void, void>,
   respond: GitGetCommitResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13137,7 +13775,7 @@ export type GitListMatchingRefsResponder = {
 } & KoaRuntimeResponder
 
 export type GitListMatchingRefs = (
-  params: Params<t_GitListMatchingRefsParamSchema, void, void>,
+  params: Params<t_GitListMatchingRefsParamSchema, void, void, void>,
   respond: GitListMatchingRefsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13153,7 +13791,7 @@ export type GitGetRefResponder = {
 } & KoaRuntimeResponder
 
 export type GitGetRef = (
-  params: Params<t_GitGetRefParamSchema, void, void>,
+  params: Params<t_GitGetRefParamSchema, void, void, void>,
   respond: GitGetRefResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13170,7 +13808,12 @@ export type GitCreateRefResponder = {
 } & KoaRuntimeResponder
 
 export type GitCreateRef = (
-  params: Params<t_GitCreateRefParamSchema, void, t_GitCreateRefBodySchema>,
+  params: Params<
+    t_GitCreateRefParamSchema,
+    void,
+    t_GitCreateRefBodySchema,
+    void
+  >,
   respond: GitCreateRefResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13187,7 +13830,12 @@ export type GitUpdateRefResponder = {
 } & KoaRuntimeResponder
 
 export type GitUpdateRef = (
-  params: Params<t_GitUpdateRefParamSchema, void, t_GitUpdateRefBodySchema>,
+  params: Params<
+    t_GitUpdateRefParamSchema,
+    void,
+    t_GitUpdateRefBodySchema,
+    void
+  >,
   respond: GitUpdateRefResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13204,7 +13852,7 @@ export type GitDeleteRefResponder = {
 } & KoaRuntimeResponder
 
 export type GitDeleteRef = (
-  params: Params<t_GitDeleteRefParamSchema, void, void>,
+  params: Params<t_GitDeleteRefParamSchema, void, void, void>,
   respond: GitDeleteRefResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13221,7 +13869,12 @@ export type GitCreateTagResponder = {
 } & KoaRuntimeResponder
 
 export type GitCreateTag = (
-  params: Params<t_GitCreateTagParamSchema, void, t_GitCreateTagBodySchema>,
+  params: Params<
+    t_GitCreateTagParamSchema,
+    void,
+    t_GitCreateTagBodySchema,
+    void
+  >,
   respond: GitCreateTagResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13238,7 +13891,7 @@ export type GitGetTagResponder = {
 } & KoaRuntimeResponder
 
 export type GitGetTag = (
-  params: Params<t_GitGetTagParamSchema, void, void>,
+  params: Params<t_GitGetTagParamSchema, void, void, void>,
   respond: GitGetTagResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13257,7 +13910,12 @@ export type GitCreateTreeResponder = {
 } & KoaRuntimeResponder
 
 export type GitCreateTree = (
-  params: Params<t_GitCreateTreeParamSchema, void, t_GitCreateTreeBodySchema>,
+  params: Params<
+    t_GitCreateTreeParamSchema,
+    void,
+    t_GitCreateTreeBodySchema,
+    void
+  >,
   respond: GitCreateTreeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13277,7 +13935,7 @@ export type GitGetTreeResponder = {
 } & KoaRuntimeResponder
 
 export type GitGetTree = (
-  params: Params<t_GitGetTreeParamSchema, t_GitGetTreeQuerySchema, void>,
+  params: Params<t_GitGetTreeParamSchema, t_GitGetTreeQuerySchema, void, void>,
   respond: GitGetTreeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13297,6 +13955,7 @@ export type ReposListWebhooks = (
   params: Params<
     t_ReposListWebhooksParamSchema,
     t_ReposListWebhooksQuerySchema,
+    void,
     void
   >,
   respond: ReposListWebhooksResponder,
@@ -13318,7 +13977,8 @@ export type ReposCreateWebhook = (
   params: Params<
     t_ReposCreateWebhookParamSchema,
     void,
-    t_ReposCreateWebhookBodySchema | undefined
+    t_ReposCreateWebhookBodySchema | undefined,
+    void
   >,
   respond: ReposCreateWebhookResponder,
   ctx: RouterContext,
@@ -13336,7 +13996,7 @@ export type ReposGetWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetWebhook = (
-  params: Params<t_ReposGetWebhookParamSchema, void, void>,
+  params: Params<t_ReposGetWebhookParamSchema, void, void, void>,
   respond: ReposGetWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13355,7 +14015,8 @@ export type ReposUpdateWebhook = (
   params: Params<
     t_ReposUpdateWebhookParamSchema,
     void,
-    t_ReposUpdateWebhookBodySchema
+    t_ReposUpdateWebhookBodySchema,
+    void
   >,
   respond: ReposUpdateWebhookResponder,
   ctx: RouterContext,
@@ -13372,7 +14033,7 @@ export type ReposDeleteWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteWebhook = (
-  params: Params<t_ReposDeleteWebhookParamSchema, void, void>,
+  params: Params<t_ReposDeleteWebhookParamSchema, void, void, void>,
   respond: ReposDeleteWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13386,7 +14047,7 @@ export type ReposGetWebhookConfigForRepoResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetWebhookConfigForRepo = (
-  params: Params<t_ReposGetWebhookConfigForRepoParamSchema, void, void>,
+  params: Params<t_ReposGetWebhookConfigForRepoParamSchema, void, void, void>,
   respond: ReposGetWebhookConfigForRepoResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_webhook_config>>
@@ -13399,7 +14060,8 @@ export type ReposUpdateWebhookConfigForRepo = (
   params: Params<
     t_ReposUpdateWebhookConfigForRepoParamSchema,
     void,
-    t_ReposUpdateWebhookConfigForRepoBodySchema | undefined
+    t_ReposUpdateWebhookConfigForRepoBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateWebhookConfigForRepoResponder,
   ctx: RouterContext,
@@ -13415,6 +14077,7 @@ export type ReposListWebhookDeliveries = (
   params: Params<
     t_ReposListWebhookDeliveriesParamSchema,
     t_ReposListWebhookDeliveriesQuerySchema,
+    void,
     void
   >,
   respond: ReposListWebhookDeliveriesResponder,
@@ -13433,7 +14096,7 @@ export type ReposGetWebhookDeliveryResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetWebhookDelivery = (
-  params: Params<t_ReposGetWebhookDeliveryParamSchema, void, void>,
+  params: Params<t_ReposGetWebhookDeliveryParamSchema, void, void, void>,
   respond: ReposGetWebhookDeliveryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13452,7 +14115,7 @@ export type ReposRedeliverWebhookDeliveryResponder = {
 } & KoaRuntimeResponder
 
 export type ReposRedeliverWebhookDelivery = (
-  params: Params<t_ReposRedeliverWebhookDeliveryParamSchema, void, void>,
+  params: Params<t_ReposRedeliverWebhookDeliveryParamSchema, void, void, void>,
   respond: ReposRedeliverWebhookDeliveryResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13473,7 +14136,7 @@ export type ReposPingWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type ReposPingWebhook = (
-  params: Params<t_ReposPingWebhookParamSchema, void, void>,
+  params: Params<t_ReposPingWebhookParamSchema, void, void, void>,
   respond: ReposPingWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13488,7 +14151,7 @@ export type ReposTestPushWebhookResponder = {
 } & KoaRuntimeResponder
 
 export type ReposTestPushWebhook = (
-  params: Params<t_ReposTestPushWebhookParamSchema, void, void>,
+  params: Params<t_ReposTestPushWebhookParamSchema, void, void, void>,
   respond: ReposTestPushWebhookResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13504,7 +14167,7 @@ export type MigrationsGetImportStatusResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsGetImportStatus = (
-  params: Params<t_MigrationsGetImportStatusParamSchema, void, void>,
+  params: Params<t_MigrationsGetImportStatusParamSchema, void, void, void>,
   respond: MigrationsGetImportStatusResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13525,7 +14188,8 @@ export type MigrationsStartImport = (
   params: Params<
     t_MigrationsStartImportParamSchema,
     void,
-    t_MigrationsStartImportBodySchema
+    t_MigrationsStartImportBodySchema,
+    void
   >,
   respond: MigrationsStartImportResponder,
   ctx: RouterContext,
@@ -13546,7 +14210,8 @@ export type MigrationsUpdateImport = (
   params: Params<
     t_MigrationsUpdateImportParamSchema,
     void,
-    t_MigrationsUpdateImportBodySchema | undefined
+    t_MigrationsUpdateImportBodySchema | undefined,
+    void
   >,
   respond: MigrationsUpdateImportResponder,
   ctx: RouterContext,
@@ -13562,7 +14227,7 @@ export type MigrationsCancelImportResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsCancelImport = (
-  params: Params<t_MigrationsCancelImportParamSchema, void, void>,
+  params: Params<t_MigrationsCancelImportParamSchema, void, void, void>,
   respond: MigrationsCancelImportResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13581,6 +14246,7 @@ export type MigrationsGetCommitAuthors = (
   params: Params<
     t_MigrationsGetCommitAuthorsParamSchema,
     t_MigrationsGetCommitAuthorsQuerySchema,
+    void,
     void
   >,
   respond: MigrationsGetCommitAuthorsResponder,
@@ -13603,7 +14269,8 @@ export type MigrationsMapCommitAuthor = (
   params: Params<
     t_MigrationsMapCommitAuthorParamSchema,
     void,
-    t_MigrationsMapCommitAuthorBodySchema | undefined
+    t_MigrationsMapCommitAuthorBodySchema | undefined,
+    void
   >,
   respond: MigrationsMapCommitAuthorResponder,
   ctx: RouterContext,
@@ -13621,7 +14288,7 @@ export type MigrationsGetLargeFilesResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsGetLargeFiles = (
-  params: Params<t_MigrationsGetLargeFilesParamSchema, void, void>,
+  params: Params<t_MigrationsGetLargeFilesParamSchema, void, void, void>,
   respond: MigrationsGetLargeFilesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13640,7 +14307,8 @@ export type MigrationsSetLfsPreference = (
   params: Params<
     t_MigrationsSetLfsPreferenceParamSchema,
     void,
-    t_MigrationsSetLfsPreferenceBodySchema
+    t_MigrationsSetLfsPreferenceBodySchema,
+    void
   >,
   respond: MigrationsSetLfsPreferenceResponder,
   ctx: RouterContext,
@@ -13658,7 +14326,7 @@ export type AppsGetRepoInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetRepoInstallation = (
-  params: Params<t_AppsGetRepoInstallationParamSchema, void, void>,
+  params: Params<t_AppsGetRepoInstallationParamSchema, void, void, void>,
   respond: AppsGetRepoInstallationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13673,7 +14341,12 @@ export type InteractionsGetRestrictionsForRepoResponder = {
 } & KoaRuntimeResponder
 
 export type InteractionsGetRestrictionsForRepo = (
-  params: Params<t_InteractionsGetRestrictionsForRepoParamSchema, void, void>,
+  params: Params<
+    t_InteractionsGetRestrictionsForRepoParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: InteractionsGetRestrictionsForRepoResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13690,7 +14363,8 @@ export type InteractionsSetRestrictionsForRepo = (
   params: Params<
     t_InteractionsSetRestrictionsForRepoParamSchema,
     void,
-    t_InteractionsSetRestrictionsForRepoBodySchema
+    t_InteractionsSetRestrictionsForRepoBodySchema,
+    void
   >,
   respond: InteractionsSetRestrictionsForRepoResponder,
   ctx: RouterContext,
@@ -13709,6 +14383,7 @@ export type InteractionsRemoveRestrictionsForRepo = (
   params: Params<
     t_InteractionsRemoveRestrictionsForRepoParamSchema,
     void,
+    void,
     void
   >,
   respond: InteractionsRemoveRestrictionsForRepoResponder,
@@ -13725,6 +14400,7 @@ export type ReposListInvitations = (
   params: Params<
     t_ReposListInvitationsParamSchema,
     t_ReposListInvitationsQuerySchema,
+    void,
     void
   >,
   respond: ReposListInvitationsResponder,
@@ -13741,7 +14417,8 @@ export type ReposUpdateInvitation = (
   params: Params<
     t_ReposUpdateInvitationParamSchema,
     void,
-    t_ReposUpdateInvitationBodySchema | undefined
+    t_ReposUpdateInvitationBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateInvitationResponder,
   ctx: RouterContext,
@@ -13754,7 +14431,7 @@ export type ReposDeleteInvitationResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteInvitation = (
-  params: Params<t_ReposDeleteInvitationParamSchema, void, void>,
+  params: Params<t_ReposDeleteInvitationParamSchema, void, void, void>,
   respond: ReposDeleteInvitationResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -13770,6 +14447,7 @@ export type IssuesListForRepo = (
   params: Params<
     t_IssuesListForRepoParamSchema,
     t_IssuesListForRepoQuerySchema,
+    void,
     void
   >,
   respond: IssuesListForRepoResponder,
@@ -13797,7 +14475,12 @@ export type IssuesCreateResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesCreate = (
-  params: Params<t_IssuesCreateParamSchema, void, t_IssuesCreateBodySchema>,
+  params: Params<
+    t_IssuesCreateParamSchema,
+    void,
+    t_IssuesCreateBodySchema,
+    void
+  >,
   respond: IssuesCreateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13828,6 +14511,7 @@ export type IssuesListCommentsForRepo = (
   params: Params<
     t_IssuesListCommentsForRepoParamSchema,
     t_IssuesListCommentsForRepoQuerySchema,
+    void,
     void
   >,
   respond: IssuesListCommentsForRepoResponder,
@@ -13845,7 +14529,7 @@ export type IssuesGetCommentResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesGetComment = (
-  params: Params<t_IssuesGetCommentParamSchema, void, void>,
+  params: Params<t_IssuesGetCommentParamSchema, void, void, void>,
   respond: IssuesGetCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13863,7 +14547,8 @@ export type IssuesUpdateComment = (
   params: Params<
     t_IssuesUpdateCommentParamSchema,
     void,
-    t_IssuesUpdateCommentBodySchema
+    t_IssuesUpdateCommentBodySchema,
+    void
   >,
   respond: IssuesUpdateCommentResponder,
   ctx: RouterContext,
@@ -13878,7 +14563,7 @@ export type IssuesDeleteCommentResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesDeleteComment = (
-  params: Params<t_IssuesDeleteCommentParamSchema, void, void>,
+  params: Params<t_IssuesDeleteCommentParamSchema, void, void, void>,
   respond: IssuesDeleteCommentResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -13892,6 +14577,7 @@ export type ReactionsListForIssueComment = (
   params: Params<
     t_ReactionsListForIssueCommentParamSchema,
     t_ReactionsListForIssueCommentQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForIssueCommentResponder,
@@ -13912,7 +14598,8 @@ export type ReactionsCreateForIssueComment = (
   params: Params<
     t_ReactionsCreateForIssueCommentParamSchema,
     void,
-    t_ReactionsCreateForIssueCommentBodySchema
+    t_ReactionsCreateForIssueCommentBodySchema,
+    void
   >,
   respond: ReactionsCreateForIssueCommentResponder,
   ctx: RouterContext,
@@ -13928,7 +14615,7 @@ export type ReactionsDeleteForIssueCommentResponder = {
 } & KoaRuntimeResponder
 
 export type ReactionsDeleteForIssueComment = (
-  params: Params<t_ReactionsDeleteForIssueCommentParamSchema, void, void>,
+  params: Params<t_ReactionsDeleteForIssueCommentParamSchema, void, void, void>,
   respond: ReactionsDeleteForIssueCommentResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -13942,6 +14629,7 @@ export type IssuesListEventsForRepo = (
   params: Params<
     t_IssuesListEventsForRepoParamSchema,
     t_IssuesListEventsForRepoQuerySchema,
+    void,
     void
   >,
   respond: IssuesListEventsForRepoResponder,
@@ -13960,7 +14648,7 @@ export type IssuesGetEventResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesGetEvent = (
-  params: Params<t_IssuesGetEventParamSchema, void, void>,
+  params: Params<t_IssuesGetEventParamSchema, void, void, void>,
   respond: IssuesGetEventResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13980,7 +14668,7 @@ export type IssuesGetResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesGet = (
-  params: Params<t_IssuesGetParamSchema, void, void>,
+  params: Params<t_IssuesGetParamSchema, void, void, void>,
   respond: IssuesGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14010,7 +14698,8 @@ export type IssuesUpdate = (
   params: Params<
     t_IssuesUpdateParamSchema,
     void,
-    t_IssuesUpdateBodySchema | undefined
+    t_IssuesUpdateBodySchema | undefined,
+    void
   >,
   respond: IssuesUpdateResponder,
   ctx: RouterContext,
@@ -14040,7 +14729,8 @@ export type IssuesAddAssignees = (
   params: Params<
     t_IssuesAddAssigneesParamSchema,
     void,
-    t_IssuesAddAssigneesBodySchema | undefined
+    t_IssuesAddAssigneesBodySchema | undefined,
+    void
   >,
   respond: IssuesAddAssigneesResponder,
   ctx: RouterContext,
@@ -14054,7 +14744,8 @@ export type IssuesRemoveAssignees = (
   params: Params<
     t_IssuesRemoveAssigneesParamSchema,
     void,
-    t_IssuesRemoveAssigneesBodySchema
+    t_IssuesRemoveAssigneesBodySchema,
+    void
   >,
   respond: IssuesRemoveAssigneesResponder,
   ctx: RouterContext,
@@ -14066,7 +14757,12 @@ export type IssuesCheckUserCanBeAssignedToIssueResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesCheckUserCanBeAssignedToIssue = (
-  params: Params<t_IssuesCheckUserCanBeAssignedToIssueParamSchema, void, void>,
+  params: Params<
+    t_IssuesCheckUserCanBeAssignedToIssueParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: IssuesCheckUserCanBeAssignedToIssueResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14085,6 +14781,7 @@ export type IssuesListComments = (
   params: Params<
     t_IssuesListCommentsParamSchema,
     t_IssuesListCommentsQuerySchema,
+    void,
     void
   >,
   respond: IssuesListCommentsResponder,
@@ -14108,7 +14805,8 @@ export type IssuesCreateComment = (
   params: Params<
     t_IssuesCreateCommentParamSchema,
     void,
-    t_IssuesCreateCommentBodySchema
+    t_IssuesCreateCommentBodySchema,
+    void
   >,
   respond: IssuesCreateCommentResponder,
   ctx: RouterContext,
@@ -14130,6 +14828,7 @@ export type IssuesListEvents = (
   params: Params<
     t_IssuesListEventsParamSchema,
     t_IssuesListEventsQuerySchema,
+    void,
     void
   >,
   respond: IssuesListEventsResponder,
@@ -14151,6 +14850,7 @@ export type IssuesListLabelsOnIssue = (
   params: Params<
     t_IssuesListLabelsOnIssueParamSchema,
     t_IssuesListLabelsOnIssueQuerySchema,
+    void,
     void
   >,
   respond: IssuesListLabelsOnIssueResponder,
@@ -14175,7 +14875,8 @@ export type IssuesAddLabels = (
   params: Params<
     t_IssuesAddLabelsParamSchema,
     void,
-    t_IssuesAddLabelsBodySchema | undefined
+    t_IssuesAddLabelsBodySchema | undefined,
+    void
   >,
   respond: IssuesAddLabelsResponder,
   ctx: RouterContext,
@@ -14200,7 +14901,8 @@ export type IssuesSetLabels = (
   params: Params<
     t_IssuesSetLabelsParamSchema,
     void,
-    t_IssuesSetLabelsBodySchema | undefined
+    t_IssuesSetLabelsBodySchema | undefined,
+    void
   >,
   respond: IssuesSetLabelsResponder,
   ctx: RouterContext,
@@ -14221,7 +14923,7 @@ export type IssuesRemoveAllLabelsResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesRemoveAllLabels = (
-  params: Params<t_IssuesRemoveAllLabelsParamSchema, void, void>,
+  params: Params<t_IssuesRemoveAllLabelsParamSchema, void, void, void>,
   respond: IssuesRemoveAllLabelsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14240,7 +14942,7 @@ export type IssuesRemoveLabelResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesRemoveLabel = (
-  params: Params<t_IssuesRemoveLabelParamSchema, void, void>,
+  params: Params<t_IssuesRemoveLabelParamSchema, void, void, void>,
   respond: IssuesRemoveLabelResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14263,7 +14965,8 @@ export type IssuesLock = (
   params: Params<
     t_IssuesLockParamSchema,
     void,
-    t_IssuesLockBodySchema | undefined
+    t_IssuesLockBodySchema | undefined,
+    void
   >,
   respond: IssuesLockResponder,
   ctx: RouterContext,
@@ -14283,7 +14986,7 @@ export type IssuesUnlockResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesUnlock = (
-  params: Params<t_IssuesUnlockParamSchema, void, void>,
+  params: Params<t_IssuesUnlockParamSchema, void, void, void>,
   respond: IssuesUnlockResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14303,6 +15006,7 @@ export type ReactionsListForIssue = (
   params: Params<
     t_ReactionsListForIssueParamSchema,
     t_ReactionsListForIssueQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForIssueResponder,
@@ -14324,7 +15028,8 @@ export type ReactionsCreateForIssue = (
   params: Params<
     t_ReactionsCreateForIssueParamSchema,
     void,
-    t_ReactionsCreateForIssueBodySchema
+    t_ReactionsCreateForIssueBodySchema,
+    void
   >,
   respond: ReactionsCreateForIssueResponder,
   ctx: RouterContext,
@@ -14340,7 +15045,7 @@ export type ReactionsDeleteForIssueResponder = {
 } & KoaRuntimeResponder
 
 export type ReactionsDeleteForIssue = (
-  params: Params<t_ReactionsDeleteForIssueParamSchema, void, void>,
+  params: Params<t_ReactionsDeleteForIssueParamSchema, void, void, void>,
   respond: ReactionsDeleteForIssueResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -14355,6 +15060,7 @@ export type IssuesListEventsForTimeline = (
   params: Params<
     t_IssuesListEventsForTimelineParamSchema,
     t_IssuesListEventsForTimelineQuerySchema,
+    void,
     void
   >,
   respond: IssuesListEventsForTimelineResponder,
@@ -14374,6 +15080,7 @@ export type ReposListDeployKeys = (
   params: Params<
     t_ReposListDeployKeysParamSchema,
     t_ReposListDeployKeysQuerySchema,
+    void,
     void
   >,
   respond: ReposListDeployKeysResponder,
@@ -14389,7 +15096,8 @@ export type ReposCreateDeployKey = (
   params: Params<
     t_ReposCreateDeployKeyParamSchema,
     void,
-    t_ReposCreateDeployKeyBodySchema
+    t_ReposCreateDeployKeyBodySchema,
+    void
   >,
   respond: ReposCreateDeployKeyResponder,
   ctx: RouterContext,
@@ -14405,7 +15113,7 @@ export type ReposGetDeployKeyResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetDeployKey = (
-  params: Params<t_ReposGetDeployKeyParamSchema, void, void>,
+  params: Params<t_ReposGetDeployKeyParamSchema, void, void, void>,
   respond: ReposGetDeployKeyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14419,7 +15127,7 @@ export type ReposDeleteDeployKeyResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteDeployKey = (
-  params: Params<t_ReposDeleteDeployKeyParamSchema, void, void>,
+  params: Params<t_ReposDeleteDeployKeyParamSchema, void, void, void>,
   respond: ReposDeleteDeployKeyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -14433,6 +15141,7 @@ export type IssuesListLabelsForRepo = (
   params: Params<
     t_IssuesListLabelsForRepoParamSchema,
     t_IssuesListLabelsForRepoQuerySchema,
+    void,
     void
   >,
   respond: IssuesListLabelsForRepoResponder,
@@ -14453,7 +15162,8 @@ export type IssuesCreateLabel = (
   params: Params<
     t_IssuesCreateLabelParamSchema,
     void,
-    t_IssuesCreateLabelBodySchema
+    t_IssuesCreateLabelBodySchema,
+    void
   >,
   respond: IssuesCreateLabelResponder,
   ctx: RouterContext,
@@ -14470,7 +15180,7 @@ export type IssuesGetLabelResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesGetLabel = (
-  params: Params<t_IssuesGetLabelParamSchema, void, void>,
+  params: Params<t_IssuesGetLabelParamSchema, void, void, void>,
   respond: IssuesGetLabelResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14487,7 +15197,8 @@ export type IssuesUpdateLabel = (
   params: Params<
     t_IssuesUpdateLabelParamSchema,
     void,
-    t_IssuesUpdateLabelBodySchema | undefined
+    t_IssuesUpdateLabelBodySchema | undefined,
+    void
   >,
   respond: IssuesUpdateLabelResponder,
   ctx: RouterContext,
@@ -14498,7 +15209,7 @@ export type IssuesDeleteLabelResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesDeleteLabel = (
-  params: Params<t_IssuesDeleteLabelParamSchema, void, void>,
+  params: Params<t_IssuesDeleteLabelParamSchema, void, void, void>,
   respond: IssuesDeleteLabelResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -14508,7 +15219,7 @@ export type ReposListLanguagesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListLanguages = (
-  params: Params<t_ReposListLanguagesParamSchema, void, void>,
+  params: Params<t_ReposListLanguagesParamSchema, void, void, void>,
   respond: ReposListLanguagesResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_language>>
@@ -14522,6 +15233,7 @@ export type LicensesGetForRepo = (
   params: Params<
     t_LicensesGetForRepoParamSchema,
     t_LicensesGetForRepoQuerySchema,
+    void,
     void
   >,
   respond: LicensesGetForRepoResponder,
@@ -14542,7 +15254,8 @@ export type ReposMergeUpstream = (
   params: Params<
     t_ReposMergeUpstreamParamSchema,
     void,
-    t_ReposMergeUpstreamBodySchema
+    t_ReposMergeUpstreamBodySchema,
+    void
   >,
   respond: ReposMergeUpstreamResponder,
   ctx: RouterContext,
@@ -14563,7 +15276,7 @@ export type ReposMergeResponder = {
 } & KoaRuntimeResponder
 
 export type ReposMerge = (
-  params: Params<t_ReposMergeParamSchema, void, t_ReposMergeBodySchema>,
+  params: Params<t_ReposMergeParamSchema, void, t_ReposMergeBodySchema, void>,
   respond: ReposMergeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14585,6 +15298,7 @@ export type IssuesListMilestones = (
   params: Params<
     t_IssuesListMilestonesParamSchema,
     t_IssuesListMilestonesQuerySchema,
+    void,
     void
   >,
   respond: IssuesListMilestonesResponder,
@@ -14605,7 +15319,8 @@ export type IssuesCreateMilestone = (
   params: Params<
     t_IssuesCreateMilestoneParamSchema,
     void,
-    t_IssuesCreateMilestoneBodySchema
+    t_IssuesCreateMilestoneBodySchema,
+    void
   >,
   respond: IssuesCreateMilestoneResponder,
   ctx: RouterContext,
@@ -14622,7 +15337,7 @@ export type IssuesGetMilestoneResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesGetMilestone = (
-  params: Params<t_IssuesGetMilestoneParamSchema, void, void>,
+  params: Params<t_IssuesGetMilestoneParamSchema, void, void, void>,
   respond: IssuesGetMilestoneResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14639,7 +15354,8 @@ export type IssuesUpdateMilestone = (
   params: Params<
     t_IssuesUpdateMilestoneParamSchema,
     void,
-    t_IssuesUpdateMilestoneBodySchema | undefined
+    t_IssuesUpdateMilestoneBodySchema | undefined,
+    void
   >,
   respond: IssuesUpdateMilestoneResponder,
   ctx: RouterContext,
@@ -14651,7 +15367,7 @@ export type IssuesDeleteMilestoneResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesDeleteMilestone = (
-  params: Params<t_IssuesDeleteMilestoneParamSchema, void, void>,
+  params: Params<t_IssuesDeleteMilestoneParamSchema, void, void, void>,
   respond: IssuesDeleteMilestoneResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14668,6 +15384,7 @@ export type IssuesListLabelsForMilestone = (
   params: Params<
     t_IssuesListLabelsForMilestoneParamSchema,
     t_IssuesListLabelsForMilestoneQuerySchema,
+    void,
     void
   >,
   respond: IssuesListLabelsForMilestoneResponder,
@@ -14682,6 +15399,7 @@ export type ActivityListRepoNotificationsForAuthenticatedUser = (
   params: Params<
     t_ActivityListRepoNotificationsForAuthenticatedUserParamSchema,
     t_ActivityListRepoNotificationsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListRepoNotificationsForAuthenticatedUserResponder,
@@ -14700,7 +15418,8 @@ export type ActivityMarkRepoNotificationsAsRead = (
   params: Params<
     t_ActivityMarkRepoNotificationsAsReadParamSchema,
     void,
-    t_ActivityMarkRepoNotificationsAsReadBodySchema | undefined
+    t_ActivityMarkRepoNotificationsAsReadBodySchema | undefined,
+    void
   >,
   respond: ActivityMarkRepoNotificationsAsReadResponder,
   ctx: RouterContext,
@@ -14722,7 +15441,7 @@ export type ReposGetPagesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetPages = (
-  params: Params<t_ReposGetPagesParamSchema, void, void>,
+  params: Params<t_ReposGetPagesParamSchema, void, void, void>,
   respond: ReposGetPagesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14741,7 +15460,8 @@ export type ReposCreatePagesSite = (
   params: Params<
     t_ReposCreatePagesSiteParamSchema,
     void,
-    t_ReposCreatePagesSiteBodySchema
+    t_ReposCreatePagesSiteBodySchema,
+    void
   >,
   respond: ReposCreatePagesSiteResponder,
   ctx: RouterContext,
@@ -14763,7 +15483,8 @@ export type ReposUpdateInformationAboutPagesSite = (
   params: Params<
     t_ReposUpdateInformationAboutPagesSiteParamSchema,
     void,
-    t_ReposUpdateInformationAboutPagesSiteBodySchema
+    t_ReposUpdateInformationAboutPagesSiteBodySchema,
+    void
   >,
   respond: ReposUpdateInformationAboutPagesSiteResponder,
   ctx: RouterContext,
@@ -14783,7 +15504,7 @@ export type ReposDeletePagesSiteResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeletePagesSite = (
-  params: Params<t_ReposDeletePagesSiteParamSchema, void, void>,
+  params: Params<t_ReposDeletePagesSiteParamSchema, void, void, void>,
   respond: ReposDeletePagesSiteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14802,6 +15523,7 @@ export type ReposListPagesBuilds = (
   params: Params<
     t_ReposListPagesBuildsParamSchema,
     t_ReposListPagesBuildsQuerySchema,
+    void,
     void
   >,
   respond: ReposListPagesBuildsResponder,
@@ -14813,7 +15535,7 @@ export type ReposRequestPagesBuildResponder = {
 } & KoaRuntimeResponder
 
 export type ReposRequestPagesBuild = (
-  params: Params<t_ReposRequestPagesBuildParamSchema, void, void>,
+  params: Params<t_ReposRequestPagesBuildParamSchema, void, void, void>,
   respond: ReposRequestPagesBuildResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<201, t_page_build_status>>
@@ -14823,7 +15545,7 @@ export type ReposGetLatestPagesBuildResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetLatestPagesBuild = (
-  params: Params<t_ReposGetLatestPagesBuildParamSchema, void, void>,
+  params: Params<t_ReposGetLatestPagesBuildParamSchema, void, void, void>,
   respond: ReposGetLatestPagesBuildResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_page_build>>
@@ -14833,7 +15555,7 @@ export type ReposGetPagesBuildResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetPagesBuild = (
-  params: Params<t_ReposGetPagesBuildParamSchema, void, void>,
+  params: Params<t_ReposGetPagesBuildParamSchema, void, void, void>,
   respond: ReposGetPagesBuildResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_page_build>>
@@ -14849,7 +15571,8 @@ export type ReposCreatePagesDeployment = (
   params: Params<
     t_ReposCreatePagesDeploymentParamSchema,
     void,
-    t_ReposCreatePagesDeploymentBodySchema
+    t_ReposCreatePagesDeploymentBodySchema,
+    void
   >,
   respond: ReposCreatePagesDeploymentResponder,
   ctx: RouterContext,
@@ -14867,7 +15590,7 @@ export type ReposGetPagesDeploymentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetPagesDeployment = (
-  params: Params<t_ReposGetPagesDeploymentParamSchema, void, void>,
+  params: Params<t_ReposGetPagesDeploymentParamSchema, void, void, void>,
   respond: ReposGetPagesDeploymentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14882,7 +15605,7 @@ export type ReposCancelPagesDeploymentResponder = {
 } & KoaRuntimeResponder
 
 export type ReposCancelPagesDeployment = (
-  params: Params<t_ReposCancelPagesDeploymentParamSchema, void, void>,
+  params: Params<t_ReposCancelPagesDeploymentParamSchema, void, void, void>,
   respond: ReposCancelPagesDeploymentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14900,7 +15623,7 @@ export type ReposGetPagesHealthCheckResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetPagesHealthCheck = (
-  params: Params<t_ReposGetPagesHealthCheckParamSchema, void, void>,
+  params: Params<t_ReposGetPagesHealthCheckParamSchema, void, void, void>,
   respond: ReposGetPagesHealthCheckResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -14922,6 +15645,7 @@ export type ReposCheckPrivateVulnerabilityReportingResponder = {
 export type ReposCheckPrivateVulnerabilityReporting = (
   params: Params<
     t_ReposCheckPrivateVulnerabilityReportingParamSchema,
+    void,
     void,
     void
   >,
@@ -14947,6 +15671,7 @@ export type ReposEnablePrivateVulnerabilityReporting = (
   params: Params<
     t_ReposEnablePrivateVulnerabilityReportingParamSchema,
     void,
+    void,
     void
   >,
   respond: ReposEnablePrivateVulnerabilityReportingResponder,
@@ -14965,6 +15690,7 @@ export type ReposDisablePrivateVulnerabilityReportingResponder = {
 export type ReposDisablePrivateVulnerabilityReporting = (
   params: Params<
     t_ReposDisablePrivateVulnerabilityReportingParamSchema,
+    void,
     void,
     void
   >,
@@ -14989,6 +15715,7 @@ export type ProjectsListForRepo = (
   params: Params<
     t_ProjectsListForRepoParamSchema,
     t_ProjectsListForRepoQuerySchema,
+    void,
     void
   >,
   respond: ProjectsListForRepoResponder,
@@ -15016,7 +15743,8 @@ export type ProjectsCreateForRepo = (
   params: Params<
     t_ProjectsCreateForRepoParamSchema,
     void,
-    t_ProjectsCreateForRepoBodySchema
+    t_ProjectsCreateForRepoBodySchema,
+    void
   >,
   respond: ProjectsCreateForRepoResponder,
   ctx: RouterContext,
@@ -15037,7 +15765,7 @@ export type ReposGetCustomPropertiesValuesResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCustomPropertiesValues = (
-  params: Params<t_ReposGetCustomPropertiesValuesParamSchema, void, void>,
+  params: Params<t_ReposGetCustomPropertiesValuesParamSchema, void, void, void>,
   respond: ReposGetCustomPropertiesValuesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15058,7 +15786,8 @@ export type ReposCreateOrUpdateCustomPropertiesValues = (
   params: Params<
     t_ReposCreateOrUpdateCustomPropertiesValuesParamSchema,
     void,
-    t_ReposCreateOrUpdateCustomPropertiesValuesBodySchema
+    t_ReposCreateOrUpdateCustomPropertiesValuesBodySchema,
+    void
   >,
   respond: ReposCreateOrUpdateCustomPropertiesValuesResponder,
   ctx: RouterContext,
@@ -15077,7 +15806,7 @@ export type PullsListResponder = {
 } & KoaRuntimeResponder
 
 export type PullsList = (
-  params: Params<t_PullsListParamSchema, t_PullsListQuerySchema, void>,
+  params: Params<t_PullsListParamSchema, t_PullsListQuerySchema, void, void>,
   respond: PullsListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15094,7 +15823,7 @@ export type PullsCreateResponder = {
 } & KoaRuntimeResponder
 
 export type PullsCreate = (
-  params: Params<t_PullsCreateParamSchema, void, t_PullsCreateBodySchema>,
+  params: Params<t_PullsCreateParamSchema, void, t_PullsCreateBodySchema, void>,
   respond: PullsCreateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15112,6 +15841,7 @@ export type PullsListReviewCommentsForRepo = (
   params: Params<
     t_PullsListReviewCommentsForRepoParamSchema,
     t_PullsListReviewCommentsForRepoQuerySchema,
+    void,
     void
   >,
   respond: PullsListReviewCommentsForRepoResponder,
@@ -15126,7 +15856,7 @@ export type PullsGetReviewCommentResponder = {
 } & KoaRuntimeResponder
 
 export type PullsGetReviewComment = (
-  params: Params<t_PullsGetReviewCommentParamSchema, void, void>,
+  params: Params<t_PullsGetReviewCommentParamSchema, void, void, void>,
   respond: PullsGetReviewCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15143,7 +15873,8 @@ export type PullsUpdateReviewComment = (
   params: Params<
     t_PullsUpdateReviewCommentParamSchema,
     void,
-    t_PullsUpdateReviewCommentBodySchema
+    t_PullsUpdateReviewCommentBodySchema,
+    void
   >,
   respond: PullsUpdateReviewCommentResponder,
   ctx: RouterContext,
@@ -15157,7 +15888,7 @@ export type PullsDeleteReviewCommentResponder = {
 } & KoaRuntimeResponder
 
 export type PullsDeleteReviewComment = (
-  params: Params<t_PullsDeleteReviewCommentParamSchema, void, void>,
+  params: Params<t_PullsDeleteReviewCommentParamSchema, void, void, void>,
   respond: PullsDeleteReviewCommentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15175,6 +15906,7 @@ export type ReactionsListForPullRequestReviewComment = (
   params: Params<
     t_ReactionsListForPullRequestReviewCommentParamSchema,
     t_ReactionsListForPullRequestReviewCommentQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForPullRequestReviewCommentResponder,
@@ -15195,7 +15927,8 @@ export type ReactionsCreateForPullRequestReviewComment = (
   params: Params<
     t_ReactionsCreateForPullRequestReviewCommentParamSchema,
     void,
-    t_ReactionsCreateForPullRequestReviewCommentBodySchema
+    t_ReactionsCreateForPullRequestReviewCommentBodySchema,
+    void
   >,
   respond: ReactionsCreateForPullRequestReviewCommentResponder,
   ctx: RouterContext,
@@ -15211,7 +15944,12 @@ export type ReactionsDeleteForPullRequestCommentResponder = {
 } & KoaRuntimeResponder
 
 export type ReactionsDeleteForPullRequestComment = (
-  params: Params<t_ReactionsDeleteForPullRequestCommentParamSchema, void, void>,
+  params: Params<
+    t_ReactionsDeleteForPullRequestCommentParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReactionsDeleteForPullRequestCommentResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -15230,7 +15968,7 @@ export type PullsGetResponder = {
 } & KoaRuntimeResponder
 
 export type PullsGet = (
-  params: Params<t_PullsGetParamSchema, void, void>,
+  params: Params<t_PullsGetParamSchema, void, void, void>,
   respond: PullsGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15260,7 +15998,8 @@ export type PullsUpdate = (
   params: Params<
     t_PullsUpdateParamSchema,
     void,
-    t_PullsUpdateBodySchema | undefined
+    t_PullsUpdateBodySchema | undefined,
+    void
   >,
   respond: PullsUpdateResponder,
   ctx: RouterContext,
@@ -15288,7 +16027,8 @@ export type CodespacesCreateWithPrForAuthenticatedUser = (
   params: Params<
     t_CodespacesCreateWithPrForAuthenticatedUserParamSchema,
     void,
-    t_CodespacesCreateWithPrForAuthenticatedUserBodySchema
+    t_CodespacesCreateWithPrForAuthenticatedUserBodySchema,
+    void
   >,
   respond: CodespacesCreateWithPrForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -15317,6 +16057,7 @@ export type PullsListReviewComments = (
   params: Params<
     t_PullsListReviewCommentsParamSchema,
     t_PullsListReviewCommentsQuerySchema,
+    void,
     void
   >,
   respond: PullsListReviewCommentsResponder,
@@ -15335,7 +16076,8 @@ export type PullsCreateReviewComment = (
   params: Params<
     t_PullsCreateReviewCommentParamSchema,
     void,
-    t_PullsCreateReviewCommentBodySchema
+    t_PullsCreateReviewCommentBodySchema,
+    void
   >,
   respond: PullsCreateReviewCommentResponder,
   ctx: RouterContext,
@@ -15355,7 +16097,8 @@ export type PullsCreateReplyForReviewComment = (
   params: Params<
     t_PullsCreateReplyForReviewCommentParamSchema,
     void,
-    t_PullsCreateReplyForReviewCommentBodySchema
+    t_PullsCreateReplyForReviewCommentBodySchema,
+    void
   >,
   respond: PullsCreateReplyForReviewCommentResponder,
   ctx: RouterContext,
@@ -15373,6 +16116,7 @@ export type PullsListCommits = (
   params: Params<
     t_PullsListCommitsParamSchema,
     t_PullsListCommitsQuerySchema,
+    void,
     void
   >,
   respond: PullsListCommitsResponder,
@@ -15394,6 +16138,7 @@ export type PullsListFiles = (
   params: Params<
     t_PullsListFilesParamSchema,
     t_PullsListFilesQuerySchema,
+    void,
     void
   >,
   respond: PullsListFilesResponder,
@@ -15419,7 +16164,7 @@ export type PullsCheckIfMergedResponder = {
 } & KoaRuntimeResponder
 
 export type PullsCheckIfMerged = (
-  params: Params<t_PullsCheckIfMergedParamSchema, void, void>,
+  params: Params<t_PullsCheckIfMergedParamSchema, void, void, void>,
   respond: PullsCheckIfMergedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15445,7 +16190,8 @@ export type PullsMerge = (
   params: Params<
     t_PullsMergeParamSchema,
     void,
-    t_PullsMergeBodySchema | undefined
+    t_PullsMergeBodySchema | undefined,
+    void
   >,
   respond: PullsMergeResponder,
   ctx: RouterContext,
@@ -15476,7 +16222,7 @@ export type PullsListRequestedReviewersResponder = {
 } & KoaRuntimeResponder
 
 export type PullsListRequestedReviewers = (
-  params: Params<t_PullsListRequestedReviewersParamSchema, void, void>,
+  params: Params<t_PullsListRequestedReviewersParamSchema, void, void, void>,
   respond: PullsListRequestedReviewersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15493,7 +16239,8 @@ export type PullsRequestReviewers = (
   params: Params<
     t_PullsRequestReviewersParamSchema,
     void,
-    t_PullsRequestReviewersBodySchema | undefined
+    t_PullsRequestReviewersBodySchema | undefined,
+    void
   >,
   respond: PullsRequestReviewersResponder,
   ctx: RouterContext,
@@ -15513,7 +16260,8 @@ export type PullsRemoveRequestedReviewers = (
   params: Params<
     t_PullsRemoveRequestedReviewersParamSchema,
     void,
-    t_PullsRemoveRequestedReviewersBodySchema
+    t_PullsRemoveRequestedReviewersBodySchema,
+    void
   >,
   respond: PullsRemoveRequestedReviewersResponder,
   ctx: RouterContext,
@@ -15531,6 +16279,7 @@ export type PullsListReviews = (
   params: Params<
     t_PullsListReviewsParamSchema,
     t_PullsListReviewsQuerySchema,
+    void,
     void
   >,
   respond: PullsListReviewsResponder,
@@ -15549,7 +16298,8 @@ export type PullsCreateReview = (
   params: Params<
     t_PullsCreateReviewParamSchema,
     void,
-    t_PullsCreateReviewBodySchema | undefined
+    t_PullsCreateReviewBodySchema | undefined,
+    void
   >,
   respond: PullsCreateReviewResponder,
   ctx: RouterContext,
@@ -15566,7 +16316,7 @@ export type PullsGetReviewResponder = {
 } & KoaRuntimeResponder
 
 export type PullsGetReview = (
-  params: Params<t_PullsGetReviewParamSchema, void, void>,
+  params: Params<t_PullsGetReviewParamSchema, void, void, void>,
   respond: PullsGetReviewResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15584,7 +16334,8 @@ export type PullsUpdateReview = (
   params: Params<
     t_PullsUpdateReviewParamSchema,
     void,
-    t_PullsUpdateReviewBodySchema
+    t_PullsUpdateReviewBodySchema,
+    void
   >,
   respond: PullsUpdateReviewResponder,
   ctx: RouterContext,
@@ -15601,7 +16352,7 @@ export type PullsDeletePendingReviewResponder = {
 } & KoaRuntimeResponder
 
 export type PullsDeletePendingReview = (
-  params: Params<t_PullsDeletePendingReviewParamSchema, void, void>,
+  params: Params<t_PullsDeletePendingReviewParamSchema, void, void, void>,
   respond: PullsDeletePendingReviewResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15620,6 +16371,7 @@ export type PullsListCommentsForReview = (
   params: Params<
     t_PullsListCommentsForReviewParamSchema,
     t_PullsListCommentsForReviewQuerySchema,
+    void,
     void
   >,
   respond: PullsListCommentsForReviewResponder,
@@ -15640,7 +16392,8 @@ export type PullsDismissReview = (
   params: Params<
     t_PullsDismissReviewParamSchema,
     void,
-    t_PullsDismissReviewBodySchema
+    t_PullsDismissReviewBodySchema,
+    void
   >,
   respond: PullsDismissReviewResponder,
   ctx: RouterContext,
@@ -15662,7 +16415,8 @@ export type PullsSubmitReview = (
   params: Params<
     t_PullsSubmitReviewParamSchema,
     void,
-    t_PullsSubmitReviewBodySchema
+    t_PullsSubmitReviewBodySchema,
+    void
   >,
   respond: PullsSubmitReviewResponder,
   ctx: RouterContext,
@@ -15687,7 +16441,8 @@ export type PullsUpdateBranch = (
   params: Params<
     t_PullsUpdateBranchParamSchema,
     void,
-    t_PullsUpdateBranchBodySchema | undefined
+    t_PullsUpdateBranchBodySchema | undefined,
+    void
   >,
   respond: PullsUpdateBranchResponder,
   ctx: RouterContext,
@@ -15715,6 +16470,7 @@ export type ReposGetReadme = (
   params: Params<
     t_ReposGetReadmeParamSchema,
     t_ReposGetReadmeQuerySchema,
+    void,
     void
   >,
   respond: ReposGetReadmeResponder,
@@ -15737,6 +16493,7 @@ export type ReposGetReadmeInDirectory = (
   params: Params<
     t_ReposGetReadmeInDirectoryParamSchema,
     t_ReposGetReadmeInDirectoryQuerySchema,
+    void,
     void
   >,
   respond: ReposGetReadmeInDirectoryResponder,
@@ -15757,6 +16514,7 @@ export type ReposListReleases = (
   params: Params<
     t_ReposListReleasesParamSchema,
     t_ReposListReleasesQuerySchema,
+    void,
     void
   >,
   respond: ReposListReleasesResponder,
@@ -15777,7 +16535,8 @@ export type ReposCreateRelease = (
   params: Params<
     t_ReposCreateReleaseParamSchema,
     void,
-    t_ReposCreateReleaseBodySchema
+    t_ReposCreateReleaseBodySchema,
+    void
   >,
   respond: ReposCreateReleaseResponder,
   ctx: RouterContext,
@@ -15795,7 +16554,7 @@ export type ReposGetReleaseAssetResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetReleaseAsset = (
-  params: Params<t_ReposGetReleaseAssetParamSchema, void, void>,
+  params: Params<t_ReposGetReleaseAssetParamSchema, void, void, void>,
   respond: ReposGetReleaseAssetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15813,7 +16572,8 @@ export type ReposUpdateReleaseAsset = (
   params: Params<
     t_ReposUpdateReleaseAssetParamSchema,
     void,
-    t_ReposUpdateReleaseAssetBodySchema | undefined
+    t_ReposUpdateReleaseAssetBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateReleaseAssetResponder,
   ctx: RouterContext,
@@ -15824,7 +16584,7 @@ export type ReposDeleteReleaseAssetResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteReleaseAsset = (
-  params: Params<t_ReposDeleteReleaseAssetParamSchema, void, void>,
+  params: Params<t_ReposDeleteReleaseAssetParamSchema, void, void, void>,
   respond: ReposDeleteReleaseAssetResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -15838,7 +16598,8 @@ export type ReposGenerateReleaseNotes = (
   params: Params<
     t_ReposGenerateReleaseNotesParamSchema,
     void,
-    t_ReposGenerateReleaseNotesBodySchema
+    t_ReposGenerateReleaseNotesBodySchema,
+    void
   >,
   respond: ReposGenerateReleaseNotesResponder,
   ctx: RouterContext,
@@ -15853,7 +16614,7 @@ export type ReposGetLatestReleaseResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetLatestRelease = (
-  params: Params<t_ReposGetLatestReleaseParamSchema, void, void>,
+  params: Params<t_ReposGetLatestReleaseParamSchema, void, void, void>,
   respond: ReposGetLatestReleaseResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_release>>
@@ -15864,7 +16625,7 @@ export type ReposGetReleaseByTagResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetReleaseByTag = (
-  params: Params<t_ReposGetReleaseByTagParamSchema, void, void>,
+  params: Params<t_ReposGetReleaseByTagParamSchema, void, void, void>,
   respond: ReposGetReleaseByTagResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15879,7 +16640,7 @@ export type ReposGetReleaseResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetRelease = (
-  params: Params<t_ReposGetReleaseParamSchema, void, void>,
+  params: Params<t_ReposGetReleaseParamSchema, void, void, void>,
   respond: ReposGetReleaseResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -15895,7 +16656,8 @@ export type ReposUpdateRelease = (
   params: Params<
     t_ReposUpdateReleaseParamSchema,
     void,
-    t_ReposUpdateReleaseBodySchema | undefined
+    t_ReposUpdateReleaseBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateReleaseResponder,
   ctx: RouterContext,
@@ -15910,7 +16672,7 @@ export type ReposDeleteReleaseResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteRelease = (
-  params: Params<t_ReposDeleteReleaseParamSchema, void, void>,
+  params: Params<t_ReposDeleteReleaseParamSchema, void, void, void>,
   respond: ReposDeleteReleaseResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -15923,6 +16685,7 @@ export type ReposListReleaseAssets = (
   params: Params<
     t_ReposListReleaseAssetsParamSchema,
     t_ReposListReleaseAssetsQuerySchema,
+    void,
     void
   >,
   respond: ReposListReleaseAssetsResponder,
@@ -15938,7 +16701,8 @@ export type ReposUploadReleaseAsset = (
   params: Params<
     t_ReposUploadReleaseAssetParamSchema,
     t_ReposUploadReleaseAssetQuerySchema,
-    t_ReposUploadReleaseAssetBodySchema | undefined
+    t_ReposUploadReleaseAssetBodySchema | undefined,
+    void
   >,
   respond: ReposUploadReleaseAssetResponder,
   ctx: RouterContext,
@@ -15957,6 +16721,7 @@ export type ReactionsListForRelease = (
   params: Params<
     t_ReactionsListForReleaseParamSchema,
     t_ReactionsListForReleaseQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForReleaseResponder,
@@ -15977,7 +16742,8 @@ export type ReactionsCreateForRelease = (
   params: Params<
     t_ReactionsCreateForReleaseParamSchema,
     void,
-    t_ReactionsCreateForReleaseBodySchema
+    t_ReactionsCreateForReleaseBodySchema,
+    void
   >,
   respond: ReactionsCreateForReleaseResponder,
   ctx: RouterContext,
@@ -15993,7 +16759,7 @@ export type ReactionsDeleteForReleaseResponder = {
 } & KoaRuntimeResponder
 
 export type ReactionsDeleteForRelease = (
-  params: Params<t_ReactionsDeleteForReleaseParamSchema, void, void>,
+  params: Params<t_ReactionsDeleteForReleaseParamSchema, void, void, void>,
   respond: ReactionsDeleteForReleaseResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -16006,6 +16772,7 @@ export type ReposGetBranchRules = (
   params: Params<
     t_ReposGetBranchRulesParamSchema,
     t_ReposGetBranchRulesQuerySchema,
+    void,
     void
   >,
   respond: ReposGetBranchRulesResponder,
@@ -16024,6 +16791,7 @@ export type ReposGetRepoRulesets = (
   params: Params<
     t_ReposGetRepoRulesetsParamSchema,
     t_ReposGetRepoRulesetsQuerySchema,
+    void,
     void
   >,
   respond: ReposGetRepoRulesetsResponder,
@@ -16045,7 +16813,8 @@ export type ReposCreateRepoRuleset = (
   params: Params<
     t_ReposCreateRepoRulesetParamSchema,
     void,
-    t_ReposCreateRepoRulesetBodySchema
+    t_ReposCreateRepoRulesetBodySchema,
+    void
   >,
   respond: ReposCreateRepoRulesetResponder,
   ctx: RouterContext,
@@ -16066,6 +16835,7 @@ export type ReposGetRepoRuleSuites = (
   params: Params<
     t_ReposGetRepoRuleSuitesParamSchema,
     t_ReposGetRepoRuleSuitesQuerySchema,
+    void,
     void
   >,
   respond: ReposGetRepoRuleSuitesResponder,
@@ -16084,7 +16854,7 @@ export type ReposGetRepoRuleSuiteResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetRepoRuleSuite = (
-  params: Params<t_ReposGetRepoRuleSuiteParamSchema, void, void>,
+  params: Params<t_ReposGetRepoRuleSuiteParamSchema, void, void, void>,
   respond: ReposGetRepoRuleSuiteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16104,6 +16874,7 @@ export type ReposGetRepoRuleset = (
   params: Params<
     t_ReposGetRepoRulesetParamSchema,
     t_ReposGetRepoRulesetQuerySchema,
+    void,
     void
   >,
   respond: ReposGetRepoRulesetResponder,
@@ -16125,7 +16896,8 @@ export type ReposUpdateRepoRuleset = (
   params: Params<
     t_ReposUpdateRepoRulesetParamSchema,
     void,
-    t_ReposUpdateRepoRulesetBodySchema | undefined
+    t_ReposUpdateRepoRulesetBodySchema | undefined,
+    void
   >,
   respond: ReposUpdateRepoRulesetResponder,
   ctx: RouterContext,
@@ -16143,7 +16915,7 @@ export type ReposDeleteRepoRulesetResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteRepoRuleset = (
-  params: Params<t_ReposDeleteRepoRulesetParamSchema, void, void>,
+  params: Params<t_ReposDeleteRepoRulesetParamSchema, void, void, void>,
   respond: ReposDeleteRepoRulesetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16167,6 +16939,7 @@ export type SecretScanningListAlertsForRepo = (
   params: Params<
     t_SecretScanningListAlertsForRepoParamSchema,
     t_SecretScanningListAlertsForRepoQuerySchema,
+    void,
     void
   >,
   respond: SecretScanningListAlertsForRepoResponder,
@@ -16197,7 +16970,7 @@ export type SecretScanningGetAlertResponder = {
 } & KoaRuntimeResponder
 
 export type SecretScanningGetAlert = (
-  params: Params<t_SecretScanningGetAlertParamSchema, void, void>,
+  params: Params<t_SecretScanningGetAlertParamSchema, void, void, void>,
   respond: SecretScanningGetAlertResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16231,7 +17004,8 @@ export type SecretScanningUpdateAlert = (
   params: Params<
     t_SecretScanningUpdateAlertParamSchema,
     void,
-    t_SecretScanningUpdateAlertBodySchema
+    t_SecretScanningUpdateAlertBodySchema,
+    void
   >,
   respond: SecretScanningUpdateAlertResponder,
   ctx: RouterContext,
@@ -16265,6 +17039,7 @@ export type SecretScanningListLocationsForAlert = (
   params: Params<
     t_SecretScanningListLocationsForAlertParamSchema,
     t_SecretScanningListLocationsForAlertQuerySchema,
+    void,
     void
   >,
   respond: SecretScanningListLocationsForAlertResponder,
@@ -16299,7 +17074,8 @@ export type SecretScanningCreatePushProtectionBypass = (
   params: Params<
     t_SecretScanningCreatePushProtectionBypassParamSchema,
     void,
-    t_SecretScanningCreatePushProtectionBypassBodySchema
+    t_SecretScanningCreatePushProtectionBypassBodySchema,
+    void
   >,
   respond: SecretScanningCreatePushProtectionBypassResponder,
   ctx: RouterContext,
@@ -16329,6 +17105,7 @@ export type SecurityAdvisoriesListRepositoryAdvisories = (
   params: Params<
     t_SecurityAdvisoriesListRepositoryAdvisoriesParamSchema,
     t_SecurityAdvisoriesListRepositoryAdvisoriesQuerySchema,
+    void,
     void
   >,
   respond: SecurityAdvisoriesListRepositoryAdvisoriesResponder,
@@ -16351,7 +17128,8 @@ export type SecurityAdvisoriesCreateRepositoryAdvisory = (
   params: Params<
     t_SecurityAdvisoriesCreateRepositoryAdvisoryParamSchema,
     void,
-    t_SecurityAdvisoriesCreateRepositoryAdvisoryBodySchema
+    t_SecurityAdvisoriesCreateRepositoryAdvisoryBodySchema,
+    void
   >,
   respond: SecurityAdvisoriesCreateRepositoryAdvisoryResponder,
   ctx: RouterContext,
@@ -16374,7 +17152,8 @@ export type SecurityAdvisoriesCreatePrivateVulnerabilityReport = (
   params: Params<
     t_SecurityAdvisoriesCreatePrivateVulnerabilityReportParamSchema,
     void,
-    t_SecurityAdvisoriesCreatePrivateVulnerabilityReportBodySchema
+    t_SecurityAdvisoriesCreatePrivateVulnerabilityReportBodySchema,
+    void
   >,
   respond: SecurityAdvisoriesCreatePrivateVulnerabilityReportResponder,
   ctx: RouterContext,
@@ -16395,6 +17174,7 @@ export type SecurityAdvisoriesGetRepositoryAdvisoryResponder = {
 export type SecurityAdvisoriesGetRepositoryAdvisory = (
   params: Params<
     t_SecurityAdvisoriesGetRepositoryAdvisoryParamSchema,
+    void,
     void,
     void
   >,
@@ -16418,7 +17198,8 @@ export type SecurityAdvisoriesUpdateRepositoryAdvisory = (
   params: Params<
     t_SecurityAdvisoriesUpdateRepositoryAdvisoryParamSchema,
     void,
-    t_SecurityAdvisoriesUpdateRepositoryAdvisoryBodySchema
+    t_SecurityAdvisoriesUpdateRepositoryAdvisoryBodySchema,
+    void
   >,
   respond: SecurityAdvisoriesUpdateRepositoryAdvisoryResponder,
   ctx: RouterContext,
@@ -16443,6 +17224,7 @@ export type SecurityAdvisoriesCreateRepositoryAdvisoryCveRequestResponder = {
 export type SecurityAdvisoriesCreateRepositoryAdvisoryCveRequest = (
   params: Params<
     t_SecurityAdvisoriesCreateRepositoryAdvisoryCveRequestParamSchema,
+    void,
     void,
     void
   >,
@@ -16471,7 +17253,7 @@ export type SecurityAdvisoriesCreateForkResponder = {
 } & KoaRuntimeResponder
 
 export type SecurityAdvisoriesCreateFork = (
-  params: Params<t_SecurityAdvisoriesCreateForkParamSchema, void, void>,
+  params: Params<t_SecurityAdvisoriesCreateForkParamSchema, void, void, void>,
   respond: SecurityAdvisoriesCreateForkResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16492,6 +17274,7 @@ export type ActivityListStargazersForRepo = (
   params: Params<
     t_ActivityListStargazersForRepoParamSchema,
     t_ActivityListStargazersForRepoQuerySchema,
+    void,
     void
   >,
   respond: ActivityListStargazersForRepoResponder,
@@ -16512,7 +17295,7 @@ export type ReposGetCodeFrequencyStatsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCodeFrequencyStats = (
-  params: Params<t_ReposGetCodeFrequencyStatsParamSchema, void, void>,
+  params: Params<t_ReposGetCodeFrequencyStatsParamSchema, void, void, void>,
   respond: ReposGetCodeFrequencyStatsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16537,7 +17320,7 @@ export type ReposGetCommitActivityStatsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetCommitActivityStats = (
-  params: Params<t_ReposGetCommitActivityStatsParamSchema, void, void>,
+  params: Params<t_ReposGetCommitActivityStatsParamSchema, void, void, void>,
   respond: ReposGetCommitActivityStatsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16561,7 +17344,7 @@ export type ReposGetContributorsStatsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetContributorsStats = (
-  params: Params<t_ReposGetContributorsStatsParamSchema, void, void>,
+  params: Params<t_ReposGetContributorsStatsParamSchema, void, void, void>,
   respond: ReposGetContributorsStatsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16582,7 +17365,7 @@ export type ReposGetParticipationStatsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetParticipationStats = (
-  params: Params<t_ReposGetParticipationStatsParamSchema, void, void>,
+  params: Params<t_ReposGetParticipationStatsParamSchema, void, void, void>,
   respond: ReposGetParticipationStatsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16597,7 +17380,7 @@ export type ReposGetPunchCardStatsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetPunchCardStats = (
-  params: Params<t_ReposGetPunchCardStatsParamSchema, void, void>,
+  params: Params<t_ReposGetPunchCardStatsParamSchema, void, void, void>,
   respond: ReposGetPunchCardStatsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16614,7 +17397,8 @@ export type ReposCreateCommitStatus = (
   params: Params<
     t_ReposCreateCommitStatusParamSchema,
     void,
-    t_ReposCreateCommitStatusBodySchema
+    t_ReposCreateCommitStatusBodySchema,
+    void
   >,
   respond: ReposCreateCommitStatusResponder,
   ctx: RouterContext,
@@ -16628,6 +17412,7 @@ export type ActivityListWatchersForRepo = (
   params: Params<
     t_ActivityListWatchersForRepoParamSchema,
     t_ActivityListWatchersForRepoQuerySchema,
+    void,
     void
   >,
   respond: ActivityListWatchersForRepoResponder,
@@ -16641,7 +17426,7 @@ export type ActivityGetRepoSubscriptionResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityGetRepoSubscription = (
-  params: Params<t_ActivityGetRepoSubscriptionParamSchema, void, void>,
+  params: Params<t_ActivityGetRepoSubscriptionParamSchema, void, void, void>,
   respond: ActivityGetRepoSubscriptionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16659,7 +17444,8 @@ export type ActivitySetRepoSubscription = (
   params: Params<
     t_ActivitySetRepoSubscriptionParamSchema,
     void,
-    t_ActivitySetRepoSubscriptionBodySchema | undefined
+    t_ActivitySetRepoSubscriptionBodySchema | undefined,
+    void
   >,
   respond: ActivitySetRepoSubscriptionResponder,
   ctx: RouterContext,
@@ -16672,7 +17458,7 @@ export type ActivityDeleteRepoSubscriptionResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityDeleteRepoSubscription = (
-  params: Params<t_ActivityDeleteRepoSubscriptionParamSchema, void, void>,
+  params: Params<t_ActivityDeleteRepoSubscriptionParamSchema, void, void, void>,
   respond: ActivityDeleteRepoSubscriptionResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -16682,7 +17468,12 @@ export type ReposListTagsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListTags = (
-  params: Params<t_ReposListTagsParamSchema, t_ReposListTagsQuerySchema, void>,
+  params: Params<
+    t_ReposListTagsParamSchema,
+    t_ReposListTagsQuerySchema,
+    void,
+    void
+  >,
   respond: ReposListTagsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_tag[]>>
@@ -16694,7 +17485,7 @@ export type ReposListTagProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListTagProtection = (
-  params: Params<t_ReposListTagProtectionParamSchema, void, void>,
+  params: Params<t_ReposListTagProtectionParamSchema, void, void, void>,
   respond: ReposListTagProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16714,7 +17505,8 @@ export type ReposCreateTagProtection = (
   params: Params<
     t_ReposCreateTagProtectionParamSchema,
     void,
-    t_ReposCreateTagProtectionBodySchema
+    t_ReposCreateTagProtectionBodySchema,
+    void
   >,
   respond: ReposCreateTagProtectionResponder,
   ctx: RouterContext,
@@ -16732,7 +17524,7 @@ export type ReposDeleteTagProtectionResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDeleteTagProtection = (
-  params: Params<t_ReposDeleteTagProtectionParamSchema, void, void>,
+  params: Params<t_ReposDeleteTagProtectionParamSchema, void, void, void>,
   respond: ReposDeleteTagProtectionResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16747,7 +17539,7 @@ export type ReposDownloadTarballArchiveResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDownloadTarballArchive = (
-  params: Params<t_ReposDownloadTarballArchiveParamSchema, void, void>,
+  params: Params<t_ReposDownloadTarballArchiveParamSchema, void, void, void>,
   respond: ReposDownloadTarballArchiveResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<302, void>>
@@ -16761,6 +17553,7 @@ export type ReposListTeams = (
   params: Params<
     t_ReposListTeamsParamSchema,
     t_ReposListTeamsQuerySchema,
+    void,
     void
   >,
   respond: ReposListTeamsResponder,
@@ -16780,6 +17573,7 @@ export type ReposGetAllTopics = (
   params: Params<
     t_ReposGetAllTopicsParamSchema,
     t_ReposGetAllTopicsQuerySchema,
+    void,
     void
   >,
   respond: ReposGetAllTopicsResponder,
@@ -16800,7 +17594,8 @@ export type ReposReplaceAllTopics = (
   params: Params<
     t_ReposReplaceAllTopicsParamSchema,
     void,
-    t_ReposReplaceAllTopicsBodySchema
+    t_ReposReplaceAllTopicsBodySchema,
+    void
   >,
   respond: ReposReplaceAllTopicsResponder,
   ctx: RouterContext,
@@ -16820,6 +17615,7 @@ export type ReposGetClones = (
   params: Params<
     t_ReposGetClonesParamSchema,
     t_ReposGetClonesQuerySchema,
+    void,
     void
   >,
   respond: ReposGetClonesResponder,
@@ -16836,7 +17632,7 @@ export type ReposGetTopPathsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetTopPaths = (
-  params: Params<t_ReposGetTopPathsParamSchema, void, void>,
+  params: Params<t_ReposGetTopPathsParamSchema, void, void, void>,
   respond: ReposGetTopPathsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16851,7 +17647,7 @@ export type ReposGetTopReferrersResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetTopReferrers = (
-  params: Params<t_ReposGetTopReferrersParamSchema, void, void>,
+  params: Params<t_ReposGetTopReferrersParamSchema, void, void, void>,
   respond: ReposGetTopReferrersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16866,7 +17662,12 @@ export type ReposGetViewsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposGetViews = (
-  params: Params<t_ReposGetViewsParamSchema, t_ReposGetViewsQuerySchema, void>,
+  params: Params<
+    t_ReposGetViewsParamSchema,
+    t_ReposGetViewsQuerySchema,
+    void,
+    void
+  >,
   respond: ReposGetViewsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16880,7 +17681,12 @@ export type ReposTransferResponder = {
 } & KoaRuntimeResponder
 
 export type ReposTransfer = (
-  params: Params<t_ReposTransferParamSchema, void, t_ReposTransferBodySchema>,
+  params: Params<
+    t_ReposTransferParamSchema,
+    void,
+    t_ReposTransferBodySchema,
+    void
+  >,
   respond: ReposTransferResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<202, t_minimal_repository>>
@@ -16891,7 +17697,7 @@ export type ReposCheckVulnerabilityAlertsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposCheckVulnerabilityAlerts = (
-  params: Params<t_ReposCheckVulnerabilityAlertsParamSchema, void, void>,
+  params: Params<t_ReposCheckVulnerabilityAlertsParamSchema, void, void, void>,
   respond: ReposCheckVulnerabilityAlertsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16903,7 +17709,7 @@ export type ReposEnableVulnerabilityAlertsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposEnableVulnerabilityAlerts = (
-  params: Params<t_ReposEnableVulnerabilityAlertsParamSchema, void, void>,
+  params: Params<t_ReposEnableVulnerabilityAlertsParamSchema, void, void, void>,
   respond: ReposEnableVulnerabilityAlertsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -16913,7 +17719,12 @@ export type ReposDisableVulnerabilityAlertsResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDisableVulnerabilityAlerts = (
-  params: Params<t_ReposDisableVulnerabilityAlertsParamSchema, void, void>,
+  params: Params<
+    t_ReposDisableVulnerabilityAlertsParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ReposDisableVulnerabilityAlertsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -16923,7 +17734,7 @@ export type ReposDownloadZipballArchiveResponder = {
 } & KoaRuntimeResponder
 
 export type ReposDownloadZipballArchive = (
-  params: Params<t_ReposDownloadZipballArchiveParamSchema, void, void>,
+  params: Params<t_ReposDownloadZipballArchiveParamSchema, void, void, void>,
   respond: ReposDownloadZipballArchiveResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<302, void>>
@@ -16936,7 +17747,8 @@ export type ReposCreateUsingTemplate = (
   params: Params<
     t_ReposCreateUsingTemplateParamSchema,
     void,
-    t_ReposCreateUsingTemplateBodySchema
+    t_ReposCreateUsingTemplateBodySchema,
+    void
   >,
   respond: ReposCreateUsingTemplateResponder,
   ctx: RouterContext,
@@ -16949,7 +17761,7 @@ export type ReposListPublicResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListPublic = (
-  params: Params<void, t_ReposListPublicQuerySchema, void>,
+  params: Params<void, t_ReposListPublicQuerySchema, void, void>,
   respond: ReposListPublicResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -16976,7 +17788,7 @@ export type SearchCodeResponder = {
 } & KoaRuntimeResponder
 
 export type SearchCode = (
-  params: Params<void, t_SearchCodeQuerySchema, void>,
+  params: Params<void, t_SearchCodeQuerySchema, void, void>,
   respond: SearchCodeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17012,7 +17824,7 @@ export type SearchCommitsResponder = {
 } & KoaRuntimeResponder
 
 export type SearchCommits = (
-  params: Params<void, t_SearchCommitsQuerySchema, void>,
+  params: Params<void, t_SearchCommitsQuerySchema, void, void>,
   respond: SearchCommitsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17045,7 +17857,7 @@ export type SearchIssuesAndPullRequestsResponder = {
 } & KoaRuntimeResponder
 
 export type SearchIssuesAndPullRequests = (
-  params: Params<void, t_SearchIssuesAndPullRequestsQuerySchema, void>,
+  params: Params<void, t_SearchIssuesAndPullRequestsQuerySchema, void, void>,
   respond: SearchIssuesAndPullRequestsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17084,7 +17896,7 @@ export type SearchLabelsResponder = {
 } & KoaRuntimeResponder
 
 export type SearchLabels = (
-  params: Params<void, t_SearchLabelsQuerySchema, void>,
+  params: Params<void, t_SearchLabelsQuerySchema, void, void>,
   respond: SearchLabelsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17119,7 +17931,7 @@ export type SearchReposResponder = {
 } & KoaRuntimeResponder
 
 export type SearchRepos = (
-  params: Params<void, t_SearchReposQuerySchema, void>,
+  params: Params<void, t_SearchReposQuerySchema, void, void>,
   respond: SearchReposResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17154,7 +17966,7 @@ export type SearchTopicsResponder = {
 } & KoaRuntimeResponder
 
 export type SearchTopics = (
-  params: Params<void, t_SearchTopicsQuerySchema, void>,
+  params: Params<void, t_SearchTopicsQuerySchema, void, void>,
   respond: SearchTopicsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17186,7 +17998,7 @@ export type SearchUsersResponder = {
 } & KoaRuntimeResponder
 
 export type SearchUsers = (
-  params: Params<void, t_SearchUsersQuerySchema, void>,
+  params: Params<void, t_SearchUsersQuerySchema, void, void>,
   respond: SearchUsersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17217,7 +18029,7 @@ export type TeamsGetLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetLegacy = (
-  params: Params<t_TeamsGetLegacyParamSchema, void, void>,
+  params: Params<t_TeamsGetLegacyParamSchema, void, void, void>,
   respond: TeamsGetLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17238,7 +18050,8 @@ export type TeamsUpdateLegacy = (
   params: Params<
     t_TeamsUpdateLegacyParamSchema,
     void,
-    t_TeamsUpdateLegacyBodySchema
+    t_TeamsUpdateLegacyBodySchema,
+    void
   >,
   respond: TeamsUpdateLegacyResponder,
   ctx: RouterContext,
@@ -17258,7 +18071,7 @@ export type TeamsDeleteLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsDeleteLegacy = (
-  params: Params<t_TeamsDeleteLegacyParamSchema, void, void>,
+  params: Params<t_TeamsDeleteLegacyParamSchema, void, void, void>,
   respond: TeamsDeleteLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17276,6 +18089,7 @@ export type TeamsListDiscussionsLegacy = (
   params: Params<
     t_TeamsListDiscussionsLegacyParamSchema,
     t_TeamsListDiscussionsLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListDiscussionsLegacyResponder,
@@ -17290,7 +18104,8 @@ export type TeamsCreateDiscussionLegacy = (
   params: Params<
     t_TeamsCreateDiscussionLegacyParamSchema,
     void,
-    t_TeamsCreateDiscussionLegacyBodySchema
+    t_TeamsCreateDiscussionLegacyBodySchema,
+    void
   >,
   respond: TeamsCreateDiscussionLegacyResponder,
   ctx: RouterContext,
@@ -17301,7 +18116,7 @@ export type TeamsGetDiscussionLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetDiscussionLegacy = (
-  params: Params<t_TeamsGetDiscussionLegacyParamSchema, void, void>,
+  params: Params<t_TeamsGetDiscussionLegacyParamSchema, void, void, void>,
   respond: TeamsGetDiscussionLegacyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_team_discussion>>
@@ -17314,7 +18129,8 @@ export type TeamsUpdateDiscussionLegacy = (
   params: Params<
     t_TeamsUpdateDiscussionLegacyParamSchema,
     void,
-    t_TeamsUpdateDiscussionLegacyBodySchema | undefined
+    t_TeamsUpdateDiscussionLegacyBodySchema | undefined,
+    void
   >,
   respond: TeamsUpdateDiscussionLegacyResponder,
   ctx: RouterContext,
@@ -17325,7 +18141,7 @@ export type TeamsDeleteDiscussionLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsDeleteDiscussionLegacy = (
-  params: Params<t_TeamsDeleteDiscussionLegacyParamSchema, void, void>,
+  params: Params<t_TeamsDeleteDiscussionLegacyParamSchema, void, void, void>,
   respond: TeamsDeleteDiscussionLegacyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -17338,6 +18154,7 @@ export type TeamsListDiscussionCommentsLegacy = (
   params: Params<
     t_TeamsListDiscussionCommentsLegacyParamSchema,
     t_TeamsListDiscussionCommentsLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListDiscussionCommentsLegacyResponder,
@@ -17354,7 +18171,8 @@ export type TeamsCreateDiscussionCommentLegacy = (
   params: Params<
     t_TeamsCreateDiscussionCommentLegacyParamSchema,
     void,
-    t_TeamsCreateDiscussionCommentLegacyBodySchema
+    t_TeamsCreateDiscussionCommentLegacyBodySchema,
+    void
   >,
   respond: TeamsCreateDiscussionCommentLegacyResponder,
   ctx: RouterContext,
@@ -17367,7 +18185,12 @@ export type TeamsGetDiscussionCommentLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetDiscussionCommentLegacy = (
-  params: Params<t_TeamsGetDiscussionCommentLegacyParamSchema, void, void>,
+  params: Params<
+    t_TeamsGetDiscussionCommentLegacyParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsGetDiscussionCommentLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17382,7 +18205,8 @@ export type TeamsUpdateDiscussionCommentLegacy = (
   params: Params<
     t_TeamsUpdateDiscussionCommentLegacyParamSchema,
     void,
-    t_TeamsUpdateDiscussionCommentLegacyBodySchema
+    t_TeamsUpdateDiscussionCommentLegacyBodySchema,
+    void
   >,
   respond: TeamsUpdateDiscussionCommentLegacyResponder,
   ctx: RouterContext,
@@ -17395,7 +18219,12 @@ export type TeamsDeleteDiscussionCommentLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsDeleteDiscussionCommentLegacy = (
-  params: Params<t_TeamsDeleteDiscussionCommentLegacyParamSchema, void, void>,
+  params: Params<
+    t_TeamsDeleteDiscussionCommentLegacyParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsDeleteDiscussionCommentLegacyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -17408,6 +18237,7 @@ export type ReactionsListForTeamDiscussionCommentLegacy = (
   params: Params<
     t_ReactionsListForTeamDiscussionCommentLegacyParamSchema,
     t_ReactionsListForTeamDiscussionCommentLegacyQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForTeamDiscussionCommentLegacyResponder,
@@ -17422,7 +18252,8 @@ export type ReactionsCreateForTeamDiscussionCommentLegacy = (
   params: Params<
     t_ReactionsCreateForTeamDiscussionCommentLegacyParamSchema,
     void,
-    t_ReactionsCreateForTeamDiscussionCommentLegacyBodySchema
+    t_ReactionsCreateForTeamDiscussionCommentLegacyBodySchema,
+    void
   >,
   respond: ReactionsCreateForTeamDiscussionCommentLegacyResponder,
   ctx: RouterContext,
@@ -17436,6 +18267,7 @@ export type ReactionsListForTeamDiscussionLegacy = (
   params: Params<
     t_ReactionsListForTeamDiscussionLegacyParamSchema,
     t_ReactionsListForTeamDiscussionLegacyQuerySchema,
+    void,
     void
   >,
   respond: ReactionsListForTeamDiscussionLegacyResponder,
@@ -17450,7 +18282,8 @@ export type ReactionsCreateForTeamDiscussionLegacy = (
   params: Params<
     t_ReactionsCreateForTeamDiscussionLegacyParamSchema,
     void,
-    t_ReactionsCreateForTeamDiscussionLegacyBodySchema
+    t_ReactionsCreateForTeamDiscussionLegacyBodySchema,
+    void
   >,
   respond: ReactionsCreateForTeamDiscussionLegacyResponder,
   ctx: RouterContext,
@@ -17464,6 +18297,7 @@ export type TeamsListPendingInvitationsLegacy = (
   params: Params<
     t_TeamsListPendingInvitationsLegacyParamSchema,
     t_TeamsListPendingInvitationsLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListPendingInvitationsLegacyResponder,
@@ -17481,6 +18315,7 @@ export type TeamsListMembersLegacy = (
   params: Params<
     t_TeamsListMembersLegacyParamSchema,
     t_TeamsListMembersLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListMembersLegacyResponder,
@@ -17497,7 +18332,7 @@ export type TeamsGetMemberLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetMemberLegacy = (
-  params: Params<t_TeamsGetMemberLegacyParamSchema, void, void>,
+  params: Params<t_TeamsGetMemberLegacyParamSchema, void, void, void>,
   respond: TeamsGetMemberLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17512,7 +18347,7 @@ export type TeamsAddMemberLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsAddMemberLegacy = (
-  params: Params<t_TeamsAddMemberLegacyParamSchema, void, void>,
+  params: Params<t_TeamsAddMemberLegacyParamSchema, void, void, void>,
   respond: TeamsAddMemberLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17529,7 +18364,7 @@ export type TeamsRemoveMemberLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveMemberLegacy = (
-  params: Params<t_TeamsRemoveMemberLegacyParamSchema, void, void>,
+  params: Params<t_TeamsRemoveMemberLegacyParamSchema, void, void, void>,
   respond: TeamsRemoveMemberLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17542,7 +18377,12 @@ export type TeamsGetMembershipForUserLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsGetMembershipForUserLegacy = (
-  params: Params<t_TeamsGetMembershipForUserLegacyParamSchema, void, void>,
+  params: Params<
+    t_TeamsGetMembershipForUserLegacyParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsGetMembershipForUserLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17562,7 +18402,8 @@ export type TeamsAddOrUpdateMembershipForUserLegacy = (
   params: Params<
     t_TeamsAddOrUpdateMembershipForUserLegacyParamSchema,
     void,
-    t_TeamsAddOrUpdateMembershipForUserLegacyBodySchema | undefined
+    t_TeamsAddOrUpdateMembershipForUserLegacyBodySchema | undefined,
+    void
   >,
   respond: TeamsAddOrUpdateMembershipForUserLegacyResponder,
   ctx: RouterContext,
@@ -17580,7 +18421,12 @@ export type TeamsRemoveMembershipForUserLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveMembershipForUserLegacy = (
-  params: Params<t_TeamsRemoveMembershipForUserLegacyParamSchema, void, void>,
+  params: Params<
+    t_TeamsRemoveMembershipForUserLegacyParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsRemoveMembershipForUserLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17596,6 +18442,7 @@ export type TeamsListProjectsLegacy = (
   params: Params<
     t_TeamsListProjectsLegacyParamSchema,
     t_TeamsListProjectsLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListProjectsLegacyResponder,
@@ -17614,6 +18461,7 @@ export type TeamsCheckPermissionsForProjectLegacyResponder = {
 export type TeamsCheckPermissionsForProjectLegacy = (
   params: Params<
     t_TeamsCheckPermissionsForProjectLegacyParamSchema,
+    void,
     void,
     void
   >,
@@ -17639,7 +18487,8 @@ export type TeamsAddOrUpdateProjectPermissionsLegacy = (
   params: Params<
     t_TeamsAddOrUpdateProjectPermissionsLegacyParamSchema,
     void,
-    t_TeamsAddOrUpdateProjectPermissionsLegacyBodySchema | undefined
+    t_TeamsAddOrUpdateProjectPermissionsLegacyBodySchema | undefined,
+    void
   >,
   respond: TeamsAddOrUpdateProjectPermissionsLegacyResponder,
   ctx: RouterContext,
@@ -17664,7 +18513,7 @@ export type TeamsRemoveProjectLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveProjectLegacy = (
-  params: Params<t_TeamsRemoveProjectLegacyParamSchema, void, void>,
+  params: Params<t_TeamsRemoveProjectLegacyParamSchema, void, void, void>,
   respond: TeamsRemoveProjectLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17683,6 +18532,7 @@ export type TeamsListReposLegacy = (
   params: Params<
     t_TeamsListReposLegacyParamSchema,
     t_TeamsListReposLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListReposLegacyResponder,
@@ -17700,7 +18550,12 @@ export type TeamsCheckPermissionsForRepoLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsCheckPermissionsForRepoLegacy = (
-  params: Params<t_TeamsCheckPermissionsForRepoLegacyParamSchema, void, void>,
+  params: Params<
+    t_TeamsCheckPermissionsForRepoLegacyParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: TeamsCheckPermissionsForRepoLegacyResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17720,7 +18575,8 @@ export type TeamsAddOrUpdateRepoPermissionsLegacy = (
   params: Params<
     t_TeamsAddOrUpdateRepoPermissionsLegacyParamSchema,
     void,
-    t_TeamsAddOrUpdateRepoPermissionsLegacyBodySchema | undefined
+    t_TeamsAddOrUpdateRepoPermissionsLegacyBodySchema | undefined,
+    void
   >,
   respond: TeamsAddOrUpdateRepoPermissionsLegacyResponder,
   ctx: RouterContext,
@@ -17736,7 +18592,7 @@ export type TeamsRemoveRepoLegacyResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsRemoveRepoLegacy = (
-  params: Params<t_TeamsRemoveRepoLegacyParamSchema, void, void>,
+  params: Params<t_TeamsRemoveRepoLegacyParamSchema, void, void, void>,
   respond: TeamsRemoveRepoLegacyResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -17752,6 +18608,7 @@ export type TeamsListChildLegacy = (
   params: Params<
     t_TeamsListChildLegacyParamSchema,
     t_TeamsListChildLegacyQuerySchema,
+    void,
     void
   >,
   respond: TeamsListChildLegacyResponder,
@@ -17772,7 +18629,7 @@ export type UsersGetAuthenticatedResponder = {
 } & KoaRuntimeResponder
 
 export type UsersGetAuthenticated = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: UsersGetAuthenticatedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17793,7 +18650,12 @@ export type UsersUpdateAuthenticatedResponder = {
 } & KoaRuntimeResponder
 
 export type UsersUpdateAuthenticated = (
-  params: Params<void, void, t_UsersUpdateAuthenticatedBodySchema | undefined>,
+  params: Params<
+    void,
+    void,
+    t_UsersUpdateAuthenticatedBodySchema | undefined,
+    void
+  >,
   respond: UsersUpdateAuthenticatedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17815,7 +18677,12 @@ export type UsersListBlockedByAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersListBlockedByAuthenticatedUser = (
-  params: Params<void, t_UsersListBlockedByAuthenticatedUserQuerySchema, void>,
+  params: Params<
+    void,
+    t_UsersListBlockedByAuthenticatedUserQuerySchema,
+    void,
+    void
+  >,
   respond: UsersListBlockedByAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17836,7 +18703,7 @@ export type UsersCheckBlockedResponder = {
 } & KoaRuntimeResponder
 
 export type UsersCheckBlocked = (
-  params: Params<t_UsersCheckBlockedParamSchema, void, void>,
+  params: Params<t_UsersCheckBlockedParamSchema, void, void, void>,
   respond: UsersCheckBlockedResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17858,7 +18725,7 @@ export type UsersBlockResponder = {
 } & KoaRuntimeResponder
 
 export type UsersBlock = (
-  params: Params<t_UsersBlockParamSchema, void, void>,
+  params: Params<t_UsersBlockParamSchema, void, void, void>,
   respond: UsersBlockResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17880,7 +18747,7 @@ export type UsersUnblockResponder = {
 } & KoaRuntimeResponder
 
 export type UsersUnblock = (
-  params: Params<t_UsersUnblockParamSchema, void, void>,
+  params: Params<t_UsersUnblockParamSchema, void, void, void>,
   respond: UsersUnblockResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17905,7 +18772,12 @@ export type CodespacesListForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesListForAuthenticatedUser = (
-  params: Params<void, t_CodespacesListForAuthenticatedUserQuerySchema, void>,
+  params: Params<
+    void,
+    t_CodespacesListForAuthenticatedUserQuerySchema,
+    void,
+    void
+  >,
   respond: CodespacesListForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17938,7 +18810,12 @@ export type CodespacesCreateForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesCreateForAuthenticatedUser = (
-  params: Params<void, void, t_CodespacesCreateForAuthenticatedUserBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_CodespacesCreateForAuthenticatedUserBodySchema,
+    void
+  >,
   respond: CodespacesCreateForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -17969,6 +18846,7 @@ export type CodespacesListSecretsForAuthenticatedUser = (
   params: Params<
     void,
     t_CodespacesListSecretsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: CodespacesListSecretsForAuthenticatedUserResponder,
@@ -17989,7 +18867,7 @@ export type CodespacesGetPublicKeyForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesGetPublicKeyForAuthenticatedUser = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: CodespacesGetPublicKeyForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18003,6 +18881,7 @@ export type CodespacesGetSecretForAuthenticatedUserResponder = {
 export type CodespacesGetSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesGetSecretForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18021,7 +18900,8 @@ export type CodespacesCreateOrUpdateSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesCreateOrUpdateSecretForAuthenticatedUserParamSchema,
     void,
-    t_CodespacesCreateOrUpdateSecretForAuthenticatedUserBodySchema
+    t_CodespacesCreateOrUpdateSecretForAuthenticatedUserBodySchema,
+    void
   >,
   respond: CodespacesCreateOrUpdateSecretForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18040,6 +18920,7 @@ export type CodespacesDeleteSecretForAuthenticatedUserResponder = {
 export type CodespacesDeleteSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesDeleteSecretForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18061,6 +18942,7 @@ export type CodespacesListRepositoriesForSecretForAuthenticatedUserResponder = {
 export type CodespacesListRepositoriesForSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesListRepositoriesForSecretForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18093,7 +18975,8 @@ export type CodespacesSetRepositoriesForSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesSetRepositoriesForSecretForAuthenticatedUserParamSchema,
     void,
-    t_CodespacesSetRepositoriesForSecretForAuthenticatedUserBodySchema
+    t_CodespacesSetRepositoriesForSecretForAuthenticatedUserBodySchema,
+    void
   >,
   respond: CodespacesSetRepositoriesForSecretForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18117,6 +19000,7 @@ export type CodespacesAddRepositoryForSecretForAuthenticatedUserResponder = {
 export type CodespacesAddRepositoryForSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesAddRepositoryForSecretForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18143,6 +19027,7 @@ export type CodespacesRemoveRepositoryForSecretForAuthenticatedUser = (
   params: Params<
     t_CodespacesRemoveRepositoryForSecretForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: CodespacesRemoveRepositoryForSecretForAuthenticatedUserResponder,
@@ -18166,7 +19051,12 @@ export type CodespacesGetForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesGetForAuthenticatedUser = (
-  params: Params<t_CodespacesGetForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_CodespacesGetForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesGetForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18190,7 +19080,8 @@ export type CodespacesUpdateForAuthenticatedUser = (
   params: Params<
     t_CodespacesUpdateForAuthenticatedUserParamSchema,
     void,
-    t_CodespacesUpdateForAuthenticatedUserBodySchema | undefined
+    t_CodespacesUpdateForAuthenticatedUserBodySchema | undefined,
+    void
   >,
   respond: CodespacesUpdateForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18214,7 +19105,12 @@ export type CodespacesDeleteForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesDeleteForAuthenticatedUser = (
-  params: Params<t_CodespacesDeleteForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_CodespacesDeleteForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesDeleteForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18242,7 +19138,12 @@ export type CodespacesExportForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesExportForAuthenticatedUser = (
-  params: Params<t_CodespacesExportForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_CodespacesExportForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesExportForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18263,6 +19164,7 @@ export type CodespacesGetExportDetailsForAuthenticatedUserResponder = {
 export type CodespacesGetExportDetailsForAuthenticatedUser = (
   params: Params<
     t_CodespacesGetExportDetailsForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18289,6 +19191,7 @@ export type CodespacesCodespaceMachinesForAuthenticatedUserResponder = {
 export type CodespacesCodespaceMachinesForAuthenticatedUser = (
   params: Params<
     t_CodespacesCodespaceMachinesForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18322,7 +19225,8 @@ export type CodespacesPublishForAuthenticatedUser = (
   params: Params<
     t_CodespacesPublishForAuthenticatedUserParamSchema,
     void,
-    t_CodespacesPublishForAuthenticatedUserBodySchema
+    t_CodespacesPublishForAuthenticatedUserBodySchema,
+    void
   >,
   respond: CodespacesPublishForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18348,7 +19252,12 @@ export type CodespacesStartForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesStartForAuthenticatedUser = (
-  params: Params<t_CodespacesStartForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_CodespacesStartForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesStartForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18373,7 +19282,12 @@ export type CodespacesStopForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type CodespacesStopForAuthenticatedUser = (
-  params: Params<t_CodespacesStopForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_CodespacesStopForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: CodespacesStopForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18392,7 +19306,7 @@ export type PackagesListDockerMigrationConflictingPackagesForAuthenticatedUserRe
 
 export type PackagesListDockerMigrationConflictingPackagesForAuthenticatedUser =
   (
-    params: Params<void, void, void>,
+    params: Params<void, void, void, void>,
     respond: PackagesListDockerMigrationConflictingPackagesForAuthenticatedUserResponder,
     ctx: RouterContext,
   ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_package[]>>
@@ -18410,7 +19324,8 @@ export type UsersSetPrimaryEmailVisibilityForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_UsersSetPrimaryEmailVisibilityForAuthenticatedUserBodySchema
+    t_UsersSetPrimaryEmailVisibilityForAuthenticatedUserBodySchema,
+    void
   >,
   respond: UsersSetPrimaryEmailVisibilityForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18433,7 +19348,12 @@ export type UsersListEmailsForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersListEmailsForAuthenticatedUser = (
-  params: Params<void, t_UsersListEmailsForAuthenticatedUserQuerySchema, void>,
+  params: Params<
+    void,
+    t_UsersListEmailsForAuthenticatedUserQuerySchema,
+    void,
+    void
+  >,
   respond: UsersListEmailsForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18458,7 +19378,8 @@ export type UsersAddEmailForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_UsersAddEmailForAuthenticatedUserBodySchema | undefined
+    t_UsersAddEmailForAuthenticatedUserBodySchema | undefined,
+    void
   >,
   respond: UsersAddEmailForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18482,7 +19403,12 @@ export type UsersDeleteEmailForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersDeleteEmailForAuthenticatedUser = (
-  params: Params<void, void, t_UsersDeleteEmailForAuthenticatedUserBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_UsersDeleteEmailForAuthenticatedUserBodySchema,
+    void
+  >,
   respond: UsersDeleteEmailForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18506,6 +19432,7 @@ export type UsersListFollowersForAuthenticatedUser = (
   params: Params<
     void,
     t_UsersListFollowersForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListFollowersForAuthenticatedUserResponder,
@@ -18526,7 +19453,12 @@ export type UsersListFollowedByAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersListFollowedByAuthenticatedUser = (
-  params: Params<void, t_UsersListFollowedByAuthenticatedUserQuerySchema, void>,
+  params: Params<
+    void,
+    t_UsersListFollowedByAuthenticatedUserQuerySchema,
+    void,
+    void
+  >,
   respond: UsersListFollowedByAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18548,6 +19480,7 @@ export type UsersCheckPersonIsFollowedByAuthenticatedResponder = {
 export type UsersCheckPersonIsFollowedByAuthenticated = (
   params: Params<
     t_UsersCheckPersonIsFollowedByAuthenticatedParamSchema,
+    void,
     void,
     void
   >,
@@ -18571,7 +19504,7 @@ export type UsersFollowResponder = {
 } & KoaRuntimeResponder
 
 export type UsersFollow = (
-  params: Params<t_UsersFollowParamSchema, void, void>,
+  params: Params<t_UsersFollowParamSchema, void, void, void>,
   respond: UsersFollowResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18592,7 +19525,7 @@ export type UsersUnfollowResponder = {
 } & KoaRuntimeResponder
 
 export type UsersUnfollow = (
-  params: Params<t_UsersUnfollowParamSchema, void, void>,
+  params: Params<t_UsersUnfollowParamSchema, void, void, void>,
   respond: UsersUnfollowResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18613,7 +19546,12 @@ export type UsersListGpgKeysForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersListGpgKeysForAuthenticatedUser = (
-  params: Params<void, t_UsersListGpgKeysForAuthenticatedUserQuerySchema, void>,
+  params: Params<
+    void,
+    t_UsersListGpgKeysForAuthenticatedUserQuerySchema,
+    void,
+    void
+  >,
   respond: UsersListGpgKeysForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18635,7 +19573,12 @@ export type UsersCreateGpgKeyForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersCreateGpgKeyForAuthenticatedUser = (
-  params: Params<void, void, t_UsersCreateGpgKeyForAuthenticatedUserBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_UsersCreateGpgKeyForAuthenticatedUserBodySchema,
+    void
+  >,
   respond: UsersCreateGpgKeyForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18657,7 +19600,12 @@ export type UsersGetGpgKeyForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersGetGpgKeyForAuthenticatedUser = (
-  params: Params<t_UsersGetGpgKeyForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_UsersGetGpgKeyForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: UsersGetGpgKeyForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18681,6 +19629,7 @@ export type UsersDeleteGpgKeyForAuthenticatedUserResponder = {
 export type UsersDeleteGpgKeyForAuthenticatedUser = (
   params: Params<
     t_UsersDeleteGpgKeyForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18710,6 +19659,7 @@ export type AppsListInstallationsForAuthenticatedUser = (
   params: Params<
     void,
     t_AppsListInstallationsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: AppsListInstallationsForAuthenticatedUserResponder,
@@ -18743,6 +19693,7 @@ export type AppsListInstallationReposForAuthenticatedUser = (
   params: Params<
     t_AppsListInstallationReposForAuthenticatedUserParamSchema,
     t_AppsListInstallationReposForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: AppsListInstallationReposForAuthenticatedUserResponder,
@@ -18773,6 +19724,7 @@ export type AppsAddRepoToInstallationForAuthenticatedUser = (
   params: Params<
     t_AppsAddRepoToInstallationForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: AppsAddRepoToInstallationForAuthenticatedUserResponder,
@@ -18797,6 +19749,7 @@ export type AppsRemoveRepoFromInstallationForAuthenticatedUser = (
   params: Params<
     t_AppsRemoveRepoFromInstallationForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: AppsRemoveRepoFromInstallationForAuthenticatedUserResponder,
@@ -18816,7 +19769,7 @@ export type InteractionsGetRestrictionsForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type InteractionsGetRestrictionsForAuthenticatedUser = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: InteractionsGetRestrictionsForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18834,7 +19787,8 @@ export type InteractionsSetRestrictionsForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_InteractionsSetRestrictionsForAuthenticatedUserBodySchema
+    t_InteractionsSetRestrictionsForAuthenticatedUserBodySchema,
+    void
   >,
   respond: InteractionsSetRestrictionsForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18849,7 +19803,7 @@ export type InteractionsRemoveRestrictionsForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type InteractionsRemoveRestrictionsForAuthenticatedUser = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: InteractionsRemoveRestrictionsForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<204, void>>
@@ -18861,7 +19815,7 @@ export type IssuesListForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type IssuesListForAuthenticatedUser = (
-  params: Params<void, t_IssuesListForAuthenticatedUserQuerySchema, void>,
+  params: Params<void, t_IssuesListForAuthenticatedUserQuerySchema, void, void>,
   respond: IssuesListForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -18883,6 +19837,7 @@ export type UsersListPublicSshKeysForAuthenticatedUser = (
   params: Params<
     void,
     t_UsersListPublicSshKeysForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListPublicSshKeysForAuthenticatedUserResponder,
@@ -18909,7 +19864,8 @@ export type UsersCreatePublicSshKeyForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_UsersCreatePublicSshKeyForAuthenticatedUserBodySchema
+    t_UsersCreatePublicSshKeyForAuthenticatedUserBodySchema,
+    void
   >,
   respond: UsersCreatePublicSshKeyForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -18934,6 +19890,7 @@ export type UsersGetPublicSshKeyForAuthenticatedUserResponder = {
 export type UsersGetPublicSshKeyForAuthenticatedUser = (
   params: Params<
     t_UsersGetPublicSshKeyForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -18960,6 +19917,7 @@ export type UsersDeletePublicSshKeyForAuthenticatedUser = (
   params: Params<
     t_UsersDeletePublicSshKeyForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: UsersDeletePublicSshKeyForAuthenticatedUserResponder,
@@ -18984,6 +19942,7 @@ export type AppsListSubscriptionsForAuthenticatedUser = (
   params: Params<
     void,
     t_AppsListSubscriptionsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: AppsListSubscriptionsForAuthenticatedUserResponder,
@@ -19006,6 +19965,7 @@ export type AppsListSubscriptionsForAuthenticatedUserStubbed = (
   params: Params<
     void,
     t_AppsListSubscriptionsForAuthenticatedUserStubbedQuerySchema,
+    void,
     void
   >,
   respond: AppsListSubscriptionsForAuthenticatedUserStubbedResponder,
@@ -19029,6 +19989,7 @@ export type OrgsListMembershipsForAuthenticatedUser = (
   params: Params<
     void,
     t_OrgsListMembershipsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: OrgsListMembershipsForAuthenticatedUserResponder,
@@ -19052,6 +20013,7 @@ export type OrgsGetMembershipForAuthenticatedUser = (
   params: Params<
     t_OrgsGetMembershipForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: OrgsGetMembershipForAuthenticatedUserResponder,
@@ -19074,7 +20036,8 @@ export type OrgsUpdateMembershipForAuthenticatedUser = (
   params: Params<
     t_OrgsUpdateMembershipForAuthenticatedUserParamSchema,
     void,
-    t_OrgsUpdateMembershipForAuthenticatedUserBodySchema
+    t_OrgsUpdateMembershipForAuthenticatedUserBodySchema,
+    void
   >,
   respond: OrgsUpdateMembershipForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -19094,7 +20057,12 @@ export type MigrationsListForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsListForAuthenticatedUser = (
-  params: Params<void, t_MigrationsListForAuthenticatedUserQuerySchema, void>,
+  params: Params<
+    void,
+    t_MigrationsListForAuthenticatedUserQuerySchema,
+    void,
+    void
+  >,
   respond: MigrationsListForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19114,7 +20082,12 @@ export type MigrationsStartForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type MigrationsStartForAuthenticatedUser = (
-  params: Params<void, void, t_MigrationsStartForAuthenticatedUserBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_MigrationsStartForAuthenticatedUserBodySchema,
+    void
+  >,
   respond: MigrationsStartForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19138,6 +20111,7 @@ export type MigrationsGetStatusForAuthenticatedUser = (
   params: Params<
     t_MigrationsGetStatusForAuthenticatedUserParamSchema,
     t_MigrationsGetStatusForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: MigrationsGetStatusForAuthenticatedUserResponder,
@@ -19162,6 +20136,7 @@ export type MigrationsGetArchiveForAuthenticatedUser = (
   params: Params<
     t_MigrationsGetArchiveForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: MigrationsGetArchiveForAuthenticatedUserResponder,
@@ -19185,6 +20160,7 @@ export type MigrationsDeleteArchiveForAuthenticatedUserResponder = {
 export type MigrationsDeleteArchiveForAuthenticatedUser = (
   params: Params<
     t_MigrationsDeleteArchiveForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19211,6 +20187,7 @@ export type MigrationsUnlockRepoForAuthenticatedUser = (
   params: Params<
     t_MigrationsUnlockRepoForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: MigrationsUnlockRepoForAuthenticatedUserResponder,
@@ -19233,6 +20210,7 @@ export type MigrationsListReposForAuthenticatedUser = (
   params: Params<
     t_MigrationsListReposForAuthenticatedUserParamSchema,
     t_MigrationsListReposForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: MigrationsListReposForAuthenticatedUserResponder,
@@ -19251,7 +20229,7 @@ export type OrgsListForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type OrgsListForAuthenticatedUser = (
-  params: Params<void, t_OrgsListForAuthenticatedUserQuerySchema, void>,
+  params: Params<void, t_OrgsListForAuthenticatedUserQuerySchema, void, void>,
   respond: OrgsListForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19271,6 +20249,7 @@ export type PackagesListPackagesForAuthenticatedUser = (
   params: Params<
     void,
     t_PackagesListPackagesForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: PackagesListPackagesForAuthenticatedUserResponder,
@@ -19286,6 +20265,7 @@ export type PackagesGetPackageForAuthenticatedUserResponder = {
 export type PackagesGetPackageForAuthenticatedUser = (
   params: Params<
     t_PackagesGetPackageForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19303,6 +20283,7 @@ export type PackagesDeletePackageForAuthenticatedUserResponder = {
 export type PackagesDeletePackageForAuthenticatedUser = (
   params: Params<
     t_PackagesDeletePackageForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19327,6 +20308,7 @@ export type PackagesRestorePackageForAuthenticatedUser = (
   params: Params<
     t_PackagesRestorePackageForAuthenticatedUserParamSchema,
     t_PackagesRestorePackageForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: PackagesRestorePackageForAuthenticatedUserResponder,
@@ -19351,6 +20333,7 @@ export type PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser = (
   params: Params<
     t_PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserParamSchema,
     t_PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: PackagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUserResponder,
@@ -19371,6 +20354,7 @@ export type PackagesGetPackageVersionForAuthenticatedUser = (
   params: Params<
     t_PackagesGetPackageVersionForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: PackagesGetPackageVersionForAuthenticatedUserResponder,
@@ -19387,6 +20371,7 @@ export type PackagesDeletePackageVersionForAuthenticatedUserResponder = {
 export type PackagesDeletePackageVersionForAuthenticatedUser = (
   params: Params<
     t_PackagesDeletePackageVersionForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19411,6 +20396,7 @@ export type PackagesRestorePackageVersionForAuthenticatedUser = (
   params: Params<
     t_PackagesRestorePackageVersionForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: PackagesRestorePackageVersionForAuthenticatedUserResponder,
@@ -19432,7 +20418,12 @@ export type ProjectsCreateForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type ProjectsCreateForAuthenticatedUser = (
-  params: Params<void, void, t_ProjectsCreateForAuthenticatedUserBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_ProjectsCreateForAuthenticatedUserBodySchema,
+    void
+  >,
   respond: ProjectsCreateForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19456,6 +20447,7 @@ export type UsersListPublicEmailsForAuthenticatedUser = (
   params: Params<
     void,
     t_UsersListPublicEmailsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListPublicEmailsForAuthenticatedUserResponder,
@@ -19478,7 +20470,7 @@ export type ReposListForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type ReposListForAuthenticatedUser = (
-  params: Params<void, t_ReposListForAuthenticatedUserQuerySchema, void>,
+  params: Params<void, t_ReposListForAuthenticatedUserQuerySchema, void, void>,
   respond: ReposListForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19501,7 +20493,7 @@ export type ReposCreateForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type ReposCreateForAuthenticatedUser = (
-  params: Params<void, void, t_ReposCreateForAuthenticatedUserBodySchema>,
+  params: Params<void, void, t_ReposCreateForAuthenticatedUserBodySchema, void>,
   respond: ReposCreateForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19527,6 +20519,7 @@ export type ReposListInvitationsForAuthenticatedUser = (
   params: Params<
     void,
     t_ReposListInvitationsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ReposListInvitationsForAuthenticatedUserResponder,
@@ -19551,6 +20544,7 @@ export type ReposAcceptInvitationForAuthenticatedUserResponder = {
 export type ReposAcceptInvitationForAuthenticatedUser = (
   params: Params<
     t_ReposAcceptInvitationForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19577,6 +20571,7 @@ export type ReposDeclineInvitationForAuthenticatedUser = (
   params: Params<
     t_ReposDeclineInvitationForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: ReposDeclineInvitationForAuthenticatedUserResponder,
@@ -19602,6 +20597,7 @@ export type UsersListSocialAccountsForAuthenticatedUser = (
   params: Params<
     void,
     t_UsersListSocialAccountsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListSocialAccountsForAuthenticatedUserResponder,
@@ -19628,7 +20624,8 @@ export type UsersAddSocialAccountForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_UsersAddSocialAccountForAuthenticatedUserBodySchema
+    t_UsersAddSocialAccountForAuthenticatedUserBodySchema,
+    void
   >,
   respond: UsersAddSocialAccountForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -19655,7 +20652,8 @@ export type UsersDeleteSocialAccountForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_UsersDeleteSocialAccountForAuthenticatedUserBodySchema
+    t_UsersDeleteSocialAccountForAuthenticatedUserBodySchema,
+    void
   >,
   respond: UsersDeleteSocialAccountForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -19681,6 +20679,7 @@ export type UsersListSshSigningKeysForAuthenticatedUser = (
   params: Params<
     void,
     t_UsersListSshSigningKeysForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListSshSigningKeysForAuthenticatedUserResponder,
@@ -19707,7 +20706,8 @@ export type UsersCreateSshSigningKeyForAuthenticatedUser = (
   params: Params<
     void,
     void,
-    t_UsersCreateSshSigningKeyForAuthenticatedUserBodySchema
+    t_UsersCreateSshSigningKeyForAuthenticatedUserBodySchema,
+    void
   >,
   respond: UsersCreateSshSigningKeyForAuthenticatedUserResponder,
   ctx: RouterContext,
@@ -19732,6 +20732,7 @@ export type UsersGetSshSigningKeyForAuthenticatedUserResponder = {
 export type UsersGetSshSigningKeyForAuthenticatedUser = (
   params: Params<
     t_UsersGetSshSigningKeyForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19758,6 +20759,7 @@ export type UsersDeleteSshSigningKeyForAuthenticatedUser = (
   params: Params<
     t_UsersDeleteSshSigningKeyForAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: UsersDeleteSshSigningKeyForAuthenticatedUserResponder,
@@ -19782,6 +20784,7 @@ export type ActivityListReposStarredByAuthenticatedUser = (
   params: Params<
     void,
     t_ActivityListReposStarredByAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListReposStarredByAuthenticatedUserResponder,
@@ -19806,6 +20809,7 @@ export type ActivityCheckRepoIsStarredByAuthenticatedUser = (
   params: Params<
     t_ActivityCheckRepoIsStarredByAuthenticatedUserParamSchema,
     void,
+    void,
     void
   >,
   respond: ActivityCheckRepoIsStarredByAuthenticatedUserResponder,
@@ -19828,7 +20832,12 @@ export type ActivityStarRepoForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type ActivityStarRepoForAuthenticatedUser = (
-  params: Params<t_ActivityStarRepoForAuthenticatedUserParamSchema, void, void>,
+  params: Params<
+    t_ActivityStarRepoForAuthenticatedUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: ActivityStarRepoForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19851,6 +20860,7 @@ export type ActivityUnstarRepoForAuthenticatedUserResponder = {
 export type ActivityUnstarRepoForAuthenticatedUser = (
   params: Params<
     t_ActivityUnstarRepoForAuthenticatedUserParamSchema,
+    void,
     void,
     void
   >,
@@ -19876,6 +20886,7 @@ export type ActivityListWatchedReposForAuthenticatedUser = (
   params: Params<
     void,
     t_ActivityListWatchedReposForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListWatchedReposForAuthenticatedUserResponder,
@@ -19896,7 +20907,7 @@ export type TeamsListForAuthenticatedUserResponder = {
 } & KoaRuntimeResponder
 
 export type TeamsListForAuthenticatedUser = (
-  params: Params<void, t_TeamsListForAuthenticatedUserQuerySchema, void>,
+  params: Params<void, t_TeamsListForAuthenticatedUserQuerySchema, void, void>,
   respond: TeamsListForAuthenticatedUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19913,7 +20924,7 @@ export type UsersGetByIdResponder = {
 } & KoaRuntimeResponder
 
 export type UsersGetById = (
-  params: Params<t_UsersGetByIdParamSchema, void, void>,
+  params: Params<t_UsersGetByIdParamSchema, void, void, void>,
   respond: UsersGetByIdResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19928,7 +20939,7 @@ export type UsersListResponder = {
 } & KoaRuntimeResponder
 
 export type UsersList = (
-  params: Params<void, t_UsersListQuerySchema, void>,
+  params: Params<void, t_UsersListQuerySchema, void, void>,
   respond: UsersListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19943,7 +20954,7 @@ export type UsersGetByUsernameResponder = {
 } & KoaRuntimeResponder
 
 export type UsersGetByUsername = (
-  params: Params<t_UsersGetByUsernameParamSchema, void, void>,
+  params: Params<t_UsersGetByUsernameParamSchema, void, void, void>,
   respond: UsersGetByUsernameResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -19968,6 +20979,7 @@ export type UsersListAttestations = (
   params: Params<
     t_UsersListAttestationsParamSchema,
     t_UsersListAttestationsQuerySchema,
+    void,
     void
   >,
   respond: UsersListAttestationsResponder,
@@ -19998,6 +21010,7 @@ export type PackagesListDockerMigrationConflictingPackagesForUser = (
   params: Params<
     t_PackagesListDockerMigrationConflictingPackagesForUserParamSchema,
     void,
+    void,
     void
   >,
   respond: PackagesListDockerMigrationConflictingPackagesForUserResponder,
@@ -20017,6 +21030,7 @@ export type ActivityListEventsForAuthenticatedUser = (
   params: Params<
     t_ActivityListEventsForAuthenticatedUserParamSchema,
     t_ActivityListEventsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListEventsForAuthenticatedUserResponder,
@@ -20031,6 +21045,7 @@ export type ActivityListOrgEventsForAuthenticatedUser = (
   params: Params<
     t_ActivityListOrgEventsForAuthenticatedUserParamSchema,
     t_ActivityListOrgEventsForAuthenticatedUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListOrgEventsForAuthenticatedUserResponder,
@@ -20045,6 +21060,7 @@ export type ActivityListPublicEventsForUser = (
   params: Params<
     t_ActivityListPublicEventsForUserParamSchema,
     t_ActivityListPublicEventsForUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListPublicEventsForUserResponder,
@@ -20059,6 +21075,7 @@ export type UsersListFollowersForUser = (
   params: Params<
     t_UsersListFollowersForUserParamSchema,
     t_UsersListFollowersForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListFollowersForUserResponder,
@@ -20073,6 +21090,7 @@ export type UsersListFollowingForUser = (
   params: Params<
     t_UsersListFollowingForUserParamSchema,
     t_UsersListFollowingForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListFollowingForUserResponder,
@@ -20085,7 +21103,7 @@ export type UsersCheckFollowingForUserResponder = {
 } & KoaRuntimeResponder
 
 export type UsersCheckFollowingForUser = (
-  params: Params<t_UsersCheckFollowingForUserParamSchema, void, void>,
+  params: Params<t_UsersCheckFollowingForUserParamSchema, void, void, void>,
   respond: UsersCheckFollowingForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20101,6 +21119,7 @@ export type GistsListForUser = (
   params: Params<
     t_GistsListForUserParamSchema,
     t_GistsListForUserQuerySchema,
+    void,
     void
   >,
   respond: GistsListForUserResponder,
@@ -20119,6 +21138,7 @@ export type UsersListGpgKeysForUser = (
   params: Params<
     t_UsersListGpgKeysForUserParamSchema,
     t_UsersListGpgKeysForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListGpgKeysForUserResponder,
@@ -20135,6 +21155,7 @@ export type UsersGetContextForUser = (
   params: Params<
     t_UsersGetContextForUserParamSchema,
     t_UsersGetContextForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersGetContextForUserResponder,
@@ -20151,7 +21172,7 @@ export type AppsGetUserInstallationResponder = {
 } & KoaRuntimeResponder
 
 export type AppsGetUserInstallation = (
-  params: Params<t_AppsGetUserInstallationParamSchema, void, void>,
+  params: Params<t_AppsGetUserInstallationParamSchema, void, void, void>,
   respond: AppsGetUserInstallationResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_installation>>
@@ -20164,6 +21185,7 @@ export type UsersListPublicKeysForUser = (
   params: Params<
     t_UsersListPublicKeysForUserParamSchema,
     t_UsersListPublicKeysForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListPublicKeysForUserResponder,
@@ -20178,6 +21200,7 @@ export type OrgsListForUser = (
   params: Params<
     t_OrgsListForUserParamSchema,
     t_OrgsListForUserQuerySchema,
+    void,
     void
   >,
   respond: OrgsListForUserResponder,
@@ -20197,6 +21220,7 @@ export type PackagesListPackagesForUser = (
   params: Params<
     t_PackagesListPackagesForUserParamSchema,
     t_PackagesListPackagesForUserQuerySchema,
+    void,
     void
   >,
   respond: PackagesListPackagesForUserResponder,
@@ -20214,7 +21238,7 @@ export type PackagesGetPackageForUserResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesGetPackageForUser = (
-  params: Params<t_PackagesGetPackageForUserParamSchema, void, void>,
+  params: Params<t_PackagesGetPackageForUserParamSchema, void, void, void>,
   respond: PackagesGetPackageForUserResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_package>>
@@ -20227,7 +21251,7 @@ export type PackagesDeletePackageForUserResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesDeletePackageForUser = (
-  params: Params<t_PackagesDeletePackageForUserParamSchema, void, void>,
+  params: Params<t_PackagesDeletePackageForUserParamSchema, void, void, void>,
   respond: PackagesDeletePackageForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20249,6 +21273,7 @@ export type PackagesRestorePackageForUser = (
   params: Params<
     t_PackagesRestorePackageForUserParamSchema,
     t_PackagesRestorePackageForUserQuerySchema,
+    void,
     void
   >,
   respond: PackagesRestorePackageForUserResponder,
@@ -20272,6 +21297,7 @@ export type PackagesGetAllPackageVersionsForPackageOwnedByUser = (
   params: Params<
     t_PackagesGetAllPackageVersionsForPackageOwnedByUserParamSchema,
     void,
+    void,
     void
   >,
   respond: PackagesGetAllPackageVersionsForPackageOwnedByUserResponder,
@@ -20289,7 +21315,12 @@ export type PackagesGetPackageVersionForUserResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesGetPackageVersionForUser = (
-  params: Params<t_PackagesGetPackageVersionForUserParamSchema, void, void>,
+  params: Params<
+    t_PackagesGetPackageVersionForUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: PackagesGetPackageVersionForUserResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_package_version>>
@@ -20302,7 +21333,12 @@ export type PackagesDeletePackageVersionForUserResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesDeletePackageVersionForUser = (
-  params: Params<t_PackagesDeletePackageVersionForUserParamSchema, void, void>,
+  params: Params<
+    t_PackagesDeletePackageVersionForUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: PackagesDeletePackageVersionForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20321,7 +21357,12 @@ export type PackagesRestorePackageVersionForUserResponder = {
 } & KoaRuntimeResponder
 
 export type PackagesRestorePackageVersionForUser = (
-  params: Params<t_PackagesRestorePackageVersionForUserParamSchema, void, void>,
+  params: Params<
+    t_PackagesRestorePackageVersionForUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: PackagesRestorePackageVersionForUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20341,6 +21382,7 @@ export type ProjectsListForUser = (
   params: Params<
     t_ProjectsListForUserParamSchema,
     t_ProjectsListForUserQuerySchema,
+    void,
     void
   >,
   respond: ProjectsListForUserResponder,
@@ -20359,6 +21401,7 @@ export type ActivityListReceivedEventsForUser = (
   params: Params<
     t_ActivityListReceivedEventsForUserParamSchema,
     t_ActivityListReceivedEventsForUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListReceivedEventsForUserResponder,
@@ -20373,6 +21416,7 @@ export type ActivityListReceivedPublicEventsForUser = (
   params: Params<
     t_ActivityListReceivedPublicEventsForUserParamSchema,
     t_ActivityListReceivedPublicEventsForUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListReceivedPublicEventsForUserResponder,
@@ -20387,6 +21431,7 @@ export type ReposListForUser = (
   params: Params<
     t_ReposListForUserParamSchema,
     t_ReposListForUserQuerySchema,
+    void,
     void
   >,
   respond: ReposListForUserResponder,
@@ -20400,7 +21445,12 @@ export type BillingGetGithubActionsBillingUserResponder = {
 } & KoaRuntimeResponder
 
 export type BillingGetGithubActionsBillingUser = (
-  params: Params<t_BillingGetGithubActionsBillingUserParamSchema, void, void>,
+  params: Params<
+    t_BillingGetGithubActionsBillingUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: BillingGetGithubActionsBillingUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20412,7 +21462,12 @@ export type BillingGetGithubPackagesBillingUserResponder = {
 } & KoaRuntimeResponder
 
 export type BillingGetGithubPackagesBillingUser = (
-  params: Params<t_BillingGetGithubPackagesBillingUserParamSchema, void, void>,
+  params: Params<
+    t_BillingGetGithubPackagesBillingUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: BillingGetGithubPackagesBillingUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20424,7 +21479,12 @@ export type BillingGetSharedStorageBillingUserResponder = {
 } & KoaRuntimeResponder
 
 export type BillingGetSharedStorageBillingUser = (
-  params: Params<t_BillingGetSharedStorageBillingUserParamSchema, void, void>,
+  params: Params<
+    t_BillingGetSharedStorageBillingUserParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: BillingGetSharedStorageBillingUserResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20439,6 +21499,7 @@ export type UsersListSocialAccountsForUser = (
   params: Params<
     t_UsersListSocialAccountsForUserParamSchema,
     t_UsersListSocialAccountsForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListSocialAccountsForUserResponder,
@@ -20453,6 +21514,7 @@ export type UsersListSshSigningKeysForUser = (
   params: Params<
     t_UsersListSshSigningKeysForUserParamSchema,
     t_UsersListSshSigningKeysForUserQuerySchema,
+    void,
     void
   >,
   respond: UsersListSshSigningKeysForUserResponder,
@@ -20467,6 +21529,7 @@ export type ActivityListReposStarredByUser = (
   params: Params<
     t_ActivityListReposStarredByUserParamSchema,
     t_ActivityListReposStarredByUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListReposStarredByUserResponder,
@@ -20484,6 +21547,7 @@ export type ActivityListReposWatchedByUser = (
   params: Params<
     t_ActivityListReposWatchedByUserParamSchema,
     t_ActivityListReposWatchedByUserQuerySchema,
+    void,
     void
   >,
   respond: ActivityListReposWatchedByUserResponder,
@@ -20498,7 +21562,7 @@ export type MetaGetAllVersionsResponder = {
 } & KoaRuntimeResponder
 
 export type MetaGetAllVersions = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: MetaGetAllVersionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -20512,7 +21576,7 @@ export type MetaGetZenResponder = {
 } & KoaRuntimeResponder
 
 export type MetaGetZen = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: MetaGetZenResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, string>>
@@ -21485,6 +22549,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -21561,6 +22626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -21621,6 +22687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -21663,6 +22730,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -21725,6 +22793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -21778,6 +22847,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -21826,6 +22896,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21879,6 +22950,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -21936,6 +23008,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -21994,6 +23067,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22055,6 +23129,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22117,6 +23192,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22167,6 +23243,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22220,6 +23297,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22289,6 +23367,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22354,6 +23433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22407,6 +23487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22466,6 +23547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22524,6 +23606,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22584,6 +23667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22641,6 +23725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22708,6 +23793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22766,6 +23852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -22821,6 +23908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22881,6 +23969,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22936,6 +24025,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -22984,6 +24074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -23033,6 +24124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23093,6 +24185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23139,6 +24232,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23195,6 +24289,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23240,6 +24335,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -23313,6 +24409,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23396,6 +24493,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23481,6 +24579,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23573,6 +24672,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23654,6 +24754,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -23726,6 +24827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -23774,6 +24876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -23823,6 +24926,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -23885,6 +24989,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -23947,6 +25052,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24006,6 +25112,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24074,6 +25181,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24156,6 +25264,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24208,6 +25317,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24275,6 +25385,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -24340,6 +25451,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24415,6 +25527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -24489,6 +25602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24545,6 +25659,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -24613,6 +25728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -24678,6 +25794,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24734,6 +25851,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24795,6 +25913,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -24851,6 +25970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24906,6 +26026,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -24964,6 +26085,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -25014,6 +26136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25065,6 +26188,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25129,6 +26253,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25182,6 +26307,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25251,6 +26377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -25308,6 +26435,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -25357,6 +26485,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -25414,6 +26543,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -25461,6 +26591,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -25515,6 +26646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25576,6 +26708,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25645,6 +26778,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25706,6 +26840,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25766,6 +26901,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25831,6 +26967,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -25873,6 +27010,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -25939,6 +27077,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26013,6 +27152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26085,6 +27225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26151,6 +27292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26211,6 +27353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26264,6 +27407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26317,6 +27461,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26395,6 +27540,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26457,6 +27603,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26508,6 +27655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -26555,6 +27703,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -26602,6 +27751,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -26704,6 +27854,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -26757,6 +27908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -26812,6 +27964,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26884,6 +28037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26935,6 +28089,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -26996,6 +28151,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27053,6 +28209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27111,6 +28268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27180,6 +28338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27242,6 +28401,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27294,6 +28454,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27346,6 +28507,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27399,6 +28561,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27454,6 +28617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27504,6 +28668,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27565,6 +28730,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27639,6 +28805,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27693,6 +28860,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27759,6 +28927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27816,6 +28985,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27864,6 +29034,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27910,6 +29081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -27956,6 +29128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28017,6 +29190,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28093,6 +29267,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28173,6 +29348,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28242,6 +29418,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28317,6 +29494,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28396,6 +29574,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28444,6 +29623,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28492,6 +29672,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28562,6 +29743,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28613,6 +29795,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28679,6 +29862,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28739,6 +29923,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28795,6 +29980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28854,6 +30040,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28922,6 +30109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -28981,6 +30169,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29029,6 +30218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29088,6 +30278,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29136,6 +30327,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29203,6 +30395,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29272,6 +30465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29331,6 +30525,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29390,6 +30585,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29474,6 +30670,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29538,6 +30735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -29588,6 +30786,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29642,6 +30841,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29693,6 +30893,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29767,6 +30968,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29842,6 +31044,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -29959,6 +31162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30012,6 +31216,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -30088,6 +31293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30154,6 +31360,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -30253,6 +31460,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30311,6 +31519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -30378,6 +31587,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30451,6 +31661,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30531,6 +31742,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -30610,6 +31822,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -30695,6 +31908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30773,6 +31987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30854,6 +32069,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30934,6 +32150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -30982,6 +32199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31030,6 +32248,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31102,6 +32321,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31165,6 +32385,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31235,6 +32456,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31305,6 +32527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31369,6 +32592,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31436,6 +32660,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31503,6 +32728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31587,6 +32813,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -31665,6 +32892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31745,6 +32973,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31828,6 +33057,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31908,6 +33138,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31990,6 +33221,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32073,6 +33305,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32152,6 +33385,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32200,6 +33434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32248,6 +33483,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32318,6 +33554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32372,6 +33609,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32438,6 +33676,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32498,6 +33737,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32554,6 +33794,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32613,6 +33854,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32670,6 +33912,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32736,6 +33979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32793,6 +34037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -32850,6 +34095,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -32916,6 +34162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -32972,6 +34219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33047,6 +34295,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33104,6 +34353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33155,6 +34405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33214,6 +34465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33276,6 +34528,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33335,6 +34588,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33395,6 +34649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33454,6 +34709,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33502,6 +34758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33564,6 +34821,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33615,6 +34873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33677,6 +34936,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33728,6 +34988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33802,6 +35063,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33870,6 +35132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33928,6 +35191,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -33994,6 +35258,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34063,6 +35328,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -34121,6 +35387,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -34175,6 +35442,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34232,6 +35500,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34306,6 +35575,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34384,6 +35654,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34458,6 +35729,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34529,6 +35801,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34599,6 +35872,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34665,6 +35939,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -34724,6 +35999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34790,6 +36066,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34855,6 +36132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -34925,6 +36203,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -34980,6 +36259,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35035,6 +36315,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35090,6 +36371,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35153,6 +36435,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35211,6 +36494,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35268,6 +36552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35321,6 +36606,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35376,6 +36662,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35424,6 +36711,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35477,6 +36765,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35532,6 +36821,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35584,6 +36874,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35651,6 +36942,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35718,6 +37010,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35777,6 +37070,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35839,6 +37133,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -35909,6 +37204,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -35986,6 +37282,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36052,6 +37349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36117,6 +37415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36196,6 +37495,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36281,6 +37581,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36353,6 +37654,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36419,6 +37721,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36494,6 +37797,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36578,6 +37882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36656,6 +37961,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36733,6 +38039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36808,6 +38115,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36892,6 +38200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -36966,6 +38275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37040,6 +38350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37115,6 +38426,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37179,6 +38491,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -37242,6 +38555,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37306,6 +38620,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37372,6 +38687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37433,6 +38749,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37512,6 +38829,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37570,6 +38888,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37638,6 +38957,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37711,6 +39031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37778,6 +39099,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37830,6 +39152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37885,6 +39208,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -37937,6 +39261,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38001,6 +39326,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -38082,6 +39408,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -38145,6 +39472,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38213,6 +39541,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -38288,6 +39617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38346,6 +39676,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38404,6 +39735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38477,6 +39809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -38535,6 +39868,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38617,6 +39951,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38697,6 +40032,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38749,6 +40085,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38797,6 +40134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38843,6 +40181,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38888,6 +40227,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38936,6 +40276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -38984,6 +40325,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39052,6 +40394,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39118,6 +40461,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -39183,6 +40527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -39239,6 +40584,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39313,6 +40659,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -39373,6 +40720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39432,6 +40780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39490,6 +40839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -39539,6 +40889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39596,6 +40947,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -39645,6 +40997,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39705,6 +41058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39760,6 +41114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -39811,6 +41166,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39867,6 +41223,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -39918,6 +41275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -39990,6 +41348,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40064,6 +41423,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -40119,6 +41479,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40190,6 +41551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40263,6 +41625,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -40317,6 +41680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40375,6 +41739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40433,6 +41798,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40486,6 +41852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40553,6 +41920,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -40615,6 +41983,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40678,6 +42047,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40731,6 +42101,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40805,6 +42176,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -40863,6 +42235,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40920,6 +42293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -40975,6 +42349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41040,6 +42415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -41093,6 +42469,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41150,6 +42527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41219,6 +42597,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -41277,6 +42656,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41352,6 +42732,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -41425,6 +42806,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41533,6 +42915,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -41618,6 +43001,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41688,6 +43072,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -41749,6 +43134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41823,6 +43209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -41910,6 +43297,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -41996,6 +43384,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42055,6 +43444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -42136,6 +43526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -42216,6 +43607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -42299,6 +43691,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -42383,6 +43776,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42453,6 +43847,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -42524,6 +43919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -42600,6 +43996,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -42668,6 +44065,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42720,6 +44118,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -42772,6 +44171,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -42886,6 +44286,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -42953,6 +44354,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -43031,6 +44433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43083,6 +44486,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43132,6 +44536,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43185,6 +44590,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43237,6 +44643,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43303,6 +44710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43358,6 +44766,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43405,6 +44814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43452,6 +44862,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43499,6 +44910,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43566,6 +44978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43622,6 +45035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43694,6 +45108,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43772,6 +45187,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43844,6 +45260,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43899,6 +45316,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -43957,6 +45375,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44009,6 +45428,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44067,6 +45487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44116,6 +45537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44172,6 +45594,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44222,6 +45645,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44289,6 +45713,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44367,6 +45792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44422,6 +45848,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44489,6 +45916,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44547,6 +45975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44596,6 +46025,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44643,6 +46073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44693,6 +46124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44755,6 +46187,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -44832,6 +46265,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44913,6 +46347,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44986,6 +46421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45062,6 +46498,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45170,6 +46607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45230,6 +46668,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45279,6 +46718,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45328,6 +46768,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45381,6 +46822,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45455,6 +46897,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45514,6 +46957,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45580,6 +47024,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45637,6 +47082,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45692,6 +47138,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45751,6 +47198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -45804,6 +47252,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45872,6 +47321,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45922,6 +47372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -45976,6 +47427,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46032,6 +47484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46092,6 +47545,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46155,6 +47609,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46213,6 +47668,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46262,6 +47718,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46327,6 +47784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46378,6 +47836,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46427,6 +47886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46496,6 +47956,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46548,6 +48009,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46613,6 +48075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46673,6 +48136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46722,6 +48186,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46780,6 +48245,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46829,6 +48295,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46894,6 +48361,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46946,6 +48414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -46995,6 +48464,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47051,6 +48521,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -47100,6 +48571,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47191,6 +48663,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47243,6 +48716,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47318,6 +48792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47381,6 +48856,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47437,6 +48913,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47504,6 +48981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -47591,6 +49069,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47652,6 +49131,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47713,6 +49193,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -47768,6 +49249,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47823,6 +49305,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47878,6 +49361,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47927,6 +49411,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -47976,6 +49461,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48040,6 +49526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48096,6 +49583,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48154,6 +49642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48270,6 +49759,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -48332,6 +49822,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48385,6 +49876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48435,6 +49927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48488,6 +49981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48541,6 +50035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48626,6 +50121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -48687,6 +50183,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48746,6 +50243,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48805,6 +50303,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48864,6 +50363,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48923,6 +50423,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -48999,6 +50500,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49052,6 +50554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -49105,6 +50608,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -49171,6 +50675,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49242,6 +50747,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49311,6 +50817,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49369,6 +50876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -49419,6 +50927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -49472,6 +50981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -49539,6 +51049,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49603,6 +51114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49668,6 +51180,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49724,6 +51237,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -49791,6 +51305,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49855,6 +51370,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49920,6 +51436,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49979,6 +51496,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50046,6 +51564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50110,6 +51629,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50175,6 +51695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50241,6 +51762,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50310,6 +51832,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50359,6 +51882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50484,6 +52008,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50542,6 +52067,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50596,6 +52122,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50662,6 +52189,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50728,6 +52256,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50777,6 +52306,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50846,6 +52376,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50898,6 +52429,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -50976,6 +52508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51054,6 +52587,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51141,6 +52675,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51226,6 +52761,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51315,6 +52851,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51389,6 +52926,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51474,6 +53012,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51551,6 +53090,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51627,6 +53167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51714,6 +53255,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51791,6 +53333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51864,6 +53407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -51940,6 +53484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52023,6 +53568,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -52120,6 +53666,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -52200,6 +53747,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52268,6 +53816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52344,6 +53893,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52417,6 +53967,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52522,6 +54073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -52623,6 +54175,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52725,6 +54278,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52820,6 +54374,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -52911,6 +54466,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53000,6 +54556,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53051,6 +54608,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53100,6 +54658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53169,6 +54728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53224,6 +54784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53288,6 +54849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53343,6 +54905,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53408,6 +54971,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53470,6 +55034,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53529,6 +55094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53592,6 +55158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53644,6 +55211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53705,6 +55273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53760,6 +55329,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53837,6 +55407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -53911,6 +55482,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53965,6 +55537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54034,6 +55607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54100,6 +55674,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54164,6 +55739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54228,6 +55804,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54296,6 +55873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54374,6 +55952,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54463,6 +56042,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54534,6 +56114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54599,6 +56180,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54664,6 +56246,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54713,6 +56296,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54783,6 +56367,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54865,6 +56450,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -54963,6 +56549,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55055,6 +56642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55134,6 +56722,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55220,6 +56809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55289,6 +56879,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55372,6 +56963,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55452,6 +57044,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55503,6 +57096,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55552,6 +57146,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55621,6 +57216,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55676,6 +57272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55737,6 +57334,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55795,6 +57393,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -55866,6 +57465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55935,6 +57535,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56006,6 +57607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56069,6 +57671,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56125,6 +57728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56193,6 +57797,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56271,6 +57876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56327,6 +57933,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56391,6 +57998,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56462,6 +58070,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56514,6 +58123,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56589,6 +58199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56641,6 +58252,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56708,6 +58320,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56775,6 +58388,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56832,6 +58446,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -56887,6 +58502,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56938,6 +58554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57001,6 +58618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57065,6 +58683,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -57137,6 +58756,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57194,6 +58814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57245,6 +58866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57315,6 +58937,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57365,6 +58988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57413,6 +59037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57482,6 +59107,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -57536,6 +59162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57603,6 +59230,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57662,6 +59290,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -57710,6 +59339,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57767,6 +59397,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -57815,6 +59446,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57872,6 +59504,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -57936,6 +59569,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58006,6 +59640,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58081,6 +59716,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58150,6 +59786,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58240,6 +59877,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58302,6 +59940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58360,6 +59999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58416,6 +60056,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58480,6 +60121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58548,6 +60190,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58607,6 +60250,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58683,6 +60327,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58742,6 +60387,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58821,6 +60467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58893,6 +60540,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -58962,6 +60610,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59039,6 +60688,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59100,6 +60750,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59168,6 +60819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59226,6 +60878,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59276,6 +60929,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59336,6 +60990,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59399,6 +61054,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59459,6 +61115,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59520,6 +61177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59580,6 +61238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59635,6 +61294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59690,6 +61350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59761,6 +61422,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59835,6 +61497,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59889,6 +61552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -59952,6 +61616,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60020,6 +61685,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60080,6 +61746,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60143,6 +61810,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60201,6 +61869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60256,6 +61925,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60319,6 +61989,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60377,6 +62048,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60440,6 +62112,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60501,6 +62174,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60550,6 +62224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60624,6 +62299,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60721,6 +62397,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60807,6 +62484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60865,6 +62543,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -60926,6 +62605,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60978,6 +62658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61052,6 +62733,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61126,6 +62808,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61180,6 +62863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61240,6 +62924,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61297,6 +62982,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61361,6 +63047,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61469,6 +63156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61548,6 +63236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61605,6 +63294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61659,6 +63349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61728,6 +63419,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61795,6 +63487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61868,6 +63561,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -61934,6 +63628,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62017,6 +63712,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62103,6 +63799,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62169,6 +63866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62233,6 +63931,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62310,6 +64009,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62375,6 +64075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62455,6 +64156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62531,6 +64233,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62587,6 +64290,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62650,6 +64354,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62713,6 +64418,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62774,6 +64480,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62829,6 +64536,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62881,6 +64589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -62941,6 +64650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63006,6 +64716,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63064,6 +64775,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63128,6 +64840,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63177,6 +64890,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63225,6 +64939,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63284,6 +64999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63345,6 +65061,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63413,6 +65130,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -63490,6 +65208,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63556,6 +65275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63614,6 +65334,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63679,6 +65400,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63731,6 +65453,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63790,6 +65513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63850,6 +65574,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -63924,6 +65649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63984,6 +65710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64055,6 +65782,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64131,6 +65859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64196,6 +65925,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64262,6 +65992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64310,6 +66041,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64358,6 +66090,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64407,6 +66140,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64472,6 +66206,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64533,6 +66268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64588,6 +66324,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64645,6 +66382,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64709,6 +66447,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64769,6 +66508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64827,6 +66567,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64898,6 +66639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -64977,6 +66719,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65045,6 +66788,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65113,6 +66857,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65188,6 +66933,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -65257,6 +67003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -65323,6 +67070,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65375,6 +67123,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65433,6 +67182,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65485,6 +67235,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65562,6 +67313,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65639,6 +67391,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65696,6 +67449,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65762,6 +67516,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -65848,6 +67603,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65939,6 +67695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66022,6 +67779,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66092,6 +67850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66160,6 +67919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66221,6 +67981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66291,6 +68052,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66356,6 +68118,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66441,6 +68204,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66512,6 +68276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66576,6 +68341,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66644,6 +68410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66705,6 +68472,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66783,6 +68551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66842,6 +68611,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -66904,6 +68674,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66961,6 +68732,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67029,6 +68801,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67095,6 +68868,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67165,6 +68939,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67242,6 +69017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67310,6 +69086,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67380,6 +69157,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67446,6 +69224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67517,6 +69296,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67576,6 +69356,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67643,6 +69424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67692,6 +69474,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67754,6 +69537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67805,6 +69589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67857,6 +69642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67912,6 +69698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -67987,6 +69774,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68039,6 +69827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68097,6 +69886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68164,6 +69954,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68231,6 +70022,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68295,6 +70087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68351,6 +70144,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68409,6 +70203,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68471,6 +70266,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68542,6 +70338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68619,6 +70416,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68678,6 +70476,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68745,6 +70544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68819,6 +70619,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68878,6 +70679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -68961,6 +70763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69032,6 +70835,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69117,6 +70921,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69203,6 +71008,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69287,6 +71093,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69377,6 +71184,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69447,6 +71255,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69518,6 +71327,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69589,6 +71399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69660,6 +71471,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69725,6 +71537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69803,6 +71616,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69876,6 +71690,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69932,6 +71747,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -69996,6 +71812,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70056,6 +71873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70115,6 +71933,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70169,6 +71988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70232,6 +72052,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70287,6 +72108,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70340,6 +72162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70403,6 +72226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70449,6 +72273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70503,6 +72328,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -70554,6 +72380,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70618,6 +72445,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70677,6 +72505,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70730,6 +72559,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70790,6 +72620,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70853,6 +72684,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -70916,6 +72748,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70981,6 +72814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71035,6 +72869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71089,6 +72924,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71151,6 +72987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71212,6 +73049,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -71264,6 +73102,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71313,6 +73152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71359,6 +73199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71406,6 +73247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71466,6 +73308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -71514,6 +73357,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -71587,6 +73431,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -71664,6 +73509,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -71756,6 +73602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -71838,6 +73685,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -71922,6 +73770,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -71994,6 +73843,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -72067,6 +73917,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -72128,6 +73979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -72193,6 +74045,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -72250,6 +74103,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -72312,6 +74166,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72367,6 +74222,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72415,6 +74271,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72469,6 +74326,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72515,6 +74373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72574,6 +74433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72631,6 +74491,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72681,6 +74542,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72736,6 +74598,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72786,6 +74649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72857,6 +74721,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -72924,6 +74789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72994,6 +74860,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73060,6 +74927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73120,6 +74988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73183,6 +75052,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73237,6 +75107,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73293,6 +75164,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73353,6 +75225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73408,6 +75281,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73475,6 +75349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73539,6 +75414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73604,6 +75480,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73659,6 +75536,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73733,6 +75611,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73800,6 +75679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73865,6 +75745,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73922,6 +75803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -73993,6 +75875,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74051,6 +75934,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74112,6 +75996,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74162,6 +76047,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -74230,6 +76116,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -74299,6 +76186,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74365,6 +76253,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74426,6 +76315,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -74488,6 +76378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -74562,6 +76453,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74674,6 +76566,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74753,6 +76646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74799,6 +76693,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74847,6 +76742,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -74923,6 +76819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74985,6 +76882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75047,6 +76945,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75130,6 +77029,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75203,6 +77103,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75276,6 +77177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75351,6 +77253,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75434,6 +77337,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75501,6 +77405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75576,6 +77481,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75646,6 +77552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75714,6 +77621,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75799,6 +77707,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75872,6 +77781,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -75953,6 +77863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76005,6 +77916,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76068,6 +77980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -76146,6 +78059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76220,6 +78134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -76295,6 +78210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -76367,6 +78283,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76433,6 +78350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76499,6 +78417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76562,6 +78481,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -76624,6 +78544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76691,6 +78612,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76762,6 +78684,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -76834,6 +78757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76904,6 +78828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -76982,6 +78907,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77066,6 +78992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77136,6 +79063,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77204,6 +79132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77267,6 +79196,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77326,6 +79256,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -77370,6 +79301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77443,6 +79375,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77504,6 +79437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77579,6 +79513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -77651,6 +79586,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77720,6 +79656,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77789,6 +79726,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77854,6 +79792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77920,6 +79859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -77987,6 +79927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78057,6 +79998,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -78123,6 +80065,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78197,6 +80140,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -78279,6 +80223,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78347,6 +80292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78413,6 +80359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78483,6 +80430,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78558,6 +80506,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78618,6 +80567,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78688,6 +80638,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78747,6 +80698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78811,6 +80763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78892,6 +80845,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -78977,6 +80931,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79048,6 +81003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79113,6 +81069,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79190,6 +81147,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79262,6 +81220,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -79332,6 +81291,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79418,6 +81378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79512,6 +81473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -79585,6 +81547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79654,6 +81617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79723,6 +81687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79793,6 +81758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -79863,6 +81829,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -79936,6 +81903,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -80009,6 +81977,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80086,6 +82055,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -80158,6 +82128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80227,6 +82198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80298,6 +82270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80365,6 +82338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80435,6 +82409,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80505,6 +82480,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80574,6 +82550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80640,6 +82617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80694,6 +82672,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -80744,6 +82723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -80791,6 +82771,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -80868,6 +82849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -80933,6 +82915,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81001,6 +82984,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81059,6 +83043,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81116,6 +83101,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81172,6 +83158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81228,6 +83215,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81279,6 +83267,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81340,6 +83329,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81397,6 +83387,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81457,6 +83448,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81508,6 +83500,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81564,6 +83557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81615,6 +83609,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -81685,6 +83680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81750,6 +83746,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81812,6 +83809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81891,6 +83889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -81963,6 +83962,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82035,6 +84035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82098,6 +84099,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82173,6 +84175,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82243,6 +84246,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82300,6 +84304,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82357,6 +84362,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82420,6 +84426,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82465,6 +84472,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82513,6 +84521,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82561,6 +84570,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82618,6 +84628,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82672,6 +84683,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82736,6 +84748,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82795,6 +84808,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -82834,6 +84848,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -82872,6 +84887,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/generated.ts
@@ -8,56 +8,73 @@ import {
   t_Azure_Core_Foundations_OperationState,
   t_Manufacturer,
   t_ManufacturersCreateManufacturerBodySchema,
+  t_ManufacturersCreateManufacturerHeaderSchema,
   t_ManufacturersCreateManufacturerParamSchema,
   t_ManufacturersCreateManufacturerQuerySchema,
+  t_ManufacturersDeleteManufacturerHeaderSchema,
   t_ManufacturersDeleteManufacturerParamSchema,
   t_ManufacturersDeleteManufacturerQuerySchema,
+  t_ManufacturersGetManufacturerHeaderSchema,
   t_ManufacturersGetManufacturerOperationStatusParamSchema,
   t_ManufacturersGetManufacturerOperationStatusQuerySchema,
   t_ManufacturersGetManufacturerParamSchema,
   t_ManufacturersGetManufacturerQuerySchema,
+  t_ManufacturersListManufacturersHeaderSchema,
   t_ManufacturersListManufacturersQuerySchema,
   t_PagedManufacturer,
   t_PagedWidget,
   t_PagedWidgetPart,
+  t_ServiceStatusHeaderSchema,
   t_ServiceStatusQuerySchema,
   t_Widget,
   t_WidgetAnalytics,
   t_WidgetPart,
   t_WidgetPartsCreateWidgetPartBodySchema,
+  t_WidgetPartsCreateWidgetPartHeaderSchema,
   t_WidgetPartsCreateWidgetPartParamSchema,
   t_WidgetPartsCreateWidgetPartQuerySchema,
+  t_WidgetPartsDeleteWidgetPartHeaderSchema,
   t_WidgetPartsDeleteWidgetPartParamSchema,
   t_WidgetPartsDeleteWidgetPartQuerySchema,
+  t_WidgetPartsGetWidgetPartHeaderSchema,
   t_WidgetPartsGetWidgetPartOperationStatusParamSchema,
   t_WidgetPartsGetWidgetPartOperationStatusQuerySchema,
   t_WidgetPartsGetWidgetPartParamSchema,
   t_WidgetPartsGetWidgetPartQuerySchema,
+  t_WidgetPartsListWidgetPartsHeaderSchema,
   t_WidgetPartsListWidgetPartsParamSchema,
   t_WidgetPartsListWidgetPartsQuerySchema,
   t_WidgetPartsReorderPartsBodySchema,
+  t_WidgetPartsReorderPartsHeaderSchema,
   t_WidgetPartsReorderPartsParamSchema,
   t_WidgetPartsReorderPartsQuerySchema,
   t_WidgetRepairRequest,
   t_WidgetRepairState,
   t_WidgetsCreateOrUpdateWidgetBodySchema,
+  t_WidgetsCreateOrUpdateWidgetHeaderSchema,
   t_WidgetsCreateOrUpdateWidgetParamSchema,
   t_WidgetsCreateOrUpdateWidgetQuerySchema,
+  t_WidgetsDeleteWidgetHeaderSchema,
   t_WidgetsDeleteWidgetParamSchema,
   t_WidgetsDeleteWidgetQuerySchema,
+  t_WidgetsGetAnalyticsHeaderSchema,
   t_WidgetsGetAnalyticsParamSchema,
   t_WidgetsGetAnalyticsQuerySchema,
   t_WidgetsGetRepairStatusParamSchema,
   t_WidgetsGetRepairStatusQuerySchema,
+  t_WidgetsGetWidgetHeaderSchema,
   t_WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusParamSchema,
   t_WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusQuerySchema,
   t_WidgetsGetWidgetParamSchema,
   t_WidgetsGetWidgetQuerySchema,
+  t_WidgetsListWidgetsHeaderSchema,
   t_WidgetsListWidgetsQuerySchema,
   t_WidgetsScheduleRepairsBodySchema,
+  t_WidgetsScheduleRepairsHeaderSchema,
   t_WidgetsScheduleRepairsParamSchema,
   t_WidgetsScheduleRepairsQuerySchema,
   t_WidgetsUpdateAnalyticsBodySchema,
+  t_WidgetsUpdateAnalyticsHeaderSchema,
   t_WidgetsUpdateAnalyticsParamSchema,
   t_WidgetsUpdateAnalyticsQuerySchema,
 } from "./models"
@@ -65,6 +82,7 @@ import {
   s_Azure_Core_Foundations_Error,
   s_Azure_Core_Foundations_ErrorResponse,
   s_Azure_Core_Foundations_OperationState,
+  s_Azure_Core_uuid,
   s_Manufacturer,
   s_PagedManufacturer,
   s_PagedWidget,
@@ -108,7 +126,12 @@ export type ServiceStatusResponder = {
 } & KoaRuntimeResponder
 
 export type ServiceStatus = (
-  params: Params<void, t_ServiceStatusQuerySchema, void>,
+  params: Params<
+    void,
+    t_ServiceStatusQuerySchema,
+    void,
+    t_ServiceStatusHeaderSchema
+  >,
   respond: ServiceStatusResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -147,6 +170,7 @@ export type WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatus
     params: Params<
       t_WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusParamSchema,
       t_WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusQuerySchema,
+      void,
       void
     >,
     respond: WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusResponder,
@@ -182,7 +206,8 @@ export type WidgetsCreateOrUpdateWidget = (
   params: Params<
     t_WidgetsCreateOrUpdateWidgetParamSchema,
     t_WidgetsCreateOrUpdateWidgetQuerySchema,
-    t_WidgetsCreateOrUpdateWidgetBodySchema
+    t_WidgetsCreateOrUpdateWidgetBodySchema,
+    t_WidgetsCreateOrUpdateWidgetHeaderSchema
   >,
   respond: WidgetsCreateOrUpdateWidgetResponder,
   ctx: RouterContext,
@@ -204,7 +229,8 @@ export type WidgetsGetWidget = (
   params: Params<
     t_WidgetsGetWidgetParamSchema,
     t_WidgetsGetWidgetQuerySchema,
-    void
+    void,
+    t_WidgetsGetWidgetHeaderSchema
   >,
   respond: WidgetsGetWidgetResponder,
   ctx: RouterContext,
@@ -229,7 +255,8 @@ export type WidgetsDeleteWidget = (
   params: Params<
     t_WidgetsDeleteWidgetParamSchema,
     t_WidgetsDeleteWidgetQuerySchema,
-    void
+    void,
+    t_WidgetsDeleteWidgetHeaderSchema
   >,
   respond: WidgetsDeleteWidgetResponder,
   ctx: RouterContext,
@@ -254,7 +281,12 @@ export type WidgetsListWidgetsResponder = {
 } & KoaRuntimeResponder
 
 export type WidgetsListWidgets = (
-  params: Params<void, t_WidgetsListWidgetsQuerySchema, void>,
+  params: Params<
+    void,
+    t_WidgetsListWidgetsQuerySchema,
+    void,
+    t_WidgetsListWidgetsHeaderSchema
+  >,
   respond: WidgetsListWidgetsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -274,7 +306,8 @@ export type WidgetsGetAnalytics = (
   params: Params<
     t_WidgetsGetAnalyticsParamSchema,
     t_WidgetsGetAnalyticsQuerySchema,
-    void
+    void,
+    t_WidgetsGetAnalyticsHeaderSchema
   >,
   respond: WidgetsGetAnalyticsResponder,
   ctx: RouterContext,
@@ -296,7 +329,8 @@ export type WidgetsUpdateAnalytics = (
   params: Params<
     t_WidgetsUpdateAnalyticsParamSchema,
     t_WidgetsUpdateAnalyticsQuerySchema,
-    t_WidgetsUpdateAnalyticsBodySchema
+    t_WidgetsUpdateAnalyticsBodySchema,
+    t_WidgetsUpdateAnalyticsHeaderSchema
   >,
   respond: WidgetsUpdateAnalyticsResponder,
   ctx: RouterContext,
@@ -323,6 +357,7 @@ export type WidgetsGetRepairStatus = (
   params: Params<
     t_WidgetsGetRepairStatusParamSchema,
     t_WidgetsGetRepairStatusQuerySchema,
+    void,
     void
   >,
   respond: WidgetsGetRepairStatusResponder,
@@ -363,7 +398,8 @@ export type WidgetsScheduleRepairs = (
   params: Params<
     t_WidgetsScheduleRepairsParamSchema,
     t_WidgetsScheduleRepairsQuerySchema,
-    t_WidgetsScheduleRepairsBodySchema
+    t_WidgetsScheduleRepairsBodySchema,
+    t_WidgetsScheduleRepairsHeaderSchema
   >,
   respond: WidgetsScheduleRepairsResponder,
   ctx: RouterContext,
@@ -403,6 +439,7 @@ export type WidgetPartsGetWidgetPartOperationStatus = (
   params: Params<
     t_WidgetPartsGetWidgetPartOperationStatusParamSchema,
     t_WidgetPartsGetWidgetPartOperationStatusQuerySchema,
+    void,
     void
   >,
   respond: WidgetPartsGetWidgetPartOperationStatusResponder,
@@ -432,7 +469,8 @@ export type WidgetPartsCreateWidgetPart = (
   params: Params<
     t_WidgetPartsCreateWidgetPartParamSchema,
     t_WidgetPartsCreateWidgetPartQuerySchema,
-    t_WidgetPartsCreateWidgetPartBodySchema
+    t_WidgetPartsCreateWidgetPartBodySchema,
+    t_WidgetPartsCreateWidgetPartHeaderSchema
   >,
   respond: WidgetPartsCreateWidgetPartResponder,
   ctx: RouterContext,
@@ -453,7 +491,8 @@ export type WidgetPartsListWidgetParts = (
   params: Params<
     t_WidgetPartsListWidgetPartsParamSchema,
     t_WidgetPartsListWidgetPartsQuerySchema,
-    void
+    void,
+    t_WidgetPartsListWidgetPartsHeaderSchema
   >,
   respond: WidgetPartsListWidgetPartsResponder,
   ctx: RouterContext,
@@ -474,7 +513,8 @@ export type WidgetPartsGetWidgetPart = (
   params: Params<
     t_WidgetPartsGetWidgetPartParamSchema,
     t_WidgetPartsGetWidgetPartQuerySchema,
-    void
+    void,
+    t_WidgetPartsGetWidgetPartHeaderSchema
   >,
   respond: WidgetPartsGetWidgetPartResponder,
   ctx: RouterContext,
@@ -495,7 +535,8 @@ export type WidgetPartsDeleteWidgetPart = (
   params: Params<
     t_WidgetPartsDeleteWidgetPartParamSchema,
     t_WidgetPartsDeleteWidgetPartQuerySchema,
-    void
+    void,
+    t_WidgetPartsDeleteWidgetPartHeaderSchema
   >,
   respond: WidgetPartsDeleteWidgetPartResponder,
   ctx: RouterContext,
@@ -520,7 +561,8 @@ export type WidgetPartsReorderParts = (
   params: Params<
     t_WidgetPartsReorderPartsParamSchema,
     t_WidgetPartsReorderPartsQuerySchema,
-    t_WidgetPartsReorderPartsBodySchema
+    t_WidgetPartsReorderPartsBodySchema,
+    t_WidgetPartsReorderPartsHeaderSchema
   >,
   respond: WidgetPartsReorderPartsResponder,
   ctx: RouterContext,
@@ -553,6 +595,7 @@ export type ManufacturersGetManufacturerOperationStatus = (
   params: Params<
     t_ManufacturersGetManufacturerOperationStatusParamSchema,
     t_ManufacturersGetManufacturerOperationStatusQuerySchema,
+    void,
     void
   >,
   respond: ManufacturersGetManufacturerOperationStatusResponder,
@@ -583,7 +626,8 @@ export type ManufacturersCreateManufacturer = (
   params: Params<
     t_ManufacturersCreateManufacturerParamSchema,
     t_ManufacturersCreateManufacturerQuerySchema,
-    t_ManufacturersCreateManufacturerBodySchema
+    t_ManufacturersCreateManufacturerBodySchema,
+    t_ManufacturersCreateManufacturerHeaderSchema
   >,
   respond: ManufacturersCreateManufacturerResponder,
   ctx: RouterContext,
@@ -605,7 +649,8 @@ export type ManufacturersGetManufacturer = (
   params: Params<
     t_ManufacturersGetManufacturerParamSchema,
     t_ManufacturersGetManufacturerQuerySchema,
-    void
+    void,
+    t_ManufacturersGetManufacturerHeaderSchema
   >,
   respond: ManufacturersGetManufacturerResponder,
   ctx: RouterContext,
@@ -630,7 +675,8 @@ export type ManufacturersDeleteManufacturer = (
   params: Params<
     t_ManufacturersDeleteManufacturerParamSchema,
     t_ManufacturersDeleteManufacturerQuerySchema,
-    void
+    void,
+    t_ManufacturersDeleteManufacturerHeaderSchema
   >,
   respond: ManufacturersDeleteManufacturerResponder,
   ctx: RouterContext,
@@ -655,7 +701,12 @@ export type ManufacturersListManufacturersResponder = {
 } & KoaRuntimeResponder
 
 export type ManufacturersListManufacturers = (
-  params: Params<void, t_ManufacturersListManufacturersQuerySchema, void>,
+  params: Params<
+    void,
+    t_ManufacturersListManufacturersQuerySchema,
+    void,
+    t_ManufacturersListManufacturersHeaderSchema
+  >,
   respond: ManufacturersListManufacturersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -695,6 +746,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const serviceStatusHeaderSchema = z.object({
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const serviceStatusResponseValidator = responseValidationFactory(
     [["200", z.object({ statusString: z.string() })]],
     s_Azure_Core_Foundations_ErrorResponse,
@@ -709,6 +764,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: parseRequestInput(
+        serviceStatusHeaderSchema,
+        Reflect.get(ctx.request, "headers"),
+        RequestInputType.RequestHeader,
+      ),
     }
 
     const responder = {
@@ -786,6 +846,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -845,6 +906,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetsCreateOrUpdateWidgetHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetsCreateOrUpdateWidgetBodySchema = s_WidgetCreateOrUpdate
 
   const widgetsCreateOrUpdateWidgetResponseValidator =
@@ -875,6 +949,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           widgetsCreateOrUpdateWidgetBodySchema,
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
+        ),
+        headers: parseRequestInput(
+          widgetsCreateOrUpdateWidgetHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
         ),
       }
 
@@ -916,6 +995,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetsGetWidgetHeaderSchema = z.object({
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetsGetWidgetResponseValidator = responseValidationFactory(
     [["200", s_Widget]],
     s_Azure_Core_Foundations_ErrorResponse,
@@ -934,6 +1021,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: parseRequestInput(
+        widgetsGetWidgetHeaderSchema,
+        Reflect.get(ctx.request, "headers"),
+        RequestInputType.RequestHeader,
+      ),
     }
 
     const responder = {
@@ -970,6 +1062,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetsDeleteWidgetHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetsDeleteWidgetResponseValidator = responseValidationFactory(
     [
       [
@@ -1000,6 +1105,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          widgetsDeleteWidgetHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -1048,6 +1158,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
   })
 
+  const widgetsListWidgetsHeaderSchema = z.object({
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetsListWidgetsResponseValidator = responseValidationFactory(
     [["200", s_PagedWidget]],
     s_Azure_Core_Foundations_ErrorResponse,
@@ -1062,6 +1176,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: parseRequestInput(
+        widgetsListWidgetsHeaderSchema,
+        Reflect.get(ctx.request, "headers"),
+        RequestInputType.RequestHeader,
+      ),
     }
 
     const responder = {
@@ -1098,6 +1217,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetsGetAnalyticsHeaderSchema = z.object({
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetsGetAnalyticsResponseValidator = responseValidationFactory(
     [["200", s_WidgetAnalytics]],
     s_Azure_Core_Foundations_ErrorResponse,
@@ -1119,6 +1246,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          widgetsGetAnalyticsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -1156,6 +1288,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetsUpdateAnalyticsHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetsUpdateAnalyticsBodySchema = s_WidgetAnalyticsCreateOrUpdate
 
   const widgetsUpdateAnalyticsResponseValidator = responseValidationFactory(
@@ -1185,6 +1330,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           widgetsUpdateAnalyticsBodySchema,
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
+        ),
+        headers: parseRequestInput(
+          widgetsUpdateAnalyticsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
         ),
       }
 
@@ -1260,6 +1410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1300,6 +1451,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const widgetsScheduleRepairsQuerySchema = z.object({
     "api-version": z.string().min(1),
+  })
+
+  const widgetsScheduleRepairsHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
   })
 
   const widgetsScheduleRepairsBodySchema = s_WidgetRepairRequest
@@ -1346,6 +1506,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           widgetsScheduleRepairsBodySchema,
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
+        ),
+        headers: parseRequestInput(
+          widgetsScheduleRepairsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
         ),
       }
 
@@ -1431,6 +1596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1478,6 +1644,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetPartsCreateWidgetPartHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetPartsCreateWidgetPartBodySchema = s_WidgetPart
 
   const widgetPartsCreateWidgetPartResponseValidator =
@@ -1505,6 +1684,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           widgetPartsCreateWidgetPartBodySchema,
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
+        ),
+        headers: parseRequestInput(
+          widgetPartsCreateWidgetPartHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
         ),
       }
 
@@ -1545,6 +1729,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetPartsListWidgetPartsHeaderSchema = z.object({
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetPartsListWidgetPartsResponseValidator = responseValidationFactory(
     [["200", s_PagedWidgetPart]],
     s_Azure_Core_Foundations_ErrorResponse,
@@ -1566,6 +1754,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          widgetPartsListWidgetPartsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -1606,6 +1799,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetPartsGetWidgetPartHeaderSchema = z.object({
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetPartsGetWidgetPartResponseValidator = responseValidationFactory(
     [["200", s_WidgetPart]],
     s_Azure_Core_Foundations_ErrorResponse,
@@ -1627,6 +1828,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          widgetPartsGetWidgetPartHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -1667,6 +1873,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetPartsDeleteWidgetPartHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetPartsDeleteWidgetPartResponseValidator =
     responseValidationFactory(
       [["204", z.undefined()]],
@@ -1689,6 +1908,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          widgetPartsDeleteWidgetPartHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -1728,6 +1952,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const widgetPartsReorderPartsHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const widgetPartsReorderPartsBodySchema = s_WidgetPartReorderRequest
 
   const widgetPartsReorderPartsResponseValidator = responseValidationFactory(
@@ -1763,6 +1996,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           widgetPartsReorderPartsBodySchema,
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
+        ),
+        headers: parseRequestInput(
+          widgetPartsReorderPartsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
         ),
       }
 
@@ -1840,6 +2078,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1887,6 +2126,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const manufacturersCreateManufacturerHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const manufacturersCreateManufacturerBodySchema = s_Manufacturer
 
   const manufacturersCreateManufacturerResponseValidator =
@@ -1917,6 +2169,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           manufacturersCreateManufacturerBodySchema,
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
+        ),
+        headers: parseRequestInput(
+          manufacturersCreateManufacturerHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
         ),
       }
 
@@ -1960,6 +2217,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const manufacturersGetManufacturerHeaderSchema = z.object({
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const manufacturersGetManufacturerResponseValidator =
     responseValidationFactory(
       [["200", s_Manufacturer]],
@@ -1982,6 +2247,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          manufacturersGetManufacturerHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -2021,6 +2291,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const manufacturersDeleteManufacturerHeaderSchema = z.object({
+    "repeatability-request-id": z.string().optional(),
+    "repeatability-first-sent": z
+      .string()
+      .datetime({ offset: true })
+      .optional(),
+    "if-match": z.string().optional(),
+    "if-none-match": z.string().optional(),
+    "if-unmodified-since": z.string().datetime({ offset: true }).optional(),
+    "if-modified-since": z.string().datetime({ offset: true }).optional(),
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const manufacturersDeleteManufacturerResponseValidator =
     responseValidationFactory(
       [
@@ -2052,6 +2335,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          manufacturersDeleteManufacturerHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -2091,6 +2379,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     "api-version": z.string().min(1),
   })
 
+  const manufacturersListManufacturersHeaderSchema = z.object({
+    "x-ms-client-request-id": s_Azure_Core_uuid.optional(),
+  })
+
   const manufacturersListManufacturersResponseValidator =
     responseValidationFactory(
       [["200", s_PagedManufacturer]],
@@ -2109,6 +2401,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: parseRequestInput(
+          manufacturersListManufacturersHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/models.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/models.ts
@@ -29,6 +29,8 @@ export type t_Azure_Core_Foundations_OperationState =
 
 export type t_Azure_Core_eTag = string
 
+export type t_Azure_Core_uuid = string
+
 export type t_Manufacturer = {
   address: string
   readonly etag: t_Azure_Core_eTag
@@ -101,6 +103,16 @@ export type t_ManufacturersCreateManufacturerBodySchema = {
   name: string
 }
 
+export type t_ManufacturersCreateManufacturerHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_ManufacturersCreateManufacturerParamSchema = {
   manufacturerId: string
 }
@@ -109,12 +121,30 @@ export type t_ManufacturersCreateManufacturerQuerySchema = {
   "api-version": string
 }
 
+export type t_ManufacturersDeleteManufacturerHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_ManufacturersDeleteManufacturerParamSchema = {
   manufacturerId: string
 }
 
 export type t_ManufacturersDeleteManufacturerQuerySchema = {
   "api-version": string
+}
+
+export type t_ManufacturersGetManufacturerHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_ManufacturersGetManufacturerParamSchema = {
@@ -134,8 +164,16 @@ export type t_ManufacturersGetManufacturerOperationStatusQuerySchema = {
   "api-version": string
 }
 
+export type t_ManufacturersListManufacturersHeaderSchema = {
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_ManufacturersListManufacturersQuerySchema = {
   "api-version": string
+}
+
+export type t_ServiceStatusHeaderSchema = {
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_ServiceStatusQuerySchema = {
@@ -149,12 +187,32 @@ export type t_WidgetPartsCreateWidgetPartBodySchema = {
   partId: string
 }
 
+export type t_WidgetPartsCreateWidgetPartHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_WidgetPartsCreateWidgetPartParamSchema = {
   widgetName: string
 }
 
 export type t_WidgetPartsCreateWidgetPartQuerySchema = {
   "api-version": string
+}
+
+export type t_WidgetPartsDeleteWidgetPartHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_WidgetPartsDeleteWidgetPartParamSchema = {
@@ -164,6 +222,14 @@ export type t_WidgetPartsDeleteWidgetPartParamSchema = {
 
 export type t_WidgetPartsDeleteWidgetPartQuerySchema = {
   "api-version": string
+}
+
+export type t_WidgetPartsGetWidgetPartHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_WidgetPartsGetWidgetPartParamSchema = {
@@ -185,6 +251,10 @@ export type t_WidgetPartsGetWidgetPartOperationStatusQuerySchema = {
   "api-version": string
 }
 
+export type t_WidgetPartsListWidgetPartsHeaderSchema = {
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_WidgetPartsListWidgetPartsParamSchema = {
   widgetName: string
 }
@@ -195,6 +265,12 @@ export type t_WidgetPartsListWidgetPartsQuerySchema = {
 
 export type t_WidgetPartsReorderPartsBodySchema = {
   signedOffBy: string
+}
+
+export type t_WidgetPartsReorderPartsHeaderSchema = {
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_WidgetPartsReorderPartsParamSchema = {
@@ -210,6 +286,16 @@ export type t_WidgetsCreateOrUpdateWidgetBodySchema = {
   manufacturerId?: string
 }
 
+export type t_WidgetsCreateOrUpdateWidgetHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_WidgetsCreateOrUpdateWidgetParamSchema = {
   widgetName: string
 }
@@ -218,12 +304,30 @@ export type t_WidgetsCreateOrUpdateWidgetQuerySchema = {
   "api-version": string
 }
 
+export type t_WidgetsDeleteWidgetHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_WidgetsDeleteWidgetParamSchema = {
   widgetName: string
 }
 
 export type t_WidgetsDeleteWidgetQuerySchema = {
   "api-version": string
+}
+
+export type t_WidgetsGetAnalyticsHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_WidgetsGetAnalyticsParamSchema = {
@@ -241,6 +345,14 @@ export type t_WidgetsGetRepairStatusParamSchema = {
 
 export type t_WidgetsGetRepairStatusQuerySchema = {
   "api-version": string
+}
+
+export type t_WidgetsGetWidgetHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_WidgetsGetWidgetParamSchema = {
@@ -262,6 +374,10 @@ export type t_WidgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStat
     "api-version": string
   }
 
+export type t_WidgetsListWidgetsHeaderSchema = {
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_WidgetsListWidgetsQuerySchema = {
   "api-version": string
   maxpagesize?: number
@@ -278,6 +394,12 @@ export type t_WidgetsScheduleRepairsBodySchema = {
   updatedDateTime: string
 }
 
+export type t_WidgetsScheduleRepairsHeaderSchema = {
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
+}
+
 export type t_WidgetsScheduleRepairsParamSchema = {
   widgetName: string
 }
@@ -289,6 +411,16 @@ export type t_WidgetsScheduleRepairsQuerySchema = {
 export type t_WidgetsUpdateAnalyticsBodySchema = {
   repairCount?: number
   useCount?: number
+}
+
+export type t_WidgetsUpdateAnalyticsHeaderSchema = {
+  "if-match"?: string
+  "if-modified-since"?: string
+  "if-none-match"?: string
+  "if-unmodified-since"?: string
+  "repeatability-first-sent"?: string
+  "repeatability-request-id"?: string
+  "x-ms-client-request-id"?: t_Azure_Core_uuid
 }
 
 export type t_WidgetsUpdateAnalyticsParamSchema = {

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/schemas.ts
@@ -16,6 +16,8 @@ export const s_Azure_Core_Foundations_OperationState = z.union([
 
 export const s_Azure_Core_eTag = z.string()
 
+export const s_Azure_Core_uuid = z.string()
+
 export const s_WidgetAnalytics = z.object({
   id: z.enum(["current"]),
   useCount: z.coerce.number(),

--- a/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/generated.ts
@@ -65,7 +65,7 @@ export type OperationsListResponder = {
 } & KoaRuntimeResponder
 
 export type OperationsList = (
-  params: Params<void, t_OperationsListQuerySchema, void>,
+  params: Params<void, t_OperationsListQuerySchema, void, void>,
   respond: OperationsListResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -82,7 +82,12 @@ export type EmployeesGetResponder = {
 } & KoaRuntimeResponder
 
 export type EmployeesGet = (
-  params: Params<t_EmployeesGetParamSchema, t_EmployeesGetQuerySchema, void>,
+  params: Params<
+    t_EmployeesGetParamSchema,
+    t_EmployeesGetQuerySchema,
+    void,
+    void
+  >,
   respond: EmployeesGetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -103,7 +108,8 @@ export type EmployeesCreateOrUpdate = (
   params: Params<
     t_EmployeesCreateOrUpdateParamSchema,
     t_EmployeesCreateOrUpdateQuerySchema,
-    t_EmployeesCreateOrUpdateBodySchema
+    t_EmployeesCreateOrUpdateBodySchema,
+    void
   >,
   respond: EmployeesCreateOrUpdateResponder,
   ctx: RouterContext,
@@ -125,7 +131,8 @@ export type EmployeesUpdate = (
   params: Params<
     t_EmployeesUpdateParamSchema,
     t_EmployeesUpdateQuerySchema,
-    t_EmployeesUpdateBodySchema
+    t_EmployeesUpdateBodySchema,
+    void
   >,
   respond: EmployeesUpdateResponder,
   ctx: RouterContext,
@@ -147,6 +154,7 @@ export type EmployeesDelete = (
   params: Params<
     t_EmployeesDeleteParamSchema,
     t_EmployeesDeleteQuerySchema,
+    void,
     void
   >,
   respond: EmployeesDeleteResponder,
@@ -169,6 +177,7 @@ export type EmployeesListByResourceGroup = (
   params: Params<
     t_EmployeesListByResourceGroupParamSchema,
     t_EmployeesListByResourceGroupQuerySchema,
+    void,
     void
   >,
   respond: EmployeesListByResourceGroupResponder,
@@ -190,6 +199,7 @@ export type EmployeesListBySubscription = (
   params: Params<
     t_EmployeesListBySubscriptionParamSchema,
     t_EmployeesListBySubscriptionQuerySchema,
+    void,
     void
   >,
   respond: EmployeesListBySubscriptionResponder,
@@ -211,7 +221,8 @@ export type EmployeesMove = (
   params: Params<
     t_EmployeesMoveParamSchema,
     t_EmployeesMoveQuerySchema,
-    t_EmployeesMoveBodySchema
+    t_EmployeesMoveBodySchema,
+    void
   >,
   respond: EmployeesMoveResponder,
   ctx: RouterContext,
@@ -256,6 +267,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -320,6 +332,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -395,6 +408,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -470,6 +484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -539,6 +554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -608,6 +624,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -669,6 +686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -741,6 +759,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -93,7 +93,12 @@ export type CreateAppAuthenticatorEnrollmentResponder = {
 } & KoaRuntimeResponder
 
 export type CreateAppAuthenticatorEnrollment = (
-  params: Params<void, void, t_CreateAppAuthenticatorEnrollmentBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_CreateAppAuthenticatorEnrollmentBodySchema,
+    void
+  >,
   respond: CreateAppAuthenticatorEnrollmentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -115,7 +120,8 @@ export type VerifyAppAuthenticatorPushNotificationChallenge = (
   params: Params<
     t_VerifyAppAuthenticatorPushNotificationChallengeParamSchema,
     void,
-    t_VerifyAppAuthenticatorPushNotificationChallengeBodySchema
+    t_VerifyAppAuthenticatorPushNotificationChallengeBodySchema,
+    void
   >,
   respond: VerifyAppAuthenticatorPushNotificationChallengeResponder,
   ctx: RouterContext,
@@ -137,7 +143,8 @@ export type UpdateAppAuthenticatorEnrollment = (
   params: Params<
     t_UpdateAppAuthenticatorEnrollmentParamSchema,
     void,
-    t_UpdateAppAuthenticatorEnrollmentBodySchema
+    t_UpdateAppAuthenticatorEnrollmentBodySchema,
+    void
   >,
   respond: UpdateAppAuthenticatorEnrollmentResponder,
   ctx: RouterContext,
@@ -157,7 +164,12 @@ export type DeleteAppAuthenticatorEnrollmentResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteAppAuthenticatorEnrollment = (
-  params: Params<t_DeleteAppAuthenticatorEnrollmentParamSchema, void, void>,
+  params: Params<
+    t_DeleteAppAuthenticatorEnrollmentParamSchema,
+    void,
+    void,
+    void
+  >,
   respond: DeleteAppAuthenticatorEnrollmentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -177,6 +189,7 @@ export type ListAppAuthenticatorPendingPushNotificationChallenges = (
   params: Params<
     t_ListAppAuthenticatorPendingPushNotificationChallengesParamSchema,
     void,
+    void,
     void
   >,
   respond: ListAppAuthenticatorPendingPushNotificationChallengesResponder,
@@ -194,7 +207,7 @@ export type ListAuthenticatorsResponder = {
 } & KoaRuntimeResponder
 
 export type ListAuthenticators = (
-  params: Params<void, t_ListAuthenticatorsQuerySchema, void>,
+  params: Params<void, t_ListAuthenticatorsQuerySchema, void, void>,
   respond: ListAuthenticatorsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -215,6 +228,7 @@ export type GetAuthenticator = (
   params: Params<
     t_GetAuthenticatorParamSchema,
     t_GetAuthenticatorQuerySchema,
+    void,
     void
   >,
   respond: GetAuthenticatorResponder,
@@ -235,7 +249,7 @@ export type ListEnrollmentsResponder = {
 } & KoaRuntimeResponder
 
 export type ListEnrollments = (
-  params: Params<t_ListEnrollmentsParamSchema, void, void>,
+  params: Params<t_ListEnrollmentsParamSchema, void, void, void>,
   respond: ListEnrollmentsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -254,7 +268,7 @@ export type GetEnrollmentResponder = {
 } & KoaRuntimeResponder
 
 export type GetEnrollment = (
-  params: Params<t_GetEnrollmentParamSchema, void, void>,
+  params: Params<t_GetEnrollmentParamSchema, void, void, void>,
   respond: GetEnrollmentResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -271,7 +285,7 @@ export type ListEmailsResponder = {
 } & KoaRuntimeResponder
 
 export type ListEmails = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: ListEmailsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -289,7 +303,7 @@ export type CreateEmailResponder = {
 } & KoaRuntimeResponder
 
 export type CreateEmail = (
-  params: Params<void, void, t_CreateEmailBodySchema>,
+  params: Params<void, void, t_CreateEmailBodySchema, void>,
   respond: CreateEmailResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -307,7 +321,7 @@ export type GetEmailResponder = {
 } & KoaRuntimeResponder
 
 export type GetEmail = (
-  params: Params<t_GetEmailParamSchema, void, void>,
+  params: Params<t_GetEmailParamSchema, void, void, void>,
   respond: GetEmailResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -322,7 +336,7 @@ export type DeleteEmailResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteEmail = (
-  params: Params<t_DeleteEmailParamSchema, void, void>,
+  params: Params<t_DeleteEmailParamSchema, void, void, void>,
   respond: DeleteEmailResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -365,7 +379,8 @@ export type SendEmailChallenge = (
   params: Params<
     t_SendEmailChallengeParamSchema,
     void,
-    t_SendEmailChallengeBodySchema
+    t_SendEmailChallengeBodySchema,
+    void
   >,
   respond: SendEmailChallengeResponder,
   ctx: RouterContext,
@@ -429,7 +444,7 @@ export type PollChallengeForEmailMagicLinkResponder = {
 } & KoaRuntimeResponder
 
 export type PollChallengeForEmailMagicLink = (
-  params: Params<t_PollChallengeForEmailMagicLinkParamSchema, void, void>,
+  params: Params<t_PollChallengeForEmailMagicLinkParamSchema, void, void, void>,
   respond: PollChallengeForEmailMagicLinkResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -471,7 +486,12 @@ export type VerifyEmailOtpResponder = {
 } & KoaRuntimeResponder
 
 export type VerifyEmailOtp = (
-  params: Params<t_VerifyEmailOtpParamSchema, void, t_VerifyEmailOtpBodySchema>,
+  params: Params<
+    t_VerifyEmailOtpParamSchema,
+    void,
+    t_VerifyEmailOtpBodySchema,
+    void
+  >,
   respond: VerifyEmailOtpResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -488,7 +508,7 @@ export type ListOktaApplicationsResponder = {
 } & KoaRuntimeResponder
 
 export type ListOktaApplications = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: ListOktaApplicationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -503,7 +523,7 @@ export type GetOrganizationResponder = {
 } & KoaRuntimeResponder
 
 export type GetOrganization = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: GetOrganizationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -518,7 +538,7 @@ export type GetPasswordResponder = {
 } & KoaRuntimeResponder
 
 export type GetPassword = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: GetPasswordResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -535,7 +555,7 @@ export type CreatePasswordResponder = {
 } & KoaRuntimeResponder
 
 export type CreatePassword = (
-  params: Params<void, void, t_CreatePasswordBodySchema>,
+  params: Params<void, void, t_CreatePasswordBodySchema, void>,
   respond: CreatePasswordResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -554,7 +574,7 @@ export type ReplacePasswordResponder = {
 } & KoaRuntimeResponder
 
 export type ReplacePassword = (
-  params: Params<void, void, t_ReplacePasswordBodySchema>,
+  params: Params<void, void, t_ReplacePasswordBodySchema, void>,
   respond: ReplacePasswordResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -572,7 +592,7 @@ export type DeletePasswordResponder = {
 } & KoaRuntimeResponder
 
 export type DeletePassword = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: DeletePasswordResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -588,7 +608,7 @@ export type ListPhonesResponder = {
 } & KoaRuntimeResponder
 
 export type ListPhones = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: ListPhonesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -607,7 +627,7 @@ export type CreatePhoneResponder = {
 } & KoaRuntimeResponder
 
 export type CreatePhone = (
-  params: Params<void, void, t_CreatePhoneBodySchema>,
+  params: Params<void, void, t_CreatePhoneBodySchema, void>,
   respond: CreatePhoneResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -627,7 +647,7 @@ export type GetPhoneResponder = {
 } & KoaRuntimeResponder
 
 export type GetPhone = (
-  params: Params<t_GetPhoneParamSchema, void, void>,
+  params: Params<t_GetPhoneParamSchema, void, void, void>,
   respond: GetPhoneResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -645,7 +665,7 @@ export type DeletePhoneResponder = {
 } & KoaRuntimeResponder
 
 export type DeletePhone = (
-  params: Params<t_DeletePhoneParamSchema, void, void>,
+  params: Params<t_DeletePhoneParamSchema, void, void, void>,
   respond: DeletePhoneResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -678,7 +698,8 @@ export type SendPhoneChallenge = (
   params: Params<
     t_SendPhoneChallengeParamSchema,
     void,
-    t_SendPhoneChallengeBodySchema
+    t_SendPhoneChallengeBodySchema,
+    void
   >,
   respond: SendPhoneChallengeResponder,
   ctx: RouterContext,
@@ -717,7 +738,8 @@ export type VerifyPhoneChallenge = (
   params: Params<
     t_VerifyPhoneChallengeParamSchema,
     void,
-    t_VerifyPhoneChallengeBodySchema
+    t_VerifyPhoneChallengeBodySchema,
+    void
   >,
   respond: VerifyPhoneChallengeResponder,
   ctx: RouterContext,
@@ -737,7 +759,7 @@ export type GetProfileResponder = {
 } & KoaRuntimeResponder
 
 export type GetProfile = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: GetProfileResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -753,7 +775,7 @@ export type ReplaceProfileResponder = {
 } & KoaRuntimeResponder
 
 export type ReplaceProfile = (
-  params: Params<void, void, t_ReplaceProfileBodySchema>,
+  params: Params<void, void, t_ReplaceProfileBodySchema, void>,
   respond: ReplaceProfileResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -769,7 +791,7 @@ export type GetProfileSchemaResponder = {
 } & KoaRuntimeResponder
 
 export type GetProfileSchema = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: GetProfileSchemaResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -783,7 +805,7 @@ export type DeleteSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteSessions = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: DeleteSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -858,6 +880,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -929,6 +952,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -999,6 +1023,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1061,6 +1086,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1120,6 +1146,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1182,6 +1209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1246,6 +1274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1305,6 +1334,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1367,6 +1397,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1415,6 +1446,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1470,6 +1502,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1526,6 +1559,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1578,6 +1612,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1661,6 +1696,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1766,6 +1802,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1852,6 +1889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1903,6 +1941,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1948,6 +1987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1990,6 +2030,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -2044,6 +2085,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2105,6 +2147,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2157,6 +2200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2202,6 +2246,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -2257,6 +2302,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -2317,6 +2363,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -2372,6 +2419,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2456,6 +2504,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2540,6 +2589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2594,6 +2644,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -2644,6 +2695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -2691,6 +2743,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2737,6 +2790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         params: undefined,
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
@@ -54,7 +54,9 @@ import {
   t_ParBodySchema,
   t_ParCustomAsBodySchema,
   t_ParCustomAsParamSchema,
+  t_ParOptionsCustomAsHeaderSchema,
   t_ParOptionsCustomAsParamSchema,
+  t_ParOptionsHeaderSchema,
   t_ParResponse,
   t_ReplaceClientBodySchema,
   t_ReplaceClientParamSchema,
@@ -64,7 +66,9 @@ import {
   t_TokenBodySchema,
   t_TokenCustomAsBodySchema,
   t_TokenCustomAsParamSchema,
+  t_TokenOptionsCustomAsHeaderSchema,
   t_TokenOptionsCustomAsParamSchema,
+  t_TokenOptionsHeaderSchema,
   t_TokenResponse,
   t_UserInfo,
   t_UserinfoCustomAsParamSchema,
@@ -127,7 +131,12 @@ export type GetWellKnownOpenIdConfigurationResponder = {
 } & KoaRuntimeResponder
 
 export type GetWellKnownOpenIdConfiguration = (
-  params: Params<void, t_GetWellKnownOpenIdConfigurationQuerySchema, void>,
+  params: Params<
+    void,
+    t_GetWellKnownOpenIdConfigurationQuerySchema,
+    void,
+    void
+  >,
   respond: GetWellKnownOpenIdConfigurationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -141,7 +150,7 @@ export type AuthorizeResponder = {
 } & KoaRuntimeResponder
 
 export type Authorize = (
-  params: Params<void, t_AuthorizeQuerySchema, void>,
+  params: Params<void, t_AuthorizeQuerySchema, void, void>,
   respond: AuthorizeResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<429, t_Error>>
@@ -154,7 +163,7 @@ export type BcAuthorizeResponder = {
 } & KoaRuntimeResponder
 
 export type BcAuthorize = (
-  params: Params<void, void, t_BcAuthorizeBodySchema>,
+  params: Params<void, void, t_BcAuthorizeBodySchema, void>,
   respond: BcAuthorizeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -174,7 +183,7 @@ export type ChallengeResponder = {
 } & KoaRuntimeResponder
 
 export type Challenge = (
-  params: Params<void, void, t_ChallengeBodySchema>,
+  params: Params<void, void, t_ChallengeBodySchema, void>,
   respond: ChallengeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -193,7 +202,7 @@ export type ListClientsResponder = {
 } & KoaRuntimeResponder
 
 export type ListClients = (
-  params: Params<void, t_ListClientsQuerySchema, void>,
+  params: Params<void, t_ListClientsQuerySchema, void, void>,
   respond: ListClientsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -211,7 +220,7 @@ export type CreateClientResponder = {
 } & KoaRuntimeResponder
 
 export type CreateClient = (
-  params: Params<void, void, t_CreateClientBodySchema>,
+  params: Params<void, void, t_CreateClientBodySchema, void>,
   respond: CreateClientResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -230,7 +239,7 @@ export type GetClientResponder = {
 } & KoaRuntimeResponder
 
 export type GetClient = (
-  params: Params<t_GetClientParamSchema, void, void>,
+  params: Params<t_GetClientParamSchema, void, void, void>,
   respond: GetClientResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -250,7 +259,12 @@ export type ReplaceClientResponder = {
 } & KoaRuntimeResponder
 
 export type ReplaceClient = (
-  params: Params<t_ReplaceClientParamSchema, void, t_ReplaceClientBodySchema>,
+  params: Params<
+    t_ReplaceClientParamSchema,
+    void,
+    t_ReplaceClientBodySchema,
+    void
+  >,
   respond: ReplaceClientResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -270,7 +284,7 @@ export type DeleteClientResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteClient = (
-  params: Params<t_DeleteClientParamSchema, void, void>,
+  params: Params<t_DeleteClientParamSchema, void, void, void>,
   respond: DeleteClientResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -289,7 +303,7 @@ export type GenerateNewClientSecretResponder = {
 } & KoaRuntimeResponder
 
 export type GenerateNewClientSecret = (
-  params: Params<t_GenerateNewClientSecretParamSchema, void, void>,
+  params: Params<t_GenerateNewClientSecretParamSchema, void, void, void>,
   respond: GenerateNewClientSecretResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -308,7 +322,7 @@ export type DeviceAuthorizeResponder = {
 } & KoaRuntimeResponder
 
 export type DeviceAuthorize = (
-  params: Params<void, void, t_DeviceAuthorizeBodySchema>,
+  params: Params<void, void, t_DeviceAuthorizeBodySchema, void>,
   respond: DeviceAuthorizeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -327,7 +341,7 @@ export type GlobalTokenRevocationResponder = {
 } & KoaRuntimeResponder
 
 export type GlobalTokenRevocation = (
-  params: Params<void, void, t_GlobalTokenRevocationBodySchema>,
+  params: Params<void, void, t_GlobalTokenRevocationBodySchema, void>,
   respond: GlobalTokenRevocationResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -346,7 +360,7 @@ export type IntrospectResponder = {
 } & KoaRuntimeResponder
 
 export type Introspect = (
-  params: Params<void, void, t_IntrospectBodySchema>,
+  params: Params<void, void, t_IntrospectBodySchema, void>,
   respond: IntrospectResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -363,7 +377,7 @@ export type OauthKeysResponder = {
 } & KoaRuntimeResponder
 
 export type OauthKeys = (
-  params: Params<void, t_OauthKeysQuerySchema, void>,
+  params: Params<void, t_OauthKeysQuerySchema, void, void>,
   respond: OauthKeysResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -378,7 +392,7 @@ export type LogoutResponder = {
 } & KoaRuntimeResponder
 
 export type Logout = (
-  params: Params<void, t_LogoutQuerySchema, void>,
+  params: Params<void, t_LogoutQuerySchema, void, void>,
   respond: LogoutResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -391,7 +405,7 @@ export type LogoutWithPostResponder = {
 } & KoaRuntimeResponder
 
 export type LogoutWithPost = (
-  params: Params<void, void, t_LogoutWithPostBodySchema>,
+  params: Params<void, void, t_LogoutWithPostBodySchema, void>,
   respond: LogoutWithPostResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -407,7 +421,7 @@ export type OobAuthenticateResponder = {
 } & KoaRuntimeResponder
 
 export type OobAuthenticate = (
-  params: Params<void, void, t_OobAuthenticateBodySchema>,
+  params: Params<void, void, t_OobAuthenticateBodySchema, void>,
   respond: OobAuthenticateResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -425,7 +439,7 @@ export type ParOptionsResponder = {
 } & KoaRuntimeResponder
 
 export type ParOptions = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, t_ParOptionsHeaderSchema>,
   respond: ParOptionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -441,7 +455,7 @@ export type ParResponder = {
 } & KoaRuntimeResponder
 
 export type Par = (
-  params: Params<void, void, t_ParBodySchema>,
+  params: Params<void, void, t_ParBodySchema, void>,
   respond: ParResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -461,7 +475,7 @@ export type RevokeResponder = {
 } & KoaRuntimeResponder
 
 export type Revoke = (
-  params: Params<void, void, t_RevokeBodySchema>,
+  params: Params<void, void, t_RevokeBodySchema, void>,
   respond: RevokeResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -478,7 +492,7 @@ export type TokenOptionsResponder = {
 } & KoaRuntimeResponder
 
 export type TokenOptions = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, t_TokenOptionsHeaderSchema>,
   respond: TokenOptionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -493,7 +507,7 @@ export type TokenResponder = {
 } & KoaRuntimeResponder
 
 export type Token = (
-  params: Params<void, void, t_TokenBodySchema>,
+  params: Params<void, void, t_TokenBodySchema, void>,
   respond: TokenResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -512,7 +526,7 @@ export type UserinfoResponder = {
 } & KoaRuntimeResponder
 
 export type Userinfo = (
-  params: Params<void, void, void>,
+  params: Params<void, void, void, void>,
   respond: UserinfoResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -533,6 +547,7 @@ export type GetWellKnownOAuthConfigurationCustomAs = (
   params: Params<
     t_GetWellKnownOAuthConfigurationCustomAsParamSchema,
     t_GetWellKnownOAuthConfigurationCustomAsQuerySchema,
+    void,
     void
   >,
   respond: GetWellKnownOAuthConfigurationCustomAsResponder,
@@ -554,6 +569,7 @@ export type GetWellKnownOpenIdConfigurationCustomAs = (
   params: Params<
     t_GetWellKnownOpenIdConfigurationCustomAsParamSchema,
     t_GetWellKnownOpenIdConfigurationCustomAsQuerySchema,
+    void,
     void
   >,
   respond: GetWellKnownOpenIdConfigurationCustomAsResponder,
@@ -573,6 +589,7 @@ export type AuthorizeCustomAs = (
   params: Params<
     t_AuthorizeCustomAsParamSchema,
     t_AuthorizeCustomAsQuerySchema,
+    void,
     void
   >,
   respond: AuthorizeCustomAsResponder,
@@ -590,7 +607,8 @@ export type BcAuthorizeCustomAs = (
   params: Params<
     t_BcAuthorizeCustomAsParamSchema,
     void,
-    t_BcAuthorizeCustomAsBodySchema
+    t_BcAuthorizeCustomAsBodySchema,
+    void
   >,
   respond: BcAuthorizeCustomAsResponder,
   ctx: RouterContext,
@@ -614,7 +632,8 @@ export type ChallengeCustomAs = (
   params: Params<
     t_ChallengeCustomAsParamSchema,
     void,
-    t_ChallengeCustomAsBodySchema
+    t_ChallengeCustomAsBodySchema,
+    void
   >,
   respond: ChallengeCustomAsResponder,
   ctx: RouterContext,
@@ -638,7 +657,8 @@ export type DeviceAuthorizeCustomAs = (
   params: Params<
     t_DeviceAuthorizeCustomAsParamSchema,
     void,
-    t_DeviceAuthorizeCustomAsBodySchema
+    t_DeviceAuthorizeCustomAsBodySchema,
+    void
   >,
   respond: DeviceAuthorizeCustomAsResponder,
   ctx: RouterContext,
@@ -661,7 +681,8 @@ export type IntrospectCustomAs = (
   params: Params<
     t_IntrospectCustomAsParamSchema,
     void,
-    t_IntrospectCustomAsBodySchema
+    t_IntrospectCustomAsBodySchema,
+    void
   >,
   respond: IntrospectCustomAsResponder,
   ctx: RouterContext,
@@ -679,7 +700,7 @@ export type OauthKeysCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type OauthKeysCustomAs = (
-  params: Params<t_OauthKeysCustomAsParamSchema, void, void>,
+  params: Params<t_OauthKeysCustomAsParamSchema, void, void, void>,
   respond: OauthKeysCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -697,6 +718,7 @@ export type LogoutCustomAs = (
   params: Params<
     t_LogoutCustomAsParamSchema,
     t_LogoutCustomAsQuerySchema,
+    void,
     void
   >,
   respond: LogoutCustomAsResponder,
@@ -714,7 +736,8 @@ export type LogoutCustomAsWithPost = (
   params: Params<
     t_LogoutCustomAsWithPostParamSchema,
     void,
-    t_LogoutCustomAsWithPostBodySchema
+    t_LogoutCustomAsWithPostBodySchema,
+    void
   >,
   respond: LogoutCustomAsWithPostResponder,
   ctx: RouterContext,
@@ -734,7 +757,8 @@ export type OobAuthenticateCustomAs = (
   params: Params<
     t_OobAuthenticateCustomAsParamSchema,
     void,
-    t_OobAuthenticateCustomAsBodySchema
+    t_OobAuthenticateCustomAsBodySchema,
+    void
   >,
   respond: OobAuthenticateCustomAsResponder,
   ctx: RouterContext,
@@ -753,7 +777,12 @@ export type ParOptionsCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type ParOptionsCustomAs = (
-  params: Params<t_ParOptionsCustomAsParamSchema, void, void>,
+  params: Params<
+    t_ParOptionsCustomAsParamSchema,
+    void,
+    void,
+    t_ParOptionsCustomAsHeaderSchema
+  >,
   respond: ParOptionsCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -769,7 +798,7 @@ export type ParCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type ParCustomAs = (
-  params: Params<t_ParCustomAsParamSchema, void, t_ParCustomAsBodySchema>,
+  params: Params<t_ParCustomAsParamSchema, void, t_ParCustomAsBodySchema, void>,
   respond: ParCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -789,7 +818,12 @@ export type RevokeCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type RevokeCustomAs = (
-  params: Params<t_RevokeCustomAsParamSchema, void, t_RevokeCustomAsBodySchema>,
+  params: Params<
+    t_RevokeCustomAsParamSchema,
+    void,
+    t_RevokeCustomAsBodySchema,
+    void
+  >,
   respond: RevokeCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -806,7 +840,12 @@ export type TokenOptionsCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type TokenOptionsCustomAs = (
-  params: Params<t_TokenOptionsCustomAsParamSchema, void, void>,
+  params: Params<
+    t_TokenOptionsCustomAsParamSchema,
+    void,
+    void,
+    t_TokenOptionsCustomAsHeaderSchema
+  >,
   respond: TokenOptionsCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -821,7 +860,12 @@ export type TokenCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type TokenCustomAs = (
-  params: Params<t_TokenCustomAsParamSchema, void, t_TokenCustomAsBodySchema>,
+  params: Params<
+    t_TokenCustomAsParamSchema,
+    void,
+    t_TokenCustomAsBodySchema,
+    void
+  >,
   respond: TokenCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -840,7 +884,7 @@ export type UserinfoCustomAsResponder = {
 } & KoaRuntimeResponder
 
 export type UserinfoCustomAs = (
-  params: Params<t_UserinfoCustomAsParamSchema, void, void>,
+  params: Params<t_UserinfoCustomAsParamSchema, void, void, void>,
   respond: UserinfoCustomAsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -922,6 +966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -988,6 +1033,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1034,6 +1080,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1090,6 +1137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1151,6 +1199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1203,6 +1252,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1258,6 +1308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1323,6 +1374,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1385,6 +1437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1444,6 +1497,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -1503,6 +1557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1562,6 +1617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1618,6 +1674,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1671,6 +1728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1722,6 +1780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -1769,6 +1828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1822,6 +1882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -1860,6 +1921,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
+  const parOptionsHeaderSchema = z.object({ origin: z.string().optional() })
+
   const parOptionsResponseValidator = responseValidationFactory(
     [
       ["204", z.undefined()],
@@ -1873,6 +1936,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: parseRequestInput(
+        parOptionsHeaderSchema,
+        Reflect.get(ctx.request, "headers"),
+        RequestInputType.RequestHeader,
+      ),
     }
 
     const responder = {
@@ -1923,6 +1991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -1981,6 +2050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -2015,6 +2085,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
+  const tokenOptionsHeaderSchema = z.object({ origin: z.string().optional() })
+
   const tokenOptionsResponseValidator = responseValidationFactory(
     [
       ["204", z.undefined()],
@@ -2028,6 +2100,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: parseRequestInput(
+        tokenOptionsHeaderSchema,
+        Reflect.get(ctx.request, "headers"),
+        RequestInputType.RequestHeader,
+      ),
     }
 
     const responder = {
@@ -2077,6 +2154,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -2126,6 +2204,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       params: undefined,
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -2194,6 +2273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2263,6 +2343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2346,6 +2427,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2404,6 +2486,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2472,6 +2555,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2542,6 +2626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2609,6 +2694,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2668,6 +2754,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2731,6 +2818,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           RequestInputType.QueryString,
         ),
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {
@@ -2790,6 +2878,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2852,6 +2941,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -2894,6 +2984,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     authorizationServerId: z.string(),
   })
 
+  const parOptionsCustomAsHeaderSchema = z.object({
+    origin: z.string().optional(),
+  })
+
   const parOptionsCustomAsResponseValidator = responseValidationFactory(
     [
       ["204", z.undefined()],
@@ -2914,6 +3008,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: parseRequestInput(
+          parOptionsCustomAsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -2974,6 +3073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -3044,6 +3144,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -3083,6 +3184,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     authorizationServerId: z.string(),
   })
 
+  const tokenOptionsCustomAsHeaderSchema = z.object({
+    origin: z.string().optional(),
+  })
+
   const tokenOptionsCustomAsResponseValidator = responseValidationFactory(
     [
       ["204", z.undefined()],
@@ -3103,6 +3208,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: parseRequestInput(
+          tokenOptionsCustomAsHeaderSchema,
+          Reflect.get(ctx.request, "headers"),
+          RequestInputType.RequestHeader,
+        ),
       }
 
       const responder = {
@@ -3164,6 +3274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -3225,6 +3336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ),
         query: undefined,
         body: undefined,
+        headers: undefined,
       }
 
       const responder = {

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/models.ts
@@ -588,6 +588,14 @@ export type t_ParCustomAsParamSchema = {
   authorizationServerId: string
 }
 
+export type t_ParOptionsHeaderSchema = {
+  origin?: string
+}
+
+export type t_ParOptionsCustomAsHeaderSchema = {
+  origin?: string
+}
+
 export type t_ParOptionsCustomAsParamSchema = {
   authorizationServerId: string
 }
@@ -645,6 +653,14 @@ export type t_TokenCustomAsBodySchema = {
 
 export type t_TokenCustomAsParamSchema = {
   authorizationServerId: string
+}
+
+export type t_TokenOptionsHeaderSchema = {
+  origin?: string
+}
+
+export type t_TokenOptionsCustomAsHeaderSchema = {
+  origin?: string
 }
 
 export type t_TokenOptionsCustomAsParamSchema = {

--- a/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
@@ -37,7 +37,7 @@ export type FindPetsResponder = {
 } & KoaRuntimeResponder
 
 export type FindPets = (
-  params: Params<void, t_FindPetsQuerySchema, void>,
+  params: Params<void, t_FindPetsQuerySchema, void, void>,
   respond: FindPetsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -52,7 +52,7 @@ export type AddPetResponder = {
 } & KoaRuntimeResponder
 
 export type AddPet = (
-  params: Params<void, void, t_AddPetBodySchema>,
+  params: Params<void, void, t_AddPetBodySchema, void>,
   respond: AddPetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -67,7 +67,7 @@ export type FindPetByIdResponder = {
 } & KoaRuntimeResponder
 
 export type FindPetById = (
-  params: Params<t_FindPetByIdParamSchema, void, void>,
+  params: Params<t_FindPetByIdParamSchema, void, void, void>,
   respond: FindPetByIdResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -82,7 +82,7 @@ export type DeletePetResponder = {
 } & KoaRuntimeResponder
 
 export type DeletePet = (
-  params: Params<t_DeletePetParamSchema, void, void>,
+  params: Params<t_DeletePetParamSchema, void, void, void>,
   respond: DeletePetResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -125,6 +125,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -169,6 +170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -213,6 +215,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -257,6 +260,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -1509,7 +1509,8 @@ export type GetAccount = (
   params: Params<
     void,
     t_GetAccountQuerySchema,
-    t_GetAccountBodySchema | undefined
+    t_GetAccountBodySchema | undefined,
+    void
   >,
   respond: GetAccountResponder,
   ctx: RouterContext,
@@ -1525,7 +1526,7 @@ export type PostAccountLinksResponder = {
 } & KoaRuntimeResponder
 
 export type PostAccountLinks = (
-  params: Params<void, void, t_PostAccountLinksBodySchema>,
+  params: Params<void, void, t_PostAccountLinksBodySchema, void>,
   respond: PostAccountLinksResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -1540,7 +1541,7 @@ export type PostAccountSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostAccountSessions = (
-  params: Params<void, void, t_PostAccountSessionsBodySchema>,
+  params: Params<void, void, t_PostAccountSessionsBodySchema, void>,
   respond: PostAccountSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -1563,7 +1564,8 @@ export type GetAccounts = (
   params: Params<
     void,
     t_GetAccountsQuerySchema,
-    t_GetAccountsBodySchema | undefined
+    t_GetAccountsBodySchema | undefined,
+    void
   >,
   respond: GetAccountsResponder,
   ctx: RouterContext,
@@ -1587,7 +1589,7 @@ export type PostAccountsResponder = {
 } & KoaRuntimeResponder
 
 export type PostAccounts = (
-  params: Params<void, void, t_PostAccountsBodySchema | undefined>,
+  params: Params<void, void, t_PostAccountsBodySchema | undefined, void>,
   respond: PostAccountsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -1605,7 +1607,8 @@ export type DeleteAccountsAccount = (
   params: Params<
     t_DeleteAccountsAccountParamSchema,
     void,
-    t_DeleteAccountsAccountBodySchema | undefined
+    t_DeleteAccountsAccountBodySchema | undefined,
+    void
   >,
   respond: DeleteAccountsAccountResponder,
   ctx: RouterContext,
@@ -1624,7 +1627,8 @@ export type GetAccountsAccount = (
   params: Params<
     t_GetAccountsAccountParamSchema,
     t_GetAccountsAccountQuerySchema,
-    t_GetAccountsAccountBodySchema | undefined
+    t_GetAccountsAccountBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountResponder,
   ctx: RouterContext,
@@ -1643,7 +1647,8 @@ export type PostAccountsAccount = (
   params: Params<
     t_PostAccountsAccountParamSchema,
     void,
-    t_PostAccountsAccountBodySchema | undefined
+    t_PostAccountsAccountBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountResponder,
   ctx: RouterContext,
@@ -1662,7 +1667,8 @@ export type PostAccountsAccountBankAccounts = (
   params: Params<
     t_PostAccountsAccountBankAccountsParamSchema,
     void,
-    t_PostAccountsAccountBankAccountsBodySchema | undefined
+    t_PostAccountsAccountBankAccountsBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountBankAccountsResponder,
   ctx: RouterContext,
@@ -1681,7 +1687,8 @@ export type DeleteAccountsAccountBankAccountsId = (
   params: Params<
     t_DeleteAccountsAccountBankAccountsIdParamSchema,
     void,
-    t_DeleteAccountsAccountBankAccountsIdBodySchema | undefined
+    t_DeleteAccountsAccountBankAccountsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteAccountsAccountBankAccountsIdResponder,
   ctx: RouterContext,
@@ -1700,7 +1707,8 @@ export type GetAccountsAccountBankAccountsId = (
   params: Params<
     t_GetAccountsAccountBankAccountsIdParamSchema,
     t_GetAccountsAccountBankAccountsIdQuerySchema,
-    t_GetAccountsAccountBankAccountsIdBodySchema | undefined
+    t_GetAccountsAccountBankAccountsIdBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountBankAccountsIdResponder,
   ctx: RouterContext,
@@ -1719,7 +1727,8 @@ export type PostAccountsAccountBankAccountsId = (
   params: Params<
     t_PostAccountsAccountBankAccountsIdParamSchema,
     void,
-    t_PostAccountsAccountBankAccountsIdBodySchema | undefined
+    t_PostAccountsAccountBankAccountsIdBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountBankAccountsIdResponder,
   ctx: RouterContext,
@@ -1743,7 +1752,8 @@ export type GetAccountsAccountCapabilities = (
   params: Params<
     t_GetAccountsAccountCapabilitiesParamSchema,
     t_GetAccountsAccountCapabilitiesQuerySchema,
-    t_GetAccountsAccountCapabilitiesBodySchema | undefined
+    t_GetAccountsAccountCapabilitiesBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountCapabilitiesResponder,
   ctx: RouterContext,
@@ -1770,7 +1780,8 @@ export type GetAccountsAccountCapabilitiesCapability = (
   params: Params<
     t_GetAccountsAccountCapabilitiesCapabilityParamSchema,
     t_GetAccountsAccountCapabilitiesCapabilityQuerySchema,
-    t_GetAccountsAccountCapabilitiesCapabilityBodySchema | undefined
+    t_GetAccountsAccountCapabilitiesCapabilityBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountCapabilitiesCapabilityResponder,
   ctx: RouterContext,
@@ -1789,7 +1800,8 @@ export type PostAccountsAccountCapabilitiesCapability = (
   params: Params<
     t_PostAccountsAccountCapabilitiesCapabilityParamSchema,
     void,
-    t_PostAccountsAccountCapabilitiesCapabilityBodySchema | undefined
+    t_PostAccountsAccountCapabilitiesCapabilityBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountCapabilitiesCapabilityResponder,
   ctx: RouterContext,
@@ -1813,7 +1825,8 @@ export type GetAccountsAccountExternalAccounts = (
   params: Params<
     t_GetAccountsAccountExternalAccountsParamSchema,
     t_GetAccountsAccountExternalAccountsQuerySchema,
-    t_GetAccountsAccountExternalAccountsBodySchema | undefined
+    t_GetAccountsAccountExternalAccountsBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountExternalAccountsResponder,
   ctx: RouterContext,
@@ -1840,7 +1853,8 @@ export type PostAccountsAccountExternalAccounts = (
   params: Params<
     t_PostAccountsAccountExternalAccountsParamSchema,
     void,
-    t_PostAccountsAccountExternalAccountsBodySchema | undefined
+    t_PostAccountsAccountExternalAccountsBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountExternalAccountsResponder,
   ctx: RouterContext,
@@ -1859,7 +1873,8 @@ export type DeleteAccountsAccountExternalAccountsId = (
   params: Params<
     t_DeleteAccountsAccountExternalAccountsIdParamSchema,
     void,
-    t_DeleteAccountsAccountExternalAccountsIdBodySchema | undefined
+    t_DeleteAccountsAccountExternalAccountsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteAccountsAccountExternalAccountsIdResponder,
   ctx: RouterContext,
@@ -1878,7 +1893,8 @@ export type GetAccountsAccountExternalAccountsId = (
   params: Params<
     t_GetAccountsAccountExternalAccountsIdParamSchema,
     t_GetAccountsAccountExternalAccountsIdQuerySchema,
-    t_GetAccountsAccountExternalAccountsIdBodySchema | undefined
+    t_GetAccountsAccountExternalAccountsIdBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountExternalAccountsIdResponder,
   ctx: RouterContext,
@@ -1897,7 +1913,8 @@ export type PostAccountsAccountExternalAccountsId = (
   params: Params<
     t_PostAccountsAccountExternalAccountsIdParamSchema,
     void,
-    t_PostAccountsAccountExternalAccountsIdBodySchema | undefined
+    t_PostAccountsAccountExternalAccountsIdBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountExternalAccountsIdResponder,
   ctx: RouterContext,
@@ -1916,7 +1933,8 @@ export type PostAccountsAccountLoginLinks = (
   params: Params<
     t_PostAccountsAccountLoginLinksParamSchema,
     void,
-    t_PostAccountsAccountLoginLinksBodySchema | undefined
+    t_PostAccountsAccountLoginLinksBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountLoginLinksResponder,
   ctx: RouterContext,
@@ -1940,7 +1958,8 @@ export type GetAccountsAccountPeople = (
   params: Params<
     t_GetAccountsAccountPeopleParamSchema,
     t_GetAccountsAccountPeopleQuerySchema,
-    t_GetAccountsAccountPeopleBodySchema | undefined
+    t_GetAccountsAccountPeopleBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountPeopleResponder,
   ctx: RouterContext,
@@ -1967,7 +1986,8 @@ export type PostAccountsAccountPeople = (
   params: Params<
     t_PostAccountsAccountPeopleParamSchema,
     void,
-    t_PostAccountsAccountPeopleBodySchema | undefined
+    t_PostAccountsAccountPeopleBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountPeopleResponder,
   ctx: RouterContext,
@@ -1986,7 +2006,8 @@ export type DeleteAccountsAccountPeoplePerson = (
   params: Params<
     t_DeleteAccountsAccountPeoplePersonParamSchema,
     void,
-    t_DeleteAccountsAccountPeoplePersonBodySchema | undefined
+    t_DeleteAccountsAccountPeoplePersonBodySchema | undefined,
+    void
   >,
   respond: DeleteAccountsAccountPeoplePersonResponder,
   ctx: RouterContext,
@@ -2005,7 +2026,8 @@ export type GetAccountsAccountPeoplePerson = (
   params: Params<
     t_GetAccountsAccountPeoplePersonParamSchema,
     t_GetAccountsAccountPeoplePersonQuerySchema,
-    t_GetAccountsAccountPeoplePersonBodySchema | undefined
+    t_GetAccountsAccountPeoplePersonBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountPeoplePersonResponder,
   ctx: RouterContext,
@@ -2024,7 +2046,8 @@ export type PostAccountsAccountPeoplePerson = (
   params: Params<
     t_PostAccountsAccountPeoplePersonParamSchema,
     void,
-    t_PostAccountsAccountPeoplePersonBodySchema | undefined
+    t_PostAccountsAccountPeoplePersonBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountPeoplePersonResponder,
   ctx: RouterContext,
@@ -2048,7 +2071,8 @@ export type GetAccountsAccountPersons = (
   params: Params<
     t_GetAccountsAccountPersonsParamSchema,
     t_GetAccountsAccountPersonsQuerySchema,
-    t_GetAccountsAccountPersonsBodySchema | undefined
+    t_GetAccountsAccountPersonsBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountPersonsResponder,
   ctx: RouterContext,
@@ -2075,7 +2099,8 @@ export type PostAccountsAccountPersons = (
   params: Params<
     t_PostAccountsAccountPersonsParamSchema,
     void,
-    t_PostAccountsAccountPersonsBodySchema | undefined
+    t_PostAccountsAccountPersonsBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountPersonsResponder,
   ctx: RouterContext,
@@ -2094,7 +2119,8 @@ export type DeleteAccountsAccountPersonsPerson = (
   params: Params<
     t_DeleteAccountsAccountPersonsPersonParamSchema,
     void,
-    t_DeleteAccountsAccountPersonsPersonBodySchema | undefined
+    t_DeleteAccountsAccountPersonsPersonBodySchema | undefined,
+    void
   >,
   respond: DeleteAccountsAccountPersonsPersonResponder,
   ctx: RouterContext,
@@ -2113,7 +2139,8 @@ export type GetAccountsAccountPersonsPerson = (
   params: Params<
     t_GetAccountsAccountPersonsPersonParamSchema,
     t_GetAccountsAccountPersonsPersonQuerySchema,
-    t_GetAccountsAccountPersonsPersonBodySchema | undefined
+    t_GetAccountsAccountPersonsPersonBodySchema | undefined,
+    void
   >,
   respond: GetAccountsAccountPersonsPersonResponder,
   ctx: RouterContext,
@@ -2132,7 +2159,8 @@ export type PostAccountsAccountPersonsPerson = (
   params: Params<
     t_PostAccountsAccountPersonsPersonParamSchema,
     void,
-    t_PostAccountsAccountPersonsPersonBodySchema | undefined
+    t_PostAccountsAccountPersonsPersonBodySchema | undefined,
+    void
   >,
   respond: PostAccountsAccountPersonsPersonResponder,
   ctx: RouterContext,
@@ -2151,7 +2179,8 @@ export type PostAccountsAccountReject = (
   params: Params<
     t_PostAccountsAccountRejectParamSchema,
     void,
-    t_PostAccountsAccountRejectBodySchema
+    t_PostAccountsAccountRejectBodySchema,
+    void
   >,
   respond: PostAccountsAccountRejectResponder,
   ctx: RouterContext,
@@ -2175,7 +2204,8 @@ export type GetApplePayDomains = (
   params: Params<
     void,
     t_GetApplePayDomainsQuerySchema,
-    t_GetApplePayDomainsBodySchema | undefined
+    t_GetApplePayDomainsBodySchema | undefined,
+    void
   >,
   respond: GetApplePayDomainsResponder,
   ctx: RouterContext,
@@ -2199,7 +2229,7 @@ export type PostApplePayDomainsResponder = {
 } & KoaRuntimeResponder
 
 export type PostApplePayDomains = (
-  params: Params<void, void, t_PostApplePayDomainsBodySchema>,
+  params: Params<void, void, t_PostApplePayDomainsBodySchema, void>,
   respond: PostApplePayDomainsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2217,7 +2247,8 @@ export type DeleteApplePayDomainsDomain = (
   params: Params<
     t_DeleteApplePayDomainsDomainParamSchema,
     void,
-    t_DeleteApplePayDomainsDomainBodySchema | undefined
+    t_DeleteApplePayDomainsDomainBodySchema | undefined,
+    void
   >,
   respond: DeleteApplePayDomainsDomainResponder,
   ctx: RouterContext,
@@ -2236,7 +2267,8 @@ export type GetApplePayDomainsDomain = (
   params: Params<
     t_GetApplePayDomainsDomainParamSchema,
     t_GetApplePayDomainsDomainQuerySchema,
-    t_GetApplePayDomainsDomainBodySchema | undefined
+    t_GetApplePayDomainsDomainBodySchema | undefined,
+    void
   >,
   respond: GetApplePayDomainsDomainResponder,
   ctx: RouterContext,
@@ -2260,7 +2292,8 @@ export type GetApplicationFees = (
   params: Params<
     void,
     t_GetApplicationFeesQuerySchema,
-    t_GetApplicationFeesBodySchema | undefined
+    t_GetApplicationFeesBodySchema | undefined,
+    void
   >,
   respond: GetApplicationFeesResponder,
   ctx: RouterContext,
@@ -2287,7 +2320,8 @@ export type GetApplicationFeesFeeRefundsId = (
   params: Params<
     t_GetApplicationFeesFeeRefundsIdParamSchema,
     t_GetApplicationFeesFeeRefundsIdQuerySchema,
-    t_GetApplicationFeesFeeRefundsIdBodySchema | undefined
+    t_GetApplicationFeesFeeRefundsIdBodySchema | undefined,
+    void
   >,
   respond: GetApplicationFeesFeeRefundsIdResponder,
   ctx: RouterContext,
@@ -2306,7 +2340,8 @@ export type PostApplicationFeesFeeRefundsId = (
   params: Params<
     t_PostApplicationFeesFeeRefundsIdParamSchema,
     void,
-    t_PostApplicationFeesFeeRefundsIdBodySchema | undefined
+    t_PostApplicationFeesFeeRefundsIdBodySchema | undefined,
+    void
   >,
   respond: PostApplicationFeesFeeRefundsIdResponder,
   ctx: RouterContext,
@@ -2325,7 +2360,8 @@ export type GetApplicationFeesId = (
   params: Params<
     t_GetApplicationFeesIdParamSchema,
     t_GetApplicationFeesIdQuerySchema,
-    t_GetApplicationFeesIdBodySchema | undefined
+    t_GetApplicationFeesIdBodySchema | undefined,
+    void
   >,
   respond: GetApplicationFeesIdResponder,
   ctx: RouterContext,
@@ -2344,7 +2380,8 @@ export type PostApplicationFeesIdRefund = (
   params: Params<
     t_PostApplicationFeesIdRefundParamSchema,
     void,
-    t_PostApplicationFeesIdRefundBodySchema | undefined
+    t_PostApplicationFeesIdRefundBodySchema | undefined,
+    void
   >,
   respond: PostApplicationFeesIdRefundResponder,
   ctx: RouterContext,
@@ -2368,7 +2405,8 @@ export type GetApplicationFeesIdRefunds = (
   params: Params<
     t_GetApplicationFeesIdRefundsParamSchema,
     t_GetApplicationFeesIdRefundsQuerySchema,
-    t_GetApplicationFeesIdRefundsBodySchema | undefined
+    t_GetApplicationFeesIdRefundsBodySchema | undefined,
+    void
   >,
   respond: GetApplicationFeesIdRefundsResponder,
   ctx: RouterContext,
@@ -2395,7 +2433,8 @@ export type PostApplicationFeesIdRefunds = (
   params: Params<
     t_PostApplicationFeesIdRefundsParamSchema,
     void,
-    t_PostApplicationFeesIdRefundsBodySchema | undefined
+    t_PostApplicationFeesIdRefundsBodySchema | undefined,
+    void
   >,
   respond: PostApplicationFeesIdRefundsResponder,
   ctx: RouterContext,
@@ -2419,7 +2458,8 @@ export type GetAppsSecrets = (
   params: Params<
     void,
     t_GetAppsSecretsQuerySchema,
-    t_GetAppsSecretsBodySchema | undefined
+    t_GetAppsSecretsBodySchema | undefined,
+    void
   >,
   respond: GetAppsSecretsResponder,
   ctx: RouterContext,
@@ -2443,7 +2483,7 @@ export type PostAppsSecretsResponder = {
 } & KoaRuntimeResponder
 
 export type PostAppsSecrets = (
-  params: Params<void, void, t_PostAppsSecretsBodySchema>,
+  params: Params<void, void, t_PostAppsSecretsBodySchema, void>,
   respond: PostAppsSecretsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2458,7 +2498,7 @@ export type PostAppsSecretsDeleteResponder = {
 } & KoaRuntimeResponder
 
 export type PostAppsSecretsDelete = (
-  params: Params<void, void, t_PostAppsSecretsDeleteBodySchema>,
+  params: Params<void, void, t_PostAppsSecretsDeleteBodySchema, void>,
   respond: PostAppsSecretsDeleteResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2476,7 +2516,8 @@ export type GetAppsSecretsFind = (
   params: Params<
     void,
     t_GetAppsSecretsFindQuerySchema,
-    t_GetAppsSecretsFindBodySchema | undefined
+    t_GetAppsSecretsFindBodySchema | undefined,
+    void
   >,
   respond: GetAppsSecretsFindResponder,
   ctx: RouterContext,
@@ -2495,7 +2536,8 @@ export type GetBalance = (
   params: Params<
     void,
     t_GetBalanceQuerySchema,
-    t_GetBalanceBodySchema | undefined
+    t_GetBalanceBodySchema | undefined,
+    void
   >,
   respond: GetBalanceResponder,
   ctx: RouterContext,
@@ -2519,7 +2561,8 @@ export type GetBalanceHistory = (
   params: Params<
     void,
     t_GetBalanceHistoryQuerySchema,
-    t_GetBalanceHistoryBodySchema | undefined
+    t_GetBalanceHistoryBodySchema | undefined,
+    void
   >,
   respond: GetBalanceHistoryResponder,
   ctx: RouterContext,
@@ -2546,7 +2589,8 @@ export type GetBalanceHistoryId = (
   params: Params<
     t_GetBalanceHistoryIdParamSchema,
     t_GetBalanceHistoryIdQuerySchema,
-    t_GetBalanceHistoryIdBodySchema | undefined
+    t_GetBalanceHistoryIdBodySchema | undefined,
+    void
   >,
   respond: GetBalanceHistoryIdResponder,
   ctx: RouterContext,
@@ -2570,7 +2614,8 @@ export type GetBalanceTransactions = (
   params: Params<
     void,
     t_GetBalanceTransactionsQuerySchema,
-    t_GetBalanceTransactionsBodySchema | undefined
+    t_GetBalanceTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetBalanceTransactionsResponder,
   ctx: RouterContext,
@@ -2597,7 +2642,8 @@ export type GetBalanceTransactionsId = (
   params: Params<
     t_GetBalanceTransactionsIdParamSchema,
     t_GetBalanceTransactionsIdQuerySchema,
-    t_GetBalanceTransactionsIdBodySchema | undefined
+    t_GetBalanceTransactionsIdBodySchema | undefined,
+    void
   >,
   respond: GetBalanceTransactionsIdResponder,
   ctx: RouterContext,
@@ -2621,7 +2667,8 @@ export type GetBillingAlerts = (
   params: Params<
     void,
     t_GetBillingAlertsQuerySchema,
-    t_GetBillingAlertsBodySchema | undefined
+    t_GetBillingAlertsBodySchema | undefined,
+    void
   >,
   respond: GetBillingAlertsResponder,
   ctx: RouterContext,
@@ -2645,7 +2692,7 @@ export type PostBillingAlertsResponder = {
 } & KoaRuntimeResponder
 
 export type PostBillingAlerts = (
-  params: Params<void, void, t_PostBillingAlertsBodySchema>,
+  params: Params<void, void, t_PostBillingAlertsBodySchema, void>,
   respond: PostBillingAlertsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2663,7 +2710,8 @@ export type GetBillingAlertsId = (
   params: Params<
     t_GetBillingAlertsIdParamSchema,
     t_GetBillingAlertsIdQuerySchema,
-    t_GetBillingAlertsIdBodySchema | undefined
+    t_GetBillingAlertsIdBodySchema | undefined,
+    void
   >,
   respond: GetBillingAlertsIdResponder,
   ctx: RouterContext,
@@ -2682,7 +2730,8 @@ export type PostBillingAlertsIdActivate = (
   params: Params<
     t_PostBillingAlertsIdActivateParamSchema,
     void,
-    t_PostBillingAlertsIdActivateBodySchema | undefined
+    t_PostBillingAlertsIdActivateBodySchema | undefined,
+    void
   >,
   respond: PostBillingAlertsIdActivateResponder,
   ctx: RouterContext,
@@ -2701,7 +2750,8 @@ export type PostBillingAlertsIdArchive = (
   params: Params<
     t_PostBillingAlertsIdArchiveParamSchema,
     void,
-    t_PostBillingAlertsIdArchiveBodySchema | undefined
+    t_PostBillingAlertsIdArchiveBodySchema | undefined,
+    void
   >,
   respond: PostBillingAlertsIdArchiveResponder,
   ctx: RouterContext,
@@ -2720,7 +2770,8 @@ export type PostBillingAlertsIdDeactivate = (
   params: Params<
     t_PostBillingAlertsIdDeactivateParamSchema,
     void,
-    t_PostBillingAlertsIdDeactivateBodySchema | undefined
+    t_PostBillingAlertsIdDeactivateBodySchema | undefined,
+    void
   >,
   respond: PostBillingAlertsIdDeactivateResponder,
   ctx: RouterContext,
@@ -2736,7 +2787,12 @@ export type PostBillingMeterEventAdjustmentsResponder = {
 } & KoaRuntimeResponder
 
 export type PostBillingMeterEventAdjustments = (
-  params: Params<void, void, t_PostBillingMeterEventAdjustmentsBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostBillingMeterEventAdjustmentsBodySchema,
+    void
+  >,
   respond: PostBillingMeterEventAdjustmentsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2751,7 +2807,7 @@ export type PostBillingMeterEventsResponder = {
 } & KoaRuntimeResponder
 
 export type PostBillingMeterEvents = (
-  params: Params<void, void, t_PostBillingMeterEventsBodySchema>,
+  params: Params<void, void, t_PostBillingMeterEventsBodySchema, void>,
   respond: PostBillingMeterEventsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2774,7 +2830,8 @@ export type GetBillingMeters = (
   params: Params<
     void,
     t_GetBillingMetersQuerySchema,
-    t_GetBillingMetersBodySchema | undefined
+    t_GetBillingMetersBodySchema | undefined,
+    void
   >,
   respond: GetBillingMetersResponder,
   ctx: RouterContext,
@@ -2798,7 +2855,7 @@ export type PostBillingMetersResponder = {
 } & KoaRuntimeResponder
 
 export type PostBillingMeters = (
-  params: Params<void, void, t_PostBillingMetersBodySchema>,
+  params: Params<void, void, t_PostBillingMetersBodySchema, void>,
   respond: PostBillingMetersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2816,7 +2873,8 @@ export type GetBillingMetersId = (
   params: Params<
     t_GetBillingMetersIdParamSchema,
     t_GetBillingMetersIdQuerySchema,
-    t_GetBillingMetersIdBodySchema | undefined
+    t_GetBillingMetersIdBodySchema | undefined,
+    void
   >,
   respond: GetBillingMetersIdResponder,
   ctx: RouterContext,
@@ -2835,7 +2893,8 @@ export type PostBillingMetersId = (
   params: Params<
     t_PostBillingMetersIdParamSchema,
     void,
-    t_PostBillingMetersIdBodySchema | undefined
+    t_PostBillingMetersIdBodySchema | undefined,
+    void
   >,
   respond: PostBillingMetersIdResponder,
   ctx: RouterContext,
@@ -2854,7 +2913,8 @@ export type PostBillingMetersIdDeactivate = (
   params: Params<
     t_PostBillingMetersIdDeactivateParamSchema,
     void,
-    t_PostBillingMetersIdDeactivateBodySchema | undefined
+    t_PostBillingMetersIdDeactivateBodySchema | undefined,
+    void
   >,
   respond: PostBillingMetersIdDeactivateResponder,
   ctx: RouterContext,
@@ -2878,7 +2938,8 @@ export type GetBillingMetersIdEventSummaries = (
   params: Params<
     t_GetBillingMetersIdEventSummariesParamSchema,
     t_GetBillingMetersIdEventSummariesQuerySchema,
-    t_GetBillingMetersIdEventSummariesBodySchema | undefined
+    t_GetBillingMetersIdEventSummariesBodySchema | undefined,
+    void
   >,
   respond: GetBillingMetersIdEventSummariesResponder,
   ctx: RouterContext,
@@ -2905,7 +2966,8 @@ export type PostBillingMetersIdReactivate = (
   params: Params<
     t_PostBillingMetersIdReactivateParamSchema,
     void,
-    t_PostBillingMetersIdReactivateBodySchema | undefined
+    t_PostBillingMetersIdReactivateBodySchema | undefined,
+    void
   >,
   respond: PostBillingMetersIdReactivateResponder,
   ctx: RouterContext,
@@ -2929,7 +2991,8 @@ export type GetBillingPortalConfigurations = (
   params: Params<
     void,
     t_GetBillingPortalConfigurationsQuerySchema,
-    t_GetBillingPortalConfigurationsBodySchema | undefined
+    t_GetBillingPortalConfigurationsBodySchema | undefined,
+    void
   >,
   respond: GetBillingPortalConfigurationsResponder,
   ctx: RouterContext,
@@ -2953,7 +3016,7 @@ export type PostBillingPortalConfigurationsResponder = {
 } & KoaRuntimeResponder
 
 export type PostBillingPortalConfigurations = (
-  params: Params<void, void, t_PostBillingPortalConfigurationsBodySchema>,
+  params: Params<void, void, t_PostBillingPortalConfigurationsBodySchema, void>,
   respond: PostBillingPortalConfigurationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -2971,7 +3034,8 @@ export type GetBillingPortalConfigurationsConfiguration = (
   params: Params<
     t_GetBillingPortalConfigurationsConfigurationParamSchema,
     t_GetBillingPortalConfigurationsConfigurationQuerySchema,
-    t_GetBillingPortalConfigurationsConfigurationBodySchema | undefined
+    t_GetBillingPortalConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: GetBillingPortalConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -2990,7 +3054,8 @@ export type PostBillingPortalConfigurationsConfiguration = (
   params: Params<
     t_PostBillingPortalConfigurationsConfigurationParamSchema,
     void,
-    t_PostBillingPortalConfigurationsConfigurationBodySchema | undefined
+    t_PostBillingPortalConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: PostBillingPortalConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -3006,7 +3071,7 @@ export type PostBillingPortalSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostBillingPortalSessions = (
-  params: Params<void, void, t_PostBillingPortalSessionsBodySchema>,
+  params: Params<void, void, t_PostBillingPortalSessionsBodySchema, void>,
   respond: PostBillingPortalSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3029,7 +3094,8 @@ export type GetCharges = (
   params: Params<
     void,
     t_GetChargesQuerySchema,
-    t_GetChargesBodySchema | undefined
+    t_GetChargesBodySchema | undefined,
+    void
   >,
   respond: GetChargesResponder,
   ctx: RouterContext,
@@ -3053,7 +3119,7 @@ export type PostChargesResponder = {
 } & KoaRuntimeResponder
 
 export type PostCharges = (
-  params: Params<void, void, t_PostChargesBodySchema | undefined>,
+  params: Params<void, void, t_PostChargesBodySchema | undefined, void>,
   respond: PostChargesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3078,7 +3144,8 @@ export type GetChargesSearch = (
   params: Params<
     void,
     t_GetChargesSearchQuerySchema,
-    t_GetChargesSearchBodySchema | undefined
+    t_GetChargesSearchBodySchema | undefined,
+    void
   >,
   respond: GetChargesSearchResponder,
   ctx: RouterContext,
@@ -3107,7 +3174,8 @@ export type GetChargesCharge = (
   params: Params<
     t_GetChargesChargeParamSchema,
     t_GetChargesChargeQuerySchema,
-    t_GetChargesChargeBodySchema | undefined
+    t_GetChargesChargeBodySchema | undefined,
+    void
   >,
   respond: GetChargesChargeResponder,
   ctx: RouterContext,
@@ -3126,7 +3194,8 @@ export type PostChargesCharge = (
   params: Params<
     t_PostChargesChargeParamSchema,
     void,
-    t_PostChargesChargeBodySchema | undefined
+    t_PostChargesChargeBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeResponder,
   ctx: RouterContext,
@@ -3145,7 +3214,8 @@ export type PostChargesChargeCapture = (
   params: Params<
     t_PostChargesChargeCaptureParamSchema,
     void,
-    t_PostChargesChargeCaptureBodySchema | undefined
+    t_PostChargesChargeCaptureBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeCaptureResponder,
   ctx: RouterContext,
@@ -3164,7 +3234,8 @@ export type GetChargesChargeDispute = (
   params: Params<
     t_GetChargesChargeDisputeParamSchema,
     t_GetChargesChargeDisputeQuerySchema,
-    t_GetChargesChargeDisputeBodySchema | undefined
+    t_GetChargesChargeDisputeBodySchema | undefined,
+    void
   >,
   respond: GetChargesChargeDisputeResponder,
   ctx: RouterContext,
@@ -3183,7 +3254,8 @@ export type PostChargesChargeDispute = (
   params: Params<
     t_PostChargesChargeDisputeParamSchema,
     void,
-    t_PostChargesChargeDisputeBodySchema | undefined
+    t_PostChargesChargeDisputeBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeDisputeResponder,
   ctx: RouterContext,
@@ -3202,7 +3274,8 @@ export type PostChargesChargeDisputeClose = (
   params: Params<
     t_PostChargesChargeDisputeCloseParamSchema,
     void,
-    t_PostChargesChargeDisputeCloseBodySchema | undefined
+    t_PostChargesChargeDisputeCloseBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeDisputeCloseResponder,
   ctx: RouterContext,
@@ -3221,7 +3294,8 @@ export type PostChargesChargeRefund = (
   params: Params<
     t_PostChargesChargeRefundParamSchema,
     void,
-    t_PostChargesChargeRefundBodySchema | undefined
+    t_PostChargesChargeRefundBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeRefundResponder,
   ctx: RouterContext,
@@ -3245,7 +3319,8 @@ export type GetChargesChargeRefunds = (
   params: Params<
     t_GetChargesChargeRefundsParamSchema,
     t_GetChargesChargeRefundsQuerySchema,
-    t_GetChargesChargeRefundsBodySchema | undefined
+    t_GetChargesChargeRefundsBodySchema | undefined,
+    void
   >,
   respond: GetChargesChargeRefundsResponder,
   ctx: RouterContext,
@@ -3272,7 +3347,8 @@ export type PostChargesChargeRefunds = (
   params: Params<
     t_PostChargesChargeRefundsParamSchema,
     void,
-    t_PostChargesChargeRefundsBodySchema | undefined
+    t_PostChargesChargeRefundsBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeRefundsResponder,
   ctx: RouterContext,
@@ -3291,7 +3367,8 @@ export type GetChargesChargeRefundsRefund = (
   params: Params<
     t_GetChargesChargeRefundsRefundParamSchema,
     t_GetChargesChargeRefundsRefundQuerySchema,
-    t_GetChargesChargeRefundsRefundBodySchema | undefined
+    t_GetChargesChargeRefundsRefundBodySchema | undefined,
+    void
   >,
   respond: GetChargesChargeRefundsRefundResponder,
   ctx: RouterContext,
@@ -3310,7 +3387,8 @@ export type PostChargesChargeRefundsRefund = (
   params: Params<
     t_PostChargesChargeRefundsRefundParamSchema,
     void,
-    t_PostChargesChargeRefundsRefundBodySchema | undefined
+    t_PostChargesChargeRefundsRefundBodySchema | undefined,
+    void
   >,
   respond: PostChargesChargeRefundsRefundResponder,
   ctx: RouterContext,
@@ -3334,7 +3412,8 @@ export type GetCheckoutSessions = (
   params: Params<
     void,
     t_GetCheckoutSessionsQuerySchema,
-    t_GetCheckoutSessionsBodySchema | undefined
+    t_GetCheckoutSessionsBodySchema | undefined,
+    void
   >,
   respond: GetCheckoutSessionsResponder,
   ctx: RouterContext,
@@ -3358,7 +3437,12 @@ export type PostCheckoutSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostCheckoutSessions = (
-  params: Params<void, void, t_PostCheckoutSessionsBodySchema | undefined>,
+  params: Params<
+    void,
+    void,
+    t_PostCheckoutSessionsBodySchema | undefined,
+    void
+  >,
   respond: PostCheckoutSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3376,7 +3460,8 @@ export type GetCheckoutSessionsSession = (
   params: Params<
     t_GetCheckoutSessionsSessionParamSchema,
     t_GetCheckoutSessionsSessionQuerySchema,
-    t_GetCheckoutSessionsSessionBodySchema | undefined
+    t_GetCheckoutSessionsSessionBodySchema | undefined,
+    void
   >,
   respond: GetCheckoutSessionsSessionResponder,
   ctx: RouterContext,
@@ -3395,7 +3480,8 @@ export type PostCheckoutSessionsSession = (
   params: Params<
     t_PostCheckoutSessionsSessionParamSchema,
     void,
-    t_PostCheckoutSessionsSessionBodySchema | undefined
+    t_PostCheckoutSessionsSessionBodySchema | undefined,
+    void
   >,
   respond: PostCheckoutSessionsSessionResponder,
   ctx: RouterContext,
@@ -3414,7 +3500,8 @@ export type PostCheckoutSessionsSessionExpire = (
   params: Params<
     t_PostCheckoutSessionsSessionExpireParamSchema,
     void,
-    t_PostCheckoutSessionsSessionExpireBodySchema | undefined
+    t_PostCheckoutSessionsSessionExpireBodySchema | undefined,
+    void
   >,
   respond: PostCheckoutSessionsSessionExpireResponder,
   ctx: RouterContext,
@@ -3438,7 +3525,8 @@ export type GetCheckoutSessionsSessionLineItems = (
   params: Params<
     t_GetCheckoutSessionsSessionLineItemsParamSchema,
     t_GetCheckoutSessionsSessionLineItemsQuerySchema,
-    t_GetCheckoutSessionsSessionLineItemsBodySchema | undefined
+    t_GetCheckoutSessionsSessionLineItemsBodySchema | undefined,
+    void
   >,
   respond: GetCheckoutSessionsSessionLineItemsResponder,
   ctx: RouterContext,
@@ -3470,7 +3558,8 @@ export type GetClimateOrders = (
   params: Params<
     void,
     t_GetClimateOrdersQuerySchema,
-    t_GetClimateOrdersBodySchema | undefined
+    t_GetClimateOrdersBodySchema | undefined,
+    void
   >,
   respond: GetClimateOrdersResponder,
   ctx: RouterContext,
@@ -3494,7 +3583,7 @@ export type PostClimateOrdersResponder = {
 } & KoaRuntimeResponder
 
 export type PostClimateOrders = (
-  params: Params<void, void, t_PostClimateOrdersBodySchema>,
+  params: Params<void, void, t_PostClimateOrdersBodySchema, void>,
   respond: PostClimateOrdersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3512,7 +3601,8 @@ export type GetClimateOrdersOrder = (
   params: Params<
     t_GetClimateOrdersOrderParamSchema,
     t_GetClimateOrdersOrderQuerySchema,
-    t_GetClimateOrdersOrderBodySchema | undefined
+    t_GetClimateOrdersOrderBodySchema | undefined,
+    void
   >,
   respond: GetClimateOrdersOrderResponder,
   ctx: RouterContext,
@@ -3531,7 +3621,8 @@ export type PostClimateOrdersOrder = (
   params: Params<
     t_PostClimateOrdersOrderParamSchema,
     void,
-    t_PostClimateOrdersOrderBodySchema | undefined
+    t_PostClimateOrdersOrderBodySchema | undefined,
+    void
   >,
   respond: PostClimateOrdersOrderResponder,
   ctx: RouterContext,
@@ -3550,7 +3641,8 @@ export type PostClimateOrdersOrderCancel = (
   params: Params<
     t_PostClimateOrdersOrderCancelParamSchema,
     void,
-    t_PostClimateOrdersOrderCancelBodySchema | undefined
+    t_PostClimateOrdersOrderCancelBodySchema | undefined,
+    void
   >,
   respond: PostClimateOrdersOrderCancelResponder,
   ctx: RouterContext,
@@ -3574,7 +3666,8 @@ export type GetClimateProducts = (
   params: Params<
     void,
     t_GetClimateProductsQuerySchema,
-    t_GetClimateProductsBodySchema | undefined
+    t_GetClimateProductsBodySchema | undefined,
+    void
   >,
   respond: GetClimateProductsResponder,
   ctx: RouterContext,
@@ -3601,7 +3694,8 @@ export type GetClimateProductsProduct = (
   params: Params<
     t_GetClimateProductsProductParamSchema,
     t_GetClimateProductsProductQuerySchema,
-    t_GetClimateProductsProductBodySchema | undefined
+    t_GetClimateProductsProductBodySchema | undefined,
+    void
   >,
   respond: GetClimateProductsProductResponder,
   ctx: RouterContext,
@@ -3625,7 +3719,8 @@ export type GetClimateSuppliers = (
   params: Params<
     void,
     t_GetClimateSuppliersQuerySchema,
-    t_GetClimateSuppliersBodySchema | undefined
+    t_GetClimateSuppliersBodySchema | undefined,
+    void
   >,
   respond: GetClimateSuppliersResponder,
   ctx: RouterContext,
@@ -3652,7 +3747,8 @@ export type GetClimateSuppliersSupplier = (
   params: Params<
     t_GetClimateSuppliersSupplierParamSchema,
     t_GetClimateSuppliersSupplierQuerySchema,
-    t_GetClimateSuppliersSupplierBodySchema | undefined
+    t_GetClimateSuppliersSupplierBodySchema | undefined,
+    void
   >,
   respond: GetClimateSuppliersSupplierResponder,
   ctx: RouterContext,
@@ -3671,7 +3767,8 @@ export type GetConfirmationTokensConfirmationToken = (
   params: Params<
     t_GetConfirmationTokensConfirmationTokenParamSchema,
     t_GetConfirmationTokensConfirmationTokenQuerySchema,
-    t_GetConfirmationTokensConfirmationTokenBodySchema | undefined
+    t_GetConfirmationTokensConfirmationTokenBodySchema | undefined,
+    void
   >,
   respond: GetConfirmationTokensConfirmationTokenResponder,
   ctx: RouterContext,
@@ -3695,7 +3792,8 @@ export type GetCountrySpecs = (
   params: Params<
     void,
     t_GetCountrySpecsQuerySchema,
-    t_GetCountrySpecsBodySchema | undefined
+    t_GetCountrySpecsBodySchema | undefined,
+    void
   >,
   respond: GetCountrySpecsResponder,
   ctx: RouterContext,
@@ -3722,7 +3820,8 @@ export type GetCountrySpecsCountry = (
   params: Params<
     t_GetCountrySpecsCountryParamSchema,
     t_GetCountrySpecsCountryQuerySchema,
-    t_GetCountrySpecsCountryBodySchema | undefined
+    t_GetCountrySpecsCountryBodySchema | undefined,
+    void
   >,
   respond: GetCountrySpecsCountryResponder,
   ctx: RouterContext,
@@ -3746,7 +3845,8 @@ export type GetCoupons = (
   params: Params<
     void,
     t_GetCouponsQuerySchema,
-    t_GetCouponsBodySchema | undefined
+    t_GetCouponsBodySchema | undefined,
+    void
   >,
   respond: GetCouponsResponder,
   ctx: RouterContext,
@@ -3770,7 +3870,7 @@ export type PostCouponsResponder = {
 } & KoaRuntimeResponder
 
 export type PostCoupons = (
-  params: Params<void, void, t_PostCouponsBodySchema | undefined>,
+  params: Params<void, void, t_PostCouponsBodySchema | undefined, void>,
   respond: PostCouponsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3788,7 +3888,8 @@ export type DeleteCouponsCoupon = (
   params: Params<
     t_DeleteCouponsCouponParamSchema,
     void,
-    t_DeleteCouponsCouponBodySchema | undefined
+    t_DeleteCouponsCouponBodySchema | undefined,
+    void
   >,
   respond: DeleteCouponsCouponResponder,
   ctx: RouterContext,
@@ -3807,7 +3908,8 @@ export type GetCouponsCoupon = (
   params: Params<
     t_GetCouponsCouponParamSchema,
     t_GetCouponsCouponQuerySchema,
-    t_GetCouponsCouponBodySchema | undefined
+    t_GetCouponsCouponBodySchema | undefined,
+    void
   >,
   respond: GetCouponsCouponResponder,
   ctx: RouterContext,
@@ -3826,7 +3928,8 @@ export type PostCouponsCoupon = (
   params: Params<
     t_PostCouponsCouponParamSchema,
     void,
-    t_PostCouponsCouponBodySchema | undefined
+    t_PostCouponsCouponBodySchema | undefined,
+    void
   >,
   respond: PostCouponsCouponResponder,
   ctx: RouterContext,
@@ -3850,7 +3953,8 @@ export type GetCreditNotes = (
   params: Params<
     void,
     t_GetCreditNotesQuerySchema,
-    t_GetCreditNotesBodySchema | undefined
+    t_GetCreditNotesBodySchema | undefined,
+    void
   >,
   respond: GetCreditNotesResponder,
   ctx: RouterContext,
@@ -3874,7 +3978,7 @@ export type PostCreditNotesResponder = {
 } & KoaRuntimeResponder
 
 export type PostCreditNotes = (
-  params: Params<void, void, t_PostCreditNotesBodySchema>,
+  params: Params<void, void, t_PostCreditNotesBodySchema, void>,
   respond: PostCreditNotesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -3892,7 +3996,8 @@ export type GetCreditNotesPreview = (
   params: Params<
     void,
     t_GetCreditNotesPreviewQuerySchema,
-    t_GetCreditNotesPreviewBodySchema | undefined
+    t_GetCreditNotesPreviewBodySchema | undefined,
+    void
   >,
   respond: GetCreditNotesPreviewResponder,
   ctx: RouterContext,
@@ -3916,7 +4021,8 @@ export type GetCreditNotesPreviewLines = (
   params: Params<
     void,
     t_GetCreditNotesPreviewLinesQuerySchema,
-    t_GetCreditNotesPreviewLinesBodySchema | undefined
+    t_GetCreditNotesPreviewLinesBodySchema | undefined,
+    void
   >,
   respond: GetCreditNotesPreviewLinesResponder,
   ctx: RouterContext,
@@ -3948,7 +4054,8 @@ export type GetCreditNotesCreditNoteLines = (
   params: Params<
     t_GetCreditNotesCreditNoteLinesParamSchema,
     t_GetCreditNotesCreditNoteLinesQuerySchema,
-    t_GetCreditNotesCreditNoteLinesBodySchema | undefined
+    t_GetCreditNotesCreditNoteLinesBodySchema | undefined,
+    void
   >,
   respond: GetCreditNotesCreditNoteLinesResponder,
   ctx: RouterContext,
@@ -3975,7 +4082,8 @@ export type GetCreditNotesId = (
   params: Params<
     t_GetCreditNotesIdParamSchema,
     t_GetCreditNotesIdQuerySchema,
-    t_GetCreditNotesIdBodySchema | undefined
+    t_GetCreditNotesIdBodySchema | undefined,
+    void
   >,
   respond: GetCreditNotesIdResponder,
   ctx: RouterContext,
@@ -3994,7 +4102,8 @@ export type PostCreditNotesId = (
   params: Params<
     t_PostCreditNotesIdParamSchema,
     void,
-    t_PostCreditNotesIdBodySchema | undefined
+    t_PostCreditNotesIdBodySchema | undefined,
+    void
   >,
   respond: PostCreditNotesIdResponder,
   ctx: RouterContext,
@@ -4013,7 +4122,8 @@ export type PostCreditNotesIdVoid = (
   params: Params<
     t_PostCreditNotesIdVoidParamSchema,
     void,
-    t_PostCreditNotesIdVoidBodySchema | undefined
+    t_PostCreditNotesIdVoidBodySchema | undefined,
+    void
   >,
   respond: PostCreditNotesIdVoidResponder,
   ctx: RouterContext,
@@ -4029,7 +4139,7 @@ export type PostCustomerSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostCustomerSessions = (
-  params: Params<void, void, t_PostCustomerSessionsBodySchema>,
+  params: Params<void, void, t_PostCustomerSessionsBodySchema, void>,
   respond: PostCustomerSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4052,7 +4162,8 @@ export type GetCustomers = (
   params: Params<
     void,
     t_GetCustomersQuerySchema,
-    t_GetCustomersBodySchema | undefined
+    t_GetCustomersBodySchema | undefined,
+    void
   >,
   respond: GetCustomersResponder,
   ctx: RouterContext,
@@ -4076,7 +4187,7 @@ export type PostCustomersResponder = {
 } & KoaRuntimeResponder
 
 export type PostCustomers = (
-  params: Params<void, void, t_PostCustomersBodySchema | undefined>,
+  params: Params<void, void, t_PostCustomersBodySchema | undefined, void>,
   respond: PostCustomersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -4101,7 +4212,8 @@ export type GetCustomersSearch = (
   params: Params<
     void,
     t_GetCustomersSearchQuerySchema,
-    t_GetCustomersSearchBodySchema | undefined
+    t_GetCustomersSearchBodySchema | undefined,
+    void
   >,
   respond: GetCustomersSearchResponder,
   ctx: RouterContext,
@@ -4130,7 +4242,8 @@ export type DeleteCustomersCustomer = (
   params: Params<
     t_DeleteCustomersCustomerParamSchema,
     void,
-    t_DeleteCustomersCustomerBodySchema | undefined
+    t_DeleteCustomersCustomerBodySchema | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerResponder,
   ctx: RouterContext,
@@ -4149,7 +4262,8 @@ export type GetCustomersCustomer = (
   params: Params<
     t_GetCustomersCustomerParamSchema,
     t_GetCustomersCustomerQuerySchema,
-    t_GetCustomersCustomerBodySchema | undefined
+    t_GetCustomersCustomerBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerResponder,
   ctx: RouterContext,
@@ -4168,7 +4282,8 @@ export type PostCustomersCustomer = (
   params: Params<
     t_PostCustomersCustomerParamSchema,
     void,
-    t_PostCustomersCustomerBodySchema | undefined
+    t_PostCustomersCustomerBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerResponder,
   ctx: RouterContext,
@@ -4192,7 +4307,8 @@ export type GetCustomersCustomerBalanceTransactions = (
   params: Params<
     t_GetCustomersCustomerBalanceTransactionsParamSchema,
     t_GetCustomersCustomerBalanceTransactionsQuerySchema,
-    t_GetCustomersCustomerBalanceTransactionsBodySchema | undefined
+    t_GetCustomersCustomerBalanceTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerBalanceTransactionsResponder,
   ctx: RouterContext,
@@ -4219,7 +4335,8 @@ export type PostCustomersCustomerBalanceTransactions = (
   params: Params<
     t_PostCustomersCustomerBalanceTransactionsParamSchema,
     void,
-    t_PostCustomersCustomerBalanceTransactionsBodySchema
+    t_PostCustomersCustomerBalanceTransactionsBodySchema,
+    void
   >,
   respond: PostCustomersCustomerBalanceTransactionsResponder,
   ctx: RouterContext,
@@ -4238,7 +4355,8 @@ export type GetCustomersCustomerBalanceTransactionsTransaction = (
   params: Params<
     t_GetCustomersCustomerBalanceTransactionsTransactionParamSchema,
     t_GetCustomersCustomerBalanceTransactionsTransactionQuerySchema,
-    t_GetCustomersCustomerBalanceTransactionsTransactionBodySchema | undefined
+    t_GetCustomersCustomerBalanceTransactionsTransactionBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerBalanceTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -4257,7 +4375,8 @@ export type PostCustomersCustomerBalanceTransactionsTransaction = (
   params: Params<
     t_PostCustomersCustomerBalanceTransactionsTransactionParamSchema,
     void,
-    t_PostCustomersCustomerBalanceTransactionsTransactionBodySchema | undefined
+    t_PostCustomersCustomerBalanceTransactionsTransactionBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerBalanceTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -4281,7 +4400,8 @@ export type GetCustomersCustomerBankAccounts = (
   params: Params<
     t_GetCustomersCustomerBankAccountsParamSchema,
     t_GetCustomersCustomerBankAccountsQuerySchema,
-    t_GetCustomersCustomerBankAccountsBodySchema | undefined
+    t_GetCustomersCustomerBankAccountsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerBankAccountsResponder,
   ctx: RouterContext,
@@ -4308,7 +4428,8 @@ export type PostCustomersCustomerBankAccounts = (
   params: Params<
     t_PostCustomersCustomerBankAccountsParamSchema,
     void,
-    t_PostCustomersCustomerBankAccountsBodySchema | undefined
+    t_PostCustomersCustomerBankAccountsBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerBankAccountsResponder,
   ctx: RouterContext,
@@ -4327,7 +4448,8 @@ export type DeleteCustomersCustomerBankAccountsId = (
   params: Params<
     t_DeleteCustomersCustomerBankAccountsIdParamSchema,
     void,
-    t_DeleteCustomersCustomerBankAccountsIdBodySchema | undefined
+    t_DeleteCustomersCustomerBankAccountsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerBankAccountsIdResponder,
   ctx: RouterContext,
@@ -4346,7 +4468,8 @@ export type GetCustomersCustomerBankAccountsId = (
   params: Params<
     t_GetCustomersCustomerBankAccountsIdParamSchema,
     t_GetCustomersCustomerBankAccountsIdQuerySchema,
-    t_GetCustomersCustomerBankAccountsIdBodySchema | undefined
+    t_GetCustomersCustomerBankAccountsIdBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerBankAccountsIdResponder,
   ctx: RouterContext,
@@ -4365,7 +4488,8 @@ export type PostCustomersCustomerBankAccountsId = (
   params: Params<
     t_PostCustomersCustomerBankAccountsIdParamSchema,
     void,
-    t_PostCustomersCustomerBankAccountsIdBodySchema | undefined
+    t_PostCustomersCustomerBankAccountsIdBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerBankAccountsIdResponder,
   ctx: RouterContext,
@@ -4384,7 +4508,8 @@ export type PostCustomersCustomerBankAccountsIdVerify = (
   params: Params<
     t_PostCustomersCustomerBankAccountsIdVerifyParamSchema,
     void,
-    t_PostCustomersCustomerBankAccountsIdVerifyBodySchema | undefined
+    t_PostCustomersCustomerBankAccountsIdVerifyBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerBankAccountsIdVerifyResponder,
   ctx: RouterContext,
@@ -4408,7 +4533,8 @@ export type GetCustomersCustomerCards = (
   params: Params<
     t_GetCustomersCustomerCardsParamSchema,
     t_GetCustomersCustomerCardsQuerySchema,
-    t_GetCustomersCustomerCardsBodySchema | undefined
+    t_GetCustomersCustomerCardsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerCardsResponder,
   ctx: RouterContext,
@@ -4435,7 +4561,8 @@ export type PostCustomersCustomerCards = (
   params: Params<
     t_PostCustomersCustomerCardsParamSchema,
     void,
-    t_PostCustomersCustomerCardsBodySchema | undefined
+    t_PostCustomersCustomerCardsBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerCardsResponder,
   ctx: RouterContext,
@@ -4454,7 +4581,8 @@ export type DeleteCustomersCustomerCardsId = (
   params: Params<
     t_DeleteCustomersCustomerCardsIdParamSchema,
     void,
-    t_DeleteCustomersCustomerCardsIdBodySchema | undefined
+    t_DeleteCustomersCustomerCardsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerCardsIdResponder,
   ctx: RouterContext,
@@ -4473,7 +4601,8 @@ export type GetCustomersCustomerCardsId = (
   params: Params<
     t_GetCustomersCustomerCardsIdParamSchema,
     t_GetCustomersCustomerCardsIdQuerySchema,
-    t_GetCustomersCustomerCardsIdBodySchema | undefined
+    t_GetCustomersCustomerCardsIdBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerCardsIdResponder,
   ctx: RouterContext,
@@ -4492,7 +4621,8 @@ export type PostCustomersCustomerCardsId = (
   params: Params<
     t_PostCustomersCustomerCardsIdParamSchema,
     void,
-    t_PostCustomersCustomerCardsIdBodySchema | undefined
+    t_PostCustomersCustomerCardsIdBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerCardsIdResponder,
   ctx: RouterContext,
@@ -4511,7 +4641,8 @@ export type GetCustomersCustomerCashBalance = (
   params: Params<
     t_GetCustomersCustomerCashBalanceParamSchema,
     t_GetCustomersCustomerCashBalanceQuerySchema,
-    t_GetCustomersCustomerCashBalanceBodySchema | undefined
+    t_GetCustomersCustomerCashBalanceBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerCashBalanceResponder,
   ctx: RouterContext,
@@ -4530,7 +4661,8 @@ export type PostCustomersCustomerCashBalance = (
   params: Params<
     t_PostCustomersCustomerCashBalanceParamSchema,
     void,
-    t_PostCustomersCustomerCashBalanceBodySchema | undefined
+    t_PostCustomersCustomerCashBalanceBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerCashBalanceResponder,
   ctx: RouterContext,
@@ -4554,7 +4686,8 @@ export type GetCustomersCustomerCashBalanceTransactions = (
   params: Params<
     t_GetCustomersCustomerCashBalanceTransactionsParamSchema,
     t_GetCustomersCustomerCashBalanceTransactionsQuerySchema,
-    t_GetCustomersCustomerCashBalanceTransactionsBodySchema | undefined
+    t_GetCustomersCustomerCashBalanceTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerCashBalanceTransactionsResponder,
   ctx: RouterContext,
@@ -4582,7 +4715,8 @@ export type GetCustomersCustomerCashBalanceTransactionsTransaction = (
     t_GetCustomersCustomerCashBalanceTransactionsTransactionParamSchema,
     t_GetCustomersCustomerCashBalanceTransactionsTransactionQuerySchema,
     | t_GetCustomersCustomerCashBalanceTransactionsTransactionBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: GetCustomersCustomerCashBalanceTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -4601,7 +4735,8 @@ export type DeleteCustomersCustomerDiscount = (
   params: Params<
     t_DeleteCustomersCustomerDiscountParamSchema,
     void,
-    t_DeleteCustomersCustomerDiscountBodySchema | undefined
+    t_DeleteCustomersCustomerDiscountBodySchema | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerDiscountResponder,
   ctx: RouterContext,
@@ -4620,7 +4755,8 @@ export type GetCustomersCustomerDiscount = (
   params: Params<
     t_GetCustomersCustomerDiscountParamSchema,
     t_GetCustomersCustomerDiscountQuerySchema,
-    t_GetCustomersCustomerDiscountBodySchema | undefined
+    t_GetCustomersCustomerDiscountBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerDiscountResponder,
   ctx: RouterContext,
@@ -4639,7 +4775,8 @@ export type PostCustomersCustomerFundingInstructions = (
   params: Params<
     t_PostCustomersCustomerFundingInstructionsParamSchema,
     void,
-    t_PostCustomersCustomerFundingInstructionsBodySchema
+    t_PostCustomersCustomerFundingInstructionsBodySchema,
+    void
   >,
   respond: PostCustomersCustomerFundingInstructionsResponder,
   ctx: RouterContext,
@@ -4663,7 +4800,8 @@ export type GetCustomersCustomerPaymentMethods = (
   params: Params<
     t_GetCustomersCustomerPaymentMethodsParamSchema,
     t_GetCustomersCustomerPaymentMethodsQuerySchema,
-    t_GetCustomersCustomerPaymentMethodsBodySchema | undefined
+    t_GetCustomersCustomerPaymentMethodsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerPaymentMethodsResponder,
   ctx: RouterContext,
@@ -4690,7 +4828,8 @@ export type GetCustomersCustomerPaymentMethodsPaymentMethod = (
   params: Params<
     t_GetCustomersCustomerPaymentMethodsPaymentMethodParamSchema,
     t_GetCustomersCustomerPaymentMethodsPaymentMethodQuerySchema,
-    t_GetCustomersCustomerPaymentMethodsPaymentMethodBodySchema | undefined
+    t_GetCustomersCustomerPaymentMethodsPaymentMethodBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerPaymentMethodsPaymentMethodResponder,
   ctx: RouterContext,
@@ -4714,7 +4853,8 @@ export type GetCustomersCustomerSources = (
   params: Params<
     t_GetCustomersCustomerSourcesParamSchema,
     t_GetCustomersCustomerSourcesQuerySchema,
-    t_GetCustomersCustomerSourcesBodySchema | undefined
+    t_GetCustomersCustomerSourcesBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerSourcesResponder,
   ctx: RouterContext,
@@ -4741,7 +4881,8 @@ export type PostCustomersCustomerSources = (
   params: Params<
     t_PostCustomersCustomerSourcesParamSchema,
     void,
-    t_PostCustomersCustomerSourcesBodySchema | undefined
+    t_PostCustomersCustomerSourcesBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerSourcesResponder,
   ctx: RouterContext,
@@ -4760,7 +4901,8 @@ export type DeleteCustomersCustomerSourcesId = (
   params: Params<
     t_DeleteCustomersCustomerSourcesIdParamSchema,
     void,
-    t_DeleteCustomersCustomerSourcesIdBodySchema | undefined
+    t_DeleteCustomersCustomerSourcesIdBodySchema | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerSourcesIdResponder,
   ctx: RouterContext,
@@ -4779,7 +4921,8 @@ export type GetCustomersCustomerSourcesId = (
   params: Params<
     t_GetCustomersCustomerSourcesIdParamSchema,
     t_GetCustomersCustomerSourcesIdQuerySchema,
-    t_GetCustomersCustomerSourcesIdBodySchema | undefined
+    t_GetCustomersCustomerSourcesIdBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerSourcesIdResponder,
   ctx: RouterContext,
@@ -4798,7 +4941,8 @@ export type PostCustomersCustomerSourcesId = (
   params: Params<
     t_PostCustomersCustomerSourcesIdParamSchema,
     void,
-    t_PostCustomersCustomerSourcesIdBodySchema | undefined
+    t_PostCustomersCustomerSourcesIdBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerSourcesIdResponder,
   ctx: RouterContext,
@@ -4817,7 +4961,8 @@ export type PostCustomersCustomerSourcesIdVerify = (
   params: Params<
     t_PostCustomersCustomerSourcesIdVerifyParamSchema,
     void,
-    t_PostCustomersCustomerSourcesIdVerifyBodySchema | undefined
+    t_PostCustomersCustomerSourcesIdVerifyBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerSourcesIdVerifyResponder,
   ctx: RouterContext,
@@ -4841,7 +4986,8 @@ export type GetCustomersCustomerSubscriptions = (
   params: Params<
     t_GetCustomersCustomerSubscriptionsParamSchema,
     t_GetCustomersCustomerSubscriptionsQuerySchema,
-    t_GetCustomersCustomerSubscriptionsBodySchema | undefined
+    t_GetCustomersCustomerSubscriptionsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerSubscriptionsResponder,
   ctx: RouterContext,
@@ -4868,7 +5014,8 @@ export type PostCustomersCustomerSubscriptions = (
   params: Params<
     t_PostCustomersCustomerSubscriptionsParamSchema,
     void,
-    t_PostCustomersCustomerSubscriptionsBodySchema | undefined
+    t_PostCustomersCustomerSubscriptionsBodySchema | undefined,
+    void
   >,
   respond: PostCustomersCustomerSubscriptionsResponder,
   ctx: RouterContext,
@@ -4889,7 +5036,8 @@ export type DeleteCustomersCustomerSubscriptionsSubscriptionExposedId = (
     t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
     void,
     | t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdResponder,
   ctx: RouterContext,
@@ -4909,7 +5057,8 @@ export type GetCustomersCustomerSubscriptionsSubscriptionExposedId = (
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdQuerySchema,
     | t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: GetCustomersCustomerSubscriptionsSubscriptionExposedIdResponder,
   ctx: RouterContext,
@@ -4929,7 +5078,8 @@ export type PostCustomersCustomerSubscriptionsSubscriptionExposedId = (
     t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdParamSchema,
     void,
     | t_PostCustomersCustomerSubscriptionsSubscriptionExposedIdBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostCustomersCustomerSubscriptionsSubscriptionExposedIdResponder,
   ctx: RouterContext,
@@ -4951,7 +5101,8 @@ export type DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount =
       t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
       void,
       | t_DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema
-      | undefined
+      | undefined,
+      void
     >,
     respond: DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponder,
     ctx: RouterContext,
@@ -4972,7 +5123,8 @@ export type GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount = (
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountParamSchema,
     t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountQuerySchema,
     | t_GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscountResponder,
   ctx: RouterContext,
@@ -4996,7 +5148,8 @@ export type GetCustomersCustomerTaxIds = (
   params: Params<
     t_GetCustomersCustomerTaxIdsParamSchema,
     t_GetCustomersCustomerTaxIdsQuerySchema,
-    t_GetCustomersCustomerTaxIdsBodySchema | undefined
+    t_GetCustomersCustomerTaxIdsBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerTaxIdsResponder,
   ctx: RouterContext,
@@ -5023,7 +5176,8 @@ export type PostCustomersCustomerTaxIds = (
   params: Params<
     t_PostCustomersCustomerTaxIdsParamSchema,
     void,
-    t_PostCustomersCustomerTaxIdsBodySchema
+    t_PostCustomersCustomerTaxIdsBodySchema,
+    void
   >,
   respond: PostCustomersCustomerTaxIdsResponder,
   ctx: RouterContext,
@@ -5042,7 +5196,8 @@ export type DeleteCustomersCustomerTaxIdsId = (
   params: Params<
     t_DeleteCustomersCustomerTaxIdsIdParamSchema,
     void,
-    t_DeleteCustomersCustomerTaxIdsIdBodySchema | undefined
+    t_DeleteCustomersCustomerTaxIdsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteCustomersCustomerTaxIdsIdResponder,
   ctx: RouterContext,
@@ -5061,7 +5216,8 @@ export type GetCustomersCustomerTaxIdsId = (
   params: Params<
     t_GetCustomersCustomerTaxIdsIdParamSchema,
     t_GetCustomersCustomerTaxIdsIdQuerySchema,
-    t_GetCustomersCustomerTaxIdsIdBodySchema | undefined
+    t_GetCustomersCustomerTaxIdsIdBodySchema | undefined,
+    void
   >,
   respond: GetCustomersCustomerTaxIdsIdResponder,
   ctx: RouterContext,
@@ -5085,7 +5241,8 @@ export type GetDisputes = (
   params: Params<
     void,
     t_GetDisputesQuerySchema,
-    t_GetDisputesBodySchema | undefined
+    t_GetDisputesBodySchema | undefined,
+    void
   >,
   respond: GetDisputesResponder,
   ctx: RouterContext,
@@ -5112,7 +5269,8 @@ export type GetDisputesDispute = (
   params: Params<
     t_GetDisputesDisputeParamSchema,
     t_GetDisputesDisputeQuerySchema,
-    t_GetDisputesDisputeBodySchema | undefined
+    t_GetDisputesDisputeBodySchema | undefined,
+    void
   >,
   respond: GetDisputesDisputeResponder,
   ctx: RouterContext,
@@ -5131,7 +5289,8 @@ export type PostDisputesDispute = (
   params: Params<
     t_PostDisputesDisputeParamSchema,
     void,
-    t_PostDisputesDisputeBodySchema | undefined
+    t_PostDisputesDisputeBodySchema | undefined,
+    void
   >,
   respond: PostDisputesDisputeResponder,
   ctx: RouterContext,
@@ -5150,7 +5309,8 @@ export type PostDisputesDisputeClose = (
   params: Params<
     t_PostDisputesDisputeCloseParamSchema,
     void,
-    t_PostDisputesDisputeCloseBodySchema | undefined
+    t_PostDisputesDisputeCloseBodySchema | undefined,
+    void
   >,
   respond: PostDisputesDisputeCloseResponder,
   ctx: RouterContext,
@@ -5174,7 +5334,8 @@ export type GetEntitlementsActiveEntitlements = (
   params: Params<
     void,
     t_GetEntitlementsActiveEntitlementsQuerySchema,
-    t_GetEntitlementsActiveEntitlementsBodySchema | undefined
+    t_GetEntitlementsActiveEntitlementsBodySchema | undefined,
+    void
   >,
   respond: GetEntitlementsActiveEntitlementsResponder,
   ctx: RouterContext,
@@ -5201,7 +5362,8 @@ export type GetEntitlementsActiveEntitlementsId = (
   params: Params<
     t_GetEntitlementsActiveEntitlementsIdParamSchema,
     t_GetEntitlementsActiveEntitlementsIdQuerySchema,
-    t_GetEntitlementsActiveEntitlementsIdBodySchema | undefined
+    t_GetEntitlementsActiveEntitlementsIdBodySchema | undefined,
+    void
   >,
   respond: GetEntitlementsActiveEntitlementsIdResponder,
   ctx: RouterContext,
@@ -5225,7 +5387,8 @@ export type GetEntitlementsFeatures = (
   params: Params<
     void,
     t_GetEntitlementsFeaturesQuerySchema,
-    t_GetEntitlementsFeaturesBodySchema | undefined
+    t_GetEntitlementsFeaturesBodySchema | undefined,
+    void
   >,
   respond: GetEntitlementsFeaturesResponder,
   ctx: RouterContext,
@@ -5249,7 +5412,7 @@ export type PostEntitlementsFeaturesResponder = {
 } & KoaRuntimeResponder
 
 export type PostEntitlementsFeatures = (
-  params: Params<void, void, t_PostEntitlementsFeaturesBodySchema>,
+  params: Params<void, void, t_PostEntitlementsFeaturesBodySchema, void>,
   respond: PostEntitlementsFeaturesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5267,7 +5430,8 @@ export type GetEntitlementsFeaturesId = (
   params: Params<
     t_GetEntitlementsFeaturesIdParamSchema,
     t_GetEntitlementsFeaturesIdQuerySchema,
-    t_GetEntitlementsFeaturesIdBodySchema | undefined
+    t_GetEntitlementsFeaturesIdBodySchema | undefined,
+    void
   >,
   respond: GetEntitlementsFeaturesIdResponder,
   ctx: RouterContext,
@@ -5286,7 +5450,8 @@ export type PostEntitlementsFeaturesId = (
   params: Params<
     t_PostEntitlementsFeaturesIdParamSchema,
     void,
-    t_PostEntitlementsFeaturesIdBodySchema | undefined
+    t_PostEntitlementsFeaturesIdBodySchema | undefined,
+    void
   >,
   respond: PostEntitlementsFeaturesIdResponder,
   ctx: RouterContext,
@@ -5302,7 +5467,7 @@ export type PostEphemeralKeysResponder = {
 } & KoaRuntimeResponder
 
 export type PostEphemeralKeys = (
-  params: Params<void, void, t_PostEphemeralKeysBodySchema | undefined>,
+  params: Params<void, void, t_PostEphemeralKeysBodySchema | undefined, void>,
   respond: PostEphemeralKeysResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5320,7 +5485,8 @@ export type DeleteEphemeralKeysKey = (
   params: Params<
     t_DeleteEphemeralKeysKeyParamSchema,
     void,
-    t_DeleteEphemeralKeysKeyBodySchema | undefined
+    t_DeleteEphemeralKeysKeyBodySchema | undefined,
+    void
   >,
   respond: DeleteEphemeralKeysKeyResponder,
   ctx: RouterContext,
@@ -5344,7 +5510,8 @@ export type GetEvents = (
   params: Params<
     void,
     t_GetEventsQuerySchema,
-    t_GetEventsBodySchema | undefined
+    t_GetEventsBodySchema | undefined,
+    void
   >,
   respond: GetEventsResponder,
   ctx: RouterContext,
@@ -5371,7 +5538,8 @@ export type GetEventsId = (
   params: Params<
     t_GetEventsIdParamSchema,
     t_GetEventsIdQuerySchema,
-    t_GetEventsIdBodySchema | undefined
+    t_GetEventsIdBodySchema | undefined,
+    void
   >,
   respond: GetEventsIdResponder,
   ctx: RouterContext,
@@ -5395,7 +5563,8 @@ export type GetExchangeRates = (
   params: Params<
     void,
     t_GetExchangeRatesQuerySchema,
-    t_GetExchangeRatesBodySchema | undefined
+    t_GetExchangeRatesBodySchema | undefined,
+    void
   >,
   respond: GetExchangeRatesResponder,
   ctx: RouterContext,
@@ -5422,7 +5591,8 @@ export type GetExchangeRatesRateId = (
   params: Params<
     t_GetExchangeRatesRateIdParamSchema,
     t_GetExchangeRatesRateIdQuerySchema,
-    t_GetExchangeRatesRateIdBodySchema | undefined
+    t_GetExchangeRatesRateIdBodySchema | undefined,
+    void
   >,
   respond: GetExchangeRatesRateIdResponder,
   ctx: RouterContext,
@@ -5446,7 +5616,8 @@ export type GetFileLinks = (
   params: Params<
     void,
     t_GetFileLinksQuerySchema,
-    t_GetFileLinksBodySchema | undefined
+    t_GetFileLinksBodySchema | undefined,
+    void
   >,
   respond: GetFileLinksResponder,
   ctx: RouterContext,
@@ -5470,7 +5641,7 @@ export type PostFileLinksResponder = {
 } & KoaRuntimeResponder
 
 export type PostFileLinks = (
-  params: Params<void, void, t_PostFileLinksBodySchema>,
+  params: Params<void, void, t_PostFileLinksBodySchema, void>,
   respond: PostFileLinksResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5488,7 +5659,8 @@ export type GetFileLinksLink = (
   params: Params<
     t_GetFileLinksLinkParamSchema,
     t_GetFileLinksLinkQuerySchema,
-    t_GetFileLinksLinkBodySchema | undefined
+    t_GetFileLinksLinkBodySchema | undefined,
+    void
   >,
   respond: GetFileLinksLinkResponder,
   ctx: RouterContext,
@@ -5507,7 +5679,8 @@ export type PostFileLinksLink = (
   params: Params<
     t_PostFileLinksLinkParamSchema,
     void,
-    t_PostFileLinksLinkBodySchema | undefined
+    t_PostFileLinksLinkBodySchema | undefined,
+    void
   >,
   respond: PostFileLinksLinkResponder,
   ctx: RouterContext,
@@ -5528,7 +5701,12 @@ export type GetFilesResponder = {
 } & KoaRuntimeResponder
 
 export type GetFiles = (
-  params: Params<void, t_GetFilesQuerySchema, t_GetFilesBodySchema | undefined>,
+  params: Params<
+    void,
+    t_GetFilesQuerySchema,
+    t_GetFilesBodySchema | undefined,
+    void
+  >,
   respond: GetFilesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5551,7 +5729,7 @@ export type PostFilesResponder = {
 } & KoaRuntimeResponder
 
 export type PostFiles = (
-  params: Params<void, void, t_PostFilesBodySchema>,
+  params: Params<void, void, t_PostFilesBodySchema, void>,
   respond: PostFilesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5569,7 +5747,8 @@ export type GetFilesFile = (
   params: Params<
     t_GetFilesFileParamSchema,
     t_GetFilesFileQuerySchema,
-    t_GetFilesFileBodySchema | undefined
+    t_GetFilesFileBodySchema | undefined,
+    void
   >,
   respond: GetFilesFileResponder,
   ctx: RouterContext,
@@ -5593,7 +5772,8 @@ export type GetFinancialConnectionsAccounts = (
   params: Params<
     void,
     t_GetFinancialConnectionsAccountsQuerySchema,
-    t_GetFinancialConnectionsAccountsBodySchema | undefined
+    t_GetFinancialConnectionsAccountsBodySchema | undefined,
+    void
   >,
   respond: GetFinancialConnectionsAccountsResponder,
   ctx: RouterContext,
@@ -5620,7 +5800,8 @@ export type GetFinancialConnectionsAccountsAccount = (
   params: Params<
     t_GetFinancialConnectionsAccountsAccountParamSchema,
     t_GetFinancialConnectionsAccountsAccountQuerySchema,
-    t_GetFinancialConnectionsAccountsAccountBodySchema | undefined
+    t_GetFinancialConnectionsAccountsAccountBodySchema | undefined,
+    void
   >,
   respond: GetFinancialConnectionsAccountsAccountResponder,
   ctx: RouterContext,
@@ -5639,7 +5820,8 @@ export type PostFinancialConnectionsAccountsAccountDisconnect = (
   params: Params<
     t_PostFinancialConnectionsAccountsAccountDisconnectParamSchema,
     void,
-    t_PostFinancialConnectionsAccountsAccountDisconnectBodySchema | undefined
+    t_PostFinancialConnectionsAccountsAccountDisconnectBodySchema | undefined,
+    void
   >,
   respond: PostFinancialConnectionsAccountsAccountDisconnectResponder,
   ctx: RouterContext,
@@ -5663,7 +5845,8 @@ export type GetFinancialConnectionsAccountsAccountOwners = (
   params: Params<
     t_GetFinancialConnectionsAccountsAccountOwnersParamSchema,
     t_GetFinancialConnectionsAccountsAccountOwnersQuerySchema,
-    t_GetFinancialConnectionsAccountsAccountOwnersBodySchema | undefined
+    t_GetFinancialConnectionsAccountsAccountOwnersBodySchema | undefined,
+    void
   >,
   respond: GetFinancialConnectionsAccountsAccountOwnersResponder,
   ctx: RouterContext,
@@ -5690,7 +5873,8 @@ export type PostFinancialConnectionsAccountsAccountRefresh = (
   params: Params<
     t_PostFinancialConnectionsAccountsAccountRefreshParamSchema,
     void,
-    t_PostFinancialConnectionsAccountsAccountRefreshBodySchema
+    t_PostFinancialConnectionsAccountsAccountRefreshBodySchema,
+    void
   >,
   respond: PostFinancialConnectionsAccountsAccountRefreshResponder,
   ctx: RouterContext,
@@ -5709,7 +5893,8 @@ export type PostFinancialConnectionsAccountsAccountSubscribe = (
   params: Params<
     t_PostFinancialConnectionsAccountsAccountSubscribeParamSchema,
     void,
-    t_PostFinancialConnectionsAccountsAccountSubscribeBodySchema
+    t_PostFinancialConnectionsAccountsAccountSubscribeBodySchema,
+    void
   >,
   respond: PostFinancialConnectionsAccountsAccountSubscribeResponder,
   ctx: RouterContext,
@@ -5728,7 +5913,8 @@ export type PostFinancialConnectionsAccountsAccountUnsubscribe = (
   params: Params<
     t_PostFinancialConnectionsAccountsAccountUnsubscribeParamSchema,
     void,
-    t_PostFinancialConnectionsAccountsAccountUnsubscribeBodySchema
+    t_PostFinancialConnectionsAccountsAccountUnsubscribeBodySchema,
+    void
   >,
   respond: PostFinancialConnectionsAccountsAccountUnsubscribeResponder,
   ctx: RouterContext,
@@ -5744,7 +5930,12 @@ export type PostFinancialConnectionsSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostFinancialConnectionsSessions = (
-  params: Params<void, void, t_PostFinancialConnectionsSessionsBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostFinancialConnectionsSessionsBodySchema,
+    void
+  >,
   respond: PostFinancialConnectionsSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5762,7 +5953,8 @@ export type GetFinancialConnectionsSessionsSession = (
   params: Params<
     t_GetFinancialConnectionsSessionsSessionParamSchema,
     t_GetFinancialConnectionsSessionsSessionQuerySchema,
-    t_GetFinancialConnectionsSessionsSessionBodySchema | undefined
+    t_GetFinancialConnectionsSessionsSessionBodySchema | undefined,
+    void
   >,
   respond: GetFinancialConnectionsSessionsSessionResponder,
   ctx: RouterContext,
@@ -5786,7 +5978,8 @@ export type GetFinancialConnectionsTransactions = (
   params: Params<
     void,
     t_GetFinancialConnectionsTransactionsQuerySchema,
-    t_GetFinancialConnectionsTransactionsBodySchema | undefined
+    t_GetFinancialConnectionsTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetFinancialConnectionsTransactionsResponder,
   ctx: RouterContext,
@@ -5813,7 +6006,8 @@ export type GetFinancialConnectionsTransactionsTransaction = (
   params: Params<
     t_GetFinancialConnectionsTransactionsTransactionParamSchema,
     t_GetFinancialConnectionsTransactionsTransactionQuerySchema,
-    t_GetFinancialConnectionsTransactionsTransactionBodySchema | undefined
+    t_GetFinancialConnectionsTransactionsTransactionBodySchema | undefined,
+    void
   >,
   respond: GetFinancialConnectionsTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -5837,7 +6031,8 @@ export type GetForwardingRequests = (
   params: Params<
     void,
     t_GetForwardingRequestsQuerySchema,
-    t_GetForwardingRequestsBodySchema | undefined
+    t_GetForwardingRequestsBodySchema | undefined,
+    void
   >,
   respond: GetForwardingRequestsResponder,
   ctx: RouterContext,
@@ -5861,7 +6056,7 @@ export type PostForwardingRequestsResponder = {
 } & KoaRuntimeResponder
 
 export type PostForwardingRequests = (
-  params: Params<void, void, t_PostForwardingRequestsBodySchema>,
+  params: Params<void, void, t_PostForwardingRequestsBodySchema, void>,
   respond: PostForwardingRequestsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -5879,7 +6074,8 @@ export type GetForwardingRequestsId = (
   params: Params<
     t_GetForwardingRequestsIdParamSchema,
     t_GetForwardingRequestsIdQuerySchema,
-    t_GetForwardingRequestsIdBodySchema | undefined
+    t_GetForwardingRequestsIdBodySchema | undefined,
+    void
   >,
   respond: GetForwardingRequestsIdResponder,
   ctx: RouterContext,
@@ -5903,7 +6099,8 @@ export type GetIdentityVerificationReports = (
   params: Params<
     void,
     t_GetIdentityVerificationReportsQuerySchema,
-    t_GetIdentityVerificationReportsBodySchema | undefined
+    t_GetIdentityVerificationReportsBodySchema | undefined,
+    void
   >,
   respond: GetIdentityVerificationReportsResponder,
   ctx: RouterContext,
@@ -5930,7 +6127,8 @@ export type GetIdentityVerificationReportsReport = (
   params: Params<
     t_GetIdentityVerificationReportsReportParamSchema,
     t_GetIdentityVerificationReportsReportQuerySchema,
-    t_GetIdentityVerificationReportsReportBodySchema | undefined
+    t_GetIdentityVerificationReportsReportBodySchema | undefined,
+    void
   >,
   respond: GetIdentityVerificationReportsReportResponder,
   ctx: RouterContext,
@@ -5954,7 +6152,8 @@ export type GetIdentityVerificationSessions = (
   params: Params<
     void,
     t_GetIdentityVerificationSessionsQuerySchema,
-    t_GetIdentityVerificationSessionsBodySchema | undefined
+    t_GetIdentityVerificationSessionsBodySchema | undefined,
+    void
   >,
   respond: GetIdentityVerificationSessionsResponder,
   ctx: RouterContext,
@@ -5981,7 +6180,8 @@ export type PostIdentityVerificationSessions = (
   params: Params<
     void,
     void,
-    t_PostIdentityVerificationSessionsBodySchema | undefined
+    t_PostIdentityVerificationSessionsBodySchema | undefined,
+    void
   >,
   respond: PostIdentityVerificationSessionsResponder,
   ctx: RouterContext,
@@ -6000,7 +6200,8 @@ export type GetIdentityVerificationSessionsSession = (
   params: Params<
     t_GetIdentityVerificationSessionsSessionParamSchema,
     t_GetIdentityVerificationSessionsSessionQuerySchema,
-    t_GetIdentityVerificationSessionsSessionBodySchema | undefined
+    t_GetIdentityVerificationSessionsSessionBodySchema | undefined,
+    void
   >,
   respond: GetIdentityVerificationSessionsSessionResponder,
   ctx: RouterContext,
@@ -6019,7 +6220,8 @@ export type PostIdentityVerificationSessionsSession = (
   params: Params<
     t_PostIdentityVerificationSessionsSessionParamSchema,
     void,
-    t_PostIdentityVerificationSessionsSessionBodySchema | undefined
+    t_PostIdentityVerificationSessionsSessionBodySchema | undefined,
+    void
   >,
   respond: PostIdentityVerificationSessionsSessionResponder,
   ctx: RouterContext,
@@ -6038,7 +6240,8 @@ export type PostIdentityVerificationSessionsSessionCancel = (
   params: Params<
     t_PostIdentityVerificationSessionsSessionCancelParamSchema,
     void,
-    t_PostIdentityVerificationSessionsSessionCancelBodySchema | undefined
+    t_PostIdentityVerificationSessionsSessionCancelBodySchema | undefined,
+    void
   >,
   respond: PostIdentityVerificationSessionsSessionCancelResponder,
   ctx: RouterContext,
@@ -6057,7 +6260,8 @@ export type PostIdentityVerificationSessionsSessionRedact = (
   params: Params<
     t_PostIdentityVerificationSessionsSessionRedactParamSchema,
     void,
-    t_PostIdentityVerificationSessionsSessionRedactBodySchema | undefined
+    t_PostIdentityVerificationSessionsSessionRedactBodySchema | undefined,
+    void
   >,
   respond: PostIdentityVerificationSessionsSessionRedactResponder,
   ctx: RouterContext,
@@ -6081,7 +6285,8 @@ export type GetInvoiceRenderingTemplates = (
   params: Params<
     void,
     t_GetInvoiceRenderingTemplatesQuerySchema,
-    t_GetInvoiceRenderingTemplatesBodySchema | undefined
+    t_GetInvoiceRenderingTemplatesBodySchema | undefined,
+    void
   >,
   respond: GetInvoiceRenderingTemplatesResponder,
   ctx: RouterContext,
@@ -6108,7 +6313,8 @@ export type GetInvoiceRenderingTemplatesTemplate = (
   params: Params<
     t_GetInvoiceRenderingTemplatesTemplateParamSchema,
     t_GetInvoiceRenderingTemplatesTemplateQuerySchema,
-    t_GetInvoiceRenderingTemplatesTemplateBodySchema | undefined
+    t_GetInvoiceRenderingTemplatesTemplateBodySchema | undefined,
+    void
   >,
   respond: GetInvoiceRenderingTemplatesTemplateResponder,
   ctx: RouterContext,
@@ -6127,7 +6333,8 @@ export type PostInvoiceRenderingTemplatesTemplateArchive = (
   params: Params<
     t_PostInvoiceRenderingTemplatesTemplateArchiveParamSchema,
     void,
-    t_PostInvoiceRenderingTemplatesTemplateArchiveBodySchema | undefined
+    t_PostInvoiceRenderingTemplatesTemplateArchiveBodySchema | undefined,
+    void
   >,
   respond: PostInvoiceRenderingTemplatesTemplateArchiveResponder,
   ctx: RouterContext,
@@ -6146,7 +6353,8 @@ export type PostInvoiceRenderingTemplatesTemplateUnarchive = (
   params: Params<
     t_PostInvoiceRenderingTemplatesTemplateUnarchiveParamSchema,
     void,
-    t_PostInvoiceRenderingTemplatesTemplateUnarchiveBodySchema | undefined
+    t_PostInvoiceRenderingTemplatesTemplateUnarchiveBodySchema | undefined,
+    void
   >,
   respond: PostInvoiceRenderingTemplatesTemplateUnarchiveResponder,
   ctx: RouterContext,
@@ -6170,7 +6378,8 @@ export type GetInvoiceitems = (
   params: Params<
     void,
     t_GetInvoiceitemsQuerySchema,
-    t_GetInvoiceitemsBodySchema | undefined
+    t_GetInvoiceitemsBodySchema | undefined,
+    void
   >,
   respond: GetInvoiceitemsResponder,
   ctx: RouterContext,
@@ -6194,7 +6403,7 @@ export type PostInvoiceitemsResponder = {
 } & KoaRuntimeResponder
 
 export type PostInvoiceitems = (
-  params: Params<void, void, t_PostInvoiceitemsBodySchema>,
+  params: Params<void, void, t_PostInvoiceitemsBodySchema, void>,
   respond: PostInvoiceitemsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6212,7 +6421,8 @@ export type DeleteInvoiceitemsInvoiceitem = (
   params: Params<
     t_DeleteInvoiceitemsInvoiceitemParamSchema,
     void,
-    t_DeleteInvoiceitemsInvoiceitemBodySchema | undefined
+    t_DeleteInvoiceitemsInvoiceitemBodySchema | undefined,
+    void
   >,
   respond: DeleteInvoiceitemsInvoiceitemResponder,
   ctx: RouterContext,
@@ -6231,7 +6441,8 @@ export type GetInvoiceitemsInvoiceitem = (
   params: Params<
     t_GetInvoiceitemsInvoiceitemParamSchema,
     t_GetInvoiceitemsInvoiceitemQuerySchema,
-    t_GetInvoiceitemsInvoiceitemBodySchema | undefined
+    t_GetInvoiceitemsInvoiceitemBodySchema | undefined,
+    void
   >,
   respond: GetInvoiceitemsInvoiceitemResponder,
   ctx: RouterContext,
@@ -6250,7 +6461,8 @@ export type PostInvoiceitemsInvoiceitem = (
   params: Params<
     t_PostInvoiceitemsInvoiceitemParamSchema,
     void,
-    t_PostInvoiceitemsInvoiceitemBodySchema | undefined
+    t_PostInvoiceitemsInvoiceitemBodySchema | undefined,
+    void
   >,
   respond: PostInvoiceitemsInvoiceitemResponder,
   ctx: RouterContext,
@@ -6274,7 +6486,8 @@ export type GetInvoices = (
   params: Params<
     void,
     t_GetInvoicesQuerySchema,
-    t_GetInvoicesBodySchema | undefined
+    t_GetInvoicesBodySchema | undefined,
+    void
   >,
   respond: GetInvoicesResponder,
   ctx: RouterContext,
@@ -6298,7 +6511,7 @@ export type PostInvoicesResponder = {
 } & KoaRuntimeResponder
 
 export type PostInvoices = (
-  params: Params<void, void, t_PostInvoicesBodySchema | undefined>,
+  params: Params<void, void, t_PostInvoicesBodySchema | undefined, void>,
   respond: PostInvoicesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6313,7 +6526,12 @@ export type PostInvoicesCreatePreviewResponder = {
 } & KoaRuntimeResponder
 
 export type PostInvoicesCreatePreview = (
-  params: Params<void, void, t_PostInvoicesCreatePreviewBodySchema | undefined>,
+  params: Params<
+    void,
+    void,
+    t_PostInvoicesCreatePreviewBodySchema | undefined,
+    void
+  >,
   respond: PostInvoicesCreatePreviewResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6338,7 +6556,8 @@ export type GetInvoicesSearch = (
   params: Params<
     void,
     t_GetInvoicesSearchQuerySchema,
-    t_GetInvoicesSearchBodySchema | undefined
+    t_GetInvoicesSearchBodySchema | undefined,
+    void
   >,
   respond: GetInvoicesSearchResponder,
   ctx: RouterContext,
@@ -6367,7 +6586,8 @@ export type GetInvoicesUpcoming = (
   params: Params<
     void,
     t_GetInvoicesUpcomingQuerySchema,
-    t_GetInvoicesUpcomingBodySchema | undefined
+    t_GetInvoicesUpcomingBodySchema | undefined,
+    void
   >,
   respond: GetInvoicesUpcomingResponder,
   ctx: RouterContext,
@@ -6391,7 +6611,8 @@ export type GetInvoicesUpcomingLines = (
   params: Params<
     void,
     t_GetInvoicesUpcomingLinesQuerySchema,
-    t_GetInvoicesUpcomingLinesBodySchema | undefined
+    t_GetInvoicesUpcomingLinesBodySchema | undefined,
+    void
   >,
   respond: GetInvoicesUpcomingLinesResponder,
   ctx: RouterContext,
@@ -6418,7 +6639,8 @@ export type DeleteInvoicesInvoice = (
   params: Params<
     t_DeleteInvoicesInvoiceParamSchema,
     void,
-    t_DeleteInvoicesInvoiceBodySchema | undefined
+    t_DeleteInvoicesInvoiceBodySchema | undefined,
+    void
   >,
   respond: DeleteInvoicesInvoiceResponder,
   ctx: RouterContext,
@@ -6437,7 +6659,8 @@ export type GetInvoicesInvoice = (
   params: Params<
     t_GetInvoicesInvoiceParamSchema,
     t_GetInvoicesInvoiceQuerySchema,
-    t_GetInvoicesInvoiceBodySchema | undefined
+    t_GetInvoicesInvoiceBodySchema | undefined,
+    void
   >,
   respond: GetInvoicesInvoiceResponder,
   ctx: RouterContext,
@@ -6456,7 +6679,8 @@ export type PostInvoicesInvoice = (
   params: Params<
     t_PostInvoicesInvoiceParamSchema,
     void,
-    t_PostInvoicesInvoiceBodySchema | undefined
+    t_PostInvoicesInvoiceBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoiceResponder,
   ctx: RouterContext,
@@ -6475,7 +6699,8 @@ export type PostInvoicesInvoiceAddLines = (
   params: Params<
     t_PostInvoicesInvoiceAddLinesParamSchema,
     void,
-    t_PostInvoicesInvoiceAddLinesBodySchema
+    t_PostInvoicesInvoiceAddLinesBodySchema,
+    void
   >,
   respond: PostInvoicesInvoiceAddLinesResponder,
   ctx: RouterContext,
@@ -6494,7 +6719,8 @@ export type PostInvoicesInvoiceFinalize = (
   params: Params<
     t_PostInvoicesInvoiceFinalizeParamSchema,
     void,
-    t_PostInvoicesInvoiceFinalizeBodySchema | undefined
+    t_PostInvoicesInvoiceFinalizeBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoiceFinalizeResponder,
   ctx: RouterContext,
@@ -6518,7 +6744,8 @@ export type GetInvoicesInvoiceLines = (
   params: Params<
     t_GetInvoicesInvoiceLinesParamSchema,
     t_GetInvoicesInvoiceLinesQuerySchema,
-    t_GetInvoicesInvoiceLinesBodySchema | undefined
+    t_GetInvoicesInvoiceLinesBodySchema | undefined,
+    void
   >,
   respond: GetInvoicesInvoiceLinesResponder,
   ctx: RouterContext,
@@ -6545,7 +6772,8 @@ export type PostInvoicesInvoiceLinesLineItemId = (
   params: Params<
     t_PostInvoicesInvoiceLinesLineItemIdParamSchema,
     void,
-    t_PostInvoicesInvoiceLinesLineItemIdBodySchema | undefined
+    t_PostInvoicesInvoiceLinesLineItemIdBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoiceLinesLineItemIdResponder,
   ctx: RouterContext,
@@ -6564,7 +6792,8 @@ export type PostInvoicesInvoiceMarkUncollectible = (
   params: Params<
     t_PostInvoicesInvoiceMarkUncollectibleParamSchema,
     void,
-    t_PostInvoicesInvoiceMarkUncollectibleBodySchema | undefined
+    t_PostInvoicesInvoiceMarkUncollectibleBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoiceMarkUncollectibleResponder,
   ctx: RouterContext,
@@ -6583,7 +6812,8 @@ export type PostInvoicesInvoicePay = (
   params: Params<
     t_PostInvoicesInvoicePayParamSchema,
     void,
-    t_PostInvoicesInvoicePayBodySchema | undefined
+    t_PostInvoicesInvoicePayBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoicePayResponder,
   ctx: RouterContext,
@@ -6602,7 +6832,8 @@ export type PostInvoicesInvoiceRemoveLines = (
   params: Params<
     t_PostInvoicesInvoiceRemoveLinesParamSchema,
     void,
-    t_PostInvoicesInvoiceRemoveLinesBodySchema
+    t_PostInvoicesInvoiceRemoveLinesBodySchema,
+    void
   >,
   respond: PostInvoicesInvoiceRemoveLinesResponder,
   ctx: RouterContext,
@@ -6621,7 +6852,8 @@ export type PostInvoicesInvoiceSend = (
   params: Params<
     t_PostInvoicesInvoiceSendParamSchema,
     void,
-    t_PostInvoicesInvoiceSendBodySchema | undefined
+    t_PostInvoicesInvoiceSendBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoiceSendResponder,
   ctx: RouterContext,
@@ -6640,7 +6872,8 @@ export type PostInvoicesInvoiceUpdateLines = (
   params: Params<
     t_PostInvoicesInvoiceUpdateLinesParamSchema,
     void,
-    t_PostInvoicesInvoiceUpdateLinesBodySchema
+    t_PostInvoicesInvoiceUpdateLinesBodySchema,
+    void
   >,
   respond: PostInvoicesInvoiceUpdateLinesResponder,
   ctx: RouterContext,
@@ -6659,7 +6892,8 @@ export type PostInvoicesInvoiceVoid = (
   params: Params<
     t_PostInvoicesInvoiceVoidParamSchema,
     void,
-    t_PostInvoicesInvoiceVoidBodySchema | undefined
+    t_PostInvoicesInvoiceVoidBodySchema | undefined,
+    void
   >,
   respond: PostInvoicesInvoiceVoidResponder,
   ctx: RouterContext,
@@ -6683,7 +6917,8 @@ export type GetIssuingAuthorizations = (
   params: Params<
     void,
     t_GetIssuingAuthorizationsQuerySchema,
-    t_GetIssuingAuthorizationsBodySchema | undefined
+    t_GetIssuingAuthorizationsBodySchema | undefined,
+    void
   >,
   respond: GetIssuingAuthorizationsResponder,
   ctx: RouterContext,
@@ -6710,7 +6945,8 @@ export type GetIssuingAuthorizationsAuthorization = (
   params: Params<
     t_GetIssuingAuthorizationsAuthorizationParamSchema,
     t_GetIssuingAuthorizationsAuthorizationQuerySchema,
-    t_GetIssuingAuthorizationsAuthorizationBodySchema | undefined
+    t_GetIssuingAuthorizationsAuthorizationBodySchema | undefined,
+    void
   >,
   respond: GetIssuingAuthorizationsAuthorizationResponder,
   ctx: RouterContext,
@@ -6729,7 +6965,8 @@ export type PostIssuingAuthorizationsAuthorization = (
   params: Params<
     t_PostIssuingAuthorizationsAuthorizationParamSchema,
     void,
-    t_PostIssuingAuthorizationsAuthorizationBodySchema | undefined
+    t_PostIssuingAuthorizationsAuthorizationBodySchema | undefined,
+    void
   >,
   respond: PostIssuingAuthorizationsAuthorizationResponder,
   ctx: RouterContext,
@@ -6748,7 +6985,8 @@ export type PostIssuingAuthorizationsAuthorizationApprove = (
   params: Params<
     t_PostIssuingAuthorizationsAuthorizationApproveParamSchema,
     void,
-    t_PostIssuingAuthorizationsAuthorizationApproveBodySchema | undefined
+    t_PostIssuingAuthorizationsAuthorizationApproveBodySchema | undefined,
+    void
   >,
   respond: PostIssuingAuthorizationsAuthorizationApproveResponder,
   ctx: RouterContext,
@@ -6767,7 +7005,8 @@ export type PostIssuingAuthorizationsAuthorizationDecline = (
   params: Params<
     t_PostIssuingAuthorizationsAuthorizationDeclineParamSchema,
     void,
-    t_PostIssuingAuthorizationsAuthorizationDeclineBodySchema | undefined
+    t_PostIssuingAuthorizationsAuthorizationDeclineBodySchema | undefined,
+    void
   >,
   respond: PostIssuingAuthorizationsAuthorizationDeclineResponder,
   ctx: RouterContext,
@@ -6791,7 +7030,8 @@ export type GetIssuingCardholders = (
   params: Params<
     void,
     t_GetIssuingCardholdersQuerySchema,
-    t_GetIssuingCardholdersBodySchema | undefined
+    t_GetIssuingCardholdersBodySchema | undefined,
+    void
   >,
   respond: GetIssuingCardholdersResponder,
   ctx: RouterContext,
@@ -6815,7 +7055,7 @@ export type PostIssuingCardholdersResponder = {
 } & KoaRuntimeResponder
 
 export type PostIssuingCardholders = (
-  params: Params<void, void, t_PostIssuingCardholdersBodySchema>,
+  params: Params<void, void, t_PostIssuingCardholdersBodySchema, void>,
   respond: PostIssuingCardholdersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6833,7 +7073,8 @@ export type GetIssuingCardholdersCardholder = (
   params: Params<
     t_GetIssuingCardholdersCardholderParamSchema,
     t_GetIssuingCardholdersCardholderQuerySchema,
-    t_GetIssuingCardholdersCardholderBodySchema | undefined
+    t_GetIssuingCardholdersCardholderBodySchema | undefined,
+    void
   >,
   respond: GetIssuingCardholdersCardholderResponder,
   ctx: RouterContext,
@@ -6852,7 +7093,8 @@ export type PostIssuingCardholdersCardholder = (
   params: Params<
     t_PostIssuingCardholdersCardholderParamSchema,
     void,
-    t_PostIssuingCardholdersCardholderBodySchema | undefined
+    t_PostIssuingCardholdersCardholderBodySchema | undefined,
+    void
   >,
   respond: PostIssuingCardholdersCardholderResponder,
   ctx: RouterContext,
@@ -6876,7 +7118,8 @@ export type GetIssuingCards = (
   params: Params<
     void,
     t_GetIssuingCardsQuerySchema,
-    t_GetIssuingCardsBodySchema | undefined
+    t_GetIssuingCardsBodySchema | undefined,
+    void
   >,
   respond: GetIssuingCardsResponder,
   ctx: RouterContext,
@@ -6900,7 +7143,7 @@ export type PostIssuingCardsResponder = {
 } & KoaRuntimeResponder
 
 export type PostIssuingCards = (
-  params: Params<void, void, t_PostIssuingCardsBodySchema>,
+  params: Params<void, void, t_PostIssuingCardsBodySchema, void>,
   respond: PostIssuingCardsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -6918,7 +7161,8 @@ export type GetIssuingCardsCard = (
   params: Params<
     t_GetIssuingCardsCardParamSchema,
     t_GetIssuingCardsCardQuerySchema,
-    t_GetIssuingCardsCardBodySchema | undefined
+    t_GetIssuingCardsCardBodySchema | undefined,
+    void
   >,
   respond: GetIssuingCardsCardResponder,
   ctx: RouterContext,
@@ -6937,7 +7181,8 @@ export type PostIssuingCardsCard = (
   params: Params<
     t_PostIssuingCardsCardParamSchema,
     void,
-    t_PostIssuingCardsCardBodySchema | undefined
+    t_PostIssuingCardsCardBodySchema | undefined,
+    void
   >,
   respond: PostIssuingCardsCardResponder,
   ctx: RouterContext,
@@ -6961,7 +7206,8 @@ export type GetIssuingDisputes = (
   params: Params<
     void,
     t_GetIssuingDisputesQuerySchema,
-    t_GetIssuingDisputesBodySchema | undefined
+    t_GetIssuingDisputesBodySchema | undefined,
+    void
   >,
   respond: GetIssuingDisputesResponder,
   ctx: RouterContext,
@@ -6985,7 +7231,7 @@ export type PostIssuingDisputesResponder = {
 } & KoaRuntimeResponder
 
 export type PostIssuingDisputes = (
-  params: Params<void, void, t_PostIssuingDisputesBodySchema | undefined>,
+  params: Params<void, void, t_PostIssuingDisputesBodySchema | undefined, void>,
   respond: PostIssuingDisputesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7003,7 +7249,8 @@ export type GetIssuingDisputesDispute = (
   params: Params<
     t_GetIssuingDisputesDisputeParamSchema,
     t_GetIssuingDisputesDisputeQuerySchema,
-    t_GetIssuingDisputesDisputeBodySchema | undefined
+    t_GetIssuingDisputesDisputeBodySchema | undefined,
+    void
   >,
   respond: GetIssuingDisputesDisputeResponder,
   ctx: RouterContext,
@@ -7022,7 +7269,8 @@ export type PostIssuingDisputesDispute = (
   params: Params<
     t_PostIssuingDisputesDisputeParamSchema,
     void,
-    t_PostIssuingDisputesDisputeBodySchema | undefined
+    t_PostIssuingDisputesDisputeBodySchema | undefined,
+    void
   >,
   respond: PostIssuingDisputesDisputeResponder,
   ctx: RouterContext,
@@ -7041,7 +7289,8 @@ export type PostIssuingDisputesDisputeSubmit = (
   params: Params<
     t_PostIssuingDisputesDisputeSubmitParamSchema,
     void,
-    t_PostIssuingDisputesDisputeSubmitBodySchema | undefined
+    t_PostIssuingDisputesDisputeSubmitBodySchema | undefined,
+    void
   >,
   respond: PostIssuingDisputesDisputeSubmitResponder,
   ctx: RouterContext,
@@ -7065,7 +7314,8 @@ export type GetIssuingPersonalizationDesigns = (
   params: Params<
     void,
     t_GetIssuingPersonalizationDesignsQuerySchema,
-    t_GetIssuingPersonalizationDesignsBodySchema | undefined
+    t_GetIssuingPersonalizationDesignsBodySchema | undefined,
+    void
   >,
   respond: GetIssuingPersonalizationDesignsResponder,
   ctx: RouterContext,
@@ -7089,7 +7339,12 @@ export type PostIssuingPersonalizationDesignsResponder = {
 } & KoaRuntimeResponder
 
 export type PostIssuingPersonalizationDesigns = (
-  params: Params<void, void, t_PostIssuingPersonalizationDesignsBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostIssuingPersonalizationDesignsBodySchema,
+    void
+  >,
   respond: PostIssuingPersonalizationDesignsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7108,7 +7363,8 @@ export type GetIssuingPersonalizationDesignsPersonalizationDesign = (
     t_GetIssuingPersonalizationDesignsPersonalizationDesignParamSchema,
     t_GetIssuingPersonalizationDesignsPersonalizationDesignQuerySchema,
     | t_GetIssuingPersonalizationDesignsPersonalizationDesignBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: GetIssuingPersonalizationDesignsPersonalizationDesignResponder,
   ctx: RouterContext,
@@ -7128,7 +7384,8 @@ export type PostIssuingPersonalizationDesignsPersonalizationDesign = (
     t_PostIssuingPersonalizationDesignsPersonalizationDesignParamSchema,
     void,
     | t_PostIssuingPersonalizationDesignsPersonalizationDesignBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostIssuingPersonalizationDesignsPersonalizationDesignResponder,
   ctx: RouterContext,
@@ -7152,7 +7409,8 @@ export type GetIssuingPhysicalBundles = (
   params: Params<
     void,
     t_GetIssuingPhysicalBundlesQuerySchema,
-    t_GetIssuingPhysicalBundlesBodySchema | undefined
+    t_GetIssuingPhysicalBundlesBodySchema | undefined,
+    void
   >,
   respond: GetIssuingPhysicalBundlesResponder,
   ctx: RouterContext,
@@ -7179,7 +7437,8 @@ export type GetIssuingPhysicalBundlesPhysicalBundle = (
   params: Params<
     t_GetIssuingPhysicalBundlesPhysicalBundleParamSchema,
     t_GetIssuingPhysicalBundlesPhysicalBundleQuerySchema,
-    t_GetIssuingPhysicalBundlesPhysicalBundleBodySchema | undefined
+    t_GetIssuingPhysicalBundlesPhysicalBundleBodySchema | undefined,
+    void
   >,
   respond: GetIssuingPhysicalBundlesPhysicalBundleResponder,
   ctx: RouterContext,
@@ -7198,7 +7457,8 @@ export type GetIssuingSettlementsSettlement = (
   params: Params<
     t_GetIssuingSettlementsSettlementParamSchema,
     t_GetIssuingSettlementsSettlementQuerySchema,
-    t_GetIssuingSettlementsSettlementBodySchema | undefined
+    t_GetIssuingSettlementsSettlementBodySchema | undefined,
+    void
   >,
   respond: GetIssuingSettlementsSettlementResponder,
   ctx: RouterContext,
@@ -7217,7 +7477,8 @@ export type PostIssuingSettlementsSettlement = (
   params: Params<
     t_PostIssuingSettlementsSettlementParamSchema,
     void,
-    t_PostIssuingSettlementsSettlementBodySchema | undefined
+    t_PostIssuingSettlementsSettlementBodySchema | undefined,
+    void
   >,
   respond: PostIssuingSettlementsSettlementResponder,
   ctx: RouterContext,
@@ -7241,7 +7502,8 @@ export type GetIssuingTokens = (
   params: Params<
     void,
     t_GetIssuingTokensQuerySchema,
-    t_GetIssuingTokensBodySchema | undefined
+    t_GetIssuingTokensBodySchema | undefined,
+    void
   >,
   respond: GetIssuingTokensResponder,
   ctx: RouterContext,
@@ -7268,7 +7530,8 @@ export type GetIssuingTokensToken = (
   params: Params<
     t_GetIssuingTokensTokenParamSchema,
     t_GetIssuingTokensTokenQuerySchema,
-    t_GetIssuingTokensTokenBodySchema | undefined
+    t_GetIssuingTokensTokenBodySchema | undefined,
+    void
   >,
   respond: GetIssuingTokensTokenResponder,
   ctx: RouterContext,
@@ -7287,7 +7550,8 @@ export type PostIssuingTokensToken = (
   params: Params<
     t_PostIssuingTokensTokenParamSchema,
     void,
-    t_PostIssuingTokensTokenBodySchema
+    t_PostIssuingTokensTokenBodySchema,
+    void
   >,
   respond: PostIssuingTokensTokenResponder,
   ctx: RouterContext,
@@ -7311,7 +7575,8 @@ export type GetIssuingTransactions = (
   params: Params<
     void,
     t_GetIssuingTransactionsQuerySchema,
-    t_GetIssuingTransactionsBodySchema | undefined
+    t_GetIssuingTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetIssuingTransactionsResponder,
   ctx: RouterContext,
@@ -7338,7 +7603,8 @@ export type GetIssuingTransactionsTransaction = (
   params: Params<
     t_GetIssuingTransactionsTransactionParamSchema,
     t_GetIssuingTransactionsTransactionQuerySchema,
-    t_GetIssuingTransactionsTransactionBodySchema | undefined
+    t_GetIssuingTransactionsTransactionBodySchema | undefined,
+    void
   >,
   respond: GetIssuingTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -7357,7 +7623,8 @@ export type PostIssuingTransactionsTransaction = (
   params: Params<
     t_PostIssuingTransactionsTransactionParamSchema,
     void,
-    t_PostIssuingTransactionsTransactionBodySchema | undefined
+    t_PostIssuingTransactionsTransactionBodySchema | undefined,
+    void
   >,
   respond: PostIssuingTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -7373,7 +7640,7 @@ export type PostLinkAccountSessionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostLinkAccountSessions = (
-  params: Params<void, void, t_PostLinkAccountSessionsBodySchema>,
+  params: Params<void, void, t_PostLinkAccountSessionsBodySchema, void>,
   respond: PostLinkAccountSessionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7391,7 +7658,8 @@ export type GetLinkAccountSessionsSession = (
   params: Params<
     t_GetLinkAccountSessionsSessionParamSchema,
     t_GetLinkAccountSessionsSessionQuerySchema,
-    t_GetLinkAccountSessionsSessionBodySchema | undefined
+    t_GetLinkAccountSessionsSessionBodySchema | undefined,
+    void
   >,
   respond: GetLinkAccountSessionsSessionResponder,
   ctx: RouterContext,
@@ -7415,7 +7683,8 @@ export type GetLinkedAccounts = (
   params: Params<
     void,
     t_GetLinkedAccountsQuerySchema,
-    t_GetLinkedAccountsBodySchema | undefined
+    t_GetLinkedAccountsBodySchema | undefined,
+    void
   >,
   respond: GetLinkedAccountsResponder,
   ctx: RouterContext,
@@ -7442,7 +7711,8 @@ export type GetLinkedAccountsAccount = (
   params: Params<
     t_GetLinkedAccountsAccountParamSchema,
     t_GetLinkedAccountsAccountQuerySchema,
-    t_GetLinkedAccountsAccountBodySchema | undefined
+    t_GetLinkedAccountsAccountBodySchema | undefined,
+    void
   >,
   respond: GetLinkedAccountsAccountResponder,
   ctx: RouterContext,
@@ -7461,7 +7731,8 @@ export type PostLinkedAccountsAccountDisconnect = (
   params: Params<
     t_PostLinkedAccountsAccountDisconnectParamSchema,
     void,
-    t_PostLinkedAccountsAccountDisconnectBodySchema | undefined
+    t_PostLinkedAccountsAccountDisconnectBodySchema | undefined,
+    void
   >,
   respond: PostLinkedAccountsAccountDisconnectResponder,
   ctx: RouterContext,
@@ -7485,7 +7756,8 @@ export type GetLinkedAccountsAccountOwners = (
   params: Params<
     t_GetLinkedAccountsAccountOwnersParamSchema,
     t_GetLinkedAccountsAccountOwnersQuerySchema,
-    t_GetLinkedAccountsAccountOwnersBodySchema | undefined
+    t_GetLinkedAccountsAccountOwnersBodySchema | undefined,
+    void
   >,
   respond: GetLinkedAccountsAccountOwnersResponder,
   ctx: RouterContext,
@@ -7512,7 +7784,8 @@ export type PostLinkedAccountsAccountRefresh = (
   params: Params<
     t_PostLinkedAccountsAccountRefreshParamSchema,
     void,
-    t_PostLinkedAccountsAccountRefreshBodySchema
+    t_PostLinkedAccountsAccountRefreshBodySchema,
+    void
   >,
   respond: PostLinkedAccountsAccountRefreshResponder,
   ctx: RouterContext,
@@ -7531,7 +7804,8 @@ export type GetMandatesMandate = (
   params: Params<
     t_GetMandatesMandateParamSchema,
     t_GetMandatesMandateQuerySchema,
-    t_GetMandatesMandateBodySchema | undefined
+    t_GetMandatesMandateBodySchema | undefined,
+    void
   >,
   respond: GetMandatesMandateResponder,
   ctx: RouterContext,
@@ -7555,7 +7829,8 @@ export type GetPaymentIntents = (
   params: Params<
     void,
     t_GetPaymentIntentsQuerySchema,
-    t_GetPaymentIntentsBodySchema | undefined
+    t_GetPaymentIntentsBodySchema | undefined,
+    void
   >,
   respond: GetPaymentIntentsResponder,
   ctx: RouterContext,
@@ -7579,7 +7854,7 @@ export type PostPaymentIntentsResponder = {
 } & KoaRuntimeResponder
 
 export type PostPaymentIntents = (
-  params: Params<void, void, t_PostPaymentIntentsBodySchema>,
+  params: Params<void, void, t_PostPaymentIntentsBodySchema, void>,
   respond: PostPaymentIntentsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7604,7 +7879,8 @@ export type GetPaymentIntentsSearch = (
   params: Params<
     void,
     t_GetPaymentIntentsSearchQuerySchema,
-    t_GetPaymentIntentsSearchBodySchema | undefined
+    t_GetPaymentIntentsSearchBodySchema | undefined,
+    void
   >,
   respond: GetPaymentIntentsSearchResponder,
   ctx: RouterContext,
@@ -7633,7 +7909,8 @@ export type GetPaymentIntentsIntent = (
   params: Params<
     t_GetPaymentIntentsIntentParamSchema,
     t_GetPaymentIntentsIntentQuerySchema,
-    t_GetPaymentIntentsIntentBodySchema | undefined
+    t_GetPaymentIntentsIntentBodySchema | undefined,
+    void
   >,
   respond: GetPaymentIntentsIntentResponder,
   ctx: RouterContext,
@@ -7652,7 +7929,8 @@ export type PostPaymentIntentsIntent = (
   params: Params<
     t_PostPaymentIntentsIntentParamSchema,
     void,
-    t_PostPaymentIntentsIntentBodySchema | undefined
+    t_PostPaymentIntentsIntentBodySchema | undefined,
+    void
   >,
   respond: PostPaymentIntentsIntentResponder,
   ctx: RouterContext,
@@ -7671,7 +7949,8 @@ export type PostPaymentIntentsIntentApplyCustomerBalance = (
   params: Params<
     t_PostPaymentIntentsIntentApplyCustomerBalanceParamSchema,
     void,
-    t_PostPaymentIntentsIntentApplyCustomerBalanceBodySchema | undefined
+    t_PostPaymentIntentsIntentApplyCustomerBalanceBodySchema | undefined,
+    void
   >,
   respond: PostPaymentIntentsIntentApplyCustomerBalanceResponder,
   ctx: RouterContext,
@@ -7690,7 +7969,8 @@ export type PostPaymentIntentsIntentCancel = (
   params: Params<
     t_PostPaymentIntentsIntentCancelParamSchema,
     void,
-    t_PostPaymentIntentsIntentCancelBodySchema | undefined
+    t_PostPaymentIntentsIntentCancelBodySchema | undefined,
+    void
   >,
   respond: PostPaymentIntentsIntentCancelResponder,
   ctx: RouterContext,
@@ -7709,7 +7989,8 @@ export type PostPaymentIntentsIntentCapture = (
   params: Params<
     t_PostPaymentIntentsIntentCaptureParamSchema,
     void,
-    t_PostPaymentIntentsIntentCaptureBodySchema | undefined
+    t_PostPaymentIntentsIntentCaptureBodySchema | undefined,
+    void
   >,
   respond: PostPaymentIntentsIntentCaptureResponder,
   ctx: RouterContext,
@@ -7728,7 +8009,8 @@ export type PostPaymentIntentsIntentConfirm = (
   params: Params<
     t_PostPaymentIntentsIntentConfirmParamSchema,
     void,
-    t_PostPaymentIntentsIntentConfirmBodySchema | undefined
+    t_PostPaymentIntentsIntentConfirmBodySchema | undefined,
+    void
   >,
   respond: PostPaymentIntentsIntentConfirmResponder,
   ctx: RouterContext,
@@ -7747,7 +8029,8 @@ export type PostPaymentIntentsIntentIncrementAuthorization = (
   params: Params<
     t_PostPaymentIntentsIntentIncrementAuthorizationParamSchema,
     void,
-    t_PostPaymentIntentsIntentIncrementAuthorizationBodySchema
+    t_PostPaymentIntentsIntentIncrementAuthorizationBodySchema,
+    void
   >,
   respond: PostPaymentIntentsIntentIncrementAuthorizationResponder,
   ctx: RouterContext,
@@ -7766,7 +8049,8 @@ export type PostPaymentIntentsIntentVerifyMicrodeposits = (
   params: Params<
     t_PostPaymentIntentsIntentVerifyMicrodepositsParamSchema,
     void,
-    t_PostPaymentIntentsIntentVerifyMicrodepositsBodySchema | undefined
+    t_PostPaymentIntentsIntentVerifyMicrodepositsBodySchema | undefined,
+    void
   >,
   respond: PostPaymentIntentsIntentVerifyMicrodepositsResponder,
   ctx: RouterContext,
@@ -7790,7 +8074,8 @@ export type GetPaymentLinks = (
   params: Params<
     void,
     t_GetPaymentLinksQuerySchema,
-    t_GetPaymentLinksBodySchema | undefined
+    t_GetPaymentLinksBodySchema | undefined,
+    void
   >,
   respond: GetPaymentLinksResponder,
   ctx: RouterContext,
@@ -7814,7 +8099,7 @@ export type PostPaymentLinksResponder = {
 } & KoaRuntimeResponder
 
 export type PostPaymentLinks = (
-  params: Params<void, void, t_PostPaymentLinksBodySchema>,
+  params: Params<void, void, t_PostPaymentLinksBodySchema, void>,
   respond: PostPaymentLinksResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -7832,7 +8117,8 @@ export type GetPaymentLinksPaymentLink = (
   params: Params<
     t_GetPaymentLinksPaymentLinkParamSchema,
     t_GetPaymentLinksPaymentLinkQuerySchema,
-    t_GetPaymentLinksPaymentLinkBodySchema | undefined
+    t_GetPaymentLinksPaymentLinkBodySchema | undefined,
+    void
   >,
   respond: GetPaymentLinksPaymentLinkResponder,
   ctx: RouterContext,
@@ -7851,7 +8137,8 @@ export type PostPaymentLinksPaymentLink = (
   params: Params<
     t_PostPaymentLinksPaymentLinkParamSchema,
     void,
-    t_PostPaymentLinksPaymentLinkBodySchema | undefined
+    t_PostPaymentLinksPaymentLinkBodySchema | undefined,
+    void
   >,
   respond: PostPaymentLinksPaymentLinkResponder,
   ctx: RouterContext,
@@ -7875,7 +8162,8 @@ export type GetPaymentLinksPaymentLinkLineItems = (
   params: Params<
     t_GetPaymentLinksPaymentLinkLineItemsParamSchema,
     t_GetPaymentLinksPaymentLinkLineItemsQuerySchema,
-    t_GetPaymentLinksPaymentLinkLineItemsBodySchema | undefined
+    t_GetPaymentLinksPaymentLinkLineItemsBodySchema | undefined,
+    void
   >,
   respond: GetPaymentLinksPaymentLinkLineItemsResponder,
   ctx: RouterContext,
@@ -7907,7 +8195,8 @@ export type GetPaymentMethodConfigurations = (
   params: Params<
     void,
     t_GetPaymentMethodConfigurationsQuerySchema,
-    t_GetPaymentMethodConfigurationsBodySchema | undefined
+    t_GetPaymentMethodConfigurationsBodySchema | undefined,
+    void
   >,
   respond: GetPaymentMethodConfigurationsResponder,
   ctx: RouterContext,
@@ -7934,7 +8223,8 @@ export type PostPaymentMethodConfigurations = (
   params: Params<
     void,
     void,
-    t_PostPaymentMethodConfigurationsBodySchema | undefined
+    t_PostPaymentMethodConfigurationsBodySchema | undefined,
+    void
   >,
   respond: PostPaymentMethodConfigurationsResponder,
   ctx: RouterContext,
@@ -7953,7 +8243,8 @@ export type GetPaymentMethodConfigurationsConfiguration = (
   params: Params<
     t_GetPaymentMethodConfigurationsConfigurationParamSchema,
     t_GetPaymentMethodConfigurationsConfigurationQuerySchema,
-    t_GetPaymentMethodConfigurationsConfigurationBodySchema | undefined
+    t_GetPaymentMethodConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: GetPaymentMethodConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -7972,7 +8263,8 @@ export type PostPaymentMethodConfigurationsConfiguration = (
   params: Params<
     t_PostPaymentMethodConfigurationsConfigurationParamSchema,
     void,
-    t_PostPaymentMethodConfigurationsConfigurationBodySchema | undefined
+    t_PostPaymentMethodConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: PostPaymentMethodConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -7996,7 +8288,8 @@ export type GetPaymentMethodDomains = (
   params: Params<
     void,
     t_GetPaymentMethodDomainsQuerySchema,
-    t_GetPaymentMethodDomainsBodySchema | undefined
+    t_GetPaymentMethodDomainsBodySchema | undefined,
+    void
   >,
   respond: GetPaymentMethodDomainsResponder,
   ctx: RouterContext,
@@ -8020,7 +8313,7 @@ export type PostPaymentMethodDomainsResponder = {
 } & KoaRuntimeResponder
 
 export type PostPaymentMethodDomains = (
-  params: Params<void, void, t_PostPaymentMethodDomainsBodySchema>,
+  params: Params<void, void, t_PostPaymentMethodDomainsBodySchema, void>,
   respond: PostPaymentMethodDomainsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8038,7 +8331,8 @@ export type GetPaymentMethodDomainsPaymentMethodDomain = (
   params: Params<
     t_GetPaymentMethodDomainsPaymentMethodDomainParamSchema,
     t_GetPaymentMethodDomainsPaymentMethodDomainQuerySchema,
-    t_GetPaymentMethodDomainsPaymentMethodDomainBodySchema | undefined
+    t_GetPaymentMethodDomainsPaymentMethodDomainBodySchema | undefined,
+    void
   >,
   respond: GetPaymentMethodDomainsPaymentMethodDomainResponder,
   ctx: RouterContext,
@@ -8057,7 +8351,8 @@ export type PostPaymentMethodDomainsPaymentMethodDomain = (
   params: Params<
     t_PostPaymentMethodDomainsPaymentMethodDomainParamSchema,
     void,
-    t_PostPaymentMethodDomainsPaymentMethodDomainBodySchema | undefined
+    t_PostPaymentMethodDomainsPaymentMethodDomainBodySchema | undefined,
+    void
   >,
   respond: PostPaymentMethodDomainsPaymentMethodDomainResponder,
   ctx: RouterContext,
@@ -8076,7 +8371,8 @@ export type PostPaymentMethodDomainsPaymentMethodDomainValidate = (
   params: Params<
     t_PostPaymentMethodDomainsPaymentMethodDomainValidateParamSchema,
     void,
-    t_PostPaymentMethodDomainsPaymentMethodDomainValidateBodySchema | undefined
+    t_PostPaymentMethodDomainsPaymentMethodDomainValidateBodySchema | undefined,
+    void
   >,
   respond: PostPaymentMethodDomainsPaymentMethodDomainValidateResponder,
   ctx: RouterContext,
@@ -8100,7 +8396,8 @@ export type GetPaymentMethods = (
   params: Params<
     void,
     t_GetPaymentMethodsQuerySchema,
-    t_GetPaymentMethodsBodySchema | undefined
+    t_GetPaymentMethodsBodySchema | undefined,
+    void
   >,
   respond: GetPaymentMethodsResponder,
   ctx: RouterContext,
@@ -8124,7 +8421,7 @@ export type PostPaymentMethodsResponder = {
 } & KoaRuntimeResponder
 
 export type PostPaymentMethods = (
-  params: Params<void, void, t_PostPaymentMethodsBodySchema | undefined>,
+  params: Params<void, void, t_PostPaymentMethodsBodySchema | undefined, void>,
   respond: PostPaymentMethodsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8142,7 +8439,8 @@ export type GetPaymentMethodsPaymentMethod = (
   params: Params<
     t_GetPaymentMethodsPaymentMethodParamSchema,
     t_GetPaymentMethodsPaymentMethodQuerySchema,
-    t_GetPaymentMethodsPaymentMethodBodySchema | undefined
+    t_GetPaymentMethodsPaymentMethodBodySchema | undefined,
+    void
   >,
   respond: GetPaymentMethodsPaymentMethodResponder,
   ctx: RouterContext,
@@ -8161,7 +8459,8 @@ export type PostPaymentMethodsPaymentMethod = (
   params: Params<
     t_PostPaymentMethodsPaymentMethodParamSchema,
     void,
-    t_PostPaymentMethodsPaymentMethodBodySchema | undefined
+    t_PostPaymentMethodsPaymentMethodBodySchema | undefined,
+    void
   >,
   respond: PostPaymentMethodsPaymentMethodResponder,
   ctx: RouterContext,
@@ -8180,7 +8479,8 @@ export type PostPaymentMethodsPaymentMethodAttach = (
   params: Params<
     t_PostPaymentMethodsPaymentMethodAttachParamSchema,
     void,
-    t_PostPaymentMethodsPaymentMethodAttachBodySchema
+    t_PostPaymentMethodsPaymentMethodAttachBodySchema,
+    void
   >,
   respond: PostPaymentMethodsPaymentMethodAttachResponder,
   ctx: RouterContext,
@@ -8199,7 +8499,8 @@ export type PostPaymentMethodsPaymentMethodDetach = (
   params: Params<
     t_PostPaymentMethodsPaymentMethodDetachParamSchema,
     void,
-    t_PostPaymentMethodsPaymentMethodDetachBodySchema | undefined
+    t_PostPaymentMethodsPaymentMethodDetachBodySchema | undefined,
+    void
   >,
   respond: PostPaymentMethodsPaymentMethodDetachResponder,
   ctx: RouterContext,
@@ -8223,7 +8524,8 @@ export type GetPayouts = (
   params: Params<
     void,
     t_GetPayoutsQuerySchema,
-    t_GetPayoutsBodySchema | undefined
+    t_GetPayoutsBodySchema | undefined,
+    void
   >,
   respond: GetPayoutsResponder,
   ctx: RouterContext,
@@ -8247,7 +8549,7 @@ export type PostPayoutsResponder = {
 } & KoaRuntimeResponder
 
 export type PostPayouts = (
-  params: Params<void, void, t_PostPayoutsBodySchema>,
+  params: Params<void, void, t_PostPayoutsBodySchema, void>,
   respond: PostPayoutsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8265,7 +8567,8 @@ export type GetPayoutsPayout = (
   params: Params<
     t_GetPayoutsPayoutParamSchema,
     t_GetPayoutsPayoutQuerySchema,
-    t_GetPayoutsPayoutBodySchema | undefined
+    t_GetPayoutsPayoutBodySchema | undefined,
+    void
   >,
   respond: GetPayoutsPayoutResponder,
   ctx: RouterContext,
@@ -8284,7 +8587,8 @@ export type PostPayoutsPayout = (
   params: Params<
     t_PostPayoutsPayoutParamSchema,
     void,
-    t_PostPayoutsPayoutBodySchema | undefined
+    t_PostPayoutsPayoutBodySchema | undefined,
+    void
   >,
   respond: PostPayoutsPayoutResponder,
   ctx: RouterContext,
@@ -8303,7 +8607,8 @@ export type PostPayoutsPayoutCancel = (
   params: Params<
     t_PostPayoutsPayoutCancelParamSchema,
     void,
-    t_PostPayoutsPayoutCancelBodySchema | undefined
+    t_PostPayoutsPayoutCancelBodySchema | undefined,
+    void
   >,
   respond: PostPayoutsPayoutCancelResponder,
   ctx: RouterContext,
@@ -8322,7 +8627,8 @@ export type PostPayoutsPayoutReverse = (
   params: Params<
     t_PostPayoutsPayoutReverseParamSchema,
     void,
-    t_PostPayoutsPayoutReverseBodySchema | undefined
+    t_PostPayoutsPayoutReverseBodySchema | undefined,
+    void
   >,
   respond: PostPayoutsPayoutReverseResponder,
   ctx: RouterContext,
@@ -8343,7 +8649,12 @@ export type GetPlansResponder = {
 } & KoaRuntimeResponder
 
 export type GetPlans = (
-  params: Params<void, t_GetPlansQuerySchema, t_GetPlansBodySchema | undefined>,
+  params: Params<
+    void,
+    t_GetPlansQuerySchema,
+    t_GetPlansBodySchema | undefined,
+    void
+  >,
   respond: GetPlansResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8366,7 +8677,7 @@ export type PostPlansResponder = {
 } & KoaRuntimeResponder
 
 export type PostPlans = (
-  params: Params<void, void, t_PostPlansBodySchema>,
+  params: Params<void, void, t_PostPlansBodySchema, void>,
   respond: PostPlansResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8384,7 +8695,8 @@ export type DeletePlansPlan = (
   params: Params<
     t_DeletePlansPlanParamSchema,
     void,
-    t_DeletePlansPlanBodySchema | undefined
+    t_DeletePlansPlanBodySchema | undefined,
+    void
   >,
   respond: DeletePlansPlanResponder,
   ctx: RouterContext,
@@ -8403,7 +8715,8 @@ export type GetPlansPlan = (
   params: Params<
     t_GetPlansPlanParamSchema,
     t_GetPlansPlanQuerySchema,
-    t_GetPlansPlanBodySchema | undefined
+    t_GetPlansPlanBodySchema | undefined,
+    void
   >,
   respond: GetPlansPlanResponder,
   ctx: RouterContext,
@@ -8422,7 +8735,8 @@ export type PostPlansPlan = (
   params: Params<
     t_PostPlansPlanParamSchema,
     void,
-    t_PostPlansPlanBodySchema | undefined
+    t_PostPlansPlanBodySchema | undefined,
+    void
   >,
   respond: PostPlansPlanResponder,
   ctx: RouterContext,
@@ -8446,7 +8760,8 @@ export type GetPrices = (
   params: Params<
     void,
     t_GetPricesQuerySchema,
-    t_GetPricesBodySchema | undefined
+    t_GetPricesBodySchema | undefined,
+    void
   >,
   respond: GetPricesResponder,
   ctx: RouterContext,
@@ -8470,7 +8785,7 @@ export type PostPricesResponder = {
 } & KoaRuntimeResponder
 
 export type PostPrices = (
-  params: Params<void, void, t_PostPricesBodySchema>,
+  params: Params<void, void, t_PostPricesBodySchema, void>,
   respond: PostPricesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8495,7 +8810,8 @@ export type GetPricesSearch = (
   params: Params<
     void,
     t_GetPricesSearchQuerySchema,
-    t_GetPricesSearchBodySchema | undefined
+    t_GetPricesSearchBodySchema | undefined,
+    void
   >,
   respond: GetPricesSearchResponder,
   ctx: RouterContext,
@@ -8524,7 +8840,8 @@ export type GetPricesPrice = (
   params: Params<
     t_GetPricesPriceParamSchema,
     t_GetPricesPriceQuerySchema,
-    t_GetPricesPriceBodySchema | undefined
+    t_GetPricesPriceBodySchema | undefined,
+    void
   >,
   respond: GetPricesPriceResponder,
   ctx: RouterContext,
@@ -8543,7 +8860,8 @@ export type PostPricesPrice = (
   params: Params<
     t_PostPricesPriceParamSchema,
     void,
-    t_PostPricesPriceBodySchema | undefined
+    t_PostPricesPriceBodySchema | undefined,
+    void
   >,
   respond: PostPricesPriceResponder,
   ctx: RouterContext,
@@ -8567,7 +8885,8 @@ export type GetProducts = (
   params: Params<
     void,
     t_GetProductsQuerySchema,
-    t_GetProductsBodySchema | undefined
+    t_GetProductsBodySchema | undefined,
+    void
   >,
   respond: GetProductsResponder,
   ctx: RouterContext,
@@ -8591,7 +8910,7 @@ export type PostProductsResponder = {
 } & KoaRuntimeResponder
 
 export type PostProducts = (
-  params: Params<void, void, t_PostProductsBodySchema>,
+  params: Params<void, void, t_PostProductsBodySchema, void>,
   respond: PostProductsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8616,7 +8935,8 @@ export type GetProductsSearch = (
   params: Params<
     void,
     t_GetProductsSearchQuerySchema,
-    t_GetProductsSearchBodySchema | undefined
+    t_GetProductsSearchBodySchema | undefined,
+    void
   >,
   respond: GetProductsSearchResponder,
   ctx: RouterContext,
@@ -8645,7 +8965,8 @@ export type DeleteProductsId = (
   params: Params<
     t_DeleteProductsIdParamSchema,
     void,
-    t_DeleteProductsIdBodySchema | undefined
+    t_DeleteProductsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteProductsIdResponder,
   ctx: RouterContext,
@@ -8664,7 +8985,8 @@ export type GetProductsId = (
   params: Params<
     t_GetProductsIdParamSchema,
     t_GetProductsIdQuerySchema,
-    t_GetProductsIdBodySchema | undefined
+    t_GetProductsIdBodySchema | undefined,
+    void
   >,
   respond: GetProductsIdResponder,
   ctx: RouterContext,
@@ -8683,7 +9005,8 @@ export type PostProductsId = (
   params: Params<
     t_PostProductsIdParamSchema,
     void,
-    t_PostProductsIdBodySchema | undefined
+    t_PostProductsIdBodySchema | undefined,
+    void
   >,
   respond: PostProductsIdResponder,
   ctx: RouterContext,
@@ -8707,7 +9030,8 @@ export type GetProductsProductFeatures = (
   params: Params<
     t_GetProductsProductFeaturesParamSchema,
     t_GetProductsProductFeaturesQuerySchema,
-    t_GetProductsProductFeaturesBodySchema | undefined
+    t_GetProductsProductFeaturesBodySchema | undefined,
+    void
   >,
   respond: GetProductsProductFeaturesResponder,
   ctx: RouterContext,
@@ -8734,7 +9058,8 @@ export type PostProductsProductFeatures = (
   params: Params<
     t_PostProductsProductFeaturesParamSchema,
     void,
-    t_PostProductsProductFeaturesBodySchema
+    t_PostProductsProductFeaturesBodySchema,
+    void
   >,
   respond: PostProductsProductFeaturesResponder,
   ctx: RouterContext,
@@ -8753,7 +9078,8 @@ export type DeleteProductsProductFeaturesId = (
   params: Params<
     t_DeleteProductsProductFeaturesIdParamSchema,
     void,
-    t_DeleteProductsProductFeaturesIdBodySchema | undefined
+    t_DeleteProductsProductFeaturesIdBodySchema | undefined,
+    void
   >,
   respond: DeleteProductsProductFeaturesIdResponder,
   ctx: RouterContext,
@@ -8772,7 +9098,8 @@ export type GetProductsProductFeaturesId = (
   params: Params<
     t_GetProductsProductFeaturesIdParamSchema,
     t_GetProductsProductFeaturesIdQuerySchema,
-    t_GetProductsProductFeaturesIdBodySchema | undefined
+    t_GetProductsProductFeaturesIdBodySchema | undefined,
+    void
   >,
   respond: GetProductsProductFeaturesIdResponder,
   ctx: RouterContext,
@@ -8796,7 +9123,8 @@ export type GetPromotionCodes = (
   params: Params<
     void,
     t_GetPromotionCodesQuerySchema,
-    t_GetPromotionCodesBodySchema | undefined
+    t_GetPromotionCodesBodySchema | undefined,
+    void
   >,
   respond: GetPromotionCodesResponder,
   ctx: RouterContext,
@@ -8820,7 +9148,7 @@ export type PostPromotionCodesResponder = {
 } & KoaRuntimeResponder
 
 export type PostPromotionCodes = (
-  params: Params<void, void, t_PostPromotionCodesBodySchema>,
+  params: Params<void, void, t_PostPromotionCodesBodySchema, void>,
   respond: PostPromotionCodesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8838,7 +9166,8 @@ export type GetPromotionCodesPromotionCode = (
   params: Params<
     t_GetPromotionCodesPromotionCodeParamSchema,
     t_GetPromotionCodesPromotionCodeQuerySchema,
-    t_GetPromotionCodesPromotionCodeBodySchema | undefined
+    t_GetPromotionCodesPromotionCodeBodySchema | undefined,
+    void
   >,
   respond: GetPromotionCodesPromotionCodeResponder,
   ctx: RouterContext,
@@ -8857,7 +9186,8 @@ export type PostPromotionCodesPromotionCode = (
   params: Params<
     t_PostPromotionCodesPromotionCodeParamSchema,
     void,
-    t_PostPromotionCodesPromotionCodeBodySchema | undefined
+    t_PostPromotionCodesPromotionCodeBodySchema | undefined,
+    void
   >,
   respond: PostPromotionCodesPromotionCodeResponder,
   ctx: RouterContext,
@@ -8881,7 +9211,8 @@ export type GetQuotes = (
   params: Params<
     void,
     t_GetQuotesQuerySchema,
-    t_GetQuotesBodySchema | undefined
+    t_GetQuotesBodySchema | undefined,
+    void
   >,
   respond: GetQuotesResponder,
   ctx: RouterContext,
@@ -8905,7 +9236,7 @@ export type PostQuotesResponder = {
 } & KoaRuntimeResponder
 
 export type PostQuotes = (
-  params: Params<void, void, t_PostQuotesBodySchema | undefined>,
+  params: Params<void, void, t_PostQuotesBodySchema | undefined, void>,
   respond: PostQuotesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -8923,7 +9254,8 @@ export type GetQuotesQuote = (
   params: Params<
     t_GetQuotesQuoteParamSchema,
     t_GetQuotesQuoteQuerySchema,
-    t_GetQuotesQuoteBodySchema | undefined
+    t_GetQuotesQuoteBodySchema | undefined,
+    void
   >,
   respond: GetQuotesQuoteResponder,
   ctx: RouterContext,
@@ -8942,7 +9274,8 @@ export type PostQuotesQuote = (
   params: Params<
     t_PostQuotesQuoteParamSchema,
     void,
-    t_PostQuotesQuoteBodySchema | undefined
+    t_PostQuotesQuoteBodySchema | undefined,
+    void
   >,
   respond: PostQuotesQuoteResponder,
   ctx: RouterContext,
@@ -8961,7 +9294,8 @@ export type PostQuotesQuoteAccept = (
   params: Params<
     t_PostQuotesQuoteAcceptParamSchema,
     void,
-    t_PostQuotesQuoteAcceptBodySchema | undefined
+    t_PostQuotesQuoteAcceptBodySchema | undefined,
+    void
   >,
   respond: PostQuotesQuoteAcceptResponder,
   ctx: RouterContext,
@@ -8980,7 +9314,8 @@ export type PostQuotesQuoteCancel = (
   params: Params<
     t_PostQuotesQuoteCancelParamSchema,
     void,
-    t_PostQuotesQuoteCancelBodySchema | undefined
+    t_PostQuotesQuoteCancelBodySchema | undefined,
+    void
   >,
   respond: PostQuotesQuoteCancelResponder,
   ctx: RouterContext,
@@ -9004,7 +9339,8 @@ export type GetQuotesQuoteComputedUpfrontLineItems = (
   params: Params<
     t_GetQuotesQuoteComputedUpfrontLineItemsParamSchema,
     t_GetQuotesQuoteComputedUpfrontLineItemsQuerySchema,
-    t_GetQuotesQuoteComputedUpfrontLineItemsBodySchema | undefined
+    t_GetQuotesQuoteComputedUpfrontLineItemsBodySchema | undefined,
+    void
   >,
   respond: GetQuotesQuoteComputedUpfrontLineItemsResponder,
   ctx: RouterContext,
@@ -9031,7 +9367,8 @@ export type PostQuotesQuoteFinalize = (
   params: Params<
     t_PostQuotesQuoteFinalizeParamSchema,
     void,
-    t_PostQuotesQuoteFinalizeBodySchema | undefined
+    t_PostQuotesQuoteFinalizeBodySchema | undefined,
+    void
   >,
   respond: PostQuotesQuoteFinalizeResponder,
   ctx: RouterContext,
@@ -9055,7 +9392,8 @@ export type GetQuotesQuoteLineItems = (
   params: Params<
     t_GetQuotesQuoteLineItemsParamSchema,
     t_GetQuotesQuoteLineItemsQuerySchema,
-    t_GetQuotesQuoteLineItemsBodySchema | undefined
+    t_GetQuotesQuoteLineItemsBodySchema | undefined,
+    void
   >,
   respond: GetQuotesQuoteLineItemsResponder,
   ctx: RouterContext,
@@ -9082,7 +9420,8 @@ export type GetQuotesQuotePdf = (
   params: Params<
     t_GetQuotesQuotePdfParamSchema,
     t_GetQuotesQuotePdfQuerySchema,
-    t_GetQuotesQuotePdfBodySchema | undefined
+    t_GetQuotesQuotePdfBodySchema | undefined,
+    void
   >,
   respond: GetQuotesQuotePdfResponder,
   ctx: RouterContext,
@@ -9106,7 +9445,8 @@ export type GetRadarEarlyFraudWarnings = (
   params: Params<
     void,
     t_GetRadarEarlyFraudWarningsQuerySchema,
-    t_GetRadarEarlyFraudWarningsBodySchema | undefined
+    t_GetRadarEarlyFraudWarningsBodySchema | undefined,
+    void
   >,
   respond: GetRadarEarlyFraudWarningsResponder,
   ctx: RouterContext,
@@ -9133,7 +9473,8 @@ export type GetRadarEarlyFraudWarningsEarlyFraudWarning = (
   params: Params<
     t_GetRadarEarlyFraudWarningsEarlyFraudWarningParamSchema,
     t_GetRadarEarlyFraudWarningsEarlyFraudWarningQuerySchema,
-    t_GetRadarEarlyFraudWarningsEarlyFraudWarningBodySchema | undefined
+    t_GetRadarEarlyFraudWarningsEarlyFraudWarningBodySchema | undefined,
+    void
   >,
   respond: GetRadarEarlyFraudWarningsEarlyFraudWarningResponder,
   ctx: RouterContext,
@@ -9157,7 +9498,8 @@ export type GetRadarValueListItems = (
   params: Params<
     void,
     t_GetRadarValueListItemsQuerySchema,
-    t_GetRadarValueListItemsBodySchema | undefined
+    t_GetRadarValueListItemsBodySchema | undefined,
+    void
   >,
   respond: GetRadarValueListItemsResponder,
   ctx: RouterContext,
@@ -9181,7 +9523,7 @@ export type PostRadarValueListItemsResponder = {
 } & KoaRuntimeResponder
 
 export type PostRadarValueListItems = (
-  params: Params<void, void, t_PostRadarValueListItemsBodySchema>,
+  params: Params<void, void, t_PostRadarValueListItemsBodySchema, void>,
   respond: PostRadarValueListItemsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9199,7 +9541,8 @@ export type DeleteRadarValueListItemsItem = (
   params: Params<
     t_DeleteRadarValueListItemsItemParamSchema,
     void,
-    t_DeleteRadarValueListItemsItemBodySchema | undefined
+    t_DeleteRadarValueListItemsItemBodySchema | undefined,
+    void
   >,
   respond: DeleteRadarValueListItemsItemResponder,
   ctx: RouterContext,
@@ -9218,7 +9561,8 @@ export type GetRadarValueListItemsItem = (
   params: Params<
     t_GetRadarValueListItemsItemParamSchema,
     t_GetRadarValueListItemsItemQuerySchema,
-    t_GetRadarValueListItemsItemBodySchema | undefined
+    t_GetRadarValueListItemsItemBodySchema | undefined,
+    void
   >,
   respond: GetRadarValueListItemsItemResponder,
   ctx: RouterContext,
@@ -9242,7 +9586,8 @@ export type GetRadarValueLists = (
   params: Params<
     void,
     t_GetRadarValueListsQuerySchema,
-    t_GetRadarValueListsBodySchema | undefined
+    t_GetRadarValueListsBodySchema | undefined,
+    void
   >,
   respond: GetRadarValueListsResponder,
   ctx: RouterContext,
@@ -9266,7 +9611,7 @@ export type PostRadarValueListsResponder = {
 } & KoaRuntimeResponder
 
 export type PostRadarValueLists = (
-  params: Params<void, void, t_PostRadarValueListsBodySchema>,
+  params: Params<void, void, t_PostRadarValueListsBodySchema, void>,
   respond: PostRadarValueListsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9284,7 +9629,8 @@ export type DeleteRadarValueListsValueList = (
   params: Params<
     t_DeleteRadarValueListsValueListParamSchema,
     void,
-    t_DeleteRadarValueListsValueListBodySchema | undefined
+    t_DeleteRadarValueListsValueListBodySchema | undefined,
+    void
   >,
   respond: DeleteRadarValueListsValueListResponder,
   ctx: RouterContext,
@@ -9303,7 +9649,8 @@ export type GetRadarValueListsValueList = (
   params: Params<
     t_GetRadarValueListsValueListParamSchema,
     t_GetRadarValueListsValueListQuerySchema,
-    t_GetRadarValueListsValueListBodySchema | undefined
+    t_GetRadarValueListsValueListBodySchema | undefined,
+    void
   >,
   respond: GetRadarValueListsValueListResponder,
   ctx: RouterContext,
@@ -9322,7 +9669,8 @@ export type PostRadarValueListsValueList = (
   params: Params<
     t_PostRadarValueListsValueListParamSchema,
     void,
-    t_PostRadarValueListsValueListBodySchema | undefined
+    t_PostRadarValueListsValueListBodySchema | undefined,
+    void
   >,
   respond: PostRadarValueListsValueListResponder,
   ctx: RouterContext,
@@ -9346,7 +9694,8 @@ export type GetRefunds = (
   params: Params<
     void,
     t_GetRefundsQuerySchema,
-    t_GetRefundsBodySchema | undefined
+    t_GetRefundsBodySchema | undefined,
+    void
   >,
   respond: GetRefundsResponder,
   ctx: RouterContext,
@@ -9370,7 +9719,7 @@ export type PostRefundsResponder = {
 } & KoaRuntimeResponder
 
 export type PostRefunds = (
-  params: Params<void, void, t_PostRefundsBodySchema | undefined>,
+  params: Params<void, void, t_PostRefundsBodySchema | undefined, void>,
   respond: PostRefundsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9388,7 +9737,8 @@ export type GetRefundsRefund = (
   params: Params<
     t_GetRefundsRefundParamSchema,
     t_GetRefundsRefundQuerySchema,
-    t_GetRefundsRefundBodySchema | undefined
+    t_GetRefundsRefundBodySchema | undefined,
+    void
   >,
   respond: GetRefundsRefundResponder,
   ctx: RouterContext,
@@ -9407,7 +9757,8 @@ export type PostRefundsRefund = (
   params: Params<
     t_PostRefundsRefundParamSchema,
     void,
-    t_PostRefundsRefundBodySchema | undefined
+    t_PostRefundsRefundBodySchema | undefined,
+    void
   >,
   respond: PostRefundsRefundResponder,
   ctx: RouterContext,
@@ -9426,7 +9777,8 @@ export type PostRefundsRefundCancel = (
   params: Params<
     t_PostRefundsRefundCancelParamSchema,
     void,
-    t_PostRefundsRefundCancelBodySchema | undefined
+    t_PostRefundsRefundCancelBodySchema | undefined,
+    void
   >,
   respond: PostRefundsRefundCancelResponder,
   ctx: RouterContext,
@@ -9450,7 +9802,8 @@ export type GetReportingReportRuns = (
   params: Params<
     void,
     t_GetReportingReportRunsQuerySchema,
-    t_GetReportingReportRunsBodySchema | undefined
+    t_GetReportingReportRunsBodySchema | undefined,
+    void
   >,
   respond: GetReportingReportRunsResponder,
   ctx: RouterContext,
@@ -9474,7 +9827,7 @@ export type PostReportingReportRunsResponder = {
 } & KoaRuntimeResponder
 
 export type PostReportingReportRuns = (
-  params: Params<void, void, t_PostReportingReportRunsBodySchema>,
+  params: Params<void, void, t_PostReportingReportRunsBodySchema, void>,
   respond: PostReportingReportRunsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9492,7 +9845,8 @@ export type GetReportingReportRunsReportRun = (
   params: Params<
     t_GetReportingReportRunsReportRunParamSchema,
     t_GetReportingReportRunsReportRunQuerySchema,
-    t_GetReportingReportRunsReportRunBodySchema | undefined
+    t_GetReportingReportRunsReportRunBodySchema | undefined,
+    void
   >,
   respond: GetReportingReportRunsReportRunResponder,
   ctx: RouterContext,
@@ -9516,7 +9870,8 @@ export type GetReportingReportTypes = (
   params: Params<
     void,
     t_GetReportingReportTypesQuerySchema,
-    t_GetReportingReportTypesBodySchema | undefined
+    t_GetReportingReportTypesBodySchema | undefined,
+    void
   >,
   respond: GetReportingReportTypesResponder,
   ctx: RouterContext,
@@ -9543,7 +9898,8 @@ export type GetReportingReportTypesReportType = (
   params: Params<
     t_GetReportingReportTypesReportTypeParamSchema,
     t_GetReportingReportTypesReportTypeQuerySchema,
-    t_GetReportingReportTypesReportTypeBodySchema | undefined
+    t_GetReportingReportTypesReportTypeBodySchema | undefined,
+    void
   >,
   respond: GetReportingReportTypesReportTypeResponder,
   ctx: RouterContext,
@@ -9567,7 +9923,8 @@ export type GetReviews = (
   params: Params<
     void,
     t_GetReviewsQuerySchema,
-    t_GetReviewsBodySchema | undefined
+    t_GetReviewsBodySchema | undefined,
+    void
   >,
   respond: GetReviewsResponder,
   ctx: RouterContext,
@@ -9594,7 +9951,8 @@ export type GetReviewsReview = (
   params: Params<
     t_GetReviewsReviewParamSchema,
     t_GetReviewsReviewQuerySchema,
-    t_GetReviewsReviewBodySchema | undefined
+    t_GetReviewsReviewBodySchema | undefined,
+    void
   >,
   respond: GetReviewsReviewResponder,
   ctx: RouterContext,
@@ -9613,7 +9971,8 @@ export type PostReviewsReviewApprove = (
   params: Params<
     t_PostReviewsReviewApproveParamSchema,
     void,
-    t_PostReviewsReviewApproveBodySchema | undefined
+    t_PostReviewsReviewApproveBodySchema | undefined,
+    void
   >,
   respond: PostReviewsReviewApproveResponder,
   ctx: RouterContext,
@@ -9637,7 +9996,8 @@ export type GetSetupAttempts = (
   params: Params<
     void,
     t_GetSetupAttemptsQuerySchema,
-    t_GetSetupAttemptsBodySchema | undefined
+    t_GetSetupAttemptsBodySchema | undefined,
+    void
   >,
   respond: GetSetupAttemptsResponder,
   ctx: RouterContext,
@@ -9669,7 +10029,8 @@ export type GetSetupIntents = (
   params: Params<
     void,
     t_GetSetupIntentsQuerySchema,
-    t_GetSetupIntentsBodySchema | undefined
+    t_GetSetupIntentsBodySchema | undefined,
+    void
   >,
   respond: GetSetupIntentsResponder,
   ctx: RouterContext,
@@ -9693,7 +10054,7 @@ export type PostSetupIntentsResponder = {
 } & KoaRuntimeResponder
 
 export type PostSetupIntents = (
-  params: Params<void, void, t_PostSetupIntentsBodySchema | undefined>,
+  params: Params<void, void, t_PostSetupIntentsBodySchema | undefined, void>,
   respond: PostSetupIntentsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9711,7 +10072,8 @@ export type GetSetupIntentsIntent = (
   params: Params<
     t_GetSetupIntentsIntentParamSchema,
     t_GetSetupIntentsIntentQuerySchema,
-    t_GetSetupIntentsIntentBodySchema | undefined
+    t_GetSetupIntentsIntentBodySchema | undefined,
+    void
   >,
   respond: GetSetupIntentsIntentResponder,
   ctx: RouterContext,
@@ -9730,7 +10092,8 @@ export type PostSetupIntentsIntent = (
   params: Params<
     t_PostSetupIntentsIntentParamSchema,
     void,
-    t_PostSetupIntentsIntentBodySchema | undefined
+    t_PostSetupIntentsIntentBodySchema | undefined,
+    void
   >,
   respond: PostSetupIntentsIntentResponder,
   ctx: RouterContext,
@@ -9749,7 +10112,8 @@ export type PostSetupIntentsIntentCancel = (
   params: Params<
     t_PostSetupIntentsIntentCancelParamSchema,
     void,
-    t_PostSetupIntentsIntentCancelBodySchema | undefined
+    t_PostSetupIntentsIntentCancelBodySchema | undefined,
+    void
   >,
   respond: PostSetupIntentsIntentCancelResponder,
   ctx: RouterContext,
@@ -9768,7 +10132,8 @@ export type PostSetupIntentsIntentConfirm = (
   params: Params<
     t_PostSetupIntentsIntentConfirmParamSchema,
     void,
-    t_PostSetupIntentsIntentConfirmBodySchema | undefined
+    t_PostSetupIntentsIntentConfirmBodySchema | undefined,
+    void
   >,
   respond: PostSetupIntentsIntentConfirmResponder,
   ctx: RouterContext,
@@ -9787,7 +10152,8 @@ export type PostSetupIntentsIntentVerifyMicrodeposits = (
   params: Params<
     t_PostSetupIntentsIntentVerifyMicrodepositsParamSchema,
     void,
-    t_PostSetupIntentsIntentVerifyMicrodepositsBodySchema | undefined
+    t_PostSetupIntentsIntentVerifyMicrodepositsBodySchema | undefined,
+    void
   >,
   respond: PostSetupIntentsIntentVerifyMicrodepositsResponder,
   ctx: RouterContext,
@@ -9811,7 +10177,8 @@ export type GetShippingRates = (
   params: Params<
     void,
     t_GetShippingRatesQuerySchema,
-    t_GetShippingRatesBodySchema | undefined
+    t_GetShippingRatesBodySchema | undefined,
+    void
   >,
   respond: GetShippingRatesResponder,
   ctx: RouterContext,
@@ -9835,7 +10202,7 @@ export type PostShippingRatesResponder = {
 } & KoaRuntimeResponder
 
 export type PostShippingRates = (
-  params: Params<void, void, t_PostShippingRatesBodySchema>,
+  params: Params<void, void, t_PostShippingRatesBodySchema, void>,
   respond: PostShippingRatesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9853,7 +10220,8 @@ export type GetShippingRatesShippingRateToken = (
   params: Params<
     t_GetShippingRatesShippingRateTokenParamSchema,
     t_GetShippingRatesShippingRateTokenQuerySchema,
-    t_GetShippingRatesShippingRateTokenBodySchema | undefined
+    t_GetShippingRatesShippingRateTokenBodySchema | undefined,
+    void
   >,
   respond: GetShippingRatesShippingRateTokenResponder,
   ctx: RouterContext,
@@ -9872,7 +10240,8 @@ export type PostShippingRatesShippingRateToken = (
   params: Params<
     t_PostShippingRatesShippingRateTokenParamSchema,
     void,
-    t_PostShippingRatesShippingRateTokenBodySchema | undefined
+    t_PostShippingRatesShippingRateTokenBodySchema | undefined,
+    void
   >,
   respond: PostShippingRatesShippingRateTokenResponder,
   ctx: RouterContext,
@@ -9896,7 +10265,8 @@ export type GetSigmaScheduledQueryRuns = (
   params: Params<
     void,
     t_GetSigmaScheduledQueryRunsQuerySchema,
-    t_GetSigmaScheduledQueryRunsBodySchema | undefined
+    t_GetSigmaScheduledQueryRunsBodySchema | undefined,
+    void
   >,
   respond: GetSigmaScheduledQueryRunsResponder,
   ctx: RouterContext,
@@ -9923,7 +10293,8 @@ export type GetSigmaScheduledQueryRunsScheduledQueryRun = (
   params: Params<
     t_GetSigmaScheduledQueryRunsScheduledQueryRunParamSchema,
     t_GetSigmaScheduledQueryRunsScheduledQueryRunQuerySchema,
-    t_GetSigmaScheduledQueryRunsScheduledQueryRunBodySchema | undefined
+    t_GetSigmaScheduledQueryRunsScheduledQueryRunBodySchema | undefined,
+    void
   >,
   respond: GetSigmaScheduledQueryRunsScheduledQueryRunResponder,
   ctx: RouterContext,
@@ -9939,7 +10310,7 @@ export type PostSourcesResponder = {
 } & KoaRuntimeResponder
 
 export type PostSources = (
-  params: Params<void, void, t_PostSourcesBodySchema | undefined>,
+  params: Params<void, void, t_PostSourcesBodySchema | undefined, void>,
   respond: PostSourcesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -9957,7 +10328,8 @@ export type GetSourcesSource = (
   params: Params<
     t_GetSourcesSourceParamSchema,
     t_GetSourcesSourceQuerySchema,
-    t_GetSourcesSourceBodySchema | undefined
+    t_GetSourcesSourceBodySchema | undefined,
+    void
   >,
   respond: GetSourcesSourceResponder,
   ctx: RouterContext,
@@ -9976,7 +10348,8 @@ export type PostSourcesSource = (
   params: Params<
     t_PostSourcesSourceParamSchema,
     void,
-    t_PostSourcesSourceBodySchema | undefined
+    t_PostSourcesSourceBodySchema | undefined,
+    void
   >,
   respond: PostSourcesSourceResponder,
   ctx: RouterContext,
@@ -9996,7 +10369,8 @@ export type GetSourcesSourceMandateNotificationsMandateNotification = (
     t_GetSourcesSourceMandateNotificationsMandateNotificationParamSchema,
     t_GetSourcesSourceMandateNotificationsMandateNotificationQuerySchema,
     | t_GetSourcesSourceMandateNotificationsMandateNotificationBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: GetSourcesSourceMandateNotificationsMandateNotificationResponder,
   ctx: RouterContext,
@@ -10020,7 +10394,8 @@ export type GetSourcesSourceSourceTransactions = (
   params: Params<
     t_GetSourcesSourceSourceTransactionsParamSchema,
     t_GetSourcesSourceSourceTransactionsQuerySchema,
-    t_GetSourcesSourceSourceTransactionsBodySchema | undefined
+    t_GetSourcesSourceSourceTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetSourcesSourceSourceTransactionsResponder,
   ctx: RouterContext,
@@ -10047,7 +10422,8 @@ export type GetSourcesSourceSourceTransactionsSourceTransaction = (
   params: Params<
     t_GetSourcesSourceSourceTransactionsSourceTransactionParamSchema,
     t_GetSourcesSourceSourceTransactionsSourceTransactionQuerySchema,
-    t_GetSourcesSourceSourceTransactionsSourceTransactionBodySchema | undefined
+    t_GetSourcesSourceSourceTransactionsSourceTransactionBodySchema | undefined,
+    void
   >,
   respond: GetSourcesSourceSourceTransactionsSourceTransactionResponder,
   ctx: RouterContext,
@@ -10066,7 +10442,8 @@ export type PostSourcesSourceVerify = (
   params: Params<
     t_PostSourcesSourceVerifyParamSchema,
     void,
-    t_PostSourcesSourceVerifyBodySchema
+    t_PostSourcesSourceVerifyBodySchema,
+    void
   >,
   respond: PostSourcesSourceVerifyResponder,
   ctx: RouterContext,
@@ -10090,7 +10467,8 @@ export type GetSubscriptionItems = (
   params: Params<
     void,
     t_GetSubscriptionItemsQuerySchema,
-    t_GetSubscriptionItemsBodySchema | undefined
+    t_GetSubscriptionItemsBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionItemsResponder,
   ctx: RouterContext,
@@ -10114,7 +10492,7 @@ export type PostSubscriptionItemsResponder = {
 } & KoaRuntimeResponder
 
 export type PostSubscriptionItems = (
-  params: Params<void, void, t_PostSubscriptionItemsBodySchema>,
+  params: Params<void, void, t_PostSubscriptionItemsBodySchema, void>,
   respond: PostSubscriptionItemsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10132,7 +10510,8 @@ export type DeleteSubscriptionItemsItem = (
   params: Params<
     t_DeleteSubscriptionItemsItemParamSchema,
     void,
-    t_DeleteSubscriptionItemsItemBodySchema | undefined
+    t_DeleteSubscriptionItemsItemBodySchema | undefined,
+    void
   >,
   respond: DeleteSubscriptionItemsItemResponder,
   ctx: RouterContext,
@@ -10151,7 +10530,8 @@ export type GetSubscriptionItemsItem = (
   params: Params<
     t_GetSubscriptionItemsItemParamSchema,
     t_GetSubscriptionItemsItemQuerySchema,
-    t_GetSubscriptionItemsItemBodySchema | undefined
+    t_GetSubscriptionItemsItemBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionItemsItemResponder,
   ctx: RouterContext,
@@ -10170,7 +10550,8 @@ export type PostSubscriptionItemsItem = (
   params: Params<
     t_PostSubscriptionItemsItemParamSchema,
     void,
-    t_PostSubscriptionItemsItemBodySchema | undefined
+    t_PostSubscriptionItemsItemBodySchema | undefined,
+    void
   >,
   respond: PostSubscriptionItemsItemResponder,
   ctx: RouterContext,
@@ -10196,7 +10577,8 @@ export type GetSubscriptionItemsSubscriptionItemUsageRecordSummaries = (
     t_GetSubscriptionItemsSubscriptionItemUsageRecordSummariesParamSchema,
     t_GetSubscriptionItemsSubscriptionItemUsageRecordSummariesQuerySchema,
     | t_GetSubscriptionItemsSubscriptionItemUsageRecordSummariesBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: GetSubscriptionItemsSubscriptionItemUsageRecordSummariesResponder,
   ctx: RouterContext,
@@ -10223,7 +10605,8 @@ export type PostSubscriptionItemsSubscriptionItemUsageRecords = (
   params: Params<
     t_PostSubscriptionItemsSubscriptionItemUsageRecordsParamSchema,
     void,
-    t_PostSubscriptionItemsSubscriptionItemUsageRecordsBodySchema
+    t_PostSubscriptionItemsSubscriptionItemUsageRecordsBodySchema,
+    void
   >,
   respond: PostSubscriptionItemsSubscriptionItemUsageRecordsResponder,
   ctx: RouterContext,
@@ -10247,7 +10630,8 @@ export type GetSubscriptionSchedules = (
   params: Params<
     void,
     t_GetSubscriptionSchedulesQuerySchema,
-    t_GetSubscriptionSchedulesBodySchema | undefined
+    t_GetSubscriptionSchedulesBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionSchedulesResponder,
   ctx: RouterContext,
@@ -10271,7 +10655,12 @@ export type PostSubscriptionSchedulesResponder = {
 } & KoaRuntimeResponder
 
 export type PostSubscriptionSchedules = (
-  params: Params<void, void, t_PostSubscriptionSchedulesBodySchema | undefined>,
+  params: Params<
+    void,
+    void,
+    t_PostSubscriptionSchedulesBodySchema | undefined,
+    void
+  >,
   respond: PostSubscriptionSchedulesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10289,7 +10678,8 @@ export type GetSubscriptionSchedulesSchedule = (
   params: Params<
     t_GetSubscriptionSchedulesScheduleParamSchema,
     t_GetSubscriptionSchedulesScheduleQuerySchema,
-    t_GetSubscriptionSchedulesScheduleBodySchema | undefined
+    t_GetSubscriptionSchedulesScheduleBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionSchedulesScheduleResponder,
   ctx: RouterContext,
@@ -10308,7 +10698,8 @@ export type PostSubscriptionSchedulesSchedule = (
   params: Params<
     t_PostSubscriptionSchedulesScheduleParamSchema,
     void,
-    t_PostSubscriptionSchedulesScheduleBodySchema | undefined
+    t_PostSubscriptionSchedulesScheduleBodySchema | undefined,
+    void
   >,
   respond: PostSubscriptionSchedulesScheduleResponder,
   ctx: RouterContext,
@@ -10327,7 +10718,8 @@ export type PostSubscriptionSchedulesScheduleCancel = (
   params: Params<
     t_PostSubscriptionSchedulesScheduleCancelParamSchema,
     void,
-    t_PostSubscriptionSchedulesScheduleCancelBodySchema | undefined
+    t_PostSubscriptionSchedulesScheduleCancelBodySchema | undefined,
+    void
   >,
   respond: PostSubscriptionSchedulesScheduleCancelResponder,
   ctx: RouterContext,
@@ -10346,7 +10738,8 @@ export type PostSubscriptionSchedulesScheduleRelease = (
   params: Params<
     t_PostSubscriptionSchedulesScheduleReleaseParamSchema,
     void,
-    t_PostSubscriptionSchedulesScheduleReleaseBodySchema | undefined
+    t_PostSubscriptionSchedulesScheduleReleaseBodySchema | undefined,
+    void
   >,
   respond: PostSubscriptionSchedulesScheduleReleaseResponder,
   ctx: RouterContext,
@@ -10370,7 +10763,8 @@ export type GetSubscriptions = (
   params: Params<
     void,
     t_GetSubscriptionsQuerySchema,
-    t_GetSubscriptionsBodySchema | undefined
+    t_GetSubscriptionsBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionsResponder,
   ctx: RouterContext,
@@ -10394,7 +10788,7 @@ export type PostSubscriptionsResponder = {
 } & KoaRuntimeResponder
 
 export type PostSubscriptions = (
-  params: Params<void, void, t_PostSubscriptionsBodySchema>,
+  params: Params<void, void, t_PostSubscriptionsBodySchema, void>,
   respond: PostSubscriptionsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10419,7 +10813,8 @@ export type GetSubscriptionsSearch = (
   params: Params<
     void,
     t_GetSubscriptionsSearchQuerySchema,
-    t_GetSubscriptionsSearchBodySchema | undefined
+    t_GetSubscriptionsSearchBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionsSearchResponder,
   ctx: RouterContext,
@@ -10448,7 +10843,8 @@ export type DeleteSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_DeleteSubscriptionsSubscriptionExposedIdParamSchema,
     void,
-    t_DeleteSubscriptionsSubscriptionExposedIdBodySchema | undefined
+    t_DeleteSubscriptionsSubscriptionExposedIdBodySchema | undefined,
+    void
   >,
   respond: DeleteSubscriptionsSubscriptionExposedIdResponder,
   ctx: RouterContext,
@@ -10467,7 +10863,8 @@ export type GetSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_GetSubscriptionsSubscriptionExposedIdParamSchema,
     t_GetSubscriptionsSubscriptionExposedIdQuerySchema,
-    t_GetSubscriptionsSubscriptionExposedIdBodySchema | undefined
+    t_GetSubscriptionsSubscriptionExposedIdBodySchema | undefined,
+    void
   >,
   respond: GetSubscriptionsSubscriptionExposedIdResponder,
   ctx: RouterContext,
@@ -10486,7 +10883,8 @@ export type PostSubscriptionsSubscriptionExposedId = (
   params: Params<
     t_PostSubscriptionsSubscriptionExposedIdParamSchema,
     void,
-    t_PostSubscriptionsSubscriptionExposedIdBodySchema | undefined
+    t_PostSubscriptionsSubscriptionExposedIdBodySchema | undefined,
+    void
   >,
   respond: PostSubscriptionsSubscriptionExposedIdResponder,
   ctx: RouterContext,
@@ -10505,7 +10903,8 @@ export type DeleteSubscriptionsSubscriptionExposedIdDiscount = (
   params: Params<
     t_DeleteSubscriptionsSubscriptionExposedIdDiscountParamSchema,
     void,
-    t_DeleteSubscriptionsSubscriptionExposedIdDiscountBodySchema | undefined
+    t_DeleteSubscriptionsSubscriptionExposedIdDiscountBodySchema | undefined,
+    void
   >,
   respond: DeleteSubscriptionsSubscriptionExposedIdDiscountResponder,
   ctx: RouterContext,
@@ -10524,7 +10923,8 @@ export type PostSubscriptionsSubscriptionResume = (
   params: Params<
     t_PostSubscriptionsSubscriptionResumeParamSchema,
     void,
-    t_PostSubscriptionsSubscriptionResumeBodySchema | undefined
+    t_PostSubscriptionsSubscriptionResumeBodySchema | undefined,
+    void
   >,
   respond: PostSubscriptionsSubscriptionResumeResponder,
   ctx: RouterContext,
@@ -10540,7 +10940,7 @@ export type PostTaxCalculationsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTaxCalculations = (
-  params: Params<void, void, t_PostTaxCalculationsBodySchema>,
+  params: Params<void, void, t_PostTaxCalculationsBodySchema, void>,
   respond: PostTaxCalculationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10558,7 +10958,8 @@ export type GetTaxCalculationsCalculation = (
   params: Params<
     t_GetTaxCalculationsCalculationParamSchema,
     t_GetTaxCalculationsCalculationQuerySchema,
-    t_GetTaxCalculationsCalculationBodySchema | undefined
+    t_GetTaxCalculationsCalculationBodySchema | undefined,
+    void
   >,
   respond: GetTaxCalculationsCalculationResponder,
   ctx: RouterContext,
@@ -10582,7 +10983,8 @@ export type GetTaxCalculationsCalculationLineItems = (
   params: Params<
     t_GetTaxCalculationsCalculationLineItemsParamSchema,
     t_GetTaxCalculationsCalculationLineItemsQuerySchema,
-    t_GetTaxCalculationsCalculationLineItemsBodySchema | undefined
+    t_GetTaxCalculationsCalculationLineItemsBodySchema | undefined,
+    void
   >,
   respond: GetTaxCalculationsCalculationLineItemsResponder,
   ctx: RouterContext,
@@ -10614,7 +11016,8 @@ export type GetTaxRegistrations = (
   params: Params<
     void,
     t_GetTaxRegistrationsQuerySchema,
-    t_GetTaxRegistrationsBodySchema | undefined
+    t_GetTaxRegistrationsBodySchema | undefined,
+    void
   >,
   respond: GetTaxRegistrationsResponder,
   ctx: RouterContext,
@@ -10638,7 +11041,7 @@ export type PostTaxRegistrationsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTaxRegistrations = (
-  params: Params<void, void, t_PostTaxRegistrationsBodySchema>,
+  params: Params<void, void, t_PostTaxRegistrationsBodySchema, void>,
   respond: PostTaxRegistrationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10656,7 +11059,8 @@ export type GetTaxRegistrationsId = (
   params: Params<
     t_GetTaxRegistrationsIdParamSchema,
     t_GetTaxRegistrationsIdQuerySchema,
-    t_GetTaxRegistrationsIdBodySchema | undefined
+    t_GetTaxRegistrationsIdBodySchema | undefined,
+    void
   >,
   respond: GetTaxRegistrationsIdResponder,
   ctx: RouterContext,
@@ -10675,7 +11079,8 @@ export type PostTaxRegistrationsId = (
   params: Params<
     t_PostTaxRegistrationsIdParamSchema,
     void,
-    t_PostTaxRegistrationsIdBodySchema | undefined
+    t_PostTaxRegistrationsIdBodySchema | undefined,
+    void
   >,
   respond: PostTaxRegistrationsIdResponder,
   ctx: RouterContext,
@@ -10694,7 +11099,8 @@ export type GetTaxSettings = (
   params: Params<
     void,
     t_GetTaxSettingsQuerySchema,
-    t_GetTaxSettingsBodySchema | undefined
+    t_GetTaxSettingsBodySchema | undefined,
+    void
   >,
   respond: GetTaxSettingsResponder,
   ctx: RouterContext,
@@ -10710,7 +11116,7 @@ export type PostTaxSettingsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTaxSettings = (
-  params: Params<void, void, t_PostTaxSettingsBodySchema | undefined>,
+  params: Params<void, void, t_PostTaxSettingsBodySchema | undefined, void>,
   respond: PostTaxSettingsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10728,7 +11134,8 @@ export type PostTaxTransactionsCreateFromCalculation = (
   params: Params<
     void,
     void,
-    t_PostTaxTransactionsCreateFromCalculationBodySchema
+    t_PostTaxTransactionsCreateFromCalculationBodySchema,
+    void
   >,
   respond: PostTaxTransactionsCreateFromCalculationResponder,
   ctx: RouterContext,
@@ -10744,7 +11151,12 @@ export type PostTaxTransactionsCreateReversalResponder = {
 } & KoaRuntimeResponder
 
 export type PostTaxTransactionsCreateReversal = (
-  params: Params<void, void, t_PostTaxTransactionsCreateReversalBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostTaxTransactionsCreateReversalBodySchema,
+    void
+  >,
   respond: PostTaxTransactionsCreateReversalResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10762,7 +11174,8 @@ export type GetTaxTransactionsTransaction = (
   params: Params<
     t_GetTaxTransactionsTransactionParamSchema,
     t_GetTaxTransactionsTransactionQuerySchema,
-    t_GetTaxTransactionsTransactionBodySchema | undefined
+    t_GetTaxTransactionsTransactionBodySchema | undefined,
+    void
   >,
   respond: GetTaxTransactionsTransactionResponder,
   ctx: RouterContext,
@@ -10786,7 +11199,8 @@ export type GetTaxTransactionsTransactionLineItems = (
   params: Params<
     t_GetTaxTransactionsTransactionLineItemsParamSchema,
     t_GetTaxTransactionsTransactionLineItemsQuerySchema,
-    t_GetTaxTransactionsTransactionLineItemsBodySchema | undefined
+    t_GetTaxTransactionsTransactionLineItemsBodySchema | undefined,
+    void
   >,
   respond: GetTaxTransactionsTransactionLineItemsResponder,
   ctx: RouterContext,
@@ -10818,7 +11232,8 @@ export type GetTaxCodes = (
   params: Params<
     void,
     t_GetTaxCodesQuerySchema,
-    t_GetTaxCodesBodySchema | undefined
+    t_GetTaxCodesBodySchema | undefined,
+    void
   >,
   respond: GetTaxCodesResponder,
   ctx: RouterContext,
@@ -10845,7 +11260,8 @@ export type GetTaxCodesId = (
   params: Params<
     t_GetTaxCodesIdParamSchema,
     t_GetTaxCodesIdQuerySchema,
-    t_GetTaxCodesIdBodySchema | undefined
+    t_GetTaxCodesIdBodySchema | undefined,
+    void
   >,
   respond: GetTaxCodesIdResponder,
   ctx: RouterContext,
@@ -10869,7 +11285,8 @@ export type GetTaxIds = (
   params: Params<
     void,
     t_GetTaxIdsQuerySchema,
-    t_GetTaxIdsBodySchema | undefined
+    t_GetTaxIdsBodySchema | undefined,
+    void
   >,
   respond: GetTaxIdsResponder,
   ctx: RouterContext,
@@ -10893,7 +11310,7 @@ export type PostTaxIdsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTaxIds = (
-  params: Params<void, void, t_PostTaxIdsBodySchema>,
+  params: Params<void, void, t_PostTaxIdsBodySchema, void>,
   respond: PostTaxIdsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10911,7 +11328,8 @@ export type DeleteTaxIdsId = (
   params: Params<
     t_DeleteTaxIdsIdParamSchema,
     void,
-    t_DeleteTaxIdsIdBodySchema | undefined
+    t_DeleteTaxIdsIdBodySchema | undefined,
+    void
   >,
   respond: DeleteTaxIdsIdResponder,
   ctx: RouterContext,
@@ -10930,7 +11348,8 @@ export type GetTaxIdsId = (
   params: Params<
     t_GetTaxIdsIdParamSchema,
     t_GetTaxIdsIdQuerySchema,
-    t_GetTaxIdsIdBodySchema | undefined
+    t_GetTaxIdsIdBodySchema | undefined,
+    void
   >,
   respond: GetTaxIdsIdResponder,
   ctx: RouterContext,
@@ -10954,7 +11373,8 @@ export type GetTaxRates = (
   params: Params<
     void,
     t_GetTaxRatesQuerySchema,
-    t_GetTaxRatesBodySchema | undefined
+    t_GetTaxRatesBodySchema | undefined,
+    void
   >,
   respond: GetTaxRatesResponder,
   ctx: RouterContext,
@@ -10978,7 +11398,7 @@ export type PostTaxRatesResponder = {
 } & KoaRuntimeResponder
 
 export type PostTaxRates = (
-  params: Params<void, void, t_PostTaxRatesBodySchema>,
+  params: Params<void, void, t_PostTaxRatesBodySchema, void>,
   respond: PostTaxRatesResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -10996,7 +11416,8 @@ export type GetTaxRatesTaxRate = (
   params: Params<
     t_GetTaxRatesTaxRateParamSchema,
     t_GetTaxRatesTaxRateQuerySchema,
-    t_GetTaxRatesTaxRateBodySchema | undefined
+    t_GetTaxRatesTaxRateBodySchema | undefined,
+    void
   >,
   respond: GetTaxRatesTaxRateResponder,
   ctx: RouterContext,
@@ -11015,7 +11436,8 @@ export type PostTaxRatesTaxRate = (
   params: Params<
     t_PostTaxRatesTaxRateParamSchema,
     void,
-    t_PostTaxRatesTaxRateBodySchema | undefined
+    t_PostTaxRatesTaxRateBodySchema | undefined,
+    void
   >,
   respond: PostTaxRatesTaxRateResponder,
   ctx: RouterContext,
@@ -11039,7 +11461,8 @@ export type GetTerminalConfigurations = (
   params: Params<
     void,
     t_GetTerminalConfigurationsQuerySchema,
-    t_GetTerminalConfigurationsBodySchema | undefined
+    t_GetTerminalConfigurationsBodySchema | undefined,
+    void
   >,
   respond: GetTerminalConfigurationsResponder,
   ctx: RouterContext,
@@ -11066,7 +11489,8 @@ export type PostTerminalConfigurations = (
   params: Params<
     void,
     void,
-    t_PostTerminalConfigurationsBodySchema | undefined
+    t_PostTerminalConfigurationsBodySchema | undefined,
+    void
   >,
   respond: PostTerminalConfigurationsResponder,
   ctx: RouterContext,
@@ -11085,7 +11509,8 @@ export type DeleteTerminalConfigurationsConfiguration = (
   params: Params<
     t_DeleteTerminalConfigurationsConfigurationParamSchema,
     void,
-    t_DeleteTerminalConfigurationsConfigurationBodySchema | undefined
+    t_DeleteTerminalConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: DeleteTerminalConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -11106,7 +11531,8 @@ export type GetTerminalConfigurationsConfiguration = (
   params: Params<
     t_GetTerminalConfigurationsConfigurationParamSchema,
     t_GetTerminalConfigurationsConfigurationQuerySchema,
-    t_GetTerminalConfigurationsConfigurationBodySchema | undefined
+    t_GetTerminalConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: GetTerminalConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -11127,7 +11553,8 @@ export type PostTerminalConfigurationsConfiguration = (
   params: Params<
     t_PostTerminalConfigurationsConfigurationParamSchema,
     void,
-    t_PostTerminalConfigurationsConfigurationBodySchema | undefined
+    t_PostTerminalConfigurationsConfigurationBodySchema | undefined,
+    void
   >,
   respond: PostTerminalConfigurationsConfigurationResponder,
   ctx: RouterContext,
@@ -11146,7 +11573,8 @@ export type PostTerminalConnectionTokens = (
   params: Params<
     void,
     void,
-    t_PostTerminalConnectionTokensBodySchema | undefined
+    t_PostTerminalConnectionTokensBodySchema | undefined,
+    void
   >,
   respond: PostTerminalConnectionTokensResponder,
   ctx: RouterContext,
@@ -11170,7 +11598,8 @@ export type GetTerminalLocations = (
   params: Params<
     void,
     t_GetTerminalLocationsQuerySchema,
-    t_GetTerminalLocationsBodySchema | undefined
+    t_GetTerminalLocationsBodySchema | undefined,
+    void
   >,
   respond: GetTerminalLocationsResponder,
   ctx: RouterContext,
@@ -11194,7 +11623,7 @@ export type PostTerminalLocationsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTerminalLocations = (
-  params: Params<void, void, t_PostTerminalLocationsBodySchema>,
+  params: Params<void, void, t_PostTerminalLocationsBodySchema, void>,
   respond: PostTerminalLocationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11212,7 +11641,8 @@ export type DeleteTerminalLocationsLocation = (
   params: Params<
     t_DeleteTerminalLocationsLocationParamSchema,
     void,
-    t_DeleteTerminalLocationsLocationBodySchema | undefined
+    t_DeleteTerminalLocationsLocationBodySchema | undefined,
+    void
   >,
   respond: DeleteTerminalLocationsLocationResponder,
   ctx: RouterContext,
@@ -11233,7 +11663,8 @@ export type GetTerminalLocationsLocation = (
   params: Params<
     t_GetTerminalLocationsLocationParamSchema,
     t_GetTerminalLocationsLocationQuerySchema,
-    t_GetTerminalLocationsLocationBodySchema | undefined
+    t_GetTerminalLocationsLocationBodySchema | undefined,
+    void
   >,
   respond: GetTerminalLocationsLocationResponder,
   ctx: RouterContext,
@@ -11254,7 +11685,8 @@ export type PostTerminalLocationsLocation = (
   params: Params<
     t_PostTerminalLocationsLocationParamSchema,
     void,
-    t_PostTerminalLocationsLocationBodySchema | undefined
+    t_PostTerminalLocationsLocationBodySchema | undefined,
+    void
   >,
   respond: PostTerminalLocationsLocationResponder,
   ctx: RouterContext,
@@ -11278,7 +11710,8 @@ export type GetTerminalReaders = (
   params: Params<
     void,
     t_GetTerminalReadersQuerySchema,
-    t_GetTerminalReadersBodySchema | undefined
+    t_GetTerminalReadersBodySchema | undefined,
+    void
   >,
   respond: GetTerminalReadersResponder,
   ctx: RouterContext,
@@ -11302,7 +11735,7 @@ export type PostTerminalReadersResponder = {
 } & KoaRuntimeResponder
 
 export type PostTerminalReaders = (
-  params: Params<void, void, t_PostTerminalReadersBodySchema>,
+  params: Params<void, void, t_PostTerminalReadersBodySchema, void>,
   respond: PostTerminalReadersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11320,7 +11753,8 @@ export type DeleteTerminalReadersReader = (
   params: Params<
     t_DeleteTerminalReadersReaderParamSchema,
     void,
-    t_DeleteTerminalReadersReaderBodySchema | undefined
+    t_DeleteTerminalReadersReaderBodySchema | undefined,
+    void
   >,
   respond: DeleteTerminalReadersReaderResponder,
   ctx: RouterContext,
@@ -11339,7 +11773,8 @@ export type GetTerminalReadersReader = (
   params: Params<
     t_GetTerminalReadersReaderParamSchema,
     t_GetTerminalReadersReaderQuerySchema,
-    t_GetTerminalReadersReaderBodySchema | undefined
+    t_GetTerminalReadersReaderBodySchema | undefined,
+    void
   >,
   respond: GetTerminalReadersReaderResponder,
   ctx: RouterContext,
@@ -11358,7 +11793,8 @@ export type PostTerminalReadersReader = (
   params: Params<
     t_PostTerminalReadersReaderParamSchema,
     void,
-    t_PostTerminalReadersReaderBodySchema | undefined
+    t_PostTerminalReadersReaderBodySchema | undefined,
+    void
   >,
   respond: PostTerminalReadersReaderResponder,
   ctx: RouterContext,
@@ -11377,7 +11813,8 @@ export type PostTerminalReadersReaderCancelAction = (
   params: Params<
     t_PostTerminalReadersReaderCancelActionParamSchema,
     void,
-    t_PostTerminalReadersReaderCancelActionBodySchema | undefined
+    t_PostTerminalReadersReaderCancelActionBodySchema | undefined,
+    void
   >,
   respond: PostTerminalReadersReaderCancelActionResponder,
   ctx: RouterContext,
@@ -11396,7 +11833,8 @@ export type PostTerminalReadersReaderProcessPaymentIntent = (
   params: Params<
     t_PostTerminalReadersReaderProcessPaymentIntentParamSchema,
     void,
-    t_PostTerminalReadersReaderProcessPaymentIntentBodySchema
+    t_PostTerminalReadersReaderProcessPaymentIntentBodySchema,
+    void
   >,
   respond: PostTerminalReadersReaderProcessPaymentIntentResponder,
   ctx: RouterContext,
@@ -11415,7 +11853,8 @@ export type PostTerminalReadersReaderProcessSetupIntent = (
   params: Params<
     t_PostTerminalReadersReaderProcessSetupIntentParamSchema,
     void,
-    t_PostTerminalReadersReaderProcessSetupIntentBodySchema
+    t_PostTerminalReadersReaderProcessSetupIntentBodySchema,
+    void
   >,
   respond: PostTerminalReadersReaderProcessSetupIntentResponder,
   ctx: RouterContext,
@@ -11434,7 +11873,8 @@ export type PostTerminalReadersReaderRefundPayment = (
   params: Params<
     t_PostTerminalReadersReaderRefundPaymentParamSchema,
     void,
-    t_PostTerminalReadersReaderRefundPaymentBodySchema | undefined
+    t_PostTerminalReadersReaderRefundPaymentBodySchema | undefined,
+    void
   >,
   respond: PostTerminalReadersReaderRefundPaymentResponder,
   ctx: RouterContext,
@@ -11453,7 +11893,8 @@ export type PostTerminalReadersReaderSetReaderDisplay = (
   params: Params<
     t_PostTerminalReadersReaderSetReaderDisplayParamSchema,
     void,
-    t_PostTerminalReadersReaderSetReaderDisplayBodySchema
+    t_PostTerminalReadersReaderSetReaderDisplayBodySchema,
+    void
   >,
   respond: PostTerminalReadersReaderSetReaderDisplayResponder,
   ctx: RouterContext,
@@ -11472,7 +11913,8 @@ export type PostTestHelpersConfirmationTokens = (
   params: Params<
     void,
     void,
-    t_PostTestHelpersConfirmationTokensBodySchema | undefined
+    t_PostTestHelpersConfirmationTokensBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersConfirmationTokensResponder,
   ctx: RouterContext,
@@ -11491,7 +11933,8 @@ export type PostTestHelpersCustomersCustomerFundCashBalance = (
   params: Params<
     t_PostTestHelpersCustomersCustomerFundCashBalanceParamSchema,
     void,
-    t_PostTestHelpersCustomersCustomerFundCashBalanceBodySchema
+    t_PostTestHelpersCustomersCustomerFundCashBalanceBodySchema,
+    void
   >,
   respond: PostTestHelpersCustomersCustomerFundCashBalanceResponder,
   ctx: RouterContext,
@@ -11507,7 +11950,12 @@ export type PostTestHelpersIssuingAuthorizationsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTestHelpersIssuingAuthorizations = (
-  params: Params<void, void, t_PostTestHelpersIssuingAuthorizationsBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostTestHelpersIssuingAuthorizationsBodySchema,
+    void
+  >,
   respond: PostTestHelpersIssuingAuthorizationsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11527,7 +11975,8 @@ export type PostTestHelpersIssuingAuthorizationsAuthorizationCapture = (
     t_PostTestHelpersIssuingAuthorizationsAuthorizationCaptureParamSchema,
     void,
     | t_PostTestHelpersIssuingAuthorizationsAuthorizationCaptureBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingAuthorizationsAuthorizationCaptureResponder,
   ctx: RouterContext,
@@ -11547,7 +11996,8 @@ export type PostTestHelpersIssuingAuthorizationsAuthorizationExpire = (
     t_PostTestHelpersIssuingAuthorizationsAuthorizationExpireParamSchema,
     void,
     | t_PostTestHelpersIssuingAuthorizationsAuthorizationExpireBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingAuthorizationsAuthorizationExpireResponder,
   ctx: RouterContext,
@@ -11567,7 +12017,8 @@ export type PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmount = (
   params: Params<
     t_PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountParamSchema,
     void,
-    t_PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountBodySchema
+    t_PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountBodySchema,
+    void
   >,
   respond: PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountResponder,
   ctx: RouterContext,
@@ -11587,7 +12038,8 @@ export type PostTestHelpersIssuingAuthorizationsAuthorizationIncrement = (
   params: Params<
     t_PostTestHelpersIssuingAuthorizationsAuthorizationIncrementParamSchema,
     void,
-    t_PostTestHelpersIssuingAuthorizationsAuthorizationIncrementBodySchema
+    t_PostTestHelpersIssuingAuthorizationsAuthorizationIncrementBodySchema,
+    void
   >,
   respond: PostTestHelpersIssuingAuthorizationsAuthorizationIncrementResponder,
   ctx: RouterContext,
@@ -11608,7 +12060,8 @@ export type PostTestHelpersIssuingAuthorizationsAuthorizationReverse = (
     t_PostTestHelpersIssuingAuthorizationsAuthorizationReverseParamSchema,
     void,
     | t_PostTestHelpersIssuingAuthorizationsAuthorizationReverseBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingAuthorizationsAuthorizationReverseResponder,
   ctx: RouterContext,
@@ -11627,7 +12080,8 @@ export type PostTestHelpersIssuingCardsCardShippingDeliver = (
   params: Params<
     t_PostTestHelpersIssuingCardsCardShippingDeliverParamSchema,
     void,
-    t_PostTestHelpersIssuingCardsCardShippingDeliverBodySchema | undefined
+    t_PostTestHelpersIssuingCardsCardShippingDeliverBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingCardsCardShippingDeliverResponder,
   ctx: RouterContext,
@@ -11646,7 +12100,8 @@ export type PostTestHelpersIssuingCardsCardShippingFail = (
   params: Params<
     t_PostTestHelpersIssuingCardsCardShippingFailParamSchema,
     void,
-    t_PostTestHelpersIssuingCardsCardShippingFailBodySchema | undefined
+    t_PostTestHelpersIssuingCardsCardShippingFailBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingCardsCardShippingFailResponder,
   ctx: RouterContext,
@@ -11665,7 +12120,8 @@ export type PostTestHelpersIssuingCardsCardShippingReturn = (
   params: Params<
     t_PostTestHelpersIssuingCardsCardShippingReturnParamSchema,
     void,
-    t_PostTestHelpersIssuingCardsCardShippingReturnBodySchema | undefined
+    t_PostTestHelpersIssuingCardsCardShippingReturnBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingCardsCardShippingReturnResponder,
   ctx: RouterContext,
@@ -11684,7 +12140,8 @@ export type PostTestHelpersIssuingCardsCardShippingShip = (
   params: Params<
     t_PostTestHelpersIssuingCardsCardShippingShipParamSchema,
     void,
-    t_PostTestHelpersIssuingCardsCardShippingShipBodySchema | undefined
+    t_PostTestHelpersIssuingCardsCardShippingShipBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingCardsCardShippingShipResponder,
   ctx: RouterContext,
@@ -11706,7 +12163,8 @@ export type PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignAct
       t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateParamSchema,
       void,
       | t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateBodySchema
-      | undefined
+      | undefined,
+      void
     >,
     respond: PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateResponder,
     ctx: RouterContext,
@@ -11728,7 +12186,8 @@ export type PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDea
       t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateParamSchema,
       void,
       | t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateBodySchema
-      | undefined
+      | undefined,
+      void
     >,
     respond: PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateResponder,
     ctx: RouterContext,
@@ -11749,7 +12208,8 @@ export type PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRej
     params: Params<
       t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectParamSchema,
       void,
-      t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectBodySchema
+      t_PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectBodySchema,
+      void
     >,
     respond: PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectResponder,
     ctx: RouterContext,
@@ -11765,7 +12225,12 @@ export type PostTestHelpersIssuingSettlementsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTestHelpersIssuingSettlements = (
-  params: Params<void, void, t_PostTestHelpersIssuingSettlementsBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostTestHelpersIssuingSettlementsBodySchema,
+    void
+  >,
   respond: PostTestHelpersIssuingSettlementsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11783,7 +12248,8 @@ export type PostTestHelpersIssuingTransactionsCreateForceCapture = (
   params: Params<
     void,
     void,
-    t_PostTestHelpersIssuingTransactionsCreateForceCaptureBodySchema
+    t_PostTestHelpersIssuingTransactionsCreateForceCaptureBodySchema,
+    void
   >,
   respond: PostTestHelpersIssuingTransactionsCreateForceCaptureResponder,
   ctx: RouterContext,
@@ -11802,7 +12268,8 @@ export type PostTestHelpersIssuingTransactionsCreateUnlinkedRefund = (
   params: Params<
     void,
     void,
-    t_PostTestHelpersIssuingTransactionsCreateUnlinkedRefundBodySchema
+    t_PostTestHelpersIssuingTransactionsCreateUnlinkedRefundBodySchema,
+    void
   >,
   respond: PostTestHelpersIssuingTransactionsCreateUnlinkedRefundResponder,
   ctx: RouterContext,
@@ -11821,7 +12288,8 @@ export type PostTestHelpersIssuingTransactionsTransactionRefund = (
   params: Params<
     t_PostTestHelpersIssuingTransactionsTransactionRefundParamSchema,
     void,
-    t_PostTestHelpersIssuingTransactionsTransactionRefundBodySchema | undefined
+    t_PostTestHelpersIssuingTransactionsTransactionRefundBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersIssuingTransactionsTransactionRefundResponder,
   ctx: RouterContext,
@@ -11840,7 +12308,8 @@ export type PostTestHelpersRefundsRefundExpire = (
   params: Params<
     t_PostTestHelpersRefundsRefundExpireParamSchema,
     void,
-    t_PostTestHelpersRefundsRefundExpireBodySchema | undefined
+    t_PostTestHelpersRefundsRefundExpireBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersRefundsRefundExpireResponder,
   ctx: RouterContext,
@@ -11861,7 +12330,8 @@ export type PostTestHelpersTerminalReadersReaderPresentPaymentMethod = (
     t_PostTestHelpersTerminalReadersReaderPresentPaymentMethodParamSchema,
     void,
     | t_PostTestHelpersTerminalReadersReaderPresentPaymentMethodBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersTerminalReadersReaderPresentPaymentMethodResponder,
   ctx: RouterContext,
@@ -11885,7 +12355,8 @@ export type GetTestHelpersTestClocks = (
   params: Params<
     void,
     t_GetTestHelpersTestClocksQuerySchema,
-    t_GetTestHelpersTestClocksBodySchema | undefined
+    t_GetTestHelpersTestClocksBodySchema | undefined,
+    void
   >,
   respond: GetTestHelpersTestClocksResponder,
   ctx: RouterContext,
@@ -11909,7 +12380,7 @@ export type PostTestHelpersTestClocksResponder = {
 } & KoaRuntimeResponder
 
 export type PostTestHelpersTestClocks = (
-  params: Params<void, void, t_PostTestHelpersTestClocksBodySchema>,
+  params: Params<void, void, t_PostTestHelpersTestClocksBodySchema, void>,
   respond: PostTestHelpersTestClocksResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -11927,7 +12398,8 @@ export type DeleteTestHelpersTestClocksTestClock = (
   params: Params<
     t_DeleteTestHelpersTestClocksTestClockParamSchema,
     void,
-    t_DeleteTestHelpersTestClocksTestClockBodySchema | undefined
+    t_DeleteTestHelpersTestClocksTestClockBodySchema | undefined,
+    void
   >,
   respond: DeleteTestHelpersTestClocksTestClockResponder,
   ctx: RouterContext,
@@ -11946,7 +12418,8 @@ export type GetTestHelpersTestClocksTestClock = (
   params: Params<
     t_GetTestHelpersTestClocksTestClockParamSchema,
     t_GetTestHelpersTestClocksTestClockQuerySchema,
-    t_GetTestHelpersTestClocksTestClockBodySchema | undefined
+    t_GetTestHelpersTestClocksTestClockBodySchema | undefined,
+    void
   >,
   respond: GetTestHelpersTestClocksTestClockResponder,
   ctx: RouterContext,
@@ -11965,7 +12438,8 @@ export type PostTestHelpersTestClocksTestClockAdvance = (
   params: Params<
     t_PostTestHelpersTestClocksTestClockAdvanceParamSchema,
     void,
-    t_PostTestHelpersTestClocksTestClockAdvanceBodySchema
+    t_PostTestHelpersTestClocksTestClockAdvanceBodySchema,
+    void
   >,
   respond: PostTestHelpersTestClocksTestClockAdvanceResponder,
   ctx: RouterContext,
@@ -11984,7 +12458,8 @@ export type PostTestHelpersTreasuryInboundTransfersIdFail = (
   params: Params<
     t_PostTestHelpersTreasuryInboundTransfersIdFailParamSchema,
     void,
-    t_PostTestHelpersTreasuryInboundTransfersIdFailBodySchema | undefined
+    t_PostTestHelpersTreasuryInboundTransfersIdFailBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryInboundTransfersIdFailResponder,
   ctx: RouterContext,
@@ -12003,7 +12478,8 @@ export type PostTestHelpersTreasuryInboundTransfersIdReturn = (
   params: Params<
     t_PostTestHelpersTreasuryInboundTransfersIdReturnParamSchema,
     void,
-    t_PostTestHelpersTreasuryInboundTransfersIdReturnBodySchema | undefined
+    t_PostTestHelpersTreasuryInboundTransfersIdReturnBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryInboundTransfersIdReturnResponder,
   ctx: RouterContext,
@@ -12022,7 +12498,8 @@ export type PostTestHelpersTreasuryInboundTransfersIdSucceed = (
   params: Params<
     t_PostTestHelpersTreasuryInboundTransfersIdSucceedParamSchema,
     void,
-    t_PostTestHelpersTreasuryInboundTransfersIdSucceedBodySchema | undefined
+    t_PostTestHelpersTreasuryInboundTransfersIdSucceedBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryInboundTransfersIdSucceedResponder,
   ctx: RouterContext,
@@ -12041,7 +12518,8 @@ export type PostTestHelpersTreasuryOutboundPaymentsId = (
   params: Params<
     t_PostTestHelpersTreasuryOutboundPaymentsIdParamSchema,
     void,
-    t_PostTestHelpersTreasuryOutboundPaymentsIdBodySchema
+    t_PostTestHelpersTreasuryOutboundPaymentsIdBodySchema,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundPaymentsIdResponder,
   ctx: RouterContext,
@@ -12060,7 +12538,8 @@ export type PostTestHelpersTreasuryOutboundPaymentsIdFail = (
   params: Params<
     t_PostTestHelpersTreasuryOutboundPaymentsIdFailParamSchema,
     void,
-    t_PostTestHelpersTreasuryOutboundPaymentsIdFailBodySchema | undefined
+    t_PostTestHelpersTreasuryOutboundPaymentsIdFailBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundPaymentsIdFailResponder,
   ctx: RouterContext,
@@ -12079,7 +12558,8 @@ export type PostTestHelpersTreasuryOutboundPaymentsIdPost = (
   params: Params<
     t_PostTestHelpersTreasuryOutboundPaymentsIdPostParamSchema,
     void,
-    t_PostTestHelpersTreasuryOutboundPaymentsIdPostBodySchema | undefined
+    t_PostTestHelpersTreasuryOutboundPaymentsIdPostBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundPaymentsIdPostResponder,
   ctx: RouterContext,
@@ -12098,7 +12578,8 @@ export type PostTestHelpersTreasuryOutboundPaymentsIdReturn = (
   params: Params<
     t_PostTestHelpersTreasuryOutboundPaymentsIdReturnParamSchema,
     void,
-    t_PostTestHelpersTreasuryOutboundPaymentsIdReturnBodySchema | undefined
+    t_PostTestHelpersTreasuryOutboundPaymentsIdReturnBodySchema | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundPaymentsIdReturnResponder,
   ctx: RouterContext,
@@ -12118,7 +12599,8 @@ export type PostTestHelpersTreasuryOutboundTransfersOutboundTransfer = (
   params: Params<
     t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferParamSchema,
     void,
-    t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferBodySchema
+    t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferBodySchema,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundTransfersOutboundTransferResponder,
   ctx: RouterContext,
@@ -12139,7 +12621,8 @@ export type PostTestHelpersTreasuryOutboundTransfersOutboundTransferFail = (
     t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferFailParamSchema,
     void,
     | t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferFailBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundTransfersOutboundTransferFailResponder,
   ctx: RouterContext,
@@ -12160,7 +12643,8 @@ export type PostTestHelpersTreasuryOutboundTransfersOutboundTransferPost = (
     t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferPostParamSchema,
     void,
     | t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferPostBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundTransfersOutboundTransferPostResponder,
   ctx: RouterContext,
@@ -12181,7 +12665,8 @@ export type PostTestHelpersTreasuryOutboundTransfersOutboundTransferReturn = (
     t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferReturnParamSchema,
     void,
     | t_PostTestHelpersTreasuryOutboundTransfersOutboundTransferReturnBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTestHelpersTreasuryOutboundTransfersOutboundTransferReturnResponder,
   ctx: RouterContext,
@@ -12200,7 +12685,8 @@ export type PostTestHelpersTreasuryReceivedCredits = (
   params: Params<
     void,
     void,
-    t_PostTestHelpersTreasuryReceivedCreditsBodySchema
+    t_PostTestHelpersTreasuryReceivedCreditsBodySchema,
+    void
   >,
   respond: PostTestHelpersTreasuryReceivedCreditsResponder,
   ctx: RouterContext,
@@ -12216,7 +12702,12 @@ export type PostTestHelpersTreasuryReceivedDebitsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTestHelpersTreasuryReceivedDebits = (
-  params: Params<void, void, t_PostTestHelpersTreasuryReceivedDebitsBodySchema>,
+  params: Params<
+    void,
+    void,
+    t_PostTestHelpersTreasuryReceivedDebitsBodySchema,
+    void
+  >,
   respond: PostTestHelpersTreasuryReceivedDebitsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12231,7 +12722,7 @@ export type PostTokensResponder = {
 } & KoaRuntimeResponder
 
 export type PostTokens = (
-  params: Params<void, void, t_PostTokensBodySchema | undefined>,
+  params: Params<void, void, t_PostTokensBodySchema | undefined, void>,
   respond: PostTokensResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12249,7 +12740,8 @@ export type GetTokensToken = (
   params: Params<
     t_GetTokensTokenParamSchema,
     t_GetTokensTokenQuerySchema,
-    t_GetTokensTokenBodySchema | undefined
+    t_GetTokensTokenBodySchema | undefined,
+    void
   >,
   respond: GetTokensTokenResponder,
   ctx: RouterContext,
@@ -12273,7 +12765,8 @@ export type GetTopups = (
   params: Params<
     void,
     t_GetTopupsQuerySchema,
-    t_GetTopupsBodySchema | undefined
+    t_GetTopupsBodySchema | undefined,
+    void
   >,
   respond: GetTopupsResponder,
   ctx: RouterContext,
@@ -12297,7 +12790,7 @@ export type PostTopupsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTopups = (
-  params: Params<void, void, t_PostTopupsBodySchema>,
+  params: Params<void, void, t_PostTopupsBodySchema, void>,
   respond: PostTopupsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12315,7 +12808,8 @@ export type GetTopupsTopup = (
   params: Params<
     t_GetTopupsTopupParamSchema,
     t_GetTopupsTopupQuerySchema,
-    t_GetTopupsTopupBodySchema | undefined
+    t_GetTopupsTopupBodySchema | undefined,
+    void
   >,
   respond: GetTopupsTopupResponder,
   ctx: RouterContext,
@@ -12334,7 +12828,8 @@ export type PostTopupsTopup = (
   params: Params<
     t_PostTopupsTopupParamSchema,
     void,
-    t_PostTopupsTopupBodySchema | undefined
+    t_PostTopupsTopupBodySchema | undefined,
+    void
   >,
   respond: PostTopupsTopupResponder,
   ctx: RouterContext,
@@ -12353,7 +12848,8 @@ export type PostTopupsTopupCancel = (
   params: Params<
     t_PostTopupsTopupCancelParamSchema,
     void,
-    t_PostTopupsTopupCancelBodySchema | undefined
+    t_PostTopupsTopupCancelBodySchema | undefined,
+    void
   >,
   respond: PostTopupsTopupCancelResponder,
   ctx: RouterContext,
@@ -12377,7 +12873,8 @@ export type GetTransfers = (
   params: Params<
     void,
     t_GetTransfersQuerySchema,
-    t_GetTransfersBodySchema | undefined
+    t_GetTransfersBodySchema | undefined,
+    void
   >,
   respond: GetTransfersResponder,
   ctx: RouterContext,
@@ -12401,7 +12898,7 @@ export type PostTransfersResponder = {
 } & KoaRuntimeResponder
 
 export type PostTransfers = (
-  params: Params<void, void, t_PostTransfersBodySchema>,
+  params: Params<void, void, t_PostTransfersBodySchema, void>,
   respond: PostTransfersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12424,7 +12921,8 @@ export type GetTransfersIdReversals = (
   params: Params<
     t_GetTransfersIdReversalsParamSchema,
     t_GetTransfersIdReversalsQuerySchema,
-    t_GetTransfersIdReversalsBodySchema | undefined
+    t_GetTransfersIdReversalsBodySchema | undefined,
+    void
   >,
   respond: GetTransfersIdReversalsResponder,
   ctx: RouterContext,
@@ -12451,7 +12949,8 @@ export type PostTransfersIdReversals = (
   params: Params<
     t_PostTransfersIdReversalsParamSchema,
     void,
-    t_PostTransfersIdReversalsBodySchema | undefined
+    t_PostTransfersIdReversalsBodySchema | undefined,
+    void
   >,
   respond: PostTransfersIdReversalsResponder,
   ctx: RouterContext,
@@ -12470,7 +12969,8 @@ export type GetTransfersTransfer = (
   params: Params<
     t_GetTransfersTransferParamSchema,
     t_GetTransfersTransferQuerySchema,
-    t_GetTransfersTransferBodySchema | undefined
+    t_GetTransfersTransferBodySchema | undefined,
+    void
   >,
   respond: GetTransfersTransferResponder,
   ctx: RouterContext,
@@ -12489,7 +12989,8 @@ export type PostTransfersTransfer = (
   params: Params<
     t_PostTransfersTransferParamSchema,
     void,
-    t_PostTransfersTransferBodySchema | undefined
+    t_PostTransfersTransferBodySchema | undefined,
+    void
   >,
   respond: PostTransfersTransferResponder,
   ctx: RouterContext,
@@ -12508,7 +13009,8 @@ export type GetTransfersTransferReversalsId = (
   params: Params<
     t_GetTransfersTransferReversalsIdParamSchema,
     t_GetTransfersTransferReversalsIdQuerySchema,
-    t_GetTransfersTransferReversalsIdBodySchema | undefined
+    t_GetTransfersTransferReversalsIdBodySchema | undefined,
+    void
   >,
   respond: GetTransfersTransferReversalsIdResponder,
   ctx: RouterContext,
@@ -12527,7 +13029,8 @@ export type PostTransfersTransferReversalsId = (
   params: Params<
     t_PostTransfersTransferReversalsIdParamSchema,
     void,
-    t_PostTransfersTransferReversalsIdBodySchema | undefined
+    t_PostTransfersTransferReversalsIdBodySchema | undefined,
+    void
   >,
   respond: PostTransfersTransferReversalsIdResponder,
   ctx: RouterContext,
@@ -12551,7 +13054,8 @@ export type GetTreasuryCreditReversals = (
   params: Params<
     void,
     t_GetTreasuryCreditReversalsQuerySchema,
-    t_GetTreasuryCreditReversalsBodySchema | undefined
+    t_GetTreasuryCreditReversalsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryCreditReversalsResponder,
   ctx: RouterContext,
@@ -12575,7 +13079,7 @@ export type PostTreasuryCreditReversalsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTreasuryCreditReversals = (
-  params: Params<void, void, t_PostTreasuryCreditReversalsBodySchema>,
+  params: Params<void, void, t_PostTreasuryCreditReversalsBodySchema, void>,
   respond: PostTreasuryCreditReversalsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12593,7 +13097,8 @@ export type GetTreasuryCreditReversalsCreditReversal = (
   params: Params<
     t_GetTreasuryCreditReversalsCreditReversalParamSchema,
     t_GetTreasuryCreditReversalsCreditReversalQuerySchema,
-    t_GetTreasuryCreditReversalsCreditReversalBodySchema | undefined
+    t_GetTreasuryCreditReversalsCreditReversalBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryCreditReversalsCreditReversalResponder,
   ctx: RouterContext,
@@ -12617,7 +13122,8 @@ export type GetTreasuryDebitReversals = (
   params: Params<
     void,
     t_GetTreasuryDebitReversalsQuerySchema,
-    t_GetTreasuryDebitReversalsBodySchema | undefined
+    t_GetTreasuryDebitReversalsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryDebitReversalsResponder,
   ctx: RouterContext,
@@ -12641,7 +13147,7 @@ export type PostTreasuryDebitReversalsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTreasuryDebitReversals = (
-  params: Params<void, void, t_PostTreasuryDebitReversalsBodySchema>,
+  params: Params<void, void, t_PostTreasuryDebitReversalsBodySchema, void>,
   respond: PostTreasuryDebitReversalsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12659,7 +13165,8 @@ export type GetTreasuryDebitReversalsDebitReversal = (
   params: Params<
     t_GetTreasuryDebitReversalsDebitReversalParamSchema,
     t_GetTreasuryDebitReversalsDebitReversalQuerySchema,
-    t_GetTreasuryDebitReversalsDebitReversalBodySchema | undefined
+    t_GetTreasuryDebitReversalsDebitReversalBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryDebitReversalsDebitReversalResponder,
   ctx: RouterContext,
@@ -12683,7 +13190,8 @@ export type GetTreasuryFinancialAccounts = (
   params: Params<
     void,
     t_GetTreasuryFinancialAccountsQuerySchema,
-    t_GetTreasuryFinancialAccountsBodySchema | undefined
+    t_GetTreasuryFinancialAccountsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryFinancialAccountsResponder,
   ctx: RouterContext,
@@ -12707,7 +13215,7 @@ export type PostTreasuryFinancialAccountsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTreasuryFinancialAccounts = (
-  params: Params<void, void, t_PostTreasuryFinancialAccountsBodySchema>,
+  params: Params<void, void, t_PostTreasuryFinancialAccountsBodySchema, void>,
   respond: PostTreasuryFinancialAccountsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12725,7 +13233,8 @@ export type GetTreasuryFinancialAccountsFinancialAccount = (
   params: Params<
     t_GetTreasuryFinancialAccountsFinancialAccountParamSchema,
     t_GetTreasuryFinancialAccountsFinancialAccountQuerySchema,
-    t_GetTreasuryFinancialAccountsFinancialAccountBodySchema | undefined
+    t_GetTreasuryFinancialAccountsFinancialAccountBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryFinancialAccountsFinancialAccountResponder,
   ctx: RouterContext,
@@ -12744,7 +13253,8 @@ export type PostTreasuryFinancialAccountsFinancialAccount = (
   params: Params<
     t_PostTreasuryFinancialAccountsFinancialAccountParamSchema,
     void,
-    t_PostTreasuryFinancialAccountsFinancialAccountBodySchema | undefined
+    t_PostTreasuryFinancialAccountsFinancialAccountBodySchema | undefined,
+    void
   >,
   respond: PostTreasuryFinancialAccountsFinancialAccountResponder,
   ctx: RouterContext,
@@ -12763,7 +13273,9 @@ export type GetTreasuryFinancialAccountsFinancialAccountFeatures = (
   params: Params<
     t_GetTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
     t_GetTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema,
-    t_GetTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema | undefined
+    | t_GetTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema
+    | undefined,
+    void
   >,
   respond: GetTreasuryFinancialAccountsFinancialAccountFeaturesResponder,
   ctx: RouterContext,
@@ -12783,7 +13295,8 @@ export type PostTreasuryFinancialAccountsFinancialAccountFeatures = (
     t_PostTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema,
     void,
     | t_PostTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema
-    | undefined
+    | undefined,
+    void
   >,
   respond: PostTreasuryFinancialAccountsFinancialAccountFeaturesResponder,
   ctx: RouterContext,
@@ -12807,7 +13320,8 @@ export type GetTreasuryInboundTransfers = (
   params: Params<
     void,
     t_GetTreasuryInboundTransfersQuerySchema,
-    t_GetTreasuryInboundTransfersBodySchema | undefined
+    t_GetTreasuryInboundTransfersBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryInboundTransfersResponder,
   ctx: RouterContext,
@@ -12831,7 +13345,7 @@ export type PostTreasuryInboundTransfersResponder = {
 } & KoaRuntimeResponder
 
 export type PostTreasuryInboundTransfers = (
-  params: Params<void, void, t_PostTreasuryInboundTransfersBodySchema>,
+  params: Params<void, void, t_PostTreasuryInboundTransfersBodySchema, void>,
   respond: PostTreasuryInboundTransfersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12849,7 +13363,8 @@ export type GetTreasuryInboundTransfersId = (
   params: Params<
     t_GetTreasuryInboundTransfersIdParamSchema,
     t_GetTreasuryInboundTransfersIdQuerySchema,
-    t_GetTreasuryInboundTransfersIdBodySchema | undefined
+    t_GetTreasuryInboundTransfersIdBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryInboundTransfersIdResponder,
   ctx: RouterContext,
@@ -12868,7 +13383,8 @@ export type PostTreasuryInboundTransfersInboundTransferCancel = (
   params: Params<
     t_PostTreasuryInboundTransfersInboundTransferCancelParamSchema,
     void,
-    t_PostTreasuryInboundTransfersInboundTransferCancelBodySchema | undefined
+    t_PostTreasuryInboundTransfersInboundTransferCancelBodySchema | undefined,
+    void
   >,
   respond: PostTreasuryInboundTransfersInboundTransferCancelResponder,
   ctx: RouterContext,
@@ -12892,7 +13408,8 @@ export type GetTreasuryOutboundPayments = (
   params: Params<
     void,
     t_GetTreasuryOutboundPaymentsQuerySchema,
-    t_GetTreasuryOutboundPaymentsBodySchema | undefined
+    t_GetTreasuryOutboundPaymentsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryOutboundPaymentsResponder,
   ctx: RouterContext,
@@ -12916,7 +13433,7 @@ export type PostTreasuryOutboundPaymentsResponder = {
 } & KoaRuntimeResponder
 
 export type PostTreasuryOutboundPayments = (
-  params: Params<void, void, t_PostTreasuryOutboundPaymentsBodySchema>,
+  params: Params<void, void, t_PostTreasuryOutboundPaymentsBodySchema, void>,
   respond: PostTreasuryOutboundPaymentsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -12934,7 +13451,8 @@ export type GetTreasuryOutboundPaymentsId = (
   params: Params<
     t_GetTreasuryOutboundPaymentsIdParamSchema,
     t_GetTreasuryOutboundPaymentsIdQuerySchema,
-    t_GetTreasuryOutboundPaymentsIdBodySchema | undefined
+    t_GetTreasuryOutboundPaymentsIdBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryOutboundPaymentsIdResponder,
   ctx: RouterContext,
@@ -12953,7 +13471,8 @@ export type PostTreasuryOutboundPaymentsIdCancel = (
   params: Params<
     t_PostTreasuryOutboundPaymentsIdCancelParamSchema,
     void,
-    t_PostTreasuryOutboundPaymentsIdCancelBodySchema | undefined
+    t_PostTreasuryOutboundPaymentsIdCancelBodySchema | undefined,
+    void
   >,
   respond: PostTreasuryOutboundPaymentsIdCancelResponder,
   ctx: RouterContext,
@@ -12977,7 +13496,8 @@ export type GetTreasuryOutboundTransfers = (
   params: Params<
     void,
     t_GetTreasuryOutboundTransfersQuerySchema,
-    t_GetTreasuryOutboundTransfersBodySchema | undefined
+    t_GetTreasuryOutboundTransfersBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryOutboundTransfersResponder,
   ctx: RouterContext,
@@ -13001,7 +13521,7 @@ export type PostTreasuryOutboundTransfersResponder = {
 } & KoaRuntimeResponder
 
 export type PostTreasuryOutboundTransfers = (
-  params: Params<void, void, t_PostTreasuryOutboundTransfersBodySchema>,
+  params: Params<void, void, t_PostTreasuryOutboundTransfersBodySchema, void>,
   respond: PostTreasuryOutboundTransfersResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13019,7 +13539,8 @@ export type GetTreasuryOutboundTransfersOutboundTransfer = (
   params: Params<
     t_GetTreasuryOutboundTransfersOutboundTransferParamSchema,
     t_GetTreasuryOutboundTransfersOutboundTransferQuerySchema,
-    t_GetTreasuryOutboundTransfersOutboundTransferBodySchema | undefined
+    t_GetTreasuryOutboundTransfersOutboundTransferBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryOutboundTransfersOutboundTransferResponder,
   ctx: RouterContext,
@@ -13038,7 +13559,8 @@ export type PostTreasuryOutboundTransfersOutboundTransferCancel = (
   params: Params<
     t_PostTreasuryOutboundTransfersOutboundTransferCancelParamSchema,
     void,
-    t_PostTreasuryOutboundTransfersOutboundTransferCancelBodySchema | undefined
+    t_PostTreasuryOutboundTransfersOutboundTransferCancelBodySchema | undefined,
+    void
   >,
   respond: PostTreasuryOutboundTransfersOutboundTransferCancelResponder,
   ctx: RouterContext,
@@ -13062,7 +13584,8 @@ export type GetTreasuryReceivedCredits = (
   params: Params<
     void,
     t_GetTreasuryReceivedCreditsQuerySchema,
-    t_GetTreasuryReceivedCreditsBodySchema | undefined
+    t_GetTreasuryReceivedCreditsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryReceivedCreditsResponder,
   ctx: RouterContext,
@@ -13089,7 +13612,8 @@ export type GetTreasuryReceivedCreditsId = (
   params: Params<
     t_GetTreasuryReceivedCreditsIdParamSchema,
     t_GetTreasuryReceivedCreditsIdQuerySchema,
-    t_GetTreasuryReceivedCreditsIdBodySchema | undefined
+    t_GetTreasuryReceivedCreditsIdBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryReceivedCreditsIdResponder,
   ctx: RouterContext,
@@ -13113,7 +13637,8 @@ export type GetTreasuryReceivedDebits = (
   params: Params<
     void,
     t_GetTreasuryReceivedDebitsQuerySchema,
-    t_GetTreasuryReceivedDebitsBodySchema | undefined
+    t_GetTreasuryReceivedDebitsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryReceivedDebitsResponder,
   ctx: RouterContext,
@@ -13140,7 +13665,8 @@ export type GetTreasuryReceivedDebitsId = (
   params: Params<
     t_GetTreasuryReceivedDebitsIdParamSchema,
     t_GetTreasuryReceivedDebitsIdQuerySchema,
-    t_GetTreasuryReceivedDebitsIdBodySchema | undefined
+    t_GetTreasuryReceivedDebitsIdBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryReceivedDebitsIdResponder,
   ctx: RouterContext,
@@ -13164,7 +13690,8 @@ export type GetTreasuryTransactionEntries = (
   params: Params<
     void,
     t_GetTreasuryTransactionEntriesQuerySchema,
-    t_GetTreasuryTransactionEntriesBodySchema | undefined
+    t_GetTreasuryTransactionEntriesBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryTransactionEntriesResponder,
   ctx: RouterContext,
@@ -13191,7 +13718,8 @@ export type GetTreasuryTransactionEntriesId = (
   params: Params<
     t_GetTreasuryTransactionEntriesIdParamSchema,
     t_GetTreasuryTransactionEntriesIdQuerySchema,
-    t_GetTreasuryTransactionEntriesIdBodySchema | undefined
+    t_GetTreasuryTransactionEntriesIdBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryTransactionEntriesIdResponder,
   ctx: RouterContext,
@@ -13215,7 +13743,8 @@ export type GetTreasuryTransactions = (
   params: Params<
     void,
     t_GetTreasuryTransactionsQuerySchema,
-    t_GetTreasuryTransactionsBodySchema | undefined
+    t_GetTreasuryTransactionsBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryTransactionsResponder,
   ctx: RouterContext,
@@ -13242,7 +13771,8 @@ export type GetTreasuryTransactionsId = (
   params: Params<
     t_GetTreasuryTransactionsIdParamSchema,
     t_GetTreasuryTransactionsIdQuerySchema,
-    t_GetTreasuryTransactionsIdBodySchema | undefined
+    t_GetTreasuryTransactionsIdBodySchema | undefined,
+    void
   >,
   respond: GetTreasuryTransactionsIdResponder,
   ctx: RouterContext,
@@ -13266,7 +13796,8 @@ export type GetWebhookEndpoints = (
   params: Params<
     void,
     t_GetWebhookEndpointsQuerySchema,
-    t_GetWebhookEndpointsBodySchema | undefined
+    t_GetWebhookEndpointsBodySchema | undefined,
+    void
   >,
   respond: GetWebhookEndpointsResponder,
   ctx: RouterContext,
@@ -13290,7 +13821,7 @@ export type PostWebhookEndpointsResponder = {
 } & KoaRuntimeResponder
 
 export type PostWebhookEndpoints = (
-  params: Params<void, void, t_PostWebhookEndpointsBodySchema>,
+  params: Params<void, void, t_PostWebhookEndpointsBodySchema, void>,
   respond: PostWebhookEndpointsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -13308,7 +13839,8 @@ export type DeleteWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_DeleteWebhookEndpointsWebhookEndpointParamSchema,
     void,
-    t_DeleteWebhookEndpointsWebhookEndpointBodySchema | undefined
+    t_DeleteWebhookEndpointsWebhookEndpointBodySchema | undefined,
+    void
   >,
   respond: DeleteWebhookEndpointsWebhookEndpointResponder,
   ctx: RouterContext,
@@ -13327,7 +13859,8 @@ export type GetWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_GetWebhookEndpointsWebhookEndpointParamSchema,
     t_GetWebhookEndpointsWebhookEndpointQuerySchema,
-    t_GetWebhookEndpointsWebhookEndpointBodySchema | undefined
+    t_GetWebhookEndpointsWebhookEndpointBodySchema | undefined,
+    void
   >,
   respond: GetWebhookEndpointsWebhookEndpointResponder,
   ctx: RouterContext,
@@ -13346,7 +13879,8 @@ export type PostWebhookEndpointsWebhookEndpoint = (
   params: Params<
     t_PostWebhookEndpointsWebhookEndpointParamSchema,
     void,
-    t_PostWebhookEndpointsWebhookEndpointBodySchema | undefined
+    t_PostWebhookEndpointsWebhookEndpointBodySchema | undefined,
+    void
   >,
   respond: PostWebhookEndpointsWebhookEndpointResponder,
   ctx: RouterContext,
@@ -13941,6 +14475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -13998,6 +14533,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -14158,6 +14694,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -14240,6 +14777,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -14839,6 +15377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -14894,6 +15433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -14963,6 +15503,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15536,6 +16077,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15621,6 +16163,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15676,6 +16219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15747,6 +16291,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15827,6 +16372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15910,6 +16456,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -15985,6 +16532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16048,6 +16596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16137,6 +16686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16230,6 +16780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16290,6 +16841,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16361,6 +16913,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16444,6 +16997,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16503,6 +17057,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16594,6 +17149,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16798,6 +17354,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16853,6 +17410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -16924,6 +17482,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17122,6 +17681,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17213,6 +17773,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17417,6 +17978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17472,6 +18034,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17543,6 +18106,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17741,6 +18305,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17800,6 +18365,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17875,6 +18441,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17931,6 +18498,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -17985,6 +18553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18054,6 +18623,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18140,6 +18710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18213,6 +18784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18273,6 +18845,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18340,6 +18913,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18400,6 +18974,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18483,6 +19058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18548,6 +19124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18623,6 +19200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -18681,6 +19259,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -18735,6 +19314,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18801,6 +19381,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -18859,6 +19440,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -18947,6 +19529,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -19018,6 +19601,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19110,6 +19694,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19184,6 +19769,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19257,6 +19843,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -19324,6 +19911,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -19390,6 +19978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19446,6 +20035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19504,6 +20094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19560,6 +20151,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19614,6 +20206,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19668,6 +20261,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19740,6 +20334,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -19804,6 +20399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -19870,6 +20466,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19929,6 +20526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -19985,6 +20583,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20075,6 +20674,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20136,6 +20736,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20216,6 +20817,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20356,6 +20958,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20428,6 +21031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20587,6 +21191,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20752,6 +21357,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -20837,6 +21443,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -20958,6 +21565,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -21030,6 +21638,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -21100,6 +21709,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -21180,6 +21790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -21249,6 +21860,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21318,6 +21930,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21411,6 +22024,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21467,6 +22081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21536,6 +22151,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21616,6 +22232,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21693,6 +22310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21761,6 +22379,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21821,6 +22440,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -21912,6 +22532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -22935,6 +23556,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23004,6 +23626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23063,6 +23686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23119,6 +23743,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23205,6 +23830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23284,6 +23910,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -23341,6 +23968,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -23409,6 +24037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23478,6 +24107,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23534,6 +24164,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23608,6 +24239,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23682,6 +24314,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23756,6 +24389,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23828,6 +24462,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23897,6 +24532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -23971,6 +24607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24044,6 +24681,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24126,6 +24764,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24195,6 +24834,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24250,6 +24890,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24314,6 +24955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24375,6 +25017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24458,6 +25101,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24558,6 +25202,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -24670,6 +25315,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24796,6 +25442,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24884,6 +25531,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -24953,6 +25601,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -25012,6 +25661,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25070,6 +25720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25146,6 +25797,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25230,6 +25882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -25456,6 +26109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -25531,6 +26185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25594,6 +26249,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25663,6 +26319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25849,6 +26506,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -25934,6 +26592,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26005,6 +26664,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26080,6 +26740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26153,6 +26814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26244,6 +26906,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26344,6 +27007,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26412,6 +27076,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26485,6 +27150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26588,6 +27254,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26651,6 +27318,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26736,6 +27404,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26838,6 +27507,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26903,6 +27573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -26973,6 +27644,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27073,6 +27745,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27140,6 +27813,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27205,6 +27879,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27290,6 +27965,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27370,6 +28046,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27434,6 +28111,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27501,6 +28179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27572,6 +28251,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27700,6 +28380,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27778,6 +28459,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27872,6 +28554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -27972,6 +28655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28037,6 +28721,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28107,6 +28792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28207,6 +28893,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28267,6 +28954,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28353,6 +29041,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28761,6 +29450,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28826,6 +29516,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -28906,6 +29597,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29347,6 +30039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29412,6 +30105,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29491,6 +30185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29581,6 +30276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29719,6 +30415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29774,6 +30471,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29842,6 +30540,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -29926,6 +30625,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -29999,6 +30699,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30092,6 +30793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30150,6 +30852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30226,6 +30929,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30304,6 +31008,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30386,6 +31091,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30444,6 +31150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30513,6 +31220,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30576,6 +31284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30629,6 +31338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -30686,6 +31396,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -30776,6 +31487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -30844,6 +31556,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -30914,6 +31627,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -30987,6 +31701,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31071,6 +31786,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -31125,6 +31841,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -31188,6 +31905,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -31249,6 +31967,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31351,6 +32070,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -31423,6 +32143,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -31486,6 +32207,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -31570,6 +32292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31647,6 +32370,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31709,6 +32433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31803,6 +32528,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31871,6 +32597,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -31935,6 +32662,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32000,6 +32728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32087,6 +32816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32159,6 +32889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32253,6 +32984,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32333,6 +33065,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32421,6 +33154,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32494,6 +33228,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32563,6 +33298,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32655,6 +33391,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32730,6 +33467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32827,6 +33565,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32911,6 +33650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -32983,6 +33723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33069,6 +33810,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33131,6 +33873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33193,6 +33936,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33272,6 +34016,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33345,6 +34090,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33404,6 +34150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33463,6 +34210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33552,6 +34300,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -33644,6 +34393,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -33697,6 +34447,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33766,6 +34517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33865,6 +34617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -33966,6 +34719,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -34332,6 +35086,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -34832,6 +35587,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -34905,6 +35661,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -35492,6 +36249,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36086,6 +36844,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36147,6 +36906,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36216,6 +36976,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36593,6 +37354,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36735,6 +37497,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36794,6 +37557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -36876,6 +37640,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37020,6 +37785,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37079,6 +37845,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37148,6 +37915,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37211,6 +37979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37269,6 +38038,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37411,6 +38181,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37469,6 +38240,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37560,6 +38332,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37634,6 +38407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37696,6 +38470,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37759,6 +38534,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37821,6 +38597,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -37916,6 +38693,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -38952,6 +39730,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -39019,6 +39798,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -40058,6 +40838,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -40147,6 +40928,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -41166,6 +41948,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -41234,6 +42017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42254,6 +43038,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42343,6 +43128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42582,6 +43368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42651,6 +43438,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42891,6 +43679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -42950,6 +43739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43041,6 +43831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43112,6 +43903,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43187,6 +43979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43281,6 +44074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43368,6 +44162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43442,6 +44237,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43512,6 +44308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43571,6 +44368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43655,6 +44453,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -43728,6 +44527,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43787,6 +44587,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43878,6 +44679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -43950,6 +44752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44012,6 +44815,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44093,6 +44897,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44163,6 +44968,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44244,6 +45050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -44317,6 +45124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44376,6 +45184,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44463,6 +45272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44528,6 +45338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44595,6 +45406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -44678,6 +45490,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -45695,6 +46508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -45771,6 +46585,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -45848,6 +46663,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46848,6 +47664,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46908,6 +47725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -46972,6 +47790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -47039,6 +47858,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -48061,6 +48881,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -48125,6 +48946,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -48190,6 +49012,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -48265,6 +49088,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -48805,6 +49629,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -48873,6 +49698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49419,6 +50245,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49502,6 +50329,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49589,6 +50417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -49936,6 +50765,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50008,6 +50838,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50361,6 +51192,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50443,6 +51275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50500,6 +51333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50569,6 +51403,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50631,6 +51466,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50689,6 +51525,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -50810,6 +51647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -51143,6 +51981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51210,6 +52049,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51310,6 +52150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51367,6 +52208,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51426,6 +52268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51524,6 +52367,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -51583,6 +52427,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -51646,6 +52491,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -51703,6 +52549,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -51760,6 +52607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51821,6 +52669,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -51905,6 +52754,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52001,6 +52851,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52051,6 +52902,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52114,6 +52966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52173,6 +53026,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52271,6 +53125,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52408,6 +53263,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52480,6 +53336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52550,6 +53407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52645,6 +53503,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52735,6 +53594,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52854,6 +53714,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52926,6 +53787,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -52983,6 +53845,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -53046,6 +53909,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -53128,6 +53992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -53209,6 +54074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53271,6 +54137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53326,6 +54193,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53394,6 +54262,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53480,6 +54349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -53551,6 +54421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53618,6 +54489,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53685,6 +54557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -53759,6 +54632,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -53938,6 +54812,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -54001,6 +54876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -54175,6 +55051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -54232,6 +55109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54290,6 +55168,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54375,6 +55254,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54444,6 +55324,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54526,6 +55407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54598,6 +55480,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54688,6 +55571,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54762,6 +55646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54855,6 +55740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54912,6 +55798,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -54969,6 +55856,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55038,6 +55926,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55125,6 +56014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55197,6 +56087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55251,6 +56142,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55318,6 +56210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55379,6 +56272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55463,6 +56357,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -55529,6 +56424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -55592,6 +56488,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -55647,6 +56544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -55702,6 +56600,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -55790,6 +56689,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56499,6 +57399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56566,6 +57467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56637,6 +57539,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56709,6 +57612,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -56794,6 +57698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -56862,6 +57767,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -56919,6 +57825,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -57002,6 +57909,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -57091,6 +57999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -57594,6 +58503,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -57663,6 +58573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58140,6 +59051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58201,6 +59113,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58700,6 +59613,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58761,6 +59675,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -58848,6 +59763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -58936,6 +59852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -59002,6 +59919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59082,6 +60000,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59162,6 +60081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59236,6 +60156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59390,6 +60311,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -59454,6 +60376,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -59594,6 +60517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -59665,6 +60589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59756,6 +60681,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59836,6 +60762,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59903,6 +60830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -59981,6 +60909,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60085,6 +61014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60147,6 +61077,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60216,6 +61147,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60325,6 +61257,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60410,6 +61343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60482,6 +61416,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60613,6 +61548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60887,6 +61823,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -60954,6 +61891,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61231,6 +62169,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61294,6 +62233,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61356,6 +62296,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -61484,6 +62425,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -61885,6 +62827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -61960,6 +62903,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62045,6 +62989,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62117,6 +63062,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62553,6 +63499,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62612,6 +63559,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62679,6 +63627,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62869,6 +63818,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -62936,6 +63886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63024,6 +63975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63107,6 +64059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63503,6 +64456,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63572,6 +64526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63636,6 +64591,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63694,6 +64650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -63762,6 +64719,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -63813,6 +64771,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63884,6 +64843,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -63954,6 +64914,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64042,6 +65003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64121,6 +65083,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64189,6 +65152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64266,6 +65230,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64401,6 +65366,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64451,6 +65417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64514,6 +65481,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64597,6 +65565,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64673,6 +65642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -64741,6 +65711,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64824,6 +65795,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -64902,6 +65874,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65086,6 +66059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65145,6 +66119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65228,6 +66203,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65444,6 +66420,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65500,6 +66477,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65577,6 +66555,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65643,6 +66622,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65697,6 +66677,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65767,6 +66748,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65845,6 +66827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65936,6 +66919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -65995,6 +66979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66049,6 +67034,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66123,6 +67109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66192,6 +67179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66250,6 +67238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66319,6 +67308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66383,6 +67373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66453,6 +67444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66527,6 +67519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66857,6 +67850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -66922,6 +67916,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67402,6 +68397,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67572,6 +68568,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67635,6 +68632,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67767,6 +68765,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67833,6 +68832,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67899,6 +68899,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -67963,6 +68964,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68023,6 +69025,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68082,6 +69085,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68141,6 +69145,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68201,6 +69206,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68266,6 +69272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68362,6 +69369,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68426,6 +69434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -68899,6 +69908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69377,6 +70387,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69443,6 +70454,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69507,6 +70519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69575,6 +70588,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69660,6 +70674,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69717,6 +70732,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69774,6 +70790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69844,6 +70861,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69904,6 +70922,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -69986,6 +71005,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70045,6 +71065,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70105,6 +71126,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70176,6 +71198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70235,6 +71258,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70294,6 +71318,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70373,6 +71398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70444,6 +71470,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70506,6 +71533,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70568,6 +71596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70652,6 +71681,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70725,6 +71755,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -70793,6 +71824,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -71237,6 +72269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71300,6 +72333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71393,6 +72427,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71451,6 +72486,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71514,6 +72550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71570,6 +72607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71627,6 +72665,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -71711,6 +72750,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71770,6 +72810,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -71851,6 +72892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -71920,6 +72962,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -71989,6 +73032,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72051,6 +73095,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72119,6 +73164,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72179,6 +73225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72256,6 +73303,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72311,6 +73359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72380,6 +73429,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72461,6 +73511,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72518,6 +73569,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72587,6 +73639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72679,6 +73732,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72777,6 +73831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72846,6 +73901,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -72951,6 +74007,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73026,6 +74083,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73121,6 +74179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73210,6 +74269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73270,6 +74330,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73337,6 +74398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73393,6 +74455,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73495,6 +74558,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73607,6 +74671,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73674,6 +74739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73730,6 +74796,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73812,6 +74879,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73884,6 +74952,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -73953,6 +75022,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74011,6 +75081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74105,6 +75176,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74177,6 +75249,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74253,6 +75326,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74325,6 +75399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74428,6 +75503,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74500,6 +75576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74603,6 +75680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74677,6 +75755,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -74751,6 +75830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75158,6 +76238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75214,6 +76295,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75284,6 +76366,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {
@@ -75593,6 +76676,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -47,7 +47,7 @@ export type GetTodoListsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTodoLists = (
-  params: Params<void, t_GetTodoListsQuerySchema, void>,
+  params: Params<void, t_GetTodoListsQuerySchema, void, void>,
   respond: GetTodoListsResponder,
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_TodoList[]>>
@@ -59,7 +59,7 @@ export type GetTodoListByIdResponder = {
 } & KoaRuntimeResponder
 
 export type GetTodoListById = (
-  params: Params<t_GetTodoListByIdParamSchema, void, void>,
+  params: Params<t_GetTodoListByIdParamSchema, void, void, void>,
   respond: GetTodoListByIdResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -79,7 +79,8 @@ export type UpdateTodoListById = (
   params: Params<
     t_UpdateTodoListByIdParamSchema,
     void,
-    t_UpdateTodoListByIdBodySchema
+    t_UpdateTodoListByIdBodySchema,
+    void
   >,
   respond: UpdateTodoListByIdResponder,
   ctx: RouterContext,
@@ -97,7 +98,7 @@ export type DeleteTodoListByIdResponder = {
 } & KoaRuntimeResponder
 
 export type DeleteTodoListById = (
-  params: Params<t_DeleteTodoListByIdParamSchema, void, void>,
+  params: Params<t_DeleteTodoListByIdParamSchema, void, void, void>,
   respond: DeleteTodoListByIdResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -121,7 +122,7 @@ export type GetTodoListItemsResponder = {
 } & KoaRuntimeResponder
 
 export type GetTodoListItems = (
-  params: Params<t_GetTodoListItemsParamSchema, void, void>,
+  params: Params<t_GetTodoListItemsParamSchema, void, void, void>,
   respond: GetTodoListItemsResponder,
   ctx: RouterContext,
 ) => Promise<
@@ -152,7 +153,8 @@ export type CreateTodoListItem = (
   params: Params<
     t_CreateTodoListItemParamSchema,
     void,
-    t_CreateTodoListItemBodySchema
+    t_CreateTodoListItemBodySchema,
+    void
   >,
   respond: CreateTodoListItemResponder,
   ctx: RouterContext,
@@ -200,6 +202,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         RequestInputType.QueryString,
       ),
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -244,6 +247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -300,6 +304,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         Reflect.get(ctx.request, "body"),
         RequestInputType.RequestBody,
       ),
+      headers: undefined,
     }
 
     const responder = {
@@ -350,6 +355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -408,6 +414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ),
       query: undefined,
       body: undefined,
+      headers: undefined,
     }
 
     const responder = {
@@ -473,6 +480,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           Reflect.get(ctx.request, "body"),
           RequestInputType.RequestBody,
         ),
+        headers: undefined,
       }
 
       const responder = {

--- a/packages/typescript-koa-runtime/src/errors.ts
+++ b/packages/typescript-koa-runtime/src/errors.ts
@@ -2,6 +2,7 @@ export enum RequestInputType {
   RouteParam = "route params",
   QueryString = "querystring",
   RequestBody = "request body",
+  RequestHeader = "request header",
 }
 
 export class KoaRuntimeError extends Error {

--- a/packages/typescript-koa-runtime/src/zod.ts
+++ b/packages/typescript-koa-runtime/src/zod.ts
@@ -1,10 +1,11 @@
 import type {z} from "zod"
 import {KoaRuntimeError, type RequestInputType} from "./errors"
 
-export type Params<Params, Query, Body> = {
+export type Params<Params, Query, Body, Header> = {
   params: Params
   query: Query
   body: Body
+  headers: Header
 }
 
 export function parseRequestInput<Schema extends z.ZodTypeAny>(


### PR DESCRIPTION
the `typescript-koa` template will now generate a type and schema for any declared header parameters,
and use this to parse the headers and pass through to the handlers.

BREAKING CHANGE: requests receiving incorrect request header parameters will now fail with a validation error