### PR TITLE
fix(client-sdks): handle 204 empty responses with runtime validation

### DIFF
--- a/e2e/openapi.yaml
+++ b/e2e/openapi.yaml
@@ -74,7 +74,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RandomNumber'
-
+  /responses/empty:
+    get:
+      tags:
+        - validation
+      responses:
+        204:
+          description: Ok
 components:
   responses:
     GetHeaders:

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -18,6 +18,7 @@ import {
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
 import { AxiosRequestConfig, AxiosResponse } from "axios"
+import { z } from "zod"
 
 export class E2ETestClientServers {
   static default(): Server<"E2ETestClient"> {
@@ -140,6 +141,24 @@ export class E2ETestClient extends AbstractAxiosClient {
     })
 
     return { ...res, data: s_RandomNumber.parse(res.data) }
+  }
+
+  async getResponsesEmpty(
+    timeout?: number,
+    opts: AxiosRequestConfig = {},
+  ): Promise<AxiosResponse<void>> {
+    const url = `/responses/empty`
+    const headers = this._headers({}, opts.headers)
+
+    const res = await this._request({
+      url: url,
+      method: "GET",
+      ...(timeout ? { timeout } : {}),
+      ...opts,
+      headers,
+    })
+
+    return { ...res, data: z.undefined().parse(res.data) }
   }
 }
 

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -158,7 +158,7 @@ export class E2ETestClient extends AbstractAxiosClient {
       headers,
     })
 
-    return { ...res, data: z.undefined().parse(res.data) }
+    return { ...res, data: z.any().parse(res.data) }
   }
 }
 

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -19,6 +19,7 @@ import {
   Server,
 } from "@nahkies/typescript-fetch-runtime/main"
 import { responseValidationFactory } from "@nahkies/typescript-fetch-runtime/zod"
+import { z } from "zod"
 
 export class E2ETestClientServers {
   static default(): Server<"E2ETestClient"> {
@@ -130,6 +131,18 @@ export class E2ETestClient extends AbstractFetchClient {
     )
 
     return responseValidationFactory([["200", s_RandomNumber]], undefined)(res)
+  }
+
+  async getResponsesEmpty(
+    timeout?: number,
+    opts: RequestInit = {},
+  ): Promise<Res<204, void>> {
+    const url = this.basePath + `/responses/empty`
+    const headers = this._headers({}, opts.headers)
+
+    const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+
+    return responseValidationFactory([["204", z.undefined()]], undefined)(res)
   }
 }
 

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -142,7 +142,7 @@ export class E2ETestClient extends AbstractFetchClient {
 
     const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
 
-    return responseValidationFactory([["204", z.undefined()]], undefined)(res)
+    return responseValidationFactory([["204", z.any()]], undefined)(res)
   }
 }
 

--- a/e2e/src/index.axios.spec.ts
+++ b/e2e/src/index.axios.spec.ts
@@ -201,8 +201,10 @@ describe("e2e - typescript-axios client", () => {
 
   describe("GET /responses/empty", () => {
     it("returns undefined", async () => {
-      const {data} = await client.getResponsesEmpty()
-      expect(data).toBeUndefined()
+      const {status, data} = await client.getResponsesEmpty()
+
+      expect(status).toBe(204)
+      expect(data).toEqual("")
     })
   })
 })

--- a/e2e/src/index.axios.spec.ts
+++ b/e2e/src/index.axios.spec.ts
@@ -198,4 +198,11 @@ describe("e2e - typescript-axios client", () => {
       })
     })
   })
+
+  describe("GET /responses/empty", () => {
+    it("returns undefined", async () => {
+      const {data} = await client.getResponsesEmpty()
+      expect(data).toBeUndefined()
+    })
+  })
 })

--- a/e2e/src/index.fetch.spec.ts
+++ b/e2e/src/index.fetch.spec.ts
@@ -229,8 +229,8 @@ describe("e2e - typescript-fetch client", () => {
     it("returns undefined", async () => {
       const res = await client.getResponsesEmpty()
 
-      const body = await res.json()
-      expect(body).toBeUndefined()
+      expect(res.status).toBe(204)
+      await expect(res.json()).rejects.toThrow("Unexpected end of JSON input")
     })
   })
 })

--- a/e2e/src/index.fetch.spec.ts
+++ b/e2e/src/index.fetch.spec.ts
@@ -224,4 +224,13 @@ describe("e2e - typescript-fetch client", () => {
       })
     })
   })
+
+  describe("GET /responses/empty", () => {
+    it("returns undefined", async () => {
+      const res = await client.getResponsesEmpty()
+
+      const body = await res.json()
+      expect(body).toBeUndefined()
+    })
+  })
 })

--- a/e2e/src/routes/validation.ts
+++ b/e2e/src/routes/validation.ts
@@ -1,4 +1,5 @@
 import {
+  type GetResponsesEmpty,
   type GetValidationNumbersRandomNumber,
   createRouter,
 } from "../generated/routes/validation"
@@ -28,8 +29,13 @@ const getValidationNumbersRandomNumber: GetValidationNumbersRandomNumber =
     return respond.withStatus(404)
   }
 
+const getResponsesEmpty: GetResponsesEmpty = async (_, respond) => {
+  return respond.with204()
+}
+
 export function createValidationRouter() {
   return createRouter({
     getValidationNumbersRandomNumber,
+    getResponsesEmpty,
   })
 }

--- a/packages/openapi-code-generator/src/typescript/common/client-operation-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/client-operation-builder.ts
@@ -128,7 +128,7 @@ export class ClientOperationBuilder {
           acc.defaultResponse = {
             schema: content
               ? schemaBuilder.fromModel(content.schema, true, true)
-              : schemaBuilder.void(),
+              : schemaBuilder.any(),
             type: content ? models.schemaObjectToType(content.schema) : "void",
           }
         } else {
@@ -138,7 +138,7 @@ export class ClientOperationBuilder {
             type: content ? models.schemaObjectToType(content.schema) : "void",
             schema: content
               ? schemaBuilder.fromModel(content.schema, true, true)
-              : schemaBuilder.void(),
+              : schemaBuilder.any(),
           })
         }
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -404,7 +404,7 @@ export abstract class AbstractSchemaBuilder<
 
   protected abstract boolean(): string
 
-  protected abstract any(): string
+  public abstract any(): string
 
   protected abstract unknown(): string
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.ts
@@ -259,7 +259,7 @@ export class JoiBuilder extends AbstractSchemaBuilder<
       .join(".")
   }
 
-  protected any(): string {
+  public any(): string {
     return [joi, "any()"].filter(isDefined).join(".")
   }
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -269,7 +269,7 @@ export class ZodBuilder extends AbstractSchemaBuilder<
     return this.addStaticSchema("PermissiveBoolean")
   }
 
-  protected any(): string {
+  public any(): string {
     return [zod, "any()"].filter(isDefined).join(".")
   }
 


### PR DESCRIPTION
Adds e2e tests for endpoints returning `204` / empty responses and relaxes runtime schema validation for clients to use `any`, allowing for `axios` returning an `""`

Keeps the type as `void` which is somewhat a lie, but I believe a pragmatic decision - in practice you shouldn't be looking at the response body for a `204` at all, so it shouldn't really matter. The `fetch` client will continue to throw a JSON parse error if you attempt to read the empty response, which I think is fine for the same reason.

An alternative might've been to use a `.transform(it => undefined)` to coerce the runtime value to `undefined` but I don't think there is all that much value in this.

closes #285 