### PR TITLE
fix: typescript is a production dependency

### DIFF
--- a/packages/openapi-code-generator/package.json
+++ b/packages/openapi-code-generator/package.json
@@ -38,8 +38,7 @@
     "@typespec/openapi3": "^0.63.0",
     "@typespec/rest": "^0.63.0",
     "@typespec/versioning": "^0.63.0",
-    "@typespec/xml": "^0.63.0",
-    "typescript": "~5.7.2"
+    "@typespec/xml": "^0.63.0"
   },
   "dependencies": {
     "@biomejs/biome": "1.9.4",
@@ -55,6 +54,7 @@
     "lodash": "^4.17.21",
     "source-map-support": "^0.5.21",
     "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
     "zod": "^3.24.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
we use typescript at runtime to discover tsconfig.json files, and so it needs to be a production dependency to allow for npx use-cases.

eg: https://github.com/mnahkies/openapi-code-generator/blob/d0d73fa8feeaa1e8883f9825598fba022f9a77a1/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts#L25