### PR TITLE
fix!: angular modules have unique export names

### DIFF
--- a/integration-tests/typescript-angular/src/app/app.component.ts
+++ b/integration-tests/typescript-angular/src/app/app.component.ts
@@ -1,14 +1,14 @@
 import {CommonModule} from "@angular/common"
 import {Component} from "@angular/core"
 import {RouterOutlet} from "@angular/router"
-import {ApiModule as GhApiModule} from "../generated/api.github.com.yaml/api.module"
-import {ApiModule as AzureCoreDataPlanServiceModule} from "../generated/azure-core-data-plane-service.tsp/api.module"
-import {ApiModule as AzureResourceManagerModule} from "../generated/azure-resource-manager.tsp/api.module"
-import {ApiModule as OktaIdpModule} from "../generated/okta.idp.yaml/api.module"
-import {ApiModule as OktaOauthModule} from "../generated/okta.oauth.yaml/api.module"
-import {ApiModule as PetStoreApiModule} from "../generated/petstore-expanded.yaml/api.module"
-import {ApiModule as StripeApiModule} from "../generated/stripe.yaml/api.module"
-import {ApiModule as TodoListsApiModule} from "../generated/todo-lists.yaml/api.module"
+import {GitHubV3RestApiModule} from "../generated/api.github.com.yaml/api.module"
+import {ContosoWidgetManagerModule} from "../generated/azure-core-data-plane-service.tsp/api.module"
+import {ContosoProviderHubClientModule} from "../generated/azure-resource-manager.tsp/api.module"
+import {MyAccountManagementModule} from "../generated/okta.idp.yaml/api.module"
+import {OktaOpenIdConnectOAuth20Module} from "../generated/okta.oauth.yaml/api.module"
+import {SwaggerPetstoreModule} from "../generated/petstore-expanded.yaml/api.module"
+import {StripeApiModule} from "../generated/stripe.yaml/api.module"
+import {TodoListsExampleApiModule} from "../generated/todo-lists.yaml/api.module"
 
 @Component({
   selector: "app-root",
@@ -16,14 +16,14 @@ import {ApiModule as TodoListsApiModule} from "../generated/todo-lists.yaml/api.
   imports: [
     CommonModule,
     RouterOutlet,
-    AzureCoreDataPlanServiceModule,
-    AzureResourceManagerModule,
-    GhApiModule,
-    OktaIdpModule,
-    OktaOauthModule,
-    PetStoreApiModule,
+    ContosoProviderHubClientModule,
+    ContosoWidgetManagerModule,
+    GitHubV3RestApiModule,
+    MyAccountManagementModule,
+    OktaOpenIdConnectOAuth20Module,
     StripeApiModule,
-    TodoListsApiModule,
+    SwaggerPetstoreModule,
+    TodoListsExampleApiModule,
   ],
   templateUrl: "./app.component.html",
   styleUrl: "./app.component.css",

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { GitHubV3RestApi } from "./client.service"
+import { GitHubV3RestApiService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [GitHubV3RestApi],
+  providers: [GitHubV3RestApiService],
 })
-export class ApiModule {}
+export class GitHubV3RestApiModule {}
+
+export { GitHubV3RestApiModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
@@ -320,7 +320,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class GitHubV3RestApiConfig {
+export class GitHubV3RestApiServiceConfig {
   basePath: "https://api.github.com" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -366,10 +366,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class GitHubV3RestApi {
+export class GitHubV3RestApiService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: GitHubV3RestApiConfig,
+    private readonly config: GitHubV3RestApiServiceConfig,
   ) {}
 
   private _headers(
@@ -25774,5 +25774,5 @@ export class GitHubV3RestApi {
   }
 }
 
-export { GitHubV3RestApi as ApiClient }
-export { GitHubV3RestApiConfig as ApiClientConfig }
+export { GitHubV3RestApiService as ApiClient }
+export { GitHubV3RestApiServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ContosoWidgetManager } from "./client.service"
+import { ContosoWidgetManagerService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ContosoWidgetManager],
+  providers: [ContosoWidgetManagerService],
 })
-export class ApiModule {}
+export class ContosoWidgetManagerModule {}
+
+export { ContosoWidgetManagerModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
@@ -24,7 +24,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ContosoWidgetManagerConfig {
+export class ContosoWidgetManagerServiceConfig {
   basePath: "{endpoint}/widget" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -70,10 +70,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ContosoWidgetManager {
+export class ContosoWidgetManagerService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ContosoWidgetManagerConfig,
+    private readonly config: ContosoWidgetManagerServiceConfig,
   ) {}
 
   private _headers(
@@ -895,5 +895,5 @@ export class ContosoWidgetManager {
   }
 }
 
-export { ContosoWidgetManager as ApiClient }
-export { ContosoWidgetManagerConfig as ApiClientConfig }
+export { ContosoWidgetManagerService as ApiClient }
+export { ContosoWidgetManagerServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ContosoProviderHubClient } from "./client.service"
+import { ContosoProviderHubClientService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [ContosoProviderHubClient],
+  providers: [ContosoProviderHubClientService],
 })
-export class ApiModule {}
+export class ContosoProviderHubClientModule {}
+
+export { ContosoProviderHubClientModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
@@ -16,7 +16,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class ContosoProviderHubClientConfig {
+export class ContosoProviderHubClientServiceConfig {
   basePath: "https://management.azure.com" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -62,10 +62,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class ContosoProviderHubClient {
+export class ContosoProviderHubClientService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: ContosoProviderHubClientConfig,
+    private readonly config: ContosoProviderHubClientServiceConfig,
   ) {}
 
   private _headers(
@@ -315,5 +315,5 @@ export class ContosoProviderHubClient {
   }
 }
 
-export { ContosoProviderHubClient as ApiClient }
-export { ContosoProviderHubClientConfig as ApiClientConfig }
+export { ContosoProviderHubClientService as ApiClient }
+export { ContosoProviderHubClientServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { MyAccountManagement } from "./client.service"
+import { MyAccountManagementService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [MyAccountManagement],
+  providers: [MyAccountManagementService],
 })
-export class ApiModule {}
+export class MyAccountManagementModule {}
+
+export { MyAccountManagementModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
@@ -24,7 +24,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class MyAccountManagementConfig {
+export class MyAccountManagementServiceConfig {
   basePath: "https://{yourOktaDomain}" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -70,10 +70,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class MyAccountManagement {
+export class MyAccountManagementService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: MyAccountManagementConfig,
+    private readonly config: MyAccountManagementServiceConfig,
   ) {}
 
   private _headers(
@@ -853,5 +853,5 @@ export class MyAccountManagement {
   }
 }
 
-export { MyAccountManagement as ApiClient }
-export { MyAccountManagementConfig as ApiClientConfig }
+export { MyAccountManagementService as ApiClient }
+export { MyAccountManagementServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { OktaOpenIdConnectOAuth20 } from "./client.service"
+import { OktaOpenIdConnectOAuth20Service } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [OktaOpenIdConnectOAuth20],
+  providers: [OktaOpenIdConnectOAuth20Service],
 })
-export class ApiModule {}
+export class OktaOpenIdConnectOAuth20Module {}
+
+export { OktaOpenIdConnectOAuth20Module as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
@@ -38,7 +38,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class OktaOpenIdConnectOAuth20Config {
+export class OktaOpenIdConnectOAuth20ServiceConfig {
   basePath: "https://{yourOktaDomain}" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -84,10 +84,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class OktaOpenIdConnectOAuth20 {
+export class OktaOpenIdConnectOAuth20Service {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: OktaOpenIdConnectOAuth20Config,
+    private readonly config: OktaOpenIdConnectOAuth20ServiceConfig,
   ) {}
 
   private _headers(
@@ -1152,5 +1152,5 @@ export class OktaOpenIdConnectOAuth20 {
   }
 }
 
-export { OktaOpenIdConnectOAuth20 as ApiClient }
-export { OktaOpenIdConnectOAuth20Config as ApiClientConfig }
+export { OktaOpenIdConnectOAuth20Service as ApiClient }
+export { OktaOpenIdConnectOAuth20ServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { SwaggerPetstore } from "./client.service"
+import { SwaggerPetstoreService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [SwaggerPetstore],
+  providers: [SwaggerPetstoreService],
 })
-export class ApiModule {}
+export class SwaggerPetstoreModule {}
+
+export { SwaggerPetstoreModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class SwaggerPetstoreConfig {
+export class SwaggerPetstoreServiceConfig {
   basePath: "https://petstore.swagger.io/v2" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -53,10 +53,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class SwaggerPetstore {
+export class SwaggerPetstoreService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: SwaggerPetstoreConfig,
+    private readonly config: SwaggerPetstoreServiceConfig,
   ) {}
 
   private _headers(
@@ -162,5 +162,5 @@ export class SwaggerPetstore {
   }
 }
 
-export { SwaggerPetstore as ApiClient }
-export { SwaggerPetstoreConfig as ApiClientConfig }
+export { SwaggerPetstoreService as ApiClient }
+export { SwaggerPetstoreServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { StripeApi } from "./client.service"
+import { StripeApiService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [StripeApi],
+  providers: [StripeApiService],
 })
-export class ApiModule {}
+export class StripeApiModule {}
+
+export { StripeApiModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -166,7 +166,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class StripeApiConfig {
+export class StripeApiServiceConfig {
   basePath: "https://api.stripe.com/" | string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -212,10 +212,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class StripeApi {
+export class StripeApiService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: StripeApiConfig,
+    private readonly config: StripeApiServiceConfig,
   ) {}
 
   private _headers(
@@ -39694,5 +39694,5 @@ export class StripeApi {
   }
 }
 
-export { StripeApi as ApiClient }
-export { StripeApiConfig as ApiClientConfig }
+export { StripeApiService as ApiClient }
+export { StripeApiServiceConfig as ApiClientConfig }

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/api.module.ts
@@ -2,13 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { TodoListsExampleApi } from "./client.service"
+import { TodoListsExampleApiService } from "./client.service"
 import { NgModule } from "@angular/core"
 
 @NgModule({
   imports: [],
   declarations: [],
   exports: [],
-  providers: [TodoListsExampleApi],
+  providers: [TodoListsExampleApiService],
 })
-export class ApiModule {}
+export class TodoListsExampleApiModule {}
+
+export { TodoListsExampleApiModule as ApiModule }

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
@@ -12,7 +12,7 @@ import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
 import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
-export class TodoListsExampleApiConfig {
+export class TodoListsExampleApiServiceConfig {
   basePath: string = ""
   defaultHeaders: Record<string, string> = {}
 }
@@ -58,10 +58,10 @@ export type QueryParams = {
 @Injectable({
   providedIn: "root",
 })
-export class TodoListsExampleApi {
+export class TodoListsExampleApiService {
   constructor(
     private readonly httpClient: HttpClient,
-    private readonly config: TodoListsExampleApiConfig,
+    private readonly config: TodoListsExampleApiServiceConfig,
   ) {}
 
   private _headers(
@@ -224,5 +224,5 @@ export class TodoListsExampleApi {
   }
 }
 
-export { TodoListsExampleApi as ApiClient }
-export { TodoListsExampleApiConfig as ApiClientConfig }
+export { TodoListsExampleApiService as ApiClient }
+export { TodoListsExampleApiServiceConfig as ApiClientConfig }

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/angular-module-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/angular-module-builder.ts
@@ -11,7 +11,7 @@ export class AngularModuleBuilder implements ICompilable {
 
   constructor(
     readonly filename: string,
-    private readonly name: string,
+    public readonly exportName: string,
   ) {
     this.tsImports = new ImportBuilder()
 
@@ -66,7 +66,9 @@ export class AngularModuleBuilder implements ICompilable {
         ${this.sorted(this.ngProviders).join(",\n")}
       ],
     })
-    export class ${this.name}Module {}
+    export class ${this.exportName} {}
+
+    export { ${this.exportName} as ApiModule }
     `
   }
 

--- a/packages/openapi-code-generator/src/typescript/typescript-angular/typescript-angular.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-angular/typescript-angular.generator.ts
@@ -27,10 +27,12 @@ export async function generateTypescriptAngular(
   const imports = new ImportBuilder()
 
   const exportName = titleCase(input.name())
+  const serviceExportName = `${exportName}Service`
+  const moduleExportName = `${exportName}Module`
 
   const client = new AngularServiceBuilder(
     "client.service.ts",
-    exportName,
+    serviceExportName,
     input,
     imports,
     rootTypeBuilder.withImports(imports),
@@ -43,7 +45,7 @@ export async function generateTypescriptAngular(
 
   input.allOperations().map((it) => client.add(it))
 
-  const module = new AngularModuleBuilder("api.module.ts", "Api")
+  const module = new AngularModuleBuilder("api.module.ts", moduleExportName)
 
   module.provides(`./${client.filename}`).add(client.exportName)
 


### PR DESCRIPTION
- adds unique export names for angular modules, keeping the old names for backwards compatibility

- suffixes the unique export names for angular services with `Service`

BREAKING CHANGE: angular service exports suffixed with `Service`