### PR TITLE
fix: don't export aliases if name is ApiClient

### DIFF
--- a/packages/openapi-code-generator/src/typescript/client/abstract-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/abstract-client-builder.ts
@@ -51,6 +51,17 @@ export abstract class AbstractClientBuilder implements ICompilable {
     this.operations.push(result)
   }
 
+  protected legacyExports(clientName: string, isConfigAClass = false) {
+    if (clientName === "ApiClient") {
+      return ""
+    }
+
+    return `
+export { ${clientName} as ApiClient }
+export ${isConfigAClass ? "" : "type"} { ${clientName}Config as ApiClientConfig }
+    `
+  }
+
   protected abstract buildImports(imports: ImportBuilder): void
 
   protected abstract buildOperation(builder: ClientOperationBuilder): string

--- a/packages/openapi-code-generator/src/typescript/client/typescript-angular/angular-service-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-angular/angular-service-builder.ts
@@ -166,8 +166,7 @@ export class ${clientName} {
   ${clientMethods.join("\n")}
 }
 
-export { ${clientName} as ApiClient }
-export { ${clientName}Config as ApiClientConfig }
+${this.legacyExports(clientName, true)}
 `
   }
 }

--- a/packages/openapi-code-generator/src/typescript/client/typescript-axios/typescript-axios-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-axios/typescript-axios-client-builder.ts
@@ -131,8 +131,7 @@ export class ${clientName} extends AbstractAxiosClient {
   ${clientMethods.join("\n")}
 }
 
-export { ${clientName} as ApiClient }
-export type { ${clientName}Config as ApiClientConfig }
+${this.legacyExports(clientName)}
 `
   }
 }

--- a/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/client/typescript-fetch/typescript-fetch-client-builder.ts
@@ -135,8 +135,7 @@ export class ${clientName} extends AbstractFetchClient {
   ${clientMethods.join("\n")}
 }
 
-export { ${clientName} as ApiClient }
-export type { ${clientName}Config as ApiClientConfig }
+${this.legacyExports(clientName)}
 `
   }
 }


### PR DESCRIPTION
we don't need the aliased exports (retained for backwards compatibility) if the main exports have the same name.