### PR TITLE
fix: intersected union schemas

### DIFF
--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -250,9 +250,17 @@ export abstract class AbstractSchemaBuilder<
             )
           }
 
+          // Note: for zod in particular it's desirable to use merge over intersection
+          //       where possible, as it returns a more malleable schema
           const isMergable = model.allOf
             .map((it) => this.input.schema(it))
-            .every((it) => it.type === "object" && !it.additionalProperties)
+            .every(
+              (it) =>
+                it.type === "object" &&
+                !it.additionalProperties &&
+                !it.anyOf.length &&
+                !it.oneOf.length,
+            )
 
           const schemas = model.allOf.map((it) => this.fromModel(it, true))
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -1185,7 +1185,8 @@ describe.each(testVersions)(
         await expect(execute({foo: "bla"})).rejects.toThrow('"bar" is required')
       })
 
-      it("can intersect unions", async () => {
+      // TODO: https://github.com/hapijs/joi/issues/3057
+      it.skip("can intersect unions", async () => {
         const {code, execute} = await getActualFromModel(
           irModelObject({
             allOf: [

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/schema-builder.test-utils.ts
@@ -1,6 +1,9 @@
 import type {Input} from "../../../core/input"
 import type {
   IRModel,
+  IRModelNumeric,
+  IRModelObject,
+  IRModelString,
   MaybeIRModel,
 } from "../../../core/openapi-types-normalized"
 import {
@@ -92,5 +95,44 @@ export function schemaBuilderTestHarness(
   return {
     getActualFromModel,
     getActual,
+  }
+}
+
+export function irModelObject(
+  partial: Partial<IRModelObject> = {},
+): IRModelObject {
+  return {
+    type: "object",
+    allOf: [],
+    anyOf: [],
+    oneOf: [],
+    properties: {},
+    additionalProperties: undefined,
+    required: [],
+    nullable: false,
+    readOnly: false,
+    ...partial,
+  }
+}
+
+export function irModelString(
+  partial: Partial<IRModelString> = {},
+): IRModelString {
+  return {
+    type: "string",
+    nullable: false,
+    readOnly: false,
+    ...partial,
+  }
+}
+
+export function irModelNumber(
+  partial: Partial<IRModelNumeric> = {},
+): IRModelNumeric {
+  return {
+    type: "number",
+    nullable: false,
+    readOnly: false,
+    ...partial,
   }
 }

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -1185,9 +1185,10 @@ describe.each(testVersions)(
         )
 
         expect(code).toMatchInlineSnapshot(`
-          "const x = z
-            .union([z.object({ foo: z.string() }), z.object({ bar: z.string() })])
-            .merge(z.object({ id: z.string() }))"
+          "const x = z.intersection(
+            z.union([z.object({ foo: z.string() }), z.object({ bar: z.string() })]),
+            z.object({ id: z.string() }),
+          )"
         `)
 
         await expect(execute({id: "1234", foo: "bla"})).resolves.toEqual({

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -9,41 +9,13 @@ import type {
 } from "../../../core/openapi-types-normalized"
 import {testVersions} from "../../../test/input.test-utils"
 import type {SchemaBuilderConfig} from "./abstract-schema-builder"
-import {schemaBuilderTestHarness} from "./schema-builder.test-utils"
+import {
+  irModelNumber,
+  irModelObject,
+  irModelString,
+  schemaBuilderTestHarness,
+} from "./schema-builder.test-utils"
 import {staticSchemas} from "./zod-schema-builder"
-
-function irModelObject(partial: Partial<IRModelObject> = {}): IRModelObject {
-  return {
-    type: "object",
-    allOf: [],
-    anyOf: [],
-    oneOf: [],
-    properties: {},
-    additionalProperties: undefined,
-    required: [],
-    nullable: false,
-    readOnly: false,
-    ...partial,
-  }
-}
-
-function irModelString(partial: Partial<IRModelString> = {}): IRModelString {
-  return {
-    type: "string",
-    nullable: false,
-    readOnly: false,
-    ...partial,
-  }
-}
-
-function irModelNumber(partial: Partial<IRModelNumeric> = {}): IRModelNumeric {
-  return {
-    type: "number",
-    nullable: false,
-    readOnly: false,
-    ...partial,
-  }
-}
 
 describe.each(testVersions)(
   "%s - typescript/common/schema-builders/zod-schema-builder",


### PR DESCRIPTION
`merge` is only available on `ZodObject` and so we must use `intersect` if a `ZodIntersection` or `ZodUnion` is involved.

it'd probably be simpler to just always use `intersect` but that comes with drawbacks like being unable to `pick` or `omit` the resulting schema.

solves #282 
