### PR TITLE
chore: adopt typescript project references

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "composite": false,
     "outDir": "./dist",
     "rootDir": "./src"
   },

--- a/integration-tests/typescript-axios/tsconfig.json
+++ b/integration-tests/typescript-axios/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": false,
     "outDir": "./dist",
     "rootDir": "./src",
     /* exercise the code path where exactOptionalPropertyTypes is enabled */

--- a/integration-tests/typescript-fetch/tsconfig.json
+++ b/integration-tests/typescript-fetch/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": false,
     "outDir": "./dist",
     "rootDir": "./src",
     /* exercise the code path where exactOptionalPropertyTypes is disabled */

--- a/integration-tests/typescript-koa/tsconfig.json
+++ b/integration-tests/typescript-koa/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": false,
     "outDir": "./dist",
     "rootDir": "./src",
     "types": [],

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "biome lint --write .",
     "format": "biome check --write .",
     "build": "node ./scripts/generate-ajv-validator.js && lerna run build  --stream --scope '@nahkies/*'",
+    "build:watch": "tsc -b tsconfig.json -w",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "integration:generate": "node ./scripts/generate.mjs",
     "integration:validate": "lerna run validate --stream",

--- a/packages/openapi-code-generator/tsconfig.json
+++ b/packages/openapi-code-generator/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": []
 }

--- a/packages/typescript-axios-runtime/tsconfig.json
+++ b/packages/typescript-axios-runtime/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": []
 }

--- a/packages/typescript-fetch-runtime/tsconfig.json
+++ b/packages/typescript-fetch-runtime/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": []
 }

--- a/packages/typescript-koa-runtime/tsconfig.json
+++ b/packages/typescript-koa-runtime/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": []
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node22/tsconfig"],
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "importHelpers": true,
+    "resolveJsonModule": true,
+    // prefer linter rule
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    // incompatible with https://biomejs.dev/linter/rules/use-literal-keys/
+    "noPropertyAccessFromIndexSignature": false,
+    "moduleResolution": "Node16",
+    "paths": {
+      "@nahkies/*": ["./packages/*/src"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,11 @@
+
 {
-  "extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node22/tsconfig"],
-  "compilerOptions": {
-    "declaration": true,
-    "sourceMap": true,
-    "importHelpers": true,
-    "resolveJsonModule": true,
-    // prefer linter rule
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    // incompatible with https://biomejs.dev/linter/rules/use-literal-keys/
-    "noPropertyAccessFromIndexSignature": false,
-    "moduleResolution": "Node16",
-    "paths": {
-      "@nahkies/*": ["./packages/*/src"]
-    }
-  }
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./packages/openapi-code-generator" },
+    { "path": "./packages/typescript-axios-runtime" },
+    { "path": "./packages/typescript-fetch-runtime" },
+    { "path": "./packages/typescript-koa-runtime" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "files": [],
   "include": [],


### PR DESCRIPTION
- adopt project references for the main packages
- add `yarn build:watch` command using new config

ref: https://www.typescriptlang.org/docs/handbook/project-references.html