### PR TITLE
fix: dynamically require prettier

### DIFF
--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
@@ -1,13 +1,19 @@
 import type {IFormatter} from "../../core/interfaces"
 import {logger} from "../../core/logger"
-const prettier = require("prettier/standalone")
-const plugins = [
-  require("prettier/plugins/estree"),
-  require("prettier/plugins/typescript"),
-]
 
 export class TypescriptFormatterPrettier implements IFormatter {
-  private constructor() {}
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  prettier: any
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  plugins: any[]
+
+  private constructor() {
+    this.prettier = require("prettier/standalone")
+    this.plugins = [
+      require("prettier/plugins/estree"),
+      require("prettier/plugins/typescript"),
+    ]
+  }
 
   async format(
     filename: string,
@@ -19,11 +25,11 @@ export class TypescriptFormatterPrettier implements IFormatter {
       .join("\n")
 
     try {
-      const formatted = await prettier.format(trimmed, {
+      const formatted = await this.prettier.format(trimmed, {
         semi: false,
         arrowParens: "always",
         parser: "typescript",
-        plugins,
+        plugins: this.plugins,
       })
 
       return {result: formatted}


### PR DESCRIPTION
solve this error when running via `npx` - prettier only used by documentation playground at present

```
docker run -it --rm node:22 /bin/bash
root@82e7ad57cd5a:/# npx @nahkies/openapi-code-generator --help
Need to install the following packages:
@nahkies/openapi-code-generator@0.19.1
Ok to proceed? (y) y

Error: Cannot find module 'prettier/standalone'
Require stack:
- /root/.npm/_npx/3f396bc669781e99/node_modules/@nahkies/openapi-code-generator/dist/typescript/common/typescript-formatter.prettier.js
- /root/.npm/_npx/3f396bc669781e99/node_modules/@nahkies/openapi-code-generator/dist/index.js
- /root/.npm/_npx/3f396bc669781e99/node_modules/@nahkies/openapi-code-generator/dist/cli.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Function._load (node:internal/modules/cjs/loader:1055:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Module.require (node:internal/modules/cjs/loader:1311:12)
    at require (node:internal/modules/helpers:136:16)
    at Object.<anonymous> (/root/.npm/_npx/3f396bc669781e99/node_modules/@nahkies/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts:3:18)
    at Module._compile (node:internal/modules/cjs/loader:1554:14)
    at Object..js (node:internal/modules/cjs/loader:1706:10)
    at Module.load (node:internal/modules/cjs/loader:1289:32)
```