### PR TITLE
fix: allow $ref to be used as a schema property

### DIFF
--- a/packages/openapi-code-generator/src/core/openapi-loader.ts
+++ b/packages/openapi-code-generator/src/core/openapi-loader.ts
@@ -148,7 +148,15 @@ export class OpenapiLoader {
         continue
       }
 
-      if (key === "$ref") {
+      // TODO: allowing $ref to be used anywhere, makes it tricky
+      //       for things like an object property named '$ref', such
+      //       as on the SCIM v2 Group member schema. Hack around by
+      //       sniffing if it looks like an actual $ref or not.
+      if (
+        key === "$ref" &&
+        typeof obj[key] === "string" &&
+        obj[key].indexOf("#") !== -1
+      ) {
         // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
         const $ref = (obj[key] = normalizeRef(obj[key]))
         await this.loadFile(pathFromRef($ref))

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
@@ -28,6 +28,9 @@ components:
         required_nullable:
           type: string
           nullable: true
+        $ref:
+          type: string
+          format: uri
 
     OptionalProperties:
       properties:

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
@@ -29,6 +29,9 @@ components:
           type:
             - string
             - "null"
+        $ref:
+          type: string
+          format: uri
 
     OptionalProperties:
       properties:

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -55,6 +55,7 @@ describe.each(testVersions)(
             datetime: joi.string().isoDate().required(),
             optional_str: joi.string(),
             required_nullable: joi.string().allow(null).required(),
+            $ref: joi.string(),
           })
           .options({ stripUnknown: true })
           .required()

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -48,6 +48,7 @@ describe.each(testVersions)(
           datetime: z.string().datetime({ offset: true }),
           optional_str: z.string().optional(),
           required_nullable: z.string().nullable(),
+          $ref: z.string().optional(),
         })"
       `)
     })

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -19,6 +19,7 @@ describe.each(testVersions)(
 
       expect(types).toMatchInlineSnapshot(`
         "export type t_SimpleObject = {
+          $ref?: string
           date: string
           datetime: string
           num: number
@@ -68,6 +69,7 @@ describe.each(testVersions)(
         }
 
         export type t_SimpleObject = {
+          $ref?: string
           date: string
           datetime: string
           num: number


### PR DESCRIPTION
The SCIM v2 RFC includes a property named `$ref` on group membership, etc

Eg:
https://datatracker.ietf.org/doc/html/rfc7643
```
{
            "name" : "$ref",
            "type" : "reference",
            "referenceTypes" : [
              "User",
              "Group"
            ],
            "multiValued" : false,
            "description" : "The URI of the corresponding 'Group'
resource to which the user belongs.",
            "required" : false,
            "caseExact" : false,
            "mutability" : "readOnly",
            "returned" : "default",
            "uniqueness" : "none"
          },
```

Previously we were naively trying to resolve any `$ref` key we found as an [OpenAPI reference](https://swagger.io/docs/specification/v3_0/using-ref/)

Now we still naively do this, but only if it [quacks](https://en.wikipedia.org/wiki/Duck_typing) like a real `$ref`