### PR TITLE
fix: joi array query params

### DIFF
--- a/e2e/src/generated/routes/request-headers.ts
+++ b/e2e/src/generated/routes/request-headers.ts
@@ -19,11 +19,11 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   StatusCode,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/e2e/src/generated/routes/validation.ts
+++ b/e2e/src/generated/routes/validation.ts
@@ -15,11 +15,11 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   StatusCode,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/e2e/src/index.axios.spec.ts
+++ b/e2e/src/index.axios.spec.ts
@@ -154,10 +154,11 @@ describe("e2e - typescript-axios client", () => {
         status: 400,
         response: expect.objectContaining({
           data: {
-            cause: {
-              message: "Request validation failed parsing request header",
-            },
             message: "Request validation failed parsing request header",
+            phase: "request_validation",
+            cause: {
+              message: expect.stringMatching("Expected number, received nan"),
+            },
           },
         }),
       })

--- a/e2e/src/index.fetch.spec.ts
+++ b/e2e/src/index.fetch.spec.ts
@@ -173,10 +173,11 @@ describe("e2e - typescript-fetch client", () => {
       const body = await res.json()
 
       expect(body).toEqual({
-        cause: {
-          message: "Request validation failed parsing request header",
-        },
         message: "Request validation failed parsing request header",
+        phase: "request_validation",
+        cause: {
+          message: expect.stringMatching("Expected number, received nan"),
+        },
       })
     })
   })
@@ -184,8 +185,6 @@ describe("e2e - typescript-fetch client", () => {
   describe("GET /validation/numbers/random-number", () => {
     it("returns a random number", async () => {
       const res = await client.getValidationNumbersRandomNumber()
-      expect(res.status).toBe(200)
-
       const body = await res.json()
 
       expect(body).toEqual({
@@ -196,6 +195,7 @@ describe("e2e - typescript-fetch client", () => {
           forbidden: [],
         },
       })
+      expect(res.status).toBe(200)
     })
 
     it("handles a query param array of 1 element", async () => {

--- a/e2e/src/index.ts
+++ b/e2e/src/index.ts
@@ -11,17 +11,20 @@ function createRouter() {
     try {
       await next()
     } catch (err) {
-      if (KoaRuntimeError.isKoaError(err)) {
-        ctx.status = 400
-        ctx.body = {
-          message: err.message,
-          cause: {
-            message: err.message,
-          },
-        }
-      } else {
-        throw err
-      }
+      ctx.status = KoaRuntimeError.isKoaError(err) ? 400 : 500
+      ctx.body =
+        err instanceof Error
+          ? {
+              message: err.message,
+              phase: KoaRuntimeError.isKoaError(err) ? err.phase : undefined,
+              cause:
+                err.cause instanceof Error
+                  ? {
+                      message: err.cause.message,
+                    }
+                  : undefined,
+            }
+          : {message: "non error thrown", value: err}
     }
   })
 

--- a/e2e/src/routes/validation.ts
+++ b/e2e/src/routes/validation.ts
@@ -15,14 +15,15 @@ const getValidationNumbersRandomNumber: GetValidationNumbersRandomNumber =
       const result = Math.random() * (max - min) + min
 
       if (!forbidden.has(result)) {
-        return respond.with200().body({
+        const response = {
           result,
           params: {
             min,
             max,
             forbidden: Array.from(forbidden),
           },
-        })
+        }
+        return respond.with200().body(response)
       }
     }
 

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -2115,13 +2115,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/generated.ts
@@ -104,13 +104,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/generated.ts
@@ -47,13 +47,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -75,13 +75,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
@@ -117,13 +117,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
@@ -19,13 +19,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -1521,13 +1521,13 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -31,6 +31,7 @@ import {
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
+  Params,
   Response,
   ServerConfig,
   StatusCode,
@@ -39,7 +40,6 @@ import {
   startServer,
 } from "@nahkies/typescript-koa-runtime/server"
 import {
-  Params,
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/abstract-schema-builder.ts
@@ -237,7 +237,7 @@ export abstract class AbstractSchemaBuilder<
         result = this.boolean()
         break
       case "array":
-        result = this.array(model, [this.fromModel(model.items, true)])
+        result = this.array(model, [this.arrayItems(model.items)])
         break
       case "object": {
         if (model.allOf.length) {
@@ -397,6 +397,8 @@ export abstract class AbstractSchemaBuilder<
   protected abstract record(schema: string): string
 
   protected abstract array(model: IRModelArray, items: string[]): string
+
+  protected abstract arrayItems(model: MaybeIRModel): string
 
   protected abstract number(model: IRModelNumeric): string
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/joi-schema-builder.spec.ts
@@ -89,10 +89,10 @@ describe.each(testVersions)(
           .try(
             joi
               .object()
-              .keys({ strs: joi.array().items(joi.string().required()).required() })
+              .keys({ strs: joi.array().items(joi.string()).required() })
               .options({ stripUnknown: true })
               .required(),
-            joi.array().items(joi.string().required()).required(),
+            joi.array().items(joi.string()).required(),
             joi.string().required(),
           )
           .required()
@@ -136,10 +136,10 @@ describe.each(testVersions)(
           .try(
             joi
               .object()
-              .keys({ strs: joi.array().items(joi.string().required()).required() })
+              .keys({ strs: joi.array().items(joi.string()).required() })
               .options({ stripUnknown: true })
               .required(),
-            joi.array().items(joi.string().required()).required(),
+            joi.array().items(joi.string()).required(),
             joi.string().required(),
           )
           .required()
@@ -858,9 +858,10 @@ describe.each(testVersions)(
         const {code, execute} = await getActualFromModel({...base})
 
         expect(code).toMatchInlineSnapshot(
-          '"const x = joi.array().items(joi.string().required()).required()"',
+          `"const x = joi.array().items(joi.string()).required()"`,
         )
 
+        await expect(execute([])).resolves.toStrictEqual([])
         await expect(execute(["foo", "bar"])).resolves.toStrictEqual([
           "foo",
           "bar",
@@ -875,7 +876,7 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          '"const x = joi.array().items(joi.string().required()).unique().required()"',
+          `"const x = joi.array().items(joi.string()).unique().required()"`,
         )
 
         await expect(execute(["foo", "bar"])).resolves.toStrictEqual([
@@ -894,7 +895,7 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          '"const x = joi.array().items(joi.string().required()).min(2).required()"',
+          `"const x = joi.array().items(joi.string()).min(2).required()"`,
         )
 
         await expect(execute(["foo", "bar"])).resolves.toStrictEqual([
@@ -913,7 +914,7 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          '"const x = joi.array().items(joi.string().required()).max(2).required()"',
+          `"const x = joi.array().items(joi.string()).max(2).required()"`,
         )
 
         await expect(execute(["foo", "bar"])).resolves.toStrictEqual([
@@ -934,19 +935,13 @@ describe.each(testVersions)(
           uniqueItems: true,
         })
 
-        expect(code).toMatchInlineSnapshot(`
-          "const x = joi
-            .array()
-            .items(joi.number().required())
-            .unique()
-            .min(1)
-            .max(3)
-            .required()"
-        `)
+        expect(code).toMatchInlineSnapshot(
+          `"const x = joi.array().items(joi.number()).unique().min(1).max(3).required()"`,
+        )
 
         await expect(execute([1, 2])).resolves.toStrictEqual([1, 2])
         await expect(execute([])).rejects.toThrow(
-          '"value" does not contain 1 required value(s)',
+          '"value" must contain at least 1 items',
         )
         await expect(execute([1, 2, 3, 4])).rejects.toThrow(
           '"value" must contain less than or equal to 3 items',
@@ -963,7 +958,7 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          `"const x = joi.array().items(joi.string().required()).default(["example"])"`,
+          `"const x = joi.array().items(joi.string()).default(["example"])"`,
         )
 
         await expect(execute(undefined)).resolves.toStrictEqual(["example"])
@@ -976,7 +971,7 @@ describe.each(testVersions)(
         })
 
         expect(code).toMatchInlineSnapshot(
-          `"const x = joi.array().items(joi.string().required()).default([])"`,
+          `"const x = joi.array().items(joi.string()).default([])"`,
         )
 
         await expect(execute(undefined)).resolves.toStrictEqual([])
@@ -1321,7 +1316,7 @@ describe.each(testVersions)(
         expect(code).toMatchInlineSnapshot(`
           "const x = joi
             .array()
-            .items(joi.object().pattern(joi.any(), joi.any()).required())
+            .items(joi.object().pattern(joi.any(), joi.any()))
             .required()"
         `)
 
@@ -1426,7 +1421,7 @@ describe.each(testVersions)(
         expect(code).toMatchInlineSnapshot(`
           "const x = joi
             .array()
-            .items(joi.object().pattern(joi.any(), joi.any()).required())
+            .items(joi.object().pattern(joi.any(), joi.any()))
             .required()"
         `)
 

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.spec.ts
@@ -840,6 +840,7 @@ describe.each(testVersions)(
 
         expect(code).toMatchInlineSnapshot('"const x = z.array(z.string())"')
 
+        await expect(execute([])).resolves.toStrictEqual([])
         await expect(execute(["foo", "bar"])).resolves.toStrictEqual([
           "foo",
           "bar",

--- a/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/schema-builders/zod-schema-builder.ts
@@ -6,6 +6,7 @@ import type {
   IRModelBase,
   IRModelNumeric,
   IRModelString,
+  MaybeIRModel,
 } from "../../../core/openapi-types-normalized"
 import {
   getSchemaNameFromRef,
@@ -195,6 +196,10 @@ export class ZodBuilder extends AbstractSchemaBuilder<
     ]
       .filter(isDefined)
       .join(".")
+  }
+
+  protected arrayItems(model: MaybeIRModel): string {
+    return this.fromModel(model, true)
   }
 
   protected number(model: IRModelNumeric) {

--- a/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/typescript-koa/typescript-koa.generator.ts
@@ -78,16 +78,17 @@ export class ServerRouterBuilder implements ICompilable {
     this.imports
       .from("@nahkies/typescript-koa-runtime/server")
       .add(
-        "startServer",
-        "ServerConfig",
-        "Response",
-        "KoaRuntimeResponse",
         "KoaRuntimeResponder",
+        "KoaRuntimeResponse",
+        "Params",
+        "Response",
+        "ServerConfig",
+        "StatusCode",
         "StatusCode2xx",
         "StatusCode3xx",
         "StatusCode4xx",
         "StatusCode5xx",
-        "StatusCode",
+        "startServer",
       )
 
     this.imports
@@ -100,11 +101,11 @@ export class ServerRouterBuilder implements ICompilable {
     if (schemaBuilder instanceof ZodBuilder) {
       imports
         .from("@nahkies/typescript-koa-runtime/zod")
-        .add("parseRequestInput", "Params", "responseValidationFactory")
+        .add("parseRequestInput", "responseValidationFactory")
     } else if (schemaBuilder instanceof JoiBuilder) {
       imports
         .from("@nahkies/typescript-koa-runtime/joi")
-        .add("parseRequestInput", "Params", "responseValidationFactory")
+        .add("parseRequestInput", "responseValidationFactory")
     }
   }
 

--- a/packages/typescript-koa-runtime/src/joi.ts
+++ b/packages/typescript-koa-runtime/src/joi.ts
@@ -1,11 +1,8 @@
 import type {Schema as JoiSchema} from "joi"
 import {KoaRuntimeError, type RequestInputType} from "./errors"
 
-export type Params<Params, Query, Body> = {
-  params: Params
-  query: Query
-  body: Body
-}
+/** @deprecated: update & re-generate to import from @nahkies/typescript-koa-runtime/server directly */
+export type {Params} from "./server"
 
 // Note: joi types don't appear to have an equivalent of z.infer,
 //       hence any seems about as good as we can do here.

--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -93,6 +93,13 @@ export type ServerConfig = {
   port?: number | ListenOptions
 }
 
+export type Params<Params, Query, Body, Header> = {
+  params: Params
+  query: Query
+  body: Body
+  headers: Header
+}
+
 /**
  * Starts a Koa server and listens on `port` or a randomly allocated port if none provided.
  * Enables CORS and body parsing by default. It's recommended to customize the CORS options

--- a/packages/typescript-koa-runtime/src/zod.ts
+++ b/packages/typescript-koa-runtime/src/zod.ts
@@ -1,12 +1,8 @@
 import type {z} from "zod"
 import {KoaRuntimeError, type RequestInputType} from "./errors"
 
-export type Params<Params, Query, Body, Header> = {
-  params: Params
-  query: Query
-  body: Body
-  headers: Header
-}
+/** @deprecated: update & re-generate to import from @nahkies/typescript-koa-runtime/server directly */
+export type {Params} from "./server"
 
 export function parseRequestInput<Schema extends z.ZodTypeAny>(
   schema: Schema,


### PR DESCRIPTION
- update `Params` type to include `Header` correctly
- fix joi handling of array query params
- fix joi handling of array items
