### PR TITLE
fix: array schema output order

### DIFF
--- a/integration-tests/typescript-express/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/api.github.com.yaml/schemas.ts
@@ -846,13 +846,6 @@ export const s_code_security_configuration = z.object({
   updated_at: z.string().datetime({ offset: true }).optional(),
 })
 
-export const s_code_security_default_configurations = z.array(
-  z.object({
-    default_for_new_repos: z.object({}).optional(),
-    configuration: s_code_security_configuration.optional(),
-  }),
-)
-
 export const s_codeowners_errors = z.object({
   errors: z.array(
     z.object({
@@ -3857,6 +3850,13 @@ export const s_code_security_configuration_for_repository = z.object({
     .optional(),
   configuration: s_code_security_configuration.optional(),
 })
+
+export const s_code_security_default_configurations = z.array(
+  z.object({
+    default_for_new_repos: z.object({}).optional(),
+    configuration: s_code_security_configuration.optional(),
+  }),
+)
 
 export const s_commit = z.object({
   url: z.string(),

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -846,13 +846,6 @@ export const s_code_security_configuration = z.object({
   updated_at: z.string().datetime({ offset: true }).optional(),
 })
 
-export const s_code_security_default_configurations = z.array(
-  z.object({
-    default_for_new_repos: z.object({}).optional(),
-    configuration: s_code_security_configuration.optional(),
-  }),
-)
-
 export const s_codeowners_errors = z.object({
   errors: z.array(
     z.object({
@@ -3857,6 +3850,13 @@ export const s_code_security_configuration_for_repository = z.object({
     .optional(),
   configuration: s_code_security_configuration.optional(),
 })
+
+export const s_code_security_default_configurations = z.array(
+  z.object({
+    default_for_new_repos: z.object({}).optional(),
+    configuration: s_code_security_configuration.optional(),
+  }),
+)
 
 export const s_commit = z.object({
   url: z.string(),

--- a/packages/openapi-code-generator/src/core/dependency-graph.spec.ts
+++ b/packages/openapi-code-generator/src/core/dependency-graph.spec.ts
@@ -21,6 +21,10 @@ describe.each(testVersions)("%s - core/dependency-graph", (version) => {
       graph.order.indexOf("s_AOrdering"),
     )
 
+    expect(graph.order.indexOf("s_AArrayOrdering")).toBeGreaterThan(
+      graph.order.indexOf("s_ZOrdering"),
+    )
+
     expect(graph.order.indexOf("s_ObjectWithRefs")).toBeGreaterThan(
       graph.order.indexOf("s_SimpleObject"),
     )

--- a/packages/openapi-code-generator/src/core/dependency-graph.ts
+++ b/packages/openapi-code-generator/src/core/dependency-graph.ts
@@ -31,6 +31,7 @@ const getDependenciesFromSchema = (
         ? [schema.additionalProperties]
         : [],
     )
+    .concat(schema.type === "array" ? [schema.items] : [])
 
   return allSources.reduce((acc, it) => {
     if (isRef(it)) {

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.0.3.yaml
@@ -152,6 +152,11 @@ components:
         name:
           type: string
 
+    AArrayOrdering:
+      type: array
+      items:
+        $ref: '#/components/schemas/ZOrdering'
+
     AdditionalPropertiesBool:
       type: object
       additionalProperties: true

--- a/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
+++ b/packages/openapi-code-generator/src/test/unit-test-inputs-3.1.0.yaml
@@ -156,6 +156,11 @@ components:
         name:
           type: string
 
+    AArrayOrdering:
+      type: array
+      items:
+        $ref: '#/components/schemas/ZOrdering'
+
     AdditionalPropertiesBool:
       type: object
       additionalProperties: true


### PR DESCRIPTION
previously the dependency graph didn't consider top-level array `items` correctly, which meant you could have situations that resulted in errors like:
```
 error TS2454: Variable 's_SomeArrayItems' is used before being assigned.
```