### PR TITLE
feat: unique client export names

### DIFF
--- a/e2e/scripts/generate.sh
+++ b/e2e/scripts/generate.sh
@@ -15,11 +15,13 @@ yarn openapi-code-generator \
   --output ./src/generated/client/fetch \
   --template typescript-fetch \
   --schema-builder zod \
-  --extract-inline-schemas
+  --extract-inline-schemas \
+  --override-specification-title "E2E Test Client"
 
 yarn openapi-code-generator \
   --input ./openapi.yaml \
   --output ./src/generated/client/axios \
   --template typescript-axios \
   --schema-builder zod \
-  --extract-inline-schemas
+  --extract-inline-schemas \
+  --override-specification-title "E2E Test Client"

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -13,10 +13,10 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {}
+export interface E2ETestClientConfig extends AbstractAxiosConfig {}
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class E2ETestClient extends AbstractAxiosClient {
+  constructor(config: E2ETestClientConfig) {
     super(config)
   }
 
@@ -90,3 +90,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { E2ETestClient as ApiClient }
+export type { E2ETestClientConfig as ApiClientConfig }

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -14,10 +14,10 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface E2ETestClientConfig extends AbstractFetchClientConfig {}
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class E2ETestClient extends AbstractFetchClient {
+  constructor(config: E2ETestClientConfig) {
     super(config)
   }
 
@@ -79,3 +79,6 @@ export class ApiClient extends AbstractFetchClient {
     )
   }
 }
+
+export { E2ETestClient as ApiClient }
+export type { E2ETestClientConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { GitHubV3RestApi } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [GitHubV3RestApi],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
@@ -313,7 +313,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class GitHubV3RestApiConfig {
   basePath: "https://api.github.com" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -359,10 +359,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class GitHubV3RestApi {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: GitHubV3RestApiConfig,
   ) {}
 
   private _headers(
@@ -25280,3 +25280,6 @@ export class ApiClient {
     })
   }
 }
+
+export { GitHubV3RestApi as ApiClient }
+export { GitHubV3RestApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { ContosoWidgetManager } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [ContosoWidgetManager],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
@@ -24,7 +24,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class ContosoWidgetManagerConfig {
   basePath: "{endpoint}/widget" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -70,10 +70,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class ContosoWidgetManager {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: ContosoWidgetManagerConfig,
   ) {}
 
   private _headers(
@@ -894,3 +894,6 @@ export class ApiClient {
     )
   }
 }
+
+export { ContosoWidgetManager as ApiClient }
+export { ContosoWidgetManagerConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { ContosoProviderHubClient } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [ContosoProviderHubClient],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
@@ -16,7 +16,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class ContosoProviderHubClientConfig {
   basePath: "https://management.azure.com" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -62,10 +62,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class ContosoProviderHubClient {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: ContosoProviderHubClientConfig,
   ) {}
 
   private _headers(
@@ -314,3 +314,6 @@ export class ApiClient {
     )
   }
 }
+
+export { ContosoProviderHubClient as ApiClient }
+export { ContosoProviderHubClientConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { MyAccountManagement } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [MyAccountManagement],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
@@ -24,7 +24,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class MyAccountManagementConfig {
   basePath: "https://{yourOktaDomain}" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -70,10 +70,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class MyAccountManagement {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: MyAccountManagementConfig,
   ) {}
 
   private _headers(
@@ -852,3 +852,6 @@ export class ApiClient {
     )
   }
 }
+
+export { MyAccountManagement as ApiClient }
+export { MyAccountManagementConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { OktaOpenIdConnectOAuth20 } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [OktaOpenIdConnectOAuth20],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
@@ -38,7 +38,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class OktaOpenIdConnectOAuth20Config {
   basePath: "https://{yourOktaDomain}" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -84,10 +84,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class OktaOpenIdConnectOAuth20 {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: OktaOpenIdConnectOAuth20Config,
   ) {}
 
   private _headers(
@@ -1151,3 +1151,6 @@ export class ApiClient {
     )
   }
 }
+
+export { OktaOpenIdConnectOAuth20 as ApiClient }
+export { OktaOpenIdConnectOAuth20Config as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { SwaggerPetstore } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [SwaggerPetstore],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class SwaggerPetstoreConfig {
   basePath: "https://petstore.swagger.io/v2" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -53,10 +53,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class SwaggerPetstore {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: SwaggerPetstoreConfig,
   ) {}
 
   private _headers(
@@ -161,3 +161,6 @@ export class ApiClient {
     )
   }
 }
+
+export { SwaggerPetstore as ApiClient }
+export { SwaggerPetstoreConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { StripeApi } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [StripeApi],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -166,7 +166,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class StripeApiConfig {
   basePath: "https://api.stripe.com/" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -212,10 +212,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class StripeApi {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: StripeApiConfig,
   ) {}
 
   private _headers(
@@ -39614,3 +39614,6 @@ export class ApiClient {
     )
   }
 }
+
+export { StripeApi as ApiClient }
+export { StripeApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/api.module.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ApiClient } from "./client.service"
+import { TodoListsExampleApi } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ApiClient],
+  providers: [TodoListsExampleApi],
 })
 export class ApiModule {}

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
@@ -12,7 +12,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ApiClientConfig {
+export class TodoListsExampleApiConfig {
   basePath: string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -58,10 +58,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ApiClient {
+export class TodoListsExampleApi {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ApiClientConfig,
+    private readonly config: TodoListsExampleApiConfig,
   ) {}
 
   private _headers(
@@ -223,3 +223,6 @@ export class ApiClient {
     )
   }
 }
+
+export { TodoListsExampleApi as ApiClient }
+export { TodoListsExampleApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
@@ -310,12 +310,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface GitHubV3RestApiConfig extends AbstractAxiosConfig {
   basePath: "https://api.github.com" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class GitHubV3RestApi extends AbstractAxiosClient {
+  constructor(config: GitHubV3RestApiConfig) {
     super(config)
   }
 
@@ -25243,3 +25243,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { GitHubV3RestApi as ApiClient }
+export type { GitHubV3RestApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -25,12 +25,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface ContosoWidgetManagerConfig extends AbstractAxiosConfig {
   basePath: "{endpoint}/widget" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class ContosoWidgetManager extends AbstractAxiosClient {
+  constructor(config: ContosoWidgetManagerConfig) {
     super(config)
   }
 
@@ -801,3 +801,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { ContosoWidgetManager as ApiClient }
+export type { ContosoWidgetManagerConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/client.ts
@@ -17,12 +17,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface ContosoProviderHubClientConfig extends AbstractAxiosConfig {
   basePath: "https://management.azure.com" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class ContosoProviderHubClient extends AbstractAxiosClient {
+  constructor(config: ContosoProviderHubClientConfig) {
     super(config)
   }
 
@@ -222,3 +222,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { ContosoProviderHubClient as ApiClient }
+export type { ContosoProviderHubClientConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
@@ -25,12 +25,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface MyAccountManagementConfig extends AbstractAxiosConfig {
   basePath: "https://{yourOktaDomain}" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class MyAccountManagement extends AbstractAxiosClient {
+  constructor(config: MyAccountManagementConfig) {
     super(config)
   }
 
@@ -776,3 +776,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { MyAccountManagement as ApiClient }
+export type { MyAccountManagementConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
@@ -38,12 +38,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface OktaOpenIdConnectOAuth20Config extends AbstractAxiosConfig {
   basePath: "https://{yourOktaDomain}" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
+  constructor(config: OktaOpenIdConnectOAuth20Config) {
     super(config)
   }
 
@@ -1032,3 +1032,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { OktaOpenIdConnectOAuth20 as ApiClient }
+export type { OktaOpenIdConnectOAuth20Config as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/petstore-expanded.yaml/client.ts
@@ -9,12 +9,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface SwaggerPetstoreConfig extends AbstractAxiosConfig {
   basePath: "https://petstore.swagger.io/v2" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class SwaggerPetstore extends AbstractAxiosClient {
+  constructor(config: SwaggerPetstoreConfig) {
     super(config)
   }
 
@@ -101,3 +101,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { SwaggerPetstore as ApiClient }
+export type { SwaggerPetstoreConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
@@ -167,12 +167,12 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {
+export interface StripeApiConfig extends AbstractAxiosConfig {
   basePath: "https://api.stripe.com/" | string
 }
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class StripeApi extends AbstractAxiosClient {
+  constructor(config: StripeApiConfig) {
     super(config)
   }
 
@@ -39268,3 +39268,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { StripeApi as ApiClient }
+export type { StripeApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
@@ -9,10 +9,10 @@ import {
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
-export interface ApiClientConfig extends AbstractAxiosConfig {}
+export interface TodoListsExampleApiConfig extends AbstractAxiosConfig {}
 
-export class ApiClient extends AbstractAxiosClient {
-  constructor(config: ApiClientConfig) {
+export class TodoListsExampleApi extends AbstractAxiosClient {
+  constructor(config: TodoListsExampleApiConfig) {
     super(config)
   }
 
@@ -160,3 +160,6 @@ export class ApiClient extends AbstractAxiosClient {
     })
   }
 }
+
+export { TodoListsExampleApi as ApiClient }
+export type { TodoListsExampleApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
@@ -316,12 +316,12 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface GitHubV3RestApiConfig extends AbstractFetchClientConfig {
   basePath: "https://api.github.com" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class GitHubV3RestApi extends AbstractFetchClient {
+  constructor(config: GitHubV3RestApiConfig) {
     super(config)
   }
 
@@ -25624,3 +25624,6 @@ export class ApiClient extends AbstractFetchClient {
     return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
   }
 }
+
+export { GitHubV3RestApi as ApiClient }
+export type { GitHubV3RestApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -28,12 +28,12 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface ContosoWidgetManagerConfig extends AbstractFetchClientConfig {
   basePath: "{endpoint}/widget" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class ContosoWidgetManager extends AbstractFetchClient {
+  constructor(config: ContosoWidgetManagerConfig) {
     super(config)
   }
 
@@ -878,3 +878,6 @@ export class ApiClient extends AbstractFetchClient {
     )
   }
 }
+
+export { ContosoWidgetManager as ApiClient }
+export type { ContosoWidgetManagerConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
@@ -20,12 +20,13 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface ContosoProviderHubClientConfig
+  extends AbstractFetchClientConfig {
   basePath: "https://management.azure.com" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class ContosoProviderHubClient extends AbstractFetchClient {
+  constructor(config: ContosoProviderHubClientConfig) {
     super(config)
   }
 
@@ -263,3 +264,6 @@ export class ApiClient extends AbstractFetchClient {
     )
   }
 }
+
+export { ContosoProviderHubClient as ApiClient }
+export type { ContosoProviderHubClientConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
@@ -27,12 +27,12 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface MyAccountManagementConfig extends AbstractFetchClientConfig {
   basePath: "https://{yourOktaDomain}" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class MyAccountManagement extends AbstractFetchClient {
+  constructor(config: MyAccountManagementConfig) {
     super(config)
   }
 
@@ -744,3 +744,6 @@ export class ApiClient extends AbstractFetchClient {
     return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
   }
 }
+
+export { MyAccountManagement as ApiClient }
+export type { MyAccountManagementConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
@@ -41,12 +41,13 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface OktaOpenIdConnectOAuth20Config
+  extends AbstractFetchClientConfig {
   basePath: "https://{yourOktaDomain}" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
+  constructor(config: OktaOpenIdConnectOAuth20Config) {
     super(config)
   }
 
@@ -1002,3 +1003,6 @@ export class ApiClient extends AbstractFetchClient {
     return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
   }
 }
+
+export { OktaOpenIdConnectOAuth20 as ApiClient }
+export type { OktaOpenIdConnectOAuth20Config as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
@@ -11,12 +11,12 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface SwaggerPetstoreConfig extends AbstractFetchClientConfig {
   basePath: "https://petstore.swagger.io/v2" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class SwaggerPetstore extends AbstractFetchClient {
+  constructor(config: SwaggerPetstoreConfig) {
     super(config)
   }
 
@@ -82,3 +82,6 @@ export class ApiClient extends AbstractFetchClient {
     return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
   }
 }
+
+export { SwaggerPetstore as ApiClient }
+export type { SwaggerPetstoreConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -170,12 +170,12 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {
+export interface StripeApiConfig extends AbstractFetchClientConfig {
   basePath: "https://api.stripe.com/" | string
 }
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class StripeApi extends AbstractFetchClient {
+  constructor(config: StripeApiConfig) {
     super(config)
   }
 
@@ -38650,3 +38650,6 @@ export class ApiClient extends AbstractFetchClient {
     return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
   }
 }
+
+export { StripeApi as ApiClient }
+export type { StripeApiConfig as ApiClientConfig }

--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
@@ -18,10 +18,10 @@ import {
   TypedFetchResponse,
 } from "@nahkies/typescript-fetch-runtime/main"
 
-export interface ApiClientConfig extends AbstractFetchClientConfig {}
+export interface TodoListsExampleApiConfig extends AbstractFetchClientConfig {}
 
-export class ApiClient extends AbstractFetchClient {
-  constructor(config: ApiClientConfig) {
+export class TodoListsExampleApi extends AbstractFetchClient {
+  constructor(config: TodoListsExampleApiConfig) {
     super(config)
   }
 
@@ -159,3 +159,6 @@ export class ApiClient extends AbstractFetchClient {
     return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
   }
 }
+
+export { TodoListsExampleApi as ApiClient }
+export type { TodoListsExampleApiConfig as ApiClientConfig }

--- a/packages/documentation/src/pages/reference/cli-options.mdx
+++ b/packages/documentation/src/pages/reference/cli-options.mdx
@@ -48,6 +48,15 @@ What type of input file is being provided, one of:
 - `openapi3` (**default**)
 - `typespec`
 
+
+#### `--override-specification-title <value>`
+As environment variable `OPENAPI_OVERRIDE_SPECIFICATION_TITLE`
+
+Allows overriding the `info.title` field of the input OpenAPI document. This field is used to generate
+some symbol names, and so this is useful when you don't directly control the source specification, and
+wish to customize the output symbol names.
+
+
 #### `-s --schema-builder <value>`
 As environment variable `OPENAPI_SCHEMA_BUILDER`
 

--- a/packages/openapi-code-generator/src/cli.ts
+++ b/packages/openapi-code-generator/src/cli.ts
@@ -96,6 +96,12 @@ const program = new Command()
   )
   .addOption(
     new Option(
+      "--override-specification-title <value>",
+      "Override the value of the info.title field, used to generate some symbol names",
+    ).env("OPENAPI_OVERRIDE_SPECIFICATION_TITLE"),
+  )
+  .addOption(
+    new Option(
       "-s --schema-builder <value>",
       "(typescript) runtime schema parsing library to use",
     )

--- a/packages/openapi-code-generator/src/core/openapi-loader.ts
+++ b/packages/openapi-code-generator/src/core/openapi-loader.ts
@@ -27,6 +27,7 @@ export class OpenapiLoader {
 
   private constructor(
     private readonly entryPointKey: string,
+    private readonly config: {titleOverride: string | undefined},
     private readonly validator: OpenapiValidator,
     private readonly genericLoader: GenericLoader,
   ) {
@@ -141,6 +142,10 @@ export class OpenapiLoader {
 
     this.library.set(loadedFrom, definition)
     await this.normalizeRefs(loadedFrom, definition)
+
+    if (this.config.titleOverride) {
+      this.entryPoint.info.title = this.config.titleOverride
+    }
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -173,7 +178,12 @@ export class OpenapiLoader {
     validator: OpenapiValidator,
     genericLoader: GenericLoader,
   ): Promise<OpenapiLoader> {
-    const loader = new OpenapiLoader("input.yaml", validator, genericLoader)
+    const loader = new OpenapiLoader(
+      "input.yaml",
+      {titleOverride: undefined},
+      validator,
+      genericLoader,
+    )
 
     await loader.loadFileContent("input.yaml", value)
 
@@ -181,7 +191,11 @@ export class OpenapiLoader {
   }
 
   static async create(
-    config: {entryPoint: string; fileType: "openapi3" | "typespec"},
+    config: {
+      entryPoint: string
+      fileType: "openapi3" | "typespec"
+      titleOverride: string | undefined
+    },
     validator: OpenapiValidator,
     genericLoader: GenericLoader,
     typespecLoader: TypespecLoader,
@@ -190,7 +204,12 @@ export class OpenapiLoader {
       ? config.entryPoint
       : path.resolve(config.entryPoint)
 
-    const loader = new OpenapiLoader(entryPoint, validator, genericLoader)
+    const loader = new OpenapiLoader(
+      entryPoint,
+      {titleOverride: config.titleOverride},
+      validator,
+      genericLoader,
+    )
 
     switch (config.fileType) {
       case "openapi3": {

--- a/packages/openapi-code-generator/src/index.ts
+++ b/packages/openapi-code-generator/src/index.ts
@@ -17,6 +17,7 @@ import {TypescriptEmitter} from "./typescript/common/typescript-emitter"
 export type Config = {
   input: string
   inputType: "openapi3" | "typespec"
+  overrideSpecificationTitle?: string | undefined
   output: string
   template:
     | "typescript-fetch"
@@ -51,7 +52,11 @@ export async function generate(
     config.remoteSpecRequestHeaders,
   )
   const loader = await OpenapiLoader.create(
-    {entryPoint: config.input, fileType: config.inputType},
+    {
+      entryPoint: config.input,
+      fileType: config.inputType,
+      titleOverride: config.overrideSpecificationTitle,
+    },
     validator,
     genericLoader,
     typespecLoader,

--- a/packages/openapi-code-generator/src/test/input.test-utils.ts
+++ b/packages/openapi-code-generator/src/test/input.test-utils.ts
@@ -45,7 +45,7 @@ export async function unitTestInput(
 
   const file = fileForVersion(version)
   const loader = await OpenapiLoader.create(
-    {entryPoint: file, fileType: "openapi3"},
+    {entryPoint: file, fileType: "openapi3", titleOverride: undefined},
     validator,
     new GenericLoader(new NodeFsAdaptor()),
     await TypespecLoader.create(),

--- a/packages/openapi-code-generator/src/typescript/common/client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/client-builder.ts
@@ -12,7 +12,7 @@ export abstract class TypescriptClientBuilder implements ICompilable {
 
   constructor(
     public readonly filename: string,
-    public readonly name: string,
+    public readonly exportName: string,
     protected readonly input: Input,
     protected readonly imports: ImportBuilder,
     protected readonly models: TypeBuilder,
@@ -57,7 +57,7 @@ export abstract class TypescriptClientBuilder implements ICompilable {
   ): string
 
   toString(): string {
-    return this.buildClient(this.name, this.operations)
+    return this.buildClient(this.exportName, this.operations)
   }
 
   toCompilationUnit(): CompilationUnit {

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/angular-service-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/angular-service-builder.ts
@@ -145,6 +145,10 @@ export class ${clientName} {
 
 
   ${clientMethods.join("\n")}
-}`
+}
+
+export { ${clientName} as ApiClient }
+export { ${clientName}Config as ApiClientConfig }
+`
   }
 }

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/typescript-angular.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/typescript-angular.generator.ts
@@ -1,3 +1,4 @@
+import {titleCase} from "../../core/utils"
 import type {OpenapiTypescriptGeneratorConfig} from "../../templates.types"
 import {ImportBuilder} from "../common/import-builder"
 import {schemaBuilderFactory} from "../common/schema-builders/schema-builder"
@@ -25,9 +26,11 @@ export async function generateTypescriptAngular(
 
   const imports = new ImportBuilder()
 
+  const exportName = titleCase(input.name())
+
   const client = new AngularServiceBuilder(
     "client.service.ts",
-    "ApiClient",
+    exportName,
     input,
     imports,
     rootTypeBuilder.withImports(imports),
@@ -42,7 +45,7 @@ export async function generateTypescriptAngular(
 
   const module = new AngularModuleBuilder("api.module.ts", "Api")
 
-  module.provides(`./${client.filename}`).add(client.name)
+  module.provides(`./${client.filename}`).add(client.exportName)
 
   await emitter.emitGenerationResult([
     module.toCompilationUnit(),

--- a/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios-client-builder.ts
@@ -114,6 +114,10 @@ export class ${clientName} extends AbstractAxiosClient {
   }
 
   ${clientMethods.join("\n")}
-}`
+}
+
+export { ${clientName} as ApiClient }
+export type { ${clientName}Config as ApiClientConfig }
+`
   }
 }

--- a/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-axios/typescript-axios.generator.ts
@@ -1,3 +1,4 @@
+import {titleCase} from "../../core/utils"
 import type {OpenapiTypescriptGeneratorConfig} from "../../templates.types"
 import {ImportBuilder} from "../common/import-builder"
 import {schemaBuilderFactory} from "../common/schema-builders/schema-builder"
@@ -28,9 +29,12 @@ export async function generateTypescriptAxios(
 
   const imports = new ImportBuilder()
 
+  const filename = "client.ts"
+  const exportName = titleCase(input.name())
+
   const client = new TypescriptAxiosClientBuilder(
-    "client.ts",
-    "ApiClient",
+    filename,
+    exportName,
     input,
     imports,
     rootTypeBuilder.withImports(imports),

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch-client-builder.ts
@@ -119,6 +119,10 @@ export class ${clientName} extends AbstractFetchClient {
   }
 
   ${clientMethods.join("\n")}
-}`
+}
+
+export { ${clientName} as ApiClient }
+export type { ${clientName}Config as ApiClientConfig }
+`
   }
 }

--- a/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-fetch/typescript-fetch.generator.ts
@@ -1,3 +1,4 @@
+import {titleCase} from "../../core/utils"
 import type {OpenapiTypescriptGeneratorConfig} from "../../templates.types"
 import {ImportBuilder} from "../common/import-builder"
 import {schemaBuilderFactory} from "../common/schema-builders/schema-builder"
@@ -27,9 +28,12 @@ export async function generateTypescriptFetch(
 
   const imports = new ImportBuilder()
 
+  const filename = "client.ts"
+  const exportName = titleCase(input.name())
+
   const client = new TypescriptFetchClientBuilder(
-    "client.ts",
-    "ApiClient",
+    filename,
+    exportName,
     input,
     imports,
     rootTypeBuilder.withImports(imports),


### PR DESCRIPTION
similar to https://github.com/mnahkies/openapi-code-generator/pull/258, split from #259

start exporting clients using unique names, whilst keeping the original
names for backwards compatibility.

the names are generated from the `info.title` field, which can
additionally be overridden by passing the new param:
```
--override-specification-title SomethingElse
```