### PR TITLE
fix: wrap response validation errors when using joi

### DIFF
--- a/packages/typescript-koa-runtime/src/server.ts
+++ b/packages/typescript-koa-runtime/src/server.ts
@@ -68,14 +68,14 @@ export type ServerConfig = {
   /**
    * set to "disabled" to disable body parsing middleware, omit or pass undefined for defaults.
    *
-   * if disabling, ensure you pass a body parsing middlware that places the parsed
+   * if disabling, ensure you pass a body parsing middleware that places the parsed
    * body on `ctx.body` for request body processing to work.
    **/
   body?: "disabled" | KoaBodyMiddlewareOptions | undefined
 
   /**
    *
-   * useful for mounting logging, alternative body parsers, etc
+   * useful for mounting logging, alternative body parsers, etc.
    */
   middleware?: Middleware[]
 
@@ -105,7 +105,7 @@ export type Params<Params, Query, Body, Header> = {
  * Enables CORS and body parsing by default. It's recommended to customize the CORS options
  * for production usage.
  *
- * If you need more control over your Koa server you should avoid calling this function,
+ * If you need more control over your Koa server, you should avoid calling this function
  * and instead mount the router from your generated codes `createRouter` call directly
  * onto a server you have constructed.
  */

--- a/packages/typescript-koa-runtime/src/zod.ts
+++ b/packages/typescript-koa-runtime/src/zod.ts
@@ -1,7 +1,7 @@
 import type {z} from "zod"
 import {KoaRuntimeError, type RequestInputType} from "./errors"
 
-/** @deprecated: update & re-generate to import from @nahkies/typescript-koa-runtime/server directly */
+/** @deprecated: update and re-generate to import from @nahkies/typescript-koa-runtime/server directly */
 export type {Params} from "./server"
 
 export function parseRequestInput<Schema extends z.ZodTypeAny>(


### PR DESCRIPTION
previously `joi` threw the raw `joi` errors when response validation failed, unlike `zod` validation which wrapped them in a `KoaRuntimeError`

this change aligns the behavior to match `zod` schema builder

also fixes a few documentation typos