### PR TITLE
feat: allow mandatory server variables

### DIFF
--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
@@ -25,17 +25,13 @@ import { Injectable } from "@angular/core"
 import { Observable } from "rxjs"
 
 export class ContosoWidgetManagerServiceServers {
-  static default(): Server<"ContosoWidgetManagerService"> {
-    return ContosoWidgetManagerServiceServers.server().build()
-  }
-
   static server(url: "{endpoint}/widget" = "{endpoint}/widget"): {
-    build: (endpoint?: string) => Server<"ContosoWidgetManagerService">
+    build: (endpoint: string) => Server<"ContosoWidgetManagerService">
   } {
     switch (url) {
       case "{endpoint}/widget":
         return {
-          build(endpoint = ""): Server<"ContosoWidgetManagerService"> {
+          build(endpoint): Server<"ContosoWidgetManagerService"> {
             return "{endpoint}/widget".replace(
               "{endpoint}",
               endpoint,
@@ -50,8 +46,7 @@ export class ContosoWidgetManagerServiceServers {
 }
 
 export class ContosoWidgetManagerServiceConfig {
-  basePath: Server<"ContosoWidgetManagerService"> | string =
-    ContosoWidgetManagerServiceServers.default()
+  basePath: Server<"ContosoWidgetManagerService"> | string = ""
   defaultHeaders: Record<string, string> = {}
 }
 

--- a/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -27,17 +27,13 @@ import {
 import { AxiosRequestConfig, AxiosResponse } from "axios"
 
 export class ContosoWidgetManagerServers {
-  static default(): Server<"ContosoWidgetManager"> {
-    return ContosoWidgetManagerServers.server().build()
-  }
-
   static server(url: "{endpoint}/widget" = "{endpoint}/widget"): {
-    build: (endpoint?: string) => Server<"ContosoWidgetManager">
+    build: (endpoint: string) => Server<"ContosoWidgetManager">
   } {
     switch (url) {
       case "{endpoint}/widget":
         return {
-          build(endpoint = ""): Server<"ContosoWidgetManager"> {
+          build(endpoint): Server<"ContosoWidgetManager"> {
             return "{endpoint}/widget".replace(
               "{endpoint}",
               endpoint,

--- a/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -29,17 +29,13 @@ import {
 } from "@nahkies/typescript-fetch-runtime/main"
 
 export class ContosoWidgetManagerServers {
-  static default(): Server<"ContosoWidgetManager"> {
-    return ContosoWidgetManagerServers.server().build()
-  }
-
   static server(url: "{endpoint}/widget" = "{endpoint}/widget"): {
-    build: (endpoint?: string) => Server<"ContosoWidgetManager">
+    build: (endpoint: string) => Server<"ContosoWidgetManager">
   } {
     switch (url) {
       case "{endpoint}/widget":
         return {
-          build(endpoint = ""): Server<"ContosoWidgetManager"> {
+          build(endpoint): Server<"ContosoWidgetManager"> {
             return "{endpoint}/widget".replace(
               "{endpoint}",
               endpoint,

--- a/packages/documentation/src/app/guides/concepts/servers-object-handling/page.mdx
+++ b/packages/documentation/src/app/guides/concepts/servers-object-handling/page.mdx
@@ -10,7 +10,7 @@ import {Callout} from "nextra/components"
 OpenAPI 3 has a `servers` property that can be used to define the base url for the whole document, or
 specific operations. This guide aims to explain how this is processed.
 
-You can find the specifications definition of the servers object [here](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-object)
+You can find the specification's definition of the servers object [here](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-object)
 
 This is fully supported, including placeholder/variable substitution, and overriding.
 
@@ -109,6 +109,20 @@ export class ApiClient {
 
 As you can see the overrides for each operation are exposed as `ApiClientServers.operations.<operationId>()` following
 the same pattern as the root servers.
+
+## Mandatory Variables
+Sometimes there are variables in urls that you can't provide a reasonable default for. A prime example would be
+an organization slug, eg: `https://api.myOrg.someSaas.com`
+
+Whilst the specification doesn't specifically discuss a concept of mandatory variables, we allow these using one
+of two methods:
+- Providing a default of `""` (as `default` is a required property)
+- Omitting the variable entirely from the `variables` map
+
+A warning will be emitted if you omit the variable entirely, so its suggested you use a default of `""` for
+this scenario.
+
+Regardless, any unconsumed/unused variables will trigger an error with the intention of picking up on typos.
 
 ## Configuration
 This behavior is optional, and be turned off by passing:

--- a/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
+++ b/packages/openapi-code-generator/src/core/openapi-types-normalized.ts
@@ -106,14 +106,13 @@ export type MaybeIRModel = IRModel | IRRef
 export interface IRServer {
   url: string
   description: string | undefined
-  variables: {
-    [k: string]: IRServerVariable
-  }
+  variables: IRServerVariable[]
 }
 
 export interface IRServerVariable {
+  name: string
   enum: string[]
-  default: string
+  default: string | undefined
   description: string | undefined
 }
 

--- a/packages/openapi-code-generator/src/core/openapi-utils.ts
+++ b/packages/openapi-code-generator/src/core/openapi-utils.ts
@@ -19,6 +19,19 @@ export function getNameFromRef({$ref}: Reference, prefix: string): string {
   return prefix + name.replace(/[-.]+/g, "_")
 }
 
+export function extractPlaceholders(
+  it: string,
+): {wholeString: string; placeholder: string | undefined}[] {
+  const regex = /{([^{}]+)}/g
+
+  return Array.from(it.matchAll(regex)).map((match) => ({
+    // includes the surrounding {}
+    wholeString: match[0],
+    // just the placeholder name
+    placeholder: match[1],
+  }))
+}
+
 export function getTypeNameFromRef(reference: Reference) {
   return getNameFromRef(reference, "t_")
 }

--- a/packages/openapi-code-generator/src/typescript/client/client-servers-builder.spec.ts
+++ b/packages/openapi-code-generator/src/typescript/client/client-servers-builder.spec.ts
@@ -64,23 +64,25 @@ describe("typescript/common/client-servers-builder", () => {
       result = await runTest([
         {
           url: "{schema}://unit-tests-default.{tenant}.example.com",
-          variables: {
-            schema: {
+          variables: [
+            {
+              name: "schema",
               default: "https",
               enum: ["https", "http"],
               description: "The protocol to use",
             },
-            tenant: {
+            {
+              name: "tenant",
               default: "example",
               enum: [],
               description: "Your tenant slug",
             },
-          },
+          ],
           description: "Default Unit test server",
         },
         {
           url: "https://unit-tests-other.example.com",
-          variables: {},
+          variables: [],
           description: "Secondary Unit test server",
         },
       ])
@@ -148,12 +150,12 @@ describe("typescript/common/client-servers-builder", () => {
         [
           {
             url: "https://unit-tests-default.example.com",
-            variables: {},
+            variables: [],
             description: "Default Unit test server",
           },
           {
             url: "https://unit-tests-other.example.com",
-            variables: {},
+            variables: [],
             description: "Secondary Unit test server",
           },
         ],
@@ -163,18 +165,20 @@ describe("typescript/common/client-servers-builder", () => {
             servers: [
               {
                 url: "{schema}}://test-operation.{tenant}.example.com",
-                variables: {
-                  schema: {
+                variables: [
+                  {
+                    name: "schema",
                     default: "https",
                     enum: ["https", "http"],
                     description: "The protocol to use",
                   },
-                  tenant: {
+                  {
+                    name: "tenant",
                     default: "example",
                     enum: [],
                     description: "Your tenant slug",
                   },
-                },
+                ],
                 description: "Test operation server",
               },
             ],
@@ -184,7 +188,7 @@ describe("typescript/common/client-servers-builder", () => {
             servers: [
               {
                 url: "https://another-test-operation.example.com",
-                variables: {},
+                variables: [],
                 description: "Another test operation server",
               },
             ],


### PR DESCRIPTION
- synthesis missing server placeholder variables as strings with no default values
- treat server placeholder variables with `""` or no default as mandatory
- refactor to put placeholder extraction into one place