### PR TITLE
fix: handle `type: "null"` in `anyOf` / `oneOf` / `allOf`

### DIFF
--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -1,4 +1,3 @@
-import {xInternalPreproccess} from "./openapi-types"
 import type {HttpMethod} from "./utils"
 
 export interface IRRef {
@@ -85,6 +84,10 @@ export interface IRModelArray extends IRModelBase {
   // TODO: contains / maxContains / minContains
 }
 
+export interface IRModelNull extends IRModelBase {
+  type: "null"
+}
+
 export type IRModel =
   | IRModelNumeric
   | IRModelString
@@ -92,6 +95,7 @@ export type IRModel =
   | IRModelObject
   | IRModelArray
   | IRModelAny
+  | IRModelNull
 
 export type MaybeIRModel = IRModel | IRRef
 

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
@@ -101,6 +101,10 @@ components:
       anyOf:
         - type: number
         - type: string
+    AnyOfNullableString:
+      anyOf:
+        - type: string
+        - type: "null"
 
     AllOf:
       allOf:

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
@@ -105,6 +105,10 @@ components:
       type:
         - number
         - string
+    AnyOfNullableString:
+      anyOf:
+        - type: string
+        - type: "null"
 
     AllOf:
       allOf:

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -320,6 +320,8 @@ export abstract class AbstractSchemaBuilder<
         result = this.config.allowAny ? this.any() : this.unknown()
         break
       }
+      case "null":
+        throw new Error("unreachable - input should normalize this out")
     }
 
     if (model["x-internal-preprocess"]) {

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -539,6 +539,31 @@ describe.each(testVersions)(
         )
       })
 
+      it("supports nullable string using allOf", async () => {
+        const {code, execute} = await getActualFromModel({
+          type: "object",
+          anyOf: [
+            {type: "string", nullable: false, readOnly: false},
+            {type: "null", nullable: false, readOnly: false},
+          ],
+          allOf: [],
+          oneOf: [],
+          properties: {},
+          additionalProperties: undefined,
+          required: [],
+          nullable: false,
+          readOnly: false,
+        })
+
+        expect(code).toMatchInlineSnapshot('"const x = z.string().nullable()"')
+
+        await expect(execute("a string")).resolves.toBe("a string")
+        await expect(execute(null)).resolves.toBe(null)
+        await expect(execute(123)).rejects.toThrow(
+          "Expected string, received number",
+        )
+      })
+
       it("supports minLength", async () => {
         const {code, execute} = await getActualFromModel({
           ...base,

--- a/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/type-builder.spec.ts
@@ -129,6 +129,22 @@ describe.each(testVersions)(
       )
     })
 
+    it("can build a type for a nullable string using anyOf correctly", async () => {
+      const {code, types} = await getActual(
+        "components/schemas/AnyOfNullableString",
+      )
+
+      expect(code).toMatchInlineSnapshot(`
+        "import {t_AnyOfNullableString} from './unit-test.types'
+
+        const x: t_AnyOfNullableString"
+      `)
+
+      expect(types).toMatchInlineSnapshot(
+        '"export type t_AnyOfNullableString = string | null"',
+      )
+    })
+
     it("can build a type for a allOf correctly", async () => {
       const {code, types} = await getActual("components/schemas/AllOf")
 


### PR DESCRIPTION
previously `EmptyObject` was erroneously being added to the resulting type / schema, which would cause a build error in the case of a header parameter that used this pattern.