### PR TITLE
feat: emit unique symbol names for Implementation / createRouter functions

### DIFF
--- a/e2e/src/generated/routes/headers.ts
+++ b/e2e/src/generated/routes/headers.ts
@@ -55,12 +55,14 @@ export type GetHeadersRequest = (
   | Response<200, t_getHeadersRequestJson200Response>
 >
 
-export type Implementation = {
+export type HeadersImplementation = {
   getHeadersUndeclared: GetHeadersUndeclared
   getHeadersRequest: GetHeadersRequest
 }
 
-export function createRouter(implementation: Implementation): KoaRouter {
+export function createHeadersRouter(
+  implementation: HeadersImplementation,
+): KoaRouter {
   const router = new KoaRouter()
 
   const getHeadersUndeclaredResponseValidator = responseValidationFactory(
@@ -153,3 +155,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   return router
 }
+
+export { createHeadersRouter as createRouter }
+export type { HeadersImplementation as Implementation }

--- a/e2e/src/generated/routes/validation.ts
+++ b/e2e/src/generated/routes/validation.ts
@@ -40,11 +40,13 @@ export type GetValidationNumbersRandomNumber = (
   ctx: RouterContext,
 ) => Promise<KoaRuntimeResponse<unknown> | Response<200, t_RandomNumber>>
 
-export type Implementation = {
+export type ValidationImplementation = {
   getValidationNumbersRandomNumber: GetValidationNumbersRandomNumber
 }
 
-export function createRouter(implementation: Implementation): KoaRouter {
+export function createValidationRouter(
+  implementation: ValidationImplementation,
+): KoaRouter {
   const router = new KoaRouter()
 
   const getValidationNumbersRandomNumberQuerySchema = z.object({
@@ -102,3 +104,6 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   return router
 }
+
+export { createValidationRouter as createRouter }
+export type { ValidationImplementation as Implementation }

--- a/packages/openapi-code-generator/src/core/input.ts
+++ b/packages/openapi-code-generator/src/core/input.ts
@@ -75,7 +75,7 @@ export class Input {
   ): OperationGroup[] {
     switch (strategy) {
       case "none": {
-        return [{name: "generated", operations: this.allOperations()}]
+        return [{name: "", operations: this.allOperations()}]
       }
       case "first-tag":
         return this.operationsByFirstTag()
@@ -154,7 +154,7 @@ export class Input {
 
   private operationsByFirstTag(): OperationGroup[] {
     return this.groupOperations((operation) => {
-      const tag = operation.tags[0] ?? "generated"
+      const tag = operation.tags[0]
 
       if (!tag) {
         throw new Error(

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -398,19 +398,31 @@ export class ServerRouterBuilder implements ICompilable {
   }
 
   toString(): string {
-    const implementationExportName = "Implementation"
+    const moduleName = titleCase(this.name)
+
+    const implementationExportName = `${moduleName}Implementation`
+    const createRouterExportName = `create${moduleName}Router`
+
     const routes = this.statements
     const code = `
 ${this.operationTypes.flatMap((it) => it.statements).join("\n\n")}
 
 ${this.implementationExport(implementationExportName)}
 
-export function createRouter(implementation: ${implementationExportName}): KoaRouter {
+export function ${createRouterExportName}(implementation: ${implementationExportName}): KoaRouter {
   const router = new KoaRouter()
 
   ${routes.join("\n\n")}
 
   return router
+}
+
+${
+  moduleName &&
+  `
+export {${createRouterExportName} as createRouter}
+export ${this.implementationMethod === "type" || this.implementationMethod === "interface" ? "type" : ""} {${implementationExportName} as Implementation}
+`
 }
 `
     return code


### PR DESCRIPTION
- previous names still exported as aliases for backwards compatibility, will probably keep these around forever, as sometimes they are more convenient, depends on how the consuming project is structured.

- only occurs when splitting the generated code by tag / slug / etc, when outputting a single file the original names are still used for now.

- I'd like to further extend this to `ApiClient` exports for the client SDKs, as this is normally where I find it most annoying

relates: #111