### PR TITLE
fix: bump engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "engines": {
-    "node": ">=20 <23"
+    "node": ">=20 <25"
   },
   "packageManager": "yarn@4.9.1"
 }


### PR DESCRIPTION
NodeJS v24 is now supported since #332 