### PR TITLE
feat: support emitting abstract classes for implementation types

### DIFF
--- a/packages/documentation/src/pages/reference/cli-options.mdx
+++ b/packages/documentation/src/pages/reference/cli-options.mdx
@@ -121,6 +121,23 @@ Default: `false` (use `unknown` rather than `any`)
 | `{type: "object",  additionalProperties: true}` | `{[key: string]: any}`     | `{[key: string]: unknown}` |
 | `{type: "array", items: {}}`                    | `any[]`                    | `unknown[]`                |
 
+#### `--ts-server-implementation-method` (experimental) (server sdks only)
+As environment variable `OPENAPI_TS_SERVER_IMPLEMENTATION_METHOD`
+
+Determines whether to represent server stubs / interfaces as `type`, `interface`, or `abstract class` entities.
+
+This is mostly a case of personal preference, but can be important for better integration with dependency injection
+frameworks, such as [diod](https://github.com/artberri/diod) which rely on `abstract class` objects to define
+interfaces for injection.
+
+| Option           | Example Output                                 |
+|------------------|------------------------------------------------|
+| `interface`      | `export interface Implementation { ... }` `    |
+| `type`           | `export type Implementation = { ... }`         |
+| `abstract-class` | `export abstract class Implementation { ... }` |
+
+Default: `type`
+
 ### Misc
 
 #### `--remote-spec-request-headers` (authenticated remote specifications)

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -18,6 +18,7 @@ import {logger} from "./core/logger"
 import {OpenapiValidator} from "./core/openapi-validator"
 import {generate} from "./index"
 import type {templates} from "./templates"
+import type {ServerImplementationMethod} from "./templates.types"
 import {TypescriptFormatterBiome} from "./typescript/common/typescript-formatter.biome"
 
 export const boolParser = (arg: string): boolean => {
@@ -111,6 +112,20 @@ const program = new Command()
       .env("OPENAPI_TS_ALLOW_ANY")
       .argParser(boolParser)
       .default(false),
+  )
+  .addOption(
+    new Option(
+      "--ts-server-implementation-method <value>",
+      "(experimental) (server templates only) how to define the route implementation types",
+    )
+      .env("OPENAPI_TS_SERVER_IMPLEMENTATION_METHOD")
+      .choices([
+        "interface",
+        "type",
+        "abstract-class",
+      ] as const satisfies ServerImplementationMethod[])
+      .default("type" as const satisfies ServerImplementationMethod)
+      .makeOptionMandatory(),
   )
   .addOption(
     new Option(

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -11,6 +11,7 @@ import {logger} from "./core/logger"
 import {OpenapiLoader} from "./core/openapi-loader"
 import type {OpenapiValidator} from "./core/openapi-validator"
 import {templates} from "./templates"
+import type {ServerImplementationMethod} from "./templates.types"
 import {TypescriptEmitter} from "./typescript/common/typescript-emitter"
 
 export type Config = {
@@ -29,6 +30,7 @@ export type Config = {
   allowUnusedImports: boolean
   groupingStrategy: "none" | "first-slug" | "first-tag"
   tsAllowAny: boolean
+  tsServerImplementationMethod: ServerImplementationMethod
   tsCompilerOptions: CompilerOptions
   remoteSpecRequestHeaders?: GenericLoaderRequestHeaders | undefined
 }
@@ -75,5 +77,6 @@ export async function generate(
     compilerOptions: config.tsCompilerOptions,
     groupingStrategy: config.groupingStrategy,
     allowAny: config.tsAllowAny,
+    serverImplementationMethod: config.tsServerImplementationMethod,
   })
 }

--- a/packages/openapi-code-generator/src/templates.types.ts
+++ b/packages/openapi-code-generator/src/templates.types.ts
@@ -3,6 +3,8 @@ import type {CompilerOptions} from "./core/loaders/tsconfig.loader"
 import type {SchemaBuilderType} from "./typescript/common/schema-builders/schema-builder"
 import type {TypescriptEmitter} from "./typescript/common/typescript-emitter"
 
+export type ServerImplementationMethod = "interface" | "type" | "abstract-class"
+
 export interface OpenapiGeneratorConfig {
   input: Input
   emitter: TypescriptEmitter
@@ -25,4 +27,8 @@ export interface OpenapiTypescriptGeneratorConfig
    * Whether to use `any` or `unknown` for unspecified types
    */
   allowAny: boolean
+  /**
+   * How to output the implementation types for server templates
+   */
+  serverImplementationMethod: ServerImplementationMethod
 }

--- a/packages/openapi-code-generator/src/typescript/common/typescript-common.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-common.ts
@@ -134,6 +134,11 @@ export type ExportDefinition =
       name: string
       value: string
     }
+  | {
+      kind: "abstract-class"
+      name: string
+      value: string
+    }
 
 export function buildExport(args: ExportDefinition) {
   if (!args.value) {
@@ -149,6 +154,8 @@ export function buildExport(args: ExportDefinition) {
       return `export type ${args.name} = ${args.value}`
     case "interface":
       return `export interface ${args.name} ${args.value}`
+    case "abstract-class":
+      return `export abstract class ${args.name} ${args.value}`
   }
 }
 

--- a/packages/openapi-code-generator/src/typescript/common/typescript-common.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-common.ts
@@ -118,11 +118,21 @@ export function asyncMethod({
 }
 
 export type ExportDefinition =
-  | {name: string; type?: string; value: string; kind: "const"}
   | {
+      kind: "const"
+      name: string
+      type?: string
+      value: string
+    }
+  | {
+      kind: "type"
       name: string
       value: string
-      kind: "type"
+    }
+  | {
+      kind: "interface"
+      name: string
+      value: string
     }
 
 export function buildExport(args: ExportDefinition) {
@@ -137,6 +147,8 @@ export function buildExport(args: ExportDefinition) {
       }`
     case "type":
       return `export type ${args.name} = ${args.value}`
+    case "interface":
+      return `export interface ${args.name} ${args.value}`
   }
 }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.spec.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from "@jest/globals"
+import type {ServerImplementationMethod} from "../../templates.types"
+import {unitTestInput} from "../../test/input.test-utils"
+import {ImportBuilder} from "../common/import-builder"
+import {schemaBuilderFactory} from "../common/schema-builders/schema-builder"
+import {TypeBuilder} from "../common/type-builder"
+import {TypescriptFormatterBiome} from "../common/typescript-formatter.biome"
+import {ServerRouterBuilder} from "./typescript-koa.generator"
+
+describe("typescript/typescript-koa", () => {
+  describe("ServerRouterBuilder#implementationExport", () => {
+    it("can output implementation types as a `export type`", async () => {
+      const actual = await getActual("type")
+      // TODO: check result is actually valid typescript
+      expect(actual).toMatchInlineSnapshot(`
+        "export type UnitTestImplementation = {
+          testOperation: TestOperation
+          anotherTestOperation: AnotherTestOperation
+        }
+        "
+      `)
+    })
+
+    it("can output implementation types as a `export interface`", async () => {
+      const actual = await getActual("interface")
+
+      expect(actual).toMatchInlineSnapshot(`
+        "export interface UnitTestImplementation {
+          testOperation: TestOperation
+          anotherTestOperation: AnotherTestOperation
+        }
+        "
+      `)
+    })
+
+    it("can output implementation types as a `export abstract class`", async () => {
+      const actual = await getActual("abstract-class")
+      expect(actual).toMatchInlineSnapshot(`
+        "export abstract class UnitTestImplementation {
+          abstract testOperation: TestOperation
+          abstract anotherTestOperation: AnotherTestOperation
+        }
+        "
+      `)
+    })
+
+    // TODO: proper test harness / refactor for testability
+    async function getActual(
+      serverImplementationMethod: ServerImplementationMethod,
+    ) {
+      const {input} = await unitTestInput("3.1.x")
+
+      const formatter = await TypescriptFormatterBiome.createNodeFormatter()
+
+      const imports = new ImportBuilder()
+      const typeBuilder = await TypeBuilder.fromInput(
+        "./unit-test.types.ts",
+        input,
+        {},
+        {allowAny: true},
+      )
+      const schemaBuilder = await schemaBuilderFactory(
+        "./unit-test.schemas.ts",
+        input,
+        "zod",
+        {allowAny: true},
+      )
+      const serverRouterBuilder = new ServerRouterBuilder(
+        "unit-test.ts",
+        "unit-test",
+        input,
+        imports,
+        typeBuilder,
+        schemaBuilder,
+        serverImplementationMethod,
+      )
+
+      serverRouterBuilder.add({
+        method: "GET",
+        parameters: [],
+        operationId: "testOperation",
+        deprecated: false,
+        summary: undefined,
+        description: undefined,
+        requestBody: undefined,
+        responses: undefined,
+        route: "",
+        tags: [],
+      })
+      serverRouterBuilder.add({
+        method: "GET",
+        parameters: [],
+        operationId: "anotherTestOperation",
+        deprecated: false,
+        summary: undefined,
+        description: undefined,
+        requestBody: undefined,
+        responses: undefined,
+        route: "",
+        tags: [],
+      })
+
+      return formatter.format(
+        "unit-test.ts",
+        serverRouterBuilder.implementationExport("UnitTestImplementation"),
+      )
+    }
+  })
+})

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -347,6 +347,7 @@ export class ServerRouterBuilder implements ICompilable {
   private implementationExport(): string {
     switch (this.implementationMethod) {
       case "type":
+      case "interface":
         return buildExport({
           name: "Implementation",
           value: object(

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -347,7 +347,7 @@ export class ServerRouterBuilder implements ICompilable {
   private implementationExport(): string {
     switch (this.implementationMethod) {
       case "type":
-      case "interface":
+      case "interface": {
         return buildExport({
           name: "Implementation",
           value: object(
@@ -358,10 +358,26 @@ export class ServerRouterBuilder implements ICompilable {
           ),
           kind: this.implementationMethod,
         })
-      default:
+      }
+
+      case "abstract-class": {
+        return buildExport({
+          name: "Implementation",
+          value: object(
+            this.operationTypes
+              .map((it) => it.operationId)
+              .map((key) => `abstract ${key}: ${titleCase(key)}`)
+              .join("\n"),
+          ),
+          kind: "abstract-class",
+        })
+      }
+
+      default: {
         throw new Error(
           `server implementation method '${this.implementationMethod}' is not supported`,
         )
+      }
     }
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -360,12 +360,12 @@ export class ServerRouterBuilder implements ICompilable {
     }
   }
 
-  private implementationExport(): string {
+  implementationExport(name: string): string {
     switch (this.implementationMethod) {
       case "type":
       case "interface": {
         return buildExport({
-          name: "Implementation",
+          name,
           value: object(
             this.operationTypes
               .map((it) => this.operationSymbolNames(it.operationId))
@@ -378,7 +378,7 @@ export class ServerRouterBuilder implements ICompilable {
 
       case "abstract-class": {
         return buildExport({
-          name: "Implementation",
+          name,
           value: object(
             this.operationTypes
               .map((it) => this.operationSymbolNames(it.operationId))
@@ -398,13 +398,14 @@ export class ServerRouterBuilder implements ICompilable {
   }
 
   toString(): string {
+    const implementationExportName = "Implementation"
     const routes = this.statements
     const code = `
 ${this.operationTypes.flatMap((it) => it.statements).join("\n\n")}
 
-${this.implementationExport()}
+${this.implementationExport(implementationExportName)}
 
-export function createRouter(implementation: Implementation): KoaRouter {
+export function createRouter(implementation: ${implementationExportName}): KoaRouter {
   const router = new KoaRouter()
 
   ${routes.join("\n\n")}


### PR DESCRIPTION
introducing a new cli flag `--ts-server-implementation-method <value>` that controls whether
the "implementation" contract for each router is emitted as a:
- type (default, previous behavior)
- interface
- abstract class

for the abstract class case I've played around with using this with the diod DI framework over here https://github.com/mnahkies/node-scim/pull/1/files?diff=unified&w=1 and it seems to work fine, albeit its annoying having to alias the imported `Implementation` and `createRouter` symbols (this has been bugging me for a while tbh, but out of scope for this change)