### PR TITLE
fix: adjust typing to reflect that boolean request headers are supported

### DIFF
--- a/e2e/openapi.yaml
+++ b/e2e/openapi.yaml
@@ -37,6 +37,14 @@ paths:
           in: header
           schema:
             type: number
+        - name: Boolean-Header
+          in: header
+          schema:
+            type: boolean
+        - name: Second-Boolean-Header
+          in: header
+          schema:
+            type: boolean
         - name: Authorization
           in: header
           schema:

--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -91,6 +91,8 @@ export class E2ETestClient extends AbstractAxiosClient {
     p: {
       routeLevelHeader?: string
       numberHeader?: number
+      booleanHeader?: boolean
+      secondBooleanHeader?: boolean
       authorization?: string
     } = {},
     timeout?: number,
@@ -101,6 +103,8 @@ export class E2ETestClient extends AbstractAxiosClient {
       {
         "Route-Level-Header": p["routeLevelHeader"],
         "Number-Header": p["numberHeader"],
+        "Boolean-Header": p["booleanHeader"],
+        "Second-Boolean-Header": p["secondBooleanHeader"],
         Authorization: p["authorization"],
       },
       opts.headers,

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -86,6 +86,8 @@ export class E2ETestClient extends AbstractFetchClient {
     p: {
       routeLevelHeader?: string
       numberHeader?: number
+      booleanHeader?: boolean
+      secondBooleanHeader?: boolean
       authorization?: string
     } = {},
     timeout?: number,
@@ -96,6 +98,8 @@ export class E2ETestClient extends AbstractFetchClient {
       {
         "Route-Level-Header": p["routeLevelHeader"],
         "Number-Header": p["numberHeader"],
+        "Boolean-Header": p["booleanHeader"],
+        "Second-Boolean-Header": p["secondBooleanHeader"],
         Authorization: p["authorization"],
       },
       opts.headers,

--- a/e2e/src/generated/server/express/models.ts
+++ b/e2e/src/generated/server/express/models.ts
@@ -20,8 +20,10 @@ export type t_RandomNumber = {
 
 export type t_GetHeadersRequestRequestHeaderSchema = {
   authorization?: string | undefined
+  "boolean-header"?: boolean | undefined
   "number-header"?: number | undefined
   "route-level-header"?: string | undefined
+  "second-boolean-header"?: boolean | undefined
 }
 
 export type t_getHeadersRequestJson200Response = {

--- a/e2e/src/generated/server/express/routes/request-headers.ts
+++ b/e2e/src/generated/server/express/routes/request-headers.ts
@@ -8,6 +8,7 @@ import {
   t_getHeadersUndeclaredJson200Response,
 } from "../models"
 import {
+  PermissiveBoolean,
   s_getHeadersRequestJson200Response,
   s_getHeadersUndeclaredJson200Response,
 } from "../schemas"
@@ -123,6 +124,8 @@ export function createRequestHeadersRouter(
   const getHeadersRequestRequestHeaderSchema = z.object({
     "route-level-header": z.string().optional(),
     "number-header": z.coerce.number().optional(),
+    "boolean-header": PermissiveBoolean.optional(),
+    "second-boolean-header": PermissiveBoolean.optional(),
     authorization: z.string().optional(),
   })
 

--- a/e2e/src/generated/server/express/schemas.ts
+++ b/e2e/src/generated/server/express/schemas.ts
@@ -4,6 +4,15 @@
 
 import { z } from "zod"
 
+export const PermissiveBoolean = z.preprocess((value) => {
+  if (typeof value === "string" && (value === "true" || value === "false")) {
+    return value === "true"
+  } else if (typeof value === "number" && (value === 1 || value === 0)) {
+    return value === 1
+  }
+  return value
+}, z.boolean())
+
 export const s_Enumerations = z.object({
   colors: z.enum(["red", "green", "blue"]),
   starRatings: z.union([z.literal(1), z.literal(2), z.literal(3)]),

--- a/e2e/src/generated/server/koa/models.ts
+++ b/e2e/src/generated/server/koa/models.ts
@@ -20,8 +20,10 @@ export type t_RandomNumber = {
 
 export type t_GetHeadersRequestHeaderSchema = {
   authorization?: string | undefined
+  "boolean-header"?: boolean | undefined
   "number-header"?: number | undefined
   "route-level-header"?: string | undefined
+  "second-boolean-header"?: boolean | undefined
 }
 
 export type t_getHeadersRequestJson200Response = {

--- a/e2e/src/generated/server/koa/routes/request-headers.ts
+++ b/e2e/src/generated/server/koa/routes/request-headers.ts
@@ -8,6 +8,7 @@ import {
   t_getHeadersUndeclaredJson200Response,
 } from "../models"
 import {
+  PermissiveBoolean,
   s_getHeadersRequestJson200Response,
   s_getHeadersUndeclaredJson200Response,
 } from "../schemas"
@@ -121,6 +122,8 @@ export function createRequestHeadersRouter(
   const getHeadersRequestHeaderSchema = z.object({
     "route-level-header": z.string().optional(),
     "number-header": z.coerce.number().optional(),
+    "boolean-header": PermissiveBoolean.optional(),
+    "second-boolean-header": PermissiveBoolean.optional(),
     authorization: z.string().optional(),
   })
 

--- a/e2e/src/generated/server/koa/schemas.ts
+++ b/e2e/src/generated/server/koa/schemas.ts
@@ -4,6 +4,15 @@
 
 import { z } from "zod"
 
+export const PermissiveBoolean = z.preprocess((value) => {
+  if (typeof value === "string" && (value === "true" || value === "false")) {
+    return value === "true"
+  } else if (typeof value === "number" && (value === 1 || value === 0)) {
+    return value === 1
+  }
+  return value
+}, z.boolean())
+
 export const s_Enumerations = z.object({
   colors: z.enum(["red", "green", "blue"]),
   starRatings: z.union([z.literal(1), z.literal(2), z.literal(3)]),

--- a/packages/typescript-axios-runtime/src/main.ts
+++ b/packages/typescript-axios-runtime/src/main.ts
@@ -21,8 +21,8 @@ export type QueryParams = {
 }
 
 export type HeaderParams =
-  | Record<string, string | number | undefined | null>
-  | [string, string | number | undefined | null][]
+  | Record<string, string | number | boolean | undefined | null>
+  | [string, string | number | boolean | undefined | null][]
   | Headers
 
 export type Server<T> = string & {__server__: T}
@@ -127,7 +127,7 @@ export abstract class AbstractAxiosClient {
 
   private headersAsArray(
     headers: HeaderParams | AxiosRequestConfig["headers"],
-  ): [string, string | number | undefined | null][] {
+  ): [string, string | number | boolean | undefined | null][] {
     if (Array.isArray(headers)) {
       return headers
     }

--- a/packages/typescript-fetch-runtime/src/main.ts
+++ b/packages/typescript-fetch-runtime/src/main.ts
@@ -150,7 +150,7 @@ export abstract class AbstractFetchClient {
 
   private headersAsArray(
     headers: HeaderParams | HeadersInit,
-  ): [string, string | number | undefined | null][] {
+  ): [string, string | number | boolean | undefined | null][] {
     if (isMultiDimArray(headers)) {
       return headers.flatMap((it) =>
         isNonEmptyArray(it) ? headerArrayToTuples(it) : [],
@@ -195,9 +195,8 @@ function isNonEmptyArray<T>(it: T[]): it is NonEmptyArray<T> {
   return Array.isArray(it) && it.length > 0
 }
 
-function headerArrayToTuples<T extends string | number | undefined | null>([
-  head,
-  ...rest
-]: [string, ...T[]]): [string, T][] {
+function headerArrayToTuples<
+  T extends string | number | boolean | undefined | null,
+>([head, ...rest]: [string, ...T[]]): [string, T][] {
   return rest.map((value) => [head, value] as const)
 }

--- a/packages/typescript-fetch-runtime/src/types.ts
+++ b/packages/typescript-fetch-runtime/src/types.ts
@@ -51,8 +51,8 @@ export type QueryParams = {
 }
 
 export type HeaderParams =
-  | Record<string, string | number | undefined | null>
-  | [string, string | number | undefined | null][]
+  | Record<string, string | number | boolean | undefined | null>
+  | [string, string | number | boolean | undefined | null][]
   | Headers
 
 // fetch HeadersInit type


### PR DESCRIPTION
they were already being parsed correctly, but the typescript types didn't reflect that.