### PR TITLE
feat: read formatter config

### DIFF
--- a/e2e/src/generated/client/axios/client.ts
+++ b/e2e/src/generated/client/axios/client.ts
@@ -19,8 +19,8 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
-import { z } from "zod"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
+import {z} from "zod"
 
 export class E2ETestClientServers {
   static default(): Server<"E2ETestClient"> {
@@ -76,15 +76,12 @@ export class E2ETestClient extends AbstractAxiosClient {
     const res = await this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
 
-    return {
-      ...res,
-      data: s_getHeadersUndeclaredJson200Response.parse(res.data),
-    }
+    return {...res, data: s_getHeadersUndeclaredJson200Response.parse(res.data)}
   }
 
   async getHeadersRequest(
@@ -113,12 +110,12 @@ export class E2ETestClient extends AbstractAxiosClient {
     const res = await this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
 
-    return { ...res, data: s_getHeadersRequestJson200Response.parse(res.data) }
+    return {...res, data: s_getHeadersRequestJson200Response.parse(res.data)}
   }
 
   async getValidationNumbersRandomNumber(
@@ -141,12 +138,12 @@ export class E2ETestClient extends AbstractAxiosClient {
     const res = await this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
 
-    return { ...res, data: s_RandomNumber.parse(res.data) }
+    return {...res, data: s_RandomNumber.parse(res.data)}
   }
 
   async postValidationEnums(
@@ -158,7 +155,7 @@ export class E2ETestClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Enumerations>> {
     const url = `/validation/enums`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -167,12 +164,12 @@ export class E2ETestClient extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
 
-    return { ...res, data: s_Enumerations.parse(res.data) }
+    return {...res, data: s_Enumerations.parse(res.data)}
   }
 
   async getResponses500(
@@ -185,7 +182,7 @@ export class E2ETestClient extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -201,12 +198,12 @@ export class E2ETestClient extends AbstractAxiosClient {
     const res = await this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
 
-    return { ...res, data: z.string().parse(res.data) }
+    return {...res, data: z.string().parse(res.data)}
   }
 
   async getResponsesEmpty(
@@ -219,14 +216,14 @@ export class E2ETestClient extends AbstractAxiosClient {
     const res = await this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
 
-    return { ...res, data: z.any().parse(res.data) }
+    return {...res, data: z.any().parse(res.data)}
   }
 }
 
-export { E2ETestClient as ApiClient }
-export type { E2ETestClientConfig as ApiClientConfig }
+export {E2ETestClient as ApiClient}
+export type {E2ETestClientConfig as ApiClientConfig}

--- a/e2e/src/generated/client/axios/schemas.ts
+++ b/e2e/src/generated/client/axios/schemas.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { UnknownEnumNumberValue, UnknownEnumStringValue } from "./models"
-import { z } from "zod"
+import {UnknownEnumNumberValue, UnknownEnumStringValue} from "./models"
+import {z} from "zod"
 
 export const s_Enumerations = z.object({
   colors: z.union([

--- a/e2e/src/generated/client/fetch/client.ts
+++ b/e2e/src/generated/client/fetch/client.ts
@@ -20,8 +20,8 @@ import {
   Res,
   Server,
 } from "@nahkies/typescript-fetch-runtime/main"
-import { responseValidationFactory } from "@nahkies/typescript-fetch-runtime/zod"
-import { z } from "zod"
+import {responseValidationFactory} from "@nahkies/typescript-fetch-runtime/zod"
+import {z} from "zod"
 
 export class E2ETestClientServers {
   static default(): Server<"E2ETestClient"> {
@@ -74,7 +74,7 @@ export class E2ETestClient extends AbstractFetchClient {
     const url = this.basePath + `/headers/undeclared`
     const headers = this._headers({}, opts.headers)
 
-    const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    const res = this._fetch(url, {method: "GET", ...opts, headers}, timeout)
 
     return responseValidationFactory(
       [["200", s_getHeadersUndeclaredJson200Response]],
@@ -105,7 +105,7 @@ export class E2ETestClient extends AbstractFetchClient {
       opts.headers,
     )
 
-    const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    const res = this._fetch(url, {method: "GET", ...opts, headers}, timeout)
 
     return responseValidationFactory(
       [["200", s_getHeadersRequestJson200Response]],
@@ -132,7 +132,7 @@ export class E2ETestClient extends AbstractFetchClient {
 
     const res = this._fetch(
       url + query,
-      { method: "GET", ...opts, headers },
+      {method: "GET", ...opts, headers},
       timeout,
     )
 
@@ -148,14 +148,14 @@ export class E2ETestClient extends AbstractFetchClient {
   ): Promise<Res<200, t_Enumerations>> {
     const url = this.basePath + `/validation/enums`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
     const res = this._fetch(
       url,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
 
@@ -169,7 +169,7 @@ export class E2ETestClient extends AbstractFetchClient {
     const url = this.basePath + `/responses/500`
     const headers = this._headers({}, opts.headers)
 
-    const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    const res = this._fetch(url, {method: "GET", ...opts, headers}, timeout)
 
     return responseValidationFactory([["500", z.any()]], undefined)(res)
   }
@@ -181,7 +181,7 @@ export class E2ETestClient extends AbstractFetchClient {
     const url = this.basePath + `/escape-hatches/plain-text`
     const headers = this._headers({}, opts.headers)
 
-    const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    const res = this._fetch(url, {method: "GET", ...opts, headers}, timeout)
 
     return responseValidationFactory([["200", z.string()]], undefined)(res)
   }
@@ -193,11 +193,11 @@ export class E2ETestClient extends AbstractFetchClient {
     const url = this.basePath + `/responses/empty`
     const headers = this._headers({}, opts.headers)
 
-    const res = this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    const res = this._fetch(url, {method: "GET", ...opts, headers}, timeout)
 
     return responseValidationFactory([["204", z.any()]], undefined)(res)
   }
 }
 
-export { E2ETestClient as ApiClient }
-export type { E2ETestClientConfig as ApiClientConfig }
+export {E2ETestClient as ApiClient}
+export type {E2ETestClientConfig as ApiClientConfig}

--- a/e2e/src/generated/client/fetch/schemas.ts
+++ b/e2e/src/generated/client/fetch/schemas.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { UnknownEnumNumberValue, UnknownEnumStringValue } from "./models"
-import { z } from "zod"
+import {UnknownEnumNumberValue, UnknownEnumStringValue} from "./models"
+import {z} from "zod"
 
 export const s_Enumerations = z.object({
   colors: z.union([

--- a/e2e/src/generated/server/express/routes/escape-hatches.ts
+++ b/e2e/src/generated/server/express/routes/escape-hatches.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ExpressRuntimeError } from "@nahkies/typescript-express-runtime/errors"
+import {ExpressRuntimeError} from "@nahkies/typescript-express-runtime/errors"
 import {
   ExpressRuntimeResponder,
   ExpressRuntimeResponse,
@@ -10,9 +10,9 @@ import {
   SkipResponse,
   StatusCode,
 } from "@nahkies/typescript-express-runtime/server"
-import { responseValidationFactory } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {responseValidationFactory} from "@nahkies/typescript-express-runtime/zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetEscapeHatchesPlainTextResponder = {
   with200(): ExpressRuntimeResponse<string>
@@ -70,7 +70,7 @@ export function createEscapeHatchesRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91,5 +91,5 @@ export function createEscapeHatchesRouter(
   return router
 }
 
-export { createEscapeHatchesRouter as createRouter }
-export type { EscapeHatchesImplementation as Implementation }
+export {createEscapeHatchesRouter as createRouter}
+export type {EscapeHatchesImplementation as Implementation}

--- a/e2e/src/generated/server/express/routes/request-headers.ts
+++ b/e2e/src/generated/server/express/routes/request-headers.ts
@@ -27,8 +27,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetHeadersUndeclaredResponder = {
   with200(): ExpressRuntimeResponse<t_getHeadersUndeclaredJson200Response>
@@ -103,7 +103,7 @@ export function createRequestHeadersRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -172,7 +172,7 @@ export function createRequestHeadersRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -193,5 +193,5 @@ export function createRequestHeadersRouter(
   return router
 }
 
-export { createRequestHeadersRouter as createRouter }
-export type { RequestHeadersImplementation as Implementation }
+export {createRequestHeadersRouter as createRouter}
+export type {RequestHeadersImplementation as Implementation}

--- a/e2e/src/generated/server/express/routes/validation.ts
+++ b/e2e/src/generated/server/express/routes/validation.ts
@@ -8,7 +8,7 @@ import {
   t_PostValidationEnumsRequestBodySchema,
   t_RandomNumber,
 } from "../models"
-import { s_Enumerations, s_RandomNumber } from "../schemas"
+import {s_Enumerations, s_RandomNumber} from "../schemas"
 import {
   ExpressRuntimeError,
   RequestInputType,
@@ -24,8 +24,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetValidationNumbersRandomNumberResponder = {
   with200(): ExpressRuntimeResponse<t_RandomNumber>
@@ -142,7 +142,7 @@ export function createValidationRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -205,7 +205,7 @@ export function createValidationRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -260,7 +260,7 @@ export function createValidationRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -315,7 +315,7 @@ export function createValidationRouter(
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -336,5 +336,5 @@ export function createValidationRouter(
   return router
 }
 
-export { createValidationRouter as createRouter }
-export type { ValidationImplementation as Implementation }
+export {createValidationRouter as createRouter}
+export type {ValidationImplementation as Implementation}

--- a/e2e/src/generated/server/express/schemas.ts
+++ b/e2e/src/generated/server/express/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {

--- a/e2e/src/generated/server/koa/index.ts
+++ b/e2e/src/generated/server/koa/index.ts
@@ -2,10 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import {
-  ServerConfig,
-  startServer,
-} from "@nahkies/typescript-koa-runtime/server"
+import {ServerConfig, startServer} from "@nahkies/typescript-koa-runtime/server"
 
 export async function bootstrap(config: ServerConfig) {
   // E2E Tests for @nahkies/openapi-code-generator

--- a/e2e/src/generated/server/koa/routes/escape-hatches.ts
+++ b/e2e/src/generated/server/koa/routes/escape-hatches.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import KoaRouter, { RouterContext } from "@koa/router"
-import { KoaRuntimeError } from "@nahkies/typescript-koa-runtime/errors"
+import KoaRouter, {RouterContext} from "@koa/router"
+import {KoaRuntimeError} from "@nahkies/typescript-koa-runtime/errors"
 import {
   KoaRuntimeResponder,
   KoaRuntimeResponse,
@@ -12,9 +12,9 @@ import {
   SkipResponse,
   StatusCode,
 } from "@nahkies/typescript-koa-runtime/server"
-import { responseValidationFactory } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {responseValidationFactory} from "@nahkies/typescript-koa-runtime/zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetEscapeHatchesPlainTextResponder = {
   with200(): KoaRuntimeResponse<string>
@@ -74,7 +74,7 @@ export function createEscapeHatchesRouter(
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getEscapeHatchesPlainTextResponseValidator(status, body)
@@ -86,5 +86,5 @@ export function createEscapeHatchesRouter(
   return router
 }
 
-export { createEscapeHatchesRouter as createRouter }
-export type { EscapeHatchesImplementation as Implementation }
+export {createEscapeHatchesRouter as createRouter}
+export type {EscapeHatchesImplementation as Implementation}

--- a/e2e/src/generated/server/koa/routes/request-headers.ts
+++ b/e2e/src/generated/server/koa/routes/request-headers.ts
@@ -12,7 +12,7 @@ import {
   s_getHeadersRequestJson200Response,
   s_getHeadersUndeclaredJson200Response,
 } from "../schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -29,8 +29,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetHeadersUndeclaredResponder = {
   with200(): KoaRuntimeResponse<t_getHeadersUndeclaredJson200Response>
@@ -110,7 +110,7 @@ export function createRequestHeadersRouter(
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getHeadersUndeclaredResponseValidator(status, body)
@@ -164,7 +164,7 @@ export function createRequestHeadersRouter(
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getHeadersRequestResponseValidator(status, body)
@@ -175,5 +175,5 @@ export function createRequestHeadersRouter(
   return router
 }
 
-export { createRequestHeadersRouter as createRouter }
-export type { RequestHeadersImplementation as Implementation }
+export {createRequestHeadersRouter as createRouter}
+export type {RequestHeadersImplementation as Implementation}

--- a/e2e/src/generated/server/koa/routes/validation.ts
+++ b/e2e/src/generated/server/koa/routes/validation.ts
@@ -8,8 +8,8 @@ import {
   t_PostValidationEnumsBodySchema,
   t_RandomNumber,
 } from "../models"
-import { s_Enumerations, s_RandomNumber } from "../schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import {s_Enumerations, s_RandomNumber} from "../schemas"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -26,8 +26,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetValidationNumbersRandomNumberResponder = {
   with200(): KoaRuntimeResponse<t_RandomNumber>
@@ -151,7 +151,7 @@ export function createValidationRouter(
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getValidationNumbersRandomNumberResponseValidator(status, body)
@@ -199,7 +199,7 @@ export function createValidationRouter(
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postValidationEnumsResponseValidator(status, body)
@@ -240,7 +240,7 @@ export function createValidationRouter(
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getResponses500ResponseValidator(status, body)
@@ -281,7 +281,7 @@ export function createValidationRouter(
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getResponsesEmptyResponseValidator(status, body)
@@ -292,5 +292,5 @@ export function createValidationRouter(
   return router
 }
 
-export { createValidationRouter as createRouter }
-export type { ValidationImplementation as Implementation }
+export {createValidationRouter as createRouter}
+export type {ValidationImplementation as Implementation}

--- a/e2e/src/generated/server/koa/schemas.ts
+++ b/e2e/src/generated/server/koa/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { GitHubV3RestApiService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {GitHubV3RestApiService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class GitHubV3RestApiModule {}
 
-export { GitHubV3RestApiModule as ApiModule }
+export {GitHubV3RestApiModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/client.service.ts
@@ -339,14 +339,14 @@ import {
   t_workflow_run_usage,
   t_workflow_usage,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class GitHubV3RestApiServiceServersOperations {
   static reposUploadReleaseAsset(
     url: "https://uploads.github.com" = "https://uploads.github.com",
-  ): { build: () => Server<"reposUploadReleaseAsset_GitHubV3RestApiService"> } {
+  ): {build: () => Server<"reposUploadReleaseAsset_GitHubV3RestApiService">} {
     switch (url) {
       case "https://uploads.github.com":
         return {
@@ -429,7 +429,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -444,7 +444,7 @@ export class GitHubV3RestApiService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -468,7 +468,7 @@ export class GitHubV3RestApiService {
   }
 
   metaRoot(): Observable<
-    (HttpResponse<t_root> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_root> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>("GET", this.config.basePath + `/`, {
       observe: "response",
@@ -509,9 +509,9 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     } = {},
   ): Observable<
-    | (HttpResponse<t_global_advisory[]> & { status: 200 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 429 })
+    | (HttpResponse<t_global_advisory[]> & {status: 200})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -549,8 +549,8 @@ export class GitHubV3RestApiService {
   securityAdvisoriesGetGlobalAdvisory(p: {
     ghsaId: string
   }): Observable<
-    | (HttpResponse<t_global_advisory> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_global_advisory> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -564,7 +564,7 @@ export class GitHubV3RestApiService {
   }
 
   appsGetAuthenticated(): Observable<
-    (HttpResponse<t_integration> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_integration> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>("GET", this.config.basePath + `/app`, {
       observe: "response",
@@ -583,9 +583,9 @@ export class GitHubV3RestApiService {
           webhook_secret: string | null
           [key: string]: unknown | undefined
         }
-      > & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      > & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -599,7 +599,7 @@ export class GitHubV3RestApiService {
   }
 
   appsGetWebhookConfigForApp(): Observable<
-    (HttpResponse<t_webhook_config> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_webhook_config> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -619,9 +619,9 @@ export class GitHubV3RestApiService {
       url?: t_webhook_config_url
     }
   }): Observable<
-    (HttpResponse<t_webhook_config> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_webhook_config> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -642,9 +642,9 @@ export class GitHubV3RestApiService {
       cursor?: string
     } = {},
   ): Observable<
-    | (HttpResponse<t_hook_delivery_item[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook_delivery_item[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -666,9 +666,9 @@ export class GitHubV3RestApiService {
   appsGetWebhookDelivery(p: {
     deliveryId: number
   }): Observable<
-    | (HttpResponse<t_hook_delivery> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook_delivery> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -686,9 +686,9 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -707,15 +707,12 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_integration_installation_request[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<t_integration_installation_request[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -736,7 +733,7 @@ export class GitHubV3RestApiService {
       outdated?: string
     } = {},
   ): Observable<
-    (HttpResponse<t_installation[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_installation[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       per_page: p["perPage"],
@@ -759,8 +756,8 @@ export class GitHubV3RestApiService {
   appsGetInstallation(p: {
     installationId: number
   }): Observable<
-    | (HttpResponse<t_installation> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_installation> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -776,8 +773,8 @@ export class GitHubV3RestApiService {
   appsDeleteInstallation(p: {
     installationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -798,14 +795,14 @@ export class GitHubV3RestApiService {
       repository_ids?: number[]
     }
   }): Observable<
-    | (HttpResponse<t_installation_token> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_installation_token> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -824,8 +821,8 @@ export class GitHubV3RestApiService {
   appsSuspendInstallation(p: {
     installationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -842,8 +839,8 @@ export class GitHubV3RestApiService {
   appsUnsuspendInstallation(p: {
     installationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -863,11 +860,11 @@ export class GitHubV3RestApiService {
       access_token: string
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -888,12 +885,12 @@ export class GitHubV3RestApiService {
       access_token: string
     }
   }): Observable<
-    | (HttpResponse<t_authorization> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_authorization> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -914,11 +911,11 @@ export class GitHubV3RestApiService {
       access_token: string
     }
   }): Observable<
-    | (HttpResponse<t_authorization> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_authorization> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -939,11 +936,11 @@ export class GitHubV3RestApiService {
       access_token: string
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -969,14 +966,14 @@ export class GitHubV3RestApiService {
       target_id?: number
     }
   }): Observable<
-    | (HttpResponse<t_authorization> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_authorization> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -994,9 +991,9 @@ export class GitHubV3RestApiService {
   appsGetBySlug(p: {
     appSlug: string
   }): Observable<
-    | (HttpResponse<t_integration> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_integration> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1012,8 +1009,8 @@ export class GitHubV3RestApiService {
   classroomGetAnAssignment(p: {
     assignmentId: number
   }): Observable<
-    | (HttpResponse<t_classroom_assignment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_classroom_assignment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1031,13 +1028,10 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_classroom_accepted_assignment[]> & { status: 200 })
+    | (HttpResponse<t_classroom_accepted_assignment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -1054,8 +1048,8 @@ export class GitHubV3RestApiService {
   classroomGetAssignmentGrades(p: {
     assignmentId: number
   }): Observable<
-    | (HttpResponse<t_classroom_assignment_grade[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_classroom_assignment_grade[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1074,13 +1068,9 @@ export class GitHubV3RestApiService {
       perPage?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_simple_classroom[]> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_simple_classroom[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -1096,8 +1086,8 @@ export class GitHubV3RestApiService {
   classroomGetAClassroom(p: {
     classroomId: number
   }): Observable<
-    | (HttpResponse<t_classroom> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_classroom> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1115,13 +1105,10 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_simple_classroom_assignment[]> & { status: 200 })
+    | (HttpResponse<t_simple_classroom_assignment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -1135,8 +1122,8 @@ export class GitHubV3RestApiService {
   }
 
   codesOfConductGetAllCodesOfConduct(): Observable<
-    | (HttpResponse<t_code_of_conduct[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_code_of_conduct[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1152,9 +1139,9 @@ export class GitHubV3RestApiService {
   codesOfConductGetConductCode(p: {
     key: string
   }): Observable<
-    | (HttpResponse<t_code_of_conduct> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_of_conduct> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1174,12 +1161,12 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 202})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1197,8 +1184,8 @@ export class GitHubV3RestApiService {
   emojisGet(): Observable<
     | (HttpResponse<{
         [key: string]: string | undefined
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1217,9 +1204,9 @@ export class GitHubV3RestApiService {
     before?: string
     after?: string
   }): Observable<
-    | (HttpResponse<t_code_security_configuration[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_security_configuration[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1323,13 +1310,13 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_code_security_configuration> & { status: 201 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_security_configuration> & {status: 201})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1348,7 +1335,7 @@ export class GitHubV3RestApiService {
   codeSecurityGetDefaultConfigurationsForEnterprise(p: {
     enterprise: string
   }): Observable<
-    | (HttpResponse<t_code_security_default_configurations> & { status: 200 })
+    | (HttpResponse<t_code_security_default_configurations> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1366,10 +1353,10 @@ export class GitHubV3RestApiService {
     enterprise: string
     configurationId: number
   }): Observable<
-    | (HttpResponse<t_code_security_configuration> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_security_configuration> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1467,14 +1454,14 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_code_security_configuration> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_code_security_configuration> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1494,11 +1481,11 @@ export class GitHubV3RestApiService {
     enterprise: string
     configurationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1521,13 +1508,13 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+      }> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1563,12 +1550,12 @@ export class GitHubV3RestApiService {
           | "private_and_internal"
           | "public"
           | UnknownEnumStringValue
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1595,8 +1582,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<t_code_security_configuration_repositories[]> & {
         status: 200
       })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1635,11 +1622,11 @@ export class GitHubV3RestApiService {
     last?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_dependabot_alert_with_repository[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_dependabot_alert_with_repository[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1686,13 +1673,13 @@ export class GitHubV3RestApiService {
     isMultiRepo?: boolean
     hideSecret?: boolean
   }): Observable<
-    | (HttpResponse<t_organization_secret_scanning_alert[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_organization_secret_scanning_alert[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1728,20 +1715,17 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_event[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_event[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -1755,7 +1739,7 @@ export class GitHubV3RestApiService {
   }
 
   activityGetFeeds(): Observable<
-    (HttpResponse<t_feed> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_feed> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -1774,9 +1758,9 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_base_gist[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_base_gist[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1809,14 +1793,14 @@ export class GitHubV3RestApiService {
       public?: boolean | "true" | "false" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_gist_simple> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_gist_simple> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1838,10 +1822,10 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_base_gist[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_base_gist[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1868,10 +1852,10 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_base_gist[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_base_gist[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1894,8 +1878,8 @@ export class GitHubV3RestApiService {
   gistsGet(p: {
     gistId: string
   }): Observable<
-    | (HttpResponse<t_gist_simple> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_gist_simple> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | (HttpResponse<{
         block?: {
           created_at?: string
@@ -1904,8 +1888,8 @@ export class GitHubV3RestApiService {
         }
         documentation_url?: string
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1932,12 +1916,12 @@ export class GitHubV3RestApiService {
       }
     } | null
   }): Observable<
-    | (HttpResponse<t_gist_simple> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_gist_simple> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1955,10 +1939,10 @@ export class GitHubV3RestApiService {
   gistsDelete(p: {
     gistId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1976,16 +1960,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_gist_comment[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gist_comment[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2004,13 +1985,13 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_gist_comment> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gist_comment> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2029,8 +2010,8 @@ export class GitHubV3RestApiService {
     gistId: string
     commentId: number
   }): Observable<
-    | (HttpResponse<t_gist_comment> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_gist_comment> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | (HttpResponse<{
         block?: {
           created_at?: string
@@ -2039,8 +2020,8 @@ export class GitHubV3RestApiService {
         }
         documentation_url?: string
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2060,11 +2041,11 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_gist_comment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gist_comment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2083,10 +2064,10 @@ export class GitHubV3RestApiService {
     gistId: string
     commentId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2104,16 +2085,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_gist_commit[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gist_commit[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2131,16 +2109,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_gist_simple[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gist_simple[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2156,11 +2131,11 @@ export class GitHubV3RestApiService {
   gistsFork(p: {
     gistId: string
   }): Observable<
-    | (HttpResponse<t_base_gist> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_base_gist> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2176,10 +2151,10 @@ export class GitHubV3RestApiService {
   gistsCheckIsStarred(p: {
     gistId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<EmptyObject> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<EmptyObject> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2195,10 +2170,10 @@ export class GitHubV3RestApiService {
   gistsStar(p: {
     gistId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2214,10 +2189,10 @@ export class GitHubV3RestApiService {
   gistsUnstar(p: {
     gistId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2234,10 +2209,10 @@ export class GitHubV3RestApiService {
     gistId: string
     sha: string
   }): Observable<
-    | (HttpResponse<t_gist_simple> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_gist_simple> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2251,8 +2226,8 @@ export class GitHubV3RestApiService {
   }
 
   gitignoreGetAllTemplates(): Observable<
-    | (HttpResponse<string[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<string[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2268,8 +2243,8 @@ export class GitHubV3RestApiService {
   gitignoreGetTemplate(p: {
     name: string
   }): Observable<
-    | (HttpResponse<t_gitignore_template> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_gitignore_template> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2292,16 +2267,13 @@ export class GitHubV3RestApiService {
         repositories: t_repository[]
         repository_selection?: string
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2315,7 +2287,7 @@ export class GitHubV3RestApiService {
   }
 
   appsRevokeInstallationAccessToken(): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
+    (HttpResponse<void> & {status: 204}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "DELETE",
@@ -2350,10 +2322,10 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_issue[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -2389,8 +2361,8 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_license_simple[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_license_simple[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -2413,10 +2385,10 @@ export class GitHubV3RestApiService {
   licensesGet(p: {
     license: string
   }): Observable<
-    | (HttpResponse<t_license> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_license> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2436,11 +2408,11 @@ export class GitHubV3RestApiService {
       text: string
     }
   }): Observable<
-    | (HttpResponse<string> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<string> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2460,11 +2432,11 @@ export class GitHubV3RestApiService {
       requestBody?: string
     } = {},
   ): Observable<
-    | (HttpResponse<string> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<string> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "text/plain" })
+    const headers = this._headers({"Content-Type": "text/plain"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2482,9 +2454,9 @@ export class GitHubV3RestApiService {
   appsGetSubscriptionPlanForAccount(p: {
     accountId: number
   }): Observable<
-    | (HttpResponse<t_marketplace_purchase> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_marketplace_purchase> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2503,15 +2475,12 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_marketplace_listing_plan[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_marketplace_listing_plan[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2531,10 +2500,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_marketplace_purchase[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_marketplace_purchase[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -2559,9 +2528,9 @@ export class GitHubV3RestApiService {
   appsGetSubscriptionPlanForAccountStubbed(p: {
     accountId: number
   }): Observable<
-    | (HttpResponse<t_marketplace_purchase> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_marketplace_purchase> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2581,14 +2550,11 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_marketplace_listing_plan[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<t_marketplace_listing_plan[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2608,8 +2574,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_marketplace_purchase[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<t_marketplace_purchase[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -2632,8 +2598,8 @@ export class GitHubV3RestApiService {
   }
 
   metaGet(): Observable<
-    | (HttpResponse<t_api_overview> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_api_overview> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>("GET", this.config.basePath + `/meta`, {
@@ -2648,17 +2614,14 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_event[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_event[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2681,11 +2644,11 @@ export class GitHubV3RestApiService {
       perPage?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_thread[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_thread[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -2718,14 +2681,14 @@ export class GitHubV3RestApiService {
   ): Observable<
     | (HttpResponse<{
         message?: string
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 205 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 205})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2743,10 +2706,10 @@ export class GitHubV3RestApiService {
   activityGetThread(p: {
     threadId: number
   }): Observable<
-    | (HttpResponse<t_thread> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_thread> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2762,9 +2725,9 @@ export class GitHubV3RestApiService {
   activityMarkThreadAsRead(p: {
     threadId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 205 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 205})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2779,9 +2742,7 @@ export class GitHubV3RestApiService {
 
   activityMarkThreadAsDone(p: {
     threadId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/notifications/threads/${p["threadId"]}`,
@@ -2795,10 +2756,10 @@ export class GitHubV3RestApiService {
   activityGetThreadSubscriptionForAuthenticatedUser(p: {
     threadId: number
   }): Observable<
-    | (HttpResponse<t_thread_subscription> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_thread_subscription> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2818,13 +2779,13 @@ export class GitHubV3RestApiService {
       ignored?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_thread_subscription> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_thread_subscription> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2843,10 +2804,10 @@ export class GitHubV3RestApiService {
   activityDeleteThreadSubscription(p: {
     threadId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -2865,9 +2826,9 @@ export class GitHubV3RestApiService {
       s?: string
     } = {},
   ): Observable<
-    (HttpResponse<string> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<string> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ s: p["s"] })
+    const params = this._queryParams({s: p["s"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2886,8 +2847,8 @@ export class GitHubV3RestApiService {
       perPage?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_organization_simple[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_organization_simple[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -2911,15 +2872,12 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_dependabot_repository_access_details> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_dependabot_repository_access_details> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -2940,12 +2898,12 @@ export class GitHubV3RestApiService {
       repository_ids_to_remove?: number[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2967,12 +2925,12 @@ export class GitHubV3RestApiService {
       default_level: "public" | "internal" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2995,15 +2953,15 @@ export class GitHubV3RestApiService {
     day?: number
     hour?: number
   }): Observable<
-    | (HttpResponse<t_billing_usage_report> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_billing_usage_report> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -3028,8 +2986,8 @@ export class GitHubV3RestApiService {
   orgsGet(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_organization_full> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_organization_full> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3086,14 +3044,14 @@ export class GitHubV3RestApiService {
       web_commit_signoff_required?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_organization_full> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_organization_full> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | (HttpResponse<t_validation_error | t_validation_error_simple> & {
         status: 422
       })
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3113,9 +3071,9 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3131,7 +3089,7 @@ export class GitHubV3RestApiService {
   actionsGetActionsCacheUsageForOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_actions_cache_usage_org_enterprise> & { status: 200 })
+    | (HttpResponse<t_actions_cache_usage_org_enterprise> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3152,13 +3110,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repository_cache_usages: t_actions_cache_usage_by_repository[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -3180,13 +3135,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         runners: t_actions_hosted_runner[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -3213,10 +3165,10 @@ export class GitHubV3RestApiService {
       size: string
     }
   }): Observable<
-    | (HttpResponse<t_actions_hosted_runner> & { status: 201 })
+    | (HttpResponse<t_actions_hosted_runner> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3237,7 +3189,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         images: t_actions_hosted_runner_image[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3257,7 +3209,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         images: t_actions_hosted_runner_image[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3274,7 +3226,7 @@ export class GitHubV3RestApiService {
   actionsGetHostedRunnersLimitsForOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_actions_hosted_runner_limits> & { status: 200 })
+    | (HttpResponse<t_actions_hosted_runner_limits> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3293,7 +3245,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         machine_specs: t_actions_hosted_runner_machine_spec[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3313,7 +3265,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         platforms: string[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3331,7 +3283,7 @@ export class GitHubV3RestApiService {
     org: string
     hostedRunnerId: number
   }): Observable<
-    | (HttpResponse<t_actions_hosted_runner> & { status: 200 })
+    | (HttpResponse<t_actions_hosted_runner> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3355,10 +3307,10 @@ export class GitHubV3RestApiService {
       runner_group_id?: number
     }
   }): Observable<
-    | (HttpResponse<t_actions_hosted_runner> & { status: 200 })
+    | (HttpResponse<t_actions_hosted_runner> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3378,7 +3330,7 @@ export class GitHubV3RestApiService {
     org: string
     hostedRunnerId: number
   }): Observable<
-    | (HttpResponse<t_actions_hosted_runner> & { status: 202 })
+    | (HttpResponse<t_actions_hosted_runner> & {status: 202})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3395,7 +3347,7 @@ export class GitHubV3RestApiService {
   oidcGetOidcCustomSubTemplateForOrg(p: {
     org: string
   }): Observable<
-    (HttpResponse<t_oidc_custom_sub> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_oidc_custom_sub> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -3411,12 +3363,12 @@ export class GitHubV3RestApiService {
     org: string
     requestBody: t_oidc_custom_sub
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3434,7 +3386,7 @@ export class GitHubV3RestApiService {
   actionsGetGithubActionsPermissionsOrganization(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_actions_organization_permissions> & { status: 200 })
+    | (HttpResponse<t_actions_organization_permissions> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3453,10 +3405,8 @@ export class GitHubV3RestApiService {
       allowed_actions?: t_allowed_actions
       enabled_repositories: t_enabled_repositories
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3479,13 +3429,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_repository[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -3504,10 +3451,8 @@ export class GitHubV3RestApiService {
     requestBody: {
       selected_repository_ids: number[]
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3526,9 +3471,7 @@ export class GitHubV3RestApiService {
   actionsEnableSelectedRepositoryGithubActionsOrganization(p: {
     org: string
     repositoryId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -3543,9 +3486,7 @@ export class GitHubV3RestApiService {
   actionsDisableSelectedRepositoryGithubActionsOrganization(p: {
     org: string
     repositoryId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -3560,7 +3501,7 @@ export class GitHubV3RestApiService {
   actionsGetAllowedActionsOrganization(p: {
     org: string
   }): Observable<
-    (HttpResponse<t_selected_actions> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_selected_actions> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -3576,10 +3517,8 @@ export class GitHubV3RestApiService {
   actionsSetAllowedActionsOrganization(p: {
     org: string
     requestBody?: t_selected_actions
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3598,9 +3537,7 @@ export class GitHubV3RestApiService {
   actionsGetGithubActionsDefaultWorkflowPermissionsOrganization(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_actions_get_default_workflow_permissions> & {
-        status: 200
-      })
+    | (HttpResponse<t_actions_get_default_workflow_permissions> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -3616,10 +3553,8 @@ export class GitHubV3RestApiService {
   actionsSetGithubActionsDefaultWorkflowPermissionsOrganization(p: {
     org: string
     requestBody?: t_actions_set_default_workflow_permissions
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3643,7 +3578,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         runner_groups: t_runner_groups_org[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -3676,10 +3611,9 @@ export class GitHubV3RestApiService {
       visibility?: "selected" | "all" | "private" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_runner_groups_org> & { status: 201 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_runner_groups_org> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3698,8 +3632,7 @@ export class GitHubV3RestApiService {
     org: string
     runnerGroupId: number
   }): Observable<
-    | (HttpResponse<t_runner_groups_org> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_runner_groups_org> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -3724,10 +3657,9 @@ export class GitHubV3RestApiService {
       visibility?: "selected" | "all" | "private" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_runner_groups_org> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_runner_groups_org> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3746,9 +3678,7 @@ export class GitHubV3RestApiService {
   actionsDeleteSelfHostedRunnerGroupFromOrg(p: {
     org: string
     runnerGroupId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -3769,13 +3699,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         runners: t_actions_hosted_runner[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -3798,13 +3725,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_minimal_repository[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -3824,10 +3748,8 @@ export class GitHubV3RestApiService {
     requestBody: {
       selected_repository_ids: number[]
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3847,9 +3769,7 @@ export class GitHubV3RestApiService {
     org: string
     runnerGroupId: number
     repositoryId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -3865,9 +3785,7 @@ export class GitHubV3RestApiService {
     org: string
     runnerGroupId: number
     repositoryId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -3888,13 +3806,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         runners: t_runner[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -3914,10 +3829,8 @@ export class GitHubV3RestApiService {
     requestBody: {
       runners: number[]
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3937,9 +3850,7 @@ export class GitHubV3RestApiService {
     org: string
     runnerGroupId: number
     runnerId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -3955,9 +3866,7 @@ export class GitHubV3RestApiService {
     org: string
     runnerGroupId: number
     runnerId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -3978,7 +3887,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         runners: t_runner[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -4001,7 +3910,7 @@ export class GitHubV3RestApiService {
   actionsListRunnerApplicationsForOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_runner_application[]> & { status: 200 })
+    | (HttpResponse<t_runner_application[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4026,13 +3935,13 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         encoded_jit_config: string
         runner: t_runner
-      }> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4051,7 +3960,7 @@ export class GitHubV3RestApiService {
   actionsCreateRegistrationTokenForOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_authentication_token> & { status: 201 })
+    | (HttpResponse<t_authentication_token> & {status: 201})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4068,7 +3977,7 @@ export class GitHubV3RestApiService {
   actionsCreateRemoveTokenForOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_authentication_token> & { status: 201 })
+    | (HttpResponse<t_authentication_token> & {status: 201})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4085,7 +3994,7 @@ export class GitHubV3RestApiService {
     org: string
     runnerId: number
   }): Observable<
-    (HttpResponse<t_runner> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_runner> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -4102,8 +4011,8 @@ export class GitHubV3RestApiService {
     org: string
     runnerId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4124,8 +4033,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4149,12 +4058,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4180,12 +4089,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4208,8 +4117,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4231,9 +4140,9 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4255,13 +4164,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_organization_actions_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -4277,8 +4183,7 @@ export class GitHubV3RestApiService {
   actionsGetOrgPublicKey(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_actions_public_key> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_actions_public_key> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -4294,7 +4199,7 @@ export class GitHubV3RestApiService {
     org: string
     secretName: string
   }): Observable<
-    | (HttpResponse<t_organization_actions_secret> & { status: 200 })
+    | (HttpResponse<t_organization_actions_secret> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4318,11 +4223,11 @@ export class GitHubV3RestApiService {
       visibility: "all" | "private" | "selected" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4341,9 +4246,7 @@ export class GitHubV3RestApiService {
   actionsDeleteOrgSecret(p: {
     org: string
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -4364,13 +4267,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_minimal_repository[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -4390,10 +4290,8 @@ export class GitHubV3RestApiService {
     requestBody: {
       selected_repository_ids: number[]
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4414,8 +4312,8 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4434,8 +4332,8 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4457,13 +4355,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         variables: t_organization_actions_variable[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -4485,9 +4380,9 @@ export class GitHubV3RestApiService {
       visibility: "all" | "private" | "selected" | UnknownEnumStringValue
     }
   }): Observable<
-    (HttpResponse<t_empty_object> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_empty_object> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4506,7 +4401,7 @@ export class GitHubV3RestApiService {
     org: string
     name: string
   }): Observable<
-    | (HttpResponse<t_organization_actions_variable> & { status: 200 })
+    | (HttpResponse<t_organization_actions_variable> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4528,10 +4423,8 @@ export class GitHubV3RestApiService {
       value?: string
       visibility?: "all" | "private" | "selected" | UnknownEnumStringValue
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4549,9 +4442,7 @@ export class GitHubV3RestApiService {
   actionsDeleteOrgVariable(p: {
     org: string
     name: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/orgs/${p["org"]}/actions/variables/${p["name"]}`,
@@ -4571,14 +4462,11 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_minimal_repository[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 409 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -4599,11 +4487,11 @@ export class GitHubV3RestApiService {
       selected_repository_ids: number[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4624,8 +4512,8 @@ export class GitHubV3RestApiService {
     name: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4644,8 +4532,8 @@ export class GitHubV3RestApiService {
     name: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4696,10 +4584,10 @@ export class GitHubV3RestApiService {
           next?: string
           previous?: string
         }
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const params = this._queryParams({
       per_page: p["perPage"],
       before: p["before"],
@@ -4730,11 +4618,11 @@ export class GitHubV3RestApiService {
           attestation_ids: number[]
         }
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4753,9 +4641,9 @@ export class GitHubV3RestApiService {
     org: string
     subjectDigest: string
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4773,10 +4661,10 @@ export class GitHubV3RestApiService {
     org: string
     attestationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4812,7 +4700,7 @@ export class GitHubV3RestApiService {
           bundle_url?: string
           repository_id?: number
         }[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -4839,12 +4727,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -4861,8 +4746,8 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4879,8 +4764,8 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -4896,9 +4781,7 @@ export class GitHubV3RestApiService {
   orgsUnblockUser(p: {
     org: string
     username: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`,
@@ -4922,13 +4805,13 @@ export class GitHubV3RestApiService {
       | "published"
       | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_campaign_summary[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_campaign_summary[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -4966,19 +4849,19 @@ export class GitHubV3RestApiService {
       team_managers?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_campaign_summary> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
-    | (HttpResponse<void> & { status: 429 })
+    | (HttpResponse<t_campaign_summary> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
+    | (HttpResponse<void> & {status: 429})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4997,14 +4880,14 @@ export class GitHubV3RestApiService {
     org: string
     campaignNumber: number
   }): Observable<
-    | (HttpResponse<t_campaign_summary> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+    | (HttpResponse<t_campaign_summary> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5031,18 +4914,18 @@ export class GitHubV3RestApiService {
       team_managers?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_campaign_summary> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+    | (HttpResponse<t_campaign_summary> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5062,13 +4945,13 @@ export class GitHubV3RestApiService {
     org: string
     campaignNumber: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5095,15 +4978,13 @@ export class GitHubV3RestApiService {
     sort?: "created" | "updated" | UnknownEnumStringValue
     severity?: t_code_scanning_alert_severity
   }): Observable<
-    | (HttpResponse<t_code_scanning_organization_alert_items[]> & {
-        status: 200
-      })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_organization_alert_items[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -5137,9 +5018,9 @@ export class GitHubV3RestApiService {
     before?: string
     after?: string
   }): Observable<
-    | (HttpResponse<t_code_security_configuration[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_security_configuration[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -5254,10 +5135,10 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_code_security_configuration> & { status: 201 })
+    | (HttpResponse<t_code_security_configuration> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5275,10 +5156,10 @@ export class GitHubV3RestApiService {
   codeSecurityGetDefaultConfigurations(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_code_security_default_configurations> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_security_default_configurations> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5298,14 +5179,14 @@ export class GitHubV3RestApiService {
       selected_repository_ids?: number[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5325,10 +5206,10 @@ export class GitHubV3RestApiService {
     org: string
     configurationId: number
   }): Observable<
-    | (HttpResponse<t_code_security_configuration> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_security_configuration> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5437,11 +5318,11 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_code_security_configuration> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_code_security_configuration> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5461,11 +5342,11 @@ export class GitHubV3RestApiService {
     org: string
     configurationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5495,10 +5376,10 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
+      }> & {status: 202})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5534,12 +5415,12 @@ export class GitHubV3RestApiService {
           | "private_and_internal"
           | "public"
           | UnknownEnumStringValue
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5566,8 +5447,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<t_code_security_configuration_repositories[]> & {
         status: 200
       })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -5597,18 +5478,15 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         codespaces: t_codespace[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -5633,15 +5511,15 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5662,15 +5540,15 @@ export class GitHubV3RestApiService {
       selected_usernames: string[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5692,15 +5570,15 @@ export class GitHubV3RestApiService {
       selected_usernames: string[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5724,13 +5602,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_codespaces_org_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -5746,7 +5621,7 @@ export class GitHubV3RestApiService {
   codespacesGetOrgPublicKey(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_codespaces_public_key> & { status: 200 })
+    | (HttpResponse<t_codespaces_public_key> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5763,7 +5638,7 @@ export class GitHubV3RestApiService {
     org: string
     secretName: string
   }): Observable<
-    | (HttpResponse<t_codespaces_org_secret> & { status: 200 })
+    | (HttpResponse<t_codespaces_org_secret> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5787,13 +5662,13 @@ export class GitHubV3RestApiService {
       visibility: "all" | "private" | "selected" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5813,8 +5688,8 @@ export class GitHubV3RestApiService {
     org: string
     secretName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5837,14 +5712,11 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_minimal_repository[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -5865,12 +5737,12 @@ export class GitHubV3RestApiService {
       selected_repository_ids: number[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5891,10 +5763,10 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5913,10 +5785,10 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5933,12 +5805,12 @@ export class GitHubV3RestApiService {
   copilotGetCopilotOrganizationDetails(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_copilot_organization_details> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_copilot_organization_details> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -5959,17 +5831,14 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         seats?: t_copilot_seat_details[]
         total_seats?: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -5990,15 +5859,15 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         seats_created: number
-      }> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6021,15 +5890,15 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         seats_cancelled: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6052,15 +5921,15 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         seats_created: number
-      }> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6083,15 +5952,15 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         seats_cancelled: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6113,11 +5982,11 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_copilot_usage_metrics_day[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_copilot_usage_metrics_day[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6155,12 +6024,12 @@ export class GitHubV3RestApiService {
     last?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_dependabot_alert_with_repository[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_dependabot_alert_with_repository[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6199,13 +6068,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_organization_dependabot_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -6221,7 +6087,7 @@ export class GitHubV3RestApiService {
   dependabotGetOrgPublicKey(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_dependabot_public_key> & { status: 200 })
+    | (HttpResponse<t_dependabot_public_key> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6238,7 +6104,7 @@ export class GitHubV3RestApiService {
     org: string
     secretName: string
   }): Observable<
-    | (HttpResponse<t_organization_dependabot_secret> & { status: 200 })
+    | (HttpResponse<t_organization_dependabot_secret> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6262,11 +6128,11 @@ export class GitHubV3RestApiService {
       visibility: "all" | "private" | "selected" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6285,9 +6151,7 @@ export class GitHubV3RestApiService {
   dependabotDeleteOrgSecret(p: {
     org: string
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -6308,13 +6172,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_minimal_repository[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -6334,10 +6195,8 @@ export class GitHubV3RestApiService {
     requestBody: {
       selected_repository_ids: number[]
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6358,8 +6217,8 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6378,8 +6237,8 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6396,9 +6255,9 @@ export class GitHubV3RestApiService {
   packagesListDockerMigrationConflictingPackagesForOrganization(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_package[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_package[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6416,12 +6275,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -6439,14 +6295,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_organization_invitation[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_organization_invitation[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -6464,14 +6317,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_org_hook[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_org_hook[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -6500,12 +6350,12 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_org_hook> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_org_hook> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6524,8 +6374,8 @@ export class GitHubV3RestApiService {
     org: string
     hookId: number
   }): Observable<
-    | (HttpResponse<t_org_hook> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_org_hook> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6553,12 +6403,12 @@ export class GitHubV3RestApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_org_hook> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_org_hook> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6577,8 +6427,8 @@ export class GitHubV3RestApiService {
     org: string
     hookId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6595,7 +6445,7 @@ export class GitHubV3RestApiService {
     org: string
     hookId: number
   }): Observable<
-    (HttpResponse<t_webhook_config> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_webhook_config> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -6617,9 +6467,9 @@ export class GitHubV3RestApiService {
       url?: t_webhook_config_url
     }
   }): Observable<
-    (HttpResponse<t_webhook_config> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_webhook_config> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -6640,9 +6490,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     cursor?: string
   }): Observable<
-    | (HttpResponse<t_hook_delivery_item[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook_delivery_item[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6667,9 +6517,9 @@ export class GitHubV3RestApiService {
     hookId: number
     deliveryId: number
   }): Observable<
-    | (HttpResponse<t_hook_delivery> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook_delivery> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6690,9 +6540,9 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6710,8 +6560,8 @@ export class GitHubV3RestApiService {
     org: string
     hookId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -6750,7 +6600,7 @@ export class GitHubV3RestApiService {
     )[]
     apiRouteSubstring?: string
   }): Observable<
-    | (HttpResponse<t_api_insights_route_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_route_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6792,7 +6642,7 @@ export class GitHubV3RestApiService {
     )[]
     subjectNameSubstring?: string
   }): Observable<
-    | (HttpResponse<t_api_insights_subject_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_subject_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6821,7 +6671,7 @@ export class GitHubV3RestApiService {
     minTimestamp: string
     maxTimestamp?: string
   }): Observable<
-    | (HttpResponse<t_api_insights_summary_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_summary_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6846,7 +6696,7 @@ export class GitHubV3RestApiService {
     minTimestamp: string
     maxTimestamp?: string
   }): Observable<
-    | (HttpResponse<t_api_insights_summary_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_summary_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6879,7 +6729,7 @@ export class GitHubV3RestApiService {
       | UnknownEnumStringValue
     actorId: number
   }): Observable<
-    | (HttpResponse<t_api_insights_summary_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_summary_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6905,7 +6755,7 @@ export class GitHubV3RestApiService {
     maxTimestamp?: string
     timestampIncrement: string
   }): Observable<
-    | (HttpResponse<t_api_insights_time_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_time_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6932,7 +6782,7 @@ export class GitHubV3RestApiService {
     maxTimestamp?: string
     timestampIncrement: string
   }): Observable<
-    | (HttpResponse<t_api_insights_time_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_time_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -6967,7 +6817,7 @@ export class GitHubV3RestApiService {
     maxTimestamp?: string
     timestampIncrement: string
   }): Observable<
-    | (HttpResponse<t_api_insights_time_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_time_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -7006,7 +6856,7 @@ export class GitHubV3RestApiService {
     )[]
     actorNameSubstring?: string
   }): Observable<
-    | (HttpResponse<t_api_insights_user_stats> & { status: 200 })
+    | (HttpResponse<t_api_insights_user_stats> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -7034,7 +6884,7 @@ export class GitHubV3RestApiService {
   appsGetOrgInstallation(p: {
     org: string
   }): Observable<
-    (HttpResponse<t_installation> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_installation> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -7054,13 +6904,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         installations: t_installation[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7076,9 +6923,7 @@ export class GitHubV3RestApiService {
   interactionsGetRestrictionsForOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_interaction_limit_response | EmptyObject> & {
-        status: 200
-      })
+    | (HttpResponse<t_interaction_limit_response | EmptyObject> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7095,11 +6940,11 @@ export class GitHubV3RestApiService {
     org: string
     requestBody: t_interaction_limit
   }): Observable<
-    | (HttpResponse<t_interaction_limit_response> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_interaction_limit_response> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7116,9 +6961,7 @@ export class GitHubV3RestApiService {
 
   interactionsRemoveRestrictionsForOrg(p: {
     org: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/orgs/${p["org"]}/interaction-limits`,
@@ -7142,8 +6985,8 @@ export class GitHubV3RestApiService {
       | UnknownEnumStringValue
     invitationSource?: "all" | "member" | "scim" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_organization_invitation[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_organization_invitation[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -7178,12 +7021,12 @@ export class GitHubV3RestApiService {
       team_ids?: number[]
     }
   }): Observable<
-    | (HttpResponse<t_organization_invitation> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_organization_invitation> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7202,9 +7045,9 @@ export class GitHubV3RestApiService {
     org: string
     invitationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7224,14 +7067,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7248,8 +7088,8 @@ export class GitHubV3RestApiService {
   orgsListIssueTypes(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_issue_type[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_issue_type[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7266,12 +7106,12 @@ export class GitHubV3RestApiService {
     org: string
     requestBody: t_organization_create_issue_type
   }): Observable<
-    | (HttpResponse<t_issue_type> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_issue_type> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7291,12 +7131,12 @@ export class GitHubV3RestApiService {
     issueTypeId: number
     requestBody: t_organization_update_issue_type
   }): Observable<
-    | (HttpResponse<t_issue_type> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_issue_type> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7316,9 +7156,9 @@ export class GitHubV3RestApiService {
     org: string
     issueTypeId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7351,8 +7191,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_issue[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -7385,8 +7225,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -7411,9 +7251,9 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7430,8 +7270,8 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7453,18 +7293,15 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         codespaces: t_codespace[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7485,12 +7322,12 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7509,12 +7346,12 @@ export class GitHubV3RestApiService {
     username: string
     codespaceName: string
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_codespace> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7532,12 +7369,12 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<t_copilot_seat_details> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_copilot_seat_details> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7555,9 +7392,9 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<t_org_membership> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_org_membership> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7577,12 +7414,12 @@ export class GitHubV3RestApiService {
       role?: "admin" | "member" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_org_membership> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_org_membership> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7601,9 +7438,9 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7622,7 +7459,7 @@ export class GitHubV3RestApiService {
     page?: number
     exclude?: ("repositories" | UnknownEnumStringValue)[]
   }): Observable<
-    (HttpResponse<t_migration[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_migration[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       per_page: p["perPage"],
@@ -7655,12 +7492,12 @@ export class GitHubV3RestApiService {
       repositories: string[]
     }
   }): Observable<
-    | (HttpResponse<t_migration> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_migration> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7680,11 +7517,11 @@ export class GitHubV3RestApiService {
     migrationId: number
     exclude?: ("repositories" | UnknownEnumStringValue)[]
   }): Observable<
-    | (HttpResponse<t_migration> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_migration> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ exclude: p["exclude"] })
+    const params = this._queryParams({exclude: p["exclude"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7701,8 +7538,8 @@ export class GitHubV3RestApiService {
     org: string
     migrationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7720,8 +7557,8 @@ export class GitHubV3RestApiService {
     org: string
     migrationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7740,8 +7577,8 @@ export class GitHubV3RestApiService {
     migrationId: number
     repoName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7761,14 +7598,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7788,9 +7622,9 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         roles?: t_organization_role[]
         total_count?: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7806,9 +7640,7 @@ export class GitHubV3RestApiService {
   orgsRevokeAllOrgRolesTeam(p: {
     org: string
     teamSlug: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -7825,9 +7657,9 @@ export class GitHubV3RestApiService {
     teamSlug: string
     roleId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7845,9 +7677,7 @@ export class GitHubV3RestApiService {
     org: string
     teamSlug: string
     roleId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -7862,9 +7692,7 @@ export class GitHubV3RestApiService {
   orgsRevokeAllOrgRolesUser(p: {
     org: string
     username: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -7881,9 +7709,9 @@ export class GitHubV3RestApiService {
     username: string
     roleId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7901,9 +7729,7 @@ export class GitHubV3RestApiService {
     org: string
     username: string
     roleId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -7919,9 +7745,9 @@ export class GitHubV3RestApiService {
     org: string
     roleId: number
   }): Observable<
-    | (HttpResponse<t_organization_role> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_organization_role> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -7941,15 +7767,12 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team_role_assignment[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_team_role_assignment[]> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7969,15 +7792,12 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_user_role_assignment[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_user_role_assignment[]> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -7997,7 +7817,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       filter: p["filter"],
@@ -8023,13 +7843,13 @@ export class GitHubV3RestApiService {
       async?: boolean
     }
   }): Observable<
-    | (HttpResponse<EmptyObject> & { status: 202 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<EmptyObject> & {status: 202})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8049,11 +7869,11 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<void> & {status: 204})
     | (HttpResponse<{
         documentation_url?: string
         message?: string
-      }> & { status: 422 })
+      }> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8081,10 +7901,10 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_package[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_package[]> & {status: 200})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -8117,7 +7937,7 @@ export class GitHubV3RestApiService {
     packageName: string
     org: string
   }): Observable<
-    (HttpResponse<t_package> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -8142,10 +7962,10 @@ export class GitHubV3RestApiService {
     packageName: string
     org: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8172,13 +7992,13 @@ export class GitHubV3RestApiService {
     org: string
     token?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ token: p["token"] })
+    const params = this._queryParams({token: p["token"]})
 
     return this.httpClient.request<any>(
       "POST",
@@ -8207,10 +8027,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     state?: "active" | "deleted" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_package_version[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_package_version[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -8244,7 +8064,7 @@ export class GitHubV3RestApiService {
     org: string
     packageVersionId: number
   }): Observable<
-    (HttpResponse<t_package_version> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package_version> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -8270,10 +8090,10 @@ export class GitHubV3RestApiService {
     org: string
     packageVersionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8300,10 +8120,10 @@ export class GitHubV3RestApiService {
     org: string
     packageVersionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8333,10 +8153,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<t_organization_programmatic_access_grant_request[]> & {
         status: 200
       })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -8373,14 +8193,14 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8403,14 +8223,14 @@ export class GitHubV3RestApiService {
       reason?: string | null
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8432,16 +8252,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -8468,13 +8285,11 @@ export class GitHubV3RestApiService {
     lastUsedAfter?: string
     tokenId?: string[]
   }): Observable<
-    | (HttpResponse<t_organization_programmatic_access_grant[]> & {
-        status: 200
-      })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_organization_programmatic_access_grant[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -8510,14 +8325,14 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8539,14 +8354,14 @@ export class GitHubV3RestApiService {
       action: "revoke" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8568,16 +8383,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -8599,15 +8411,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         configurations: t_org_private_registry_configuration[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -8639,11 +8448,11 @@ export class GitHubV3RestApiService {
     | (HttpResponse<t_org_private_registry_configuration_with_selected_repositories> & {
         status: 201
       })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8664,8 +8473,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         key: string
         key_id: string
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8682,8 +8491,8 @@ export class GitHubV3RestApiService {
     org: string
     secretName: string
   }): Observable<
-    | (HttpResponse<t_org_private_registry_configuration> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_org_private_registry_configuration> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8714,12 +8523,12 @@ export class GitHubV3RestApiService {
       visibility?: "all" | "private" | "selected" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8739,9 +8548,9 @@ export class GitHubV3RestApiService {
     org: string
     secretName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8761,8 +8570,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_project[]> & { status: 200 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project[]> & {status: 200})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -8789,15 +8598,15 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_project> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8815,9 +8624,9 @@ export class GitHubV3RestApiService {
   orgsGetAllCustomProperties(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_custom_property[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_custom_property[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8836,12 +8645,12 @@ export class GitHubV3RestApiService {
       properties: t_custom_property[]
     }
   }): Observable<
-    | (HttpResponse<t_custom_property[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_custom_property[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8860,9 +8669,9 @@ export class GitHubV3RestApiService {
     org: string
     customPropertyName: string
   }): Observable<
-    | (HttpResponse<t_custom_property> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_custom_property> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8881,12 +8690,12 @@ export class GitHubV3RestApiService {
     customPropertyName: string
     requestBody: t_custom_property_set_payload
   }): Observable<
-    | (HttpResponse<t_custom_property> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_custom_property> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8906,9 +8715,9 @@ export class GitHubV3RestApiService {
     org: string
     customPropertyName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -8928,9 +8737,9 @@ export class GitHubV3RestApiService {
     page?: number
     repositoryQuery?: string
   }): Observable<
-    | (HttpResponse<t_org_repo_custom_property_values[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_org_repo_custom_property_values[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -8957,13 +8766,13 @@ export class GitHubV3RestApiService {
       repository_names: string[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8983,12 +8792,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -9005,8 +8811,8 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9024,8 +8830,8 @@ export class GitHubV3RestApiService {
     org: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9042,9 +8848,7 @@ export class GitHubV3RestApiService {
   orgsRemovePublicMembershipForAuthenticatedUser(p: {
     org: string
     username: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -9076,7 +8880,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -9141,12 +8945,12 @@ export class GitHubV3RestApiService {
       visibility?: "public" | "private" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_full_repository> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_full_repository> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9167,9 +8971,9 @@ export class GitHubV3RestApiService {
     page?: number
     targets?: string
   }): Observable<
-    | (HttpResponse<t_repository_ruleset[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -9200,12 +9004,12 @@ export class GitHubV3RestApiService {
       target?: "branch" | "tag" | "push" | "repository" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_repository_ruleset> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9235,9 +9039,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_rule_suites> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_rule_suites> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -9265,9 +9069,9 @@ export class GitHubV3RestApiService {
     org: string
     ruleSuiteId: number
   }): Observable<
-    | (HttpResponse<t_rule_suite> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_rule_suite> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9285,9 +9089,9 @@ export class GitHubV3RestApiService {
     org: string
     rulesetId: number
   }): Observable<
-    | (HttpResponse<t_repository_ruleset> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9312,12 +9116,12 @@ export class GitHubV3RestApiService {
       target?: "branch" | "tag" | "push" | "repository" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_repository_ruleset> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9336,9 +9140,9 @@ export class GitHubV3RestApiService {
     org: string
     rulesetId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9357,15 +9161,12 @@ export class GitHubV3RestApiService {
     page?: number
     rulesetId: number
   }): Observable<
-    | (HttpResponse<t_ruleset_version[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_ruleset_version[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -9384,9 +9185,9 @@ export class GitHubV3RestApiService {
     rulesetId: number
     versionId: number
   }): Observable<
-    | (HttpResponse<t_ruleset_version_with_state> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_ruleset_version_with_state> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9416,13 +9217,13 @@ export class GitHubV3RestApiService {
     isMultiRepo?: boolean
     hideSecret?: boolean
   }): Observable<
-    | (HttpResponse<t_organization_secret_scanning_alert[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_organization_secret_scanning_alert[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -9461,9 +9262,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     state?: "triage" | "draft" | "published" | "closed" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_repository_advisory[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_repository_advisory[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -9489,7 +9290,7 @@ export class GitHubV3RestApiService {
   orgsListSecurityManagerTeams(p: {
     org: string
   }): Observable<
-    (HttpResponse<t_team_simple[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_simple[]> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -9504,9 +9305,7 @@ export class GitHubV3RestApiService {
   orgsAddSecurityManagerTeam(p: {
     org: string
     teamSlug: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -9521,9 +9320,7 @@ export class GitHubV3RestApiService {
   orgsRemoveSecurityManagerTeam(p: {
     org: string
     teamSlug: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -9538,7 +9335,7 @@ export class GitHubV3RestApiService {
   billingGetGithubActionsBillingOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_actions_billing_usage> & { status: 200 })
+    | (HttpResponse<t_actions_billing_usage> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9554,7 +9351,7 @@ export class GitHubV3RestApiService {
   billingGetGithubPackagesBillingOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_packages_billing_usage> & { status: 200 })
+    | (HttpResponse<t_packages_billing_usage> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9570,7 +9367,7 @@ export class GitHubV3RestApiService {
   billingGetSharedStorageBillingOrg(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_combined_billing_usage> & { status: 200 })
+    | (HttpResponse<t_combined_billing_usage> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9592,13 +9389,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         network_configurations: t_network_configuration[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -9620,10 +9414,10 @@ export class GitHubV3RestApiService {
       network_settings_ids: string[]
     }
   }): Observable<
-    | (HttpResponse<t_network_configuration> & { status: 201 })
+    | (HttpResponse<t_network_configuration> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9643,7 +9437,7 @@ export class GitHubV3RestApiService {
     org: string
     networkConfigurationId: string
   }): Observable<
-    | (HttpResponse<t_network_configuration> & { status: 200 })
+    | (HttpResponse<t_network_configuration> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9666,10 +9460,10 @@ export class GitHubV3RestApiService {
       network_settings_ids?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_network_configuration> & { status: 200 })
+    | (HttpResponse<t_network_configuration> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9688,9 +9482,7 @@ export class GitHubV3RestApiService {
   hostedComputeDeleteNetworkConfigurationFromOrg(p: {
     org: string
     networkConfigurationId: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -9706,7 +9498,7 @@ export class GitHubV3RestApiService {
     org: string
     networkSettingsId: string
   }): Observable<
-    (HttpResponse<t_network_settings> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_network_settings> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -9727,11 +9519,11 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_copilot_usage_metrics_day[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_copilot_usage_metrics_day[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -9758,14 +9550,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -9794,12 +9583,12 @@ export class GitHubV3RestApiService {
       repo_names?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_team_full> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team_full> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9818,8 +9607,8 @@ export class GitHubV3RestApiService {
     org: string
     teamSlug: string
   }): Observable<
-    | (HttpResponse<t_team_full> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team_full> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -9847,14 +9636,14 @@ export class GitHubV3RestApiService {
       privacy?: "secret" | "closed" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_team_full> & { status: 200 })
-    | (HttpResponse<t_team_full> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team_full> & {status: 200})
+    | (HttpResponse<t_team_full> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9872,9 +9661,7 @@ export class GitHubV3RestApiService {
   teamsDeleteInOrg(p: {
     org: string
     teamSlug: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`,
@@ -9893,8 +9680,7 @@ export class GitHubV3RestApiService {
     page?: number
     pinned?: string
   }): Observable<
-    | (HttpResponse<t_team_discussion[]> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       direction: p["direction"],
@@ -9924,9 +9710,9 @@ export class GitHubV3RestApiService {
       title: string
     }
   }): Observable<
-    (HttpResponse<t_team_discussion> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9947,7 +9733,7 @@ export class GitHubV3RestApiService {
     teamSlug: string
     discussionNumber: number
   }): Observable<
-    (HttpResponse<t_team_discussion> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -9969,9 +9755,9 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    (HttpResponse<t_team_discussion> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9991,9 +9777,7 @@ export class GitHubV3RestApiService {
     org: string
     teamSlug: string
     discussionNumber: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -10013,7 +9797,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment[]> & { status: 200 })
+    | (HttpResponse<t_team_discussion_comment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -10042,10 +9826,10 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment> & { status: 201 })
+    | (HttpResponse<t_team_discussion_comment> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10067,7 +9851,7 @@ export class GitHubV3RestApiService {
     discussionNumber: number
     commentNumber: number
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment> & { status: 200 })
+    | (HttpResponse<t_team_discussion_comment> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10090,10 +9874,10 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment> & { status: 200 })
+    | (HttpResponse<t_team_discussion_comment> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10114,9 +9898,7 @@ export class GitHubV3RestApiService {
     teamSlug: string
     discussionNumber: number
     commentNumber: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -10146,7 +9928,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_reaction[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_reaction[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       content: p["content"],
@@ -10184,11 +9966,11 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10210,9 +9992,7 @@ export class GitHubV3RestApiService {
     discussionNumber: number
     commentNumber: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -10241,7 +10021,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_reaction[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_reaction[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       content: p["content"],
@@ -10278,11 +10058,11 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10303,9 +10083,7 @@ export class GitHubV3RestApiService {
     teamSlug: string
     discussionNumber: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -10323,13 +10101,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_organization_invitation[]> & { status: 200 })
+    | (HttpResponse<t_organization_invitation[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -10350,7 +10125,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       role: p["role"],
@@ -10374,8 +10149,8 @@ export class GitHubV3RestApiService {
     teamSlug: string
     username: string
   }): Observable<
-    | (HttpResponse<t_team_membership> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_team_membership> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10397,12 +10172,12 @@ export class GitHubV3RestApiService {
       role?: "member" | "maintainer" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_team_membership> & { status: 200 })
-    | (HttpResponse<void> & { status: 403 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_team_membership> & {status: 200})
+    | (HttpResponse<void> & {status: 403})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10423,8 +10198,8 @@ export class GitHubV3RestApiService {
     teamSlug: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10444,12 +10219,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_team_project[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_project[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -10468,8 +10240,8 @@ export class GitHubV3RestApiService {
     teamSlug: string
     projectId: number
   }): Observable<
-    | (HttpResponse<t_team_project> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_team_project> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10491,14 +10263,14 @@ export class GitHubV3RestApiService {
       permission?: "read" | "write" | "admin" | UnknownEnumStringValue
     } | null
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<void> & {status: 204})
     | (HttpResponse<{
         documentation_url?: string
         message?: string
-      }> & { status: 403 })
+      }> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10518,9 +10290,7 @@ export class GitHubV3RestApiService {
     org: string
     teamSlug: string
     projectId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -10538,13 +10308,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -10563,9 +10330,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_team_repository> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_team_repository> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10587,10 +10354,8 @@ export class GitHubV3RestApiService {
     requestBody?: {
       permission?: string
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10611,9 +10376,7 @@ export class GitHubV3RestApiService {
     teamSlug: string
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -10631,12 +10394,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_team[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -10665,11 +10425,11 @@ export class GitHubV3RestApiService {
       query_suite?: "default" | "extended" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10688,11 +10448,11 @@ export class GitHubV3RestApiService {
   projectsGetCard(p: {
     cardId: number
   }): Observable<
-    | (HttpResponse<t_project_card> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_project_card> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10712,15 +10472,15 @@ export class GitHubV3RestApiService {
       note?: string | null
     }
   }): Observable<
-    | (HttpResponse<t_project_card> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project_card> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10738,15 +10498,15 @@ export class GitHubV3RestApiService {
   projectsDeleteCard(p: {
     cardId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | (HttpResponse<{
         documentation_url?: string
         errors?: string[]
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10766,9 +10526,9 @@ export class GitHubV3RestApiService {
       position: string
     }
   }): Observable<
-    | (HttpResponse<EmptyObject> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<EmptyObject> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | (HttpResponse<{
         documentation_url?: string
         errors?: {
@@ -10778,8 +10538,8 @@ export class GitHubV3RestApiService {
           resource?: string
         }[]
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
@@ -10788,10 +10548,10 @@ export class GitHubV3RestApiService {
           message?: string
         }[]
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10809,11 +10569,11 @@ export class GitHubV3RestApiService {
   projectsGetColumn(p: {
     columnId: number
   }): Observable<
-    | (HttpResponse<t_project_column> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_project_column> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10832,13 +10592,13 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_project_column> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_project_column> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10856,10 +10616,10 @@ export class GitHubV3RestApiService {
   projectsDeleteColumn(p: {
     columnId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -10878,10 +10638,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_project_card[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_project_card[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -10912,10 +10672,10 @@ export class GitHubV3RestApiService {
           content_type: string
         }
   }): Observable<
-    | (HttpResponse<t_project_card> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_project_card> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | (HttpResponse<t_validation_error | t_validation_error_simple> & {
         status: 422
       })
@@ -10927,10 +10687,10 @@ export class GitHubV3RestApiService {
           message?: string
         }[]
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10951,14 +10711,14 @@ export class GitHubV3RestApiService {
       position: string
     }
   }): Observable<
-    | (HttpResponse<EmptyObject> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<EmptyObject> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10976,10 +10736,10 @@ export class GitHubV3RestApiService {
   projectsGet(p: {
     projectId: number
   }): Observable<
-    | (HttpResponse<t_project> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_project> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11007,20 +10767,20 @@ export class GitHubV3RestApiService {
       state?: string
     }
   }): Observable<
-    | (HttpResponse<t_project> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<t_project> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | (HttpResponse<{
         documentation_url?: string
         errors?: string[]
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 403})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11038,16 +10798,16 @@ export class GitHubV3RestApiService {
   projectsDelete(p: {
     projectId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | (HttpResponse<{
         documentation_url?: string
         errors?: string[]
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+      }> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11066,12 +10826,12 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -11098,15 +10858,15 @@ export class GitHubV3RestApiService {
       permission?: "read" | "write" | "admin" | UnknownEnumStringValue
     } | null
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11126,12 +10886,12 @@ export class GitHubV3RestApiService {
     projectId: number
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11149,12 +10909,12 @@ export class GitHubV3RestApiService {
     projectId: number
     username: string
   }): Observable<
-    | (HttpResponse<t_project_collaborator_permission> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_project_collaborator_permission> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11173,16 +10933,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_project_column[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_project_column[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -11201,14 +10958,14 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_project_column> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project_column> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11224,9 +10981,9 @@ export class GitHubV3RestApiService {
   }
 
   rateLimitGet(): Observable<
-    | (HttpResponse<t_rate_limit_overview> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_rate_limit_overview> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11243,10 +11000,10 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_full_repository> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_full_repository> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11320,14 +11077,14 @@ export class GitHubV3RestApiService {
       web_commit_signoff_required?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_full_repository> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 307 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_full_repository> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 307})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11346,14 +11103,14 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 307 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 307})
     | (HttpResponse<{
         documentation_url?: string
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+      }> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11376,7 +11133,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         artifacts: t_artifact[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -11402,7 +11159,7 @@ export class GitHubV3RestApiService {
     repo: string
     artifactId: number
   }): Observable<
-    (HttpResponse<t_artifact> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_artifact> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -11419,9 +11176,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     artifactId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -11439,8 +11194,8 @@ export class GitHubV3RestApiService {
     artifactId: number
     archiveFormat: string
   }): Observable<
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11458,7 +11213,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_actions_cache_usage_by_repository> & { status: 200 })
+    | (HttpResponse<t_actions_cache_usage_by_repository> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11486,8 +11241,7 @@ export class GitHubV3RestApiService {
       | UnknownEnumStringValue
     direction?: "asc" | "desc" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_actions_cache_list> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_actions_cache_list> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       per_page: p["perPage"],
@@ -11515,10 +11269,9 @@ export class GitHubV3RestApiService {
     key: string
     ref?: string
   }): Observable<
-    | (HttpResponse<t_actions_cache_list> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_actions_cache_list> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ key: p["key"], ref: p["ref"] })
+    const params = this._queryParams({key: p["key"], ref: p["ref"]})
 
     return this.httpClient.request<any>(
       "DELETE",
@@ -11535,9 +11288,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     cacheId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -11554,7 +11305,7 @@ export class GitHubV3RestApiService {
     repo: string
     jobId: number
   }): Observable<
-    (HttpResponse<t_job> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_job> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -11571,9 +11322,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     jobId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 302 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 302}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -11593,11 +11342,11 @@ export class GitHubV3RestApiService {
       enable_debug_logging?: boolean
     } | null
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11617,9 +11366,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_oidc_custom_sub_repo> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_oidc_custom_sub_repo> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11641,13 +11390,13 @@ export class GitHubV3RestApiService {
       use_default: boolean
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11672,13 +11421,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_actions_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -11701,13 +11447,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         variables: t_actions_variable[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -11725,7 +11468,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_actions_repository_permissions> & { status: 200 })
+    | (HttpResponse<t_actions_repository_permissions> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11746,10 +11489,8 @@ export class GitHubV3RestApiService {
       allowed_actions?: t_allowed_actions
       enabled: t_actions_enabled
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11769,7 +11510,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_actions_workflow_access_to_repository> & { status: 200 })
+    | (HttpResponse<t_actions_workflow_access_to_repository> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11787,10 +11528,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     requestBody: t_actions_workflow_access_to_repository
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11810,7 +11549,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    (HttpResponse<t_selected_actions> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_selected_actions> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -11827,10 +11566,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     requestBody?: t_selected_actions
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11850,9 +11587,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_actions_get_default_workflow_permissions> & {
-        status: 200
-      })
+    | (HttpResponse<t_actions_get_default_workflow_permissions> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11871,11 +11606,11 @@ export class GitHubV3RestApiService {
     repo: string
     requestBody: t_actions_set_default_workflow_permissions
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11901,7 +11636,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         runners: t_runner[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -11926,7 +11661,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_runner_application[]> & { status: 200 })
+    | (HttpResponse<t_runner_application[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11953,13 +11688,13 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         encoded_jit_config: string
         runner: t_runner
-      }> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11979,7 +11714,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_authentication_token> & { status: 201 })
+    | (HttpResponse<t_authentication_token> & {status: 201})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -11997,7 +11732,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_authentication_token> & { status: 201 })
+    | (HttpResponse<t_authentication_token> & {status: 201})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12016,7 +11751,7 @@ export class GitHubV3RestApiService {
     repo: string
     runnerId: number
   }): Observable<
-    (HttpResponse<t_runner> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_runner> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -12034,8 +11769,8 @@ export class GitHubV3RestApiService {
     repo: string
     runnerId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12057,8 +11792,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12083,12 +11818,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12115,12 +11850,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12144,8 +11879,8 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12168,9 +11903,9 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         labels: t_runner_label[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12216,7 +11951,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         workflow_runs: t_workflow_run[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -12249,7 +11984,7 @@ export class GitHubV3RestApiService {
     runId: number
     excludePullRequests?: boolean
   }): Observable<
-    (HttpResponse<t_workflow_run> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_workflow_run> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       exclude_pull_requests: p["excludePullRequests"],
@@ -12271,9 +12006,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     runId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -12290,7 +12023,7 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<t_environment_approvals[]> & { status: 200 })
+    | (HttpResponse<t_environment_approvals[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12309,9 +12042,9 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12336,7 +12069,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         artifacts: t_artifact[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -12364,7 +12097,7 @@ export class GitHubV3RestApiService {
     attemptNumber: number
     excludePullRequests?: boolean
   }): Observable<
-    (HttpResponse<t_workflow_run> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_workflow_run> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       exclude_pull_requests: p["excludePullRequests"],
@@ -12393,14 +12126,11 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         jobs: t_job[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -12419,9 +12149,7 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
     attemptNumber: number
-  }): Observable<
-    (HttpResponse<void> & { status: 302 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 302}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -12438,8 +12166,8 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_empty_object> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12460,10 +12188,8 @@ export class GitHubV3RestApiService {
     requestBody:
       | t_review_custom_gates_comment_required
       | t_review_custom_gates_state_required
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12484,8 +12210,8 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_empty_object> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12510,7 +12236,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         jobs: t_job[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -12535,9 +12261,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     runId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 302 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 302}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -12554,9 +12278,9 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12575,7 +12299,7 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<t_pending_deployment[]> & { status: 200 })
+    | (HttpResponse<t_pending_deployment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -12599,9 +12323,9 @@ export class GitHubV3RestApiService {
       state: "approved" | "rejected" | UnknownEnumStringValue
     }
   }): Observable<
-    (HttpResponse<t_deployment[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_deployment[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12625,9 +12349,9 @@ export class GitHubV3RestApiService {
       enable_debug_logging?: boolean
     } | null
   }): Observable<
-    (HttpResponse<t_empty_object> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_empty_object> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12651,9 +12375,9 @@ export class GitHubV3RestApiService {
       enable_debug_logging?: boolean
     } | null
   }): Observable<
-    (HttpResponse<t_empty_object> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_empty_object> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12674,8 +12398,7 @@ export class GitHubV3RestApiService {
     repo: string
     runId: number
   }): Observable<
-    | (HttpResponse<t_workflow_run_usage> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_workflow_run_usage> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -12697,13 +12420,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_actions_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -12721,8 +12441,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_actions_public_key> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_actions_public_key> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -12740,7 +12459,7 @@ export class GitHubV3RestApiService {
     repo: string
     secretName: string
   }): Observable<
-    (HttpResponse<t_actions_secret> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_actions_secret> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -12762,11 +12481,11 @@ export class GitHubV3RestApiService {
       key_id: string
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12786,9 +12505,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -12809,13 +12526,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         variables: t_actions_variable[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -12837,9 +12551,9 @@ export class GitHubV3RestApiService {
       value: string
     }
   }): Observable<
-    (HttpResponse<t_empty_object> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_empty_object> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12860,7 +12574,7 @@ export class GitHubV3RestApiService {
     repo: string
     name: string
   }): Observable<
-    (HttpResponse<t_actions_variable> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_actions_variable> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -12881,10 +12595,8 @@ export class GitHubV3RestApiService {
       name?: string
       value?: string
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12904,9 +12616,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     name: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -12927,13 +12637,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         workflows: t_workflow[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -12952,7 +12659,7 @@ export class GitHubV3RestApiService {
     repo: string
     workflowId: number | string
   }): Observable<
-    (HttpResponse<t_workflow> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_workflow> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -12969,9 +12676,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     workflowId: number | string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -12993,10 +12698,8 @@ export class GitHubV3RestApiService {
       }
       ref: string
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13016,9 +12719,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     workflowId: number | string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -13063,7 +12764,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         workflow_runs: t_workflow_run[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -13096,7 +12797,7 @@ export class GitHubV3RestApiService {
     repo: string
     workflowId: number | string
   }): Observable<
-    (HttpResponse<t_workflow_usage> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_workflow_usage> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -13134,8 +12835,8 @@ export class GitHubV3RestApiService {
       | "merge_queue_merge"
       | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_activity[]> & { status: 200 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_activity[]> & {status: 200})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -13166,14 +12867,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -13191,8 +12889,8 @@ export class GitHubV3RestApiService {
     repo: string
     assignee: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13223,12 +12921,12 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         id?: number
-      }> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13266,7 +12964,7 @@ export class GitHubV3RestApiService {
           bundle_url?: string
           repository_id?: number
         }[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -13292,7 +12990,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    (HttpResponse<t_autolink[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_autolink[]> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -13313,11 +13011,11 @@ export class GitHubV3RestApiService {
       url_template: string
     }
   }): Observable<
-    | (HttpResponse<t_autolink> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_autolink> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13337,8 +13035,8 @@ export class GitHubV3RestApiService {
     repo: string
     autolinkId: number
   }): Observable<
-    | (HttpResponse<t_autolink> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_autolink> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13357,8 +13055,8 @@ export class GitHubV3RestApiService {
     repo: string
     autolinkId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13376,8 +13074,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_check_automated_security_fixes> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_check_automated_security_fixes> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13394,9 +13092,7 @@ export class GitHubV3RestApiService {
   reposEnableAutomatedSecurityFixes(p: {
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -13411,9 +13107,7 @@ export class GitHubV3RestApiService {
   reposDisableAutomatedSecurityFixes(p: {
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -13432,8 +13126,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_short_branch[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_short_branch[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -13458,9 +13152,9 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_branch_with_protection> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_branch_with_protection> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13479,8 +13173,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_branch_protection> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_branch_protection> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13538,13 +13232,13 @@ export class GitHubV3RestApiService {
       } | null
     }
   }): Observable<
-    | (HttpResponse<t_protected_branch> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_protected_branch> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13565,8 +13259,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13585,7 +13279,7 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_protected_branch_admin_enforced> & { status: 200 })
+    | (HttpResponse<t_protected_branch_admin_enforced> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13604,7 +13298,7 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_protected_branch_admin_enforced> & { status: 200 })
+    | (HttpResponse<t_protected_branch_admin_enforced> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13623,8 +13317,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13643,7 +13337,7 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_protected_branch_pull_request_review> & { status: 200 })
+    | (HttpResponse<t_protected_branch_pull_request_review> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13678,11 +13372,11 @@ export class GitHubV3RestApiService {
       required_approving_review_count?: number
     }
   }): Observable<
-    | (HttpResponse<t_protected_branch_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_protected_branch_pull_request_review> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13703,8 +13397,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13723,8 +13417,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_protected_branch_admin_enforced> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_protected_branch_admin_enforced> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13743,8 +13437,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_protected_branch_admin_enforced> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_protected_branch_admin_enforced> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13763,8 +13457,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13783,8 +13477,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_status_check_policy> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_status_check_policy> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13811,12 +13505,12 @@ export class GitHubV3RestApiService {
       strict?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_status_check_policy> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_status_check_policy> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13836,9 +13530,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     branch: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -13855,8 +13547,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<string[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<string[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13880,13 +13572,13 @@ export class GitHubV3RestApiService {
         }
       | string[]
   }): Observable<
-    | (HttpResponse<string[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<string[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13912,12 +13604,12 @@ export class GitHubV3RestApiService {
         }
       | string[]
   }): Observable<
-    | (HttpResponse<string[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<string[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13943,12 +13635,12 @@ export class GitHubV3RestApiService {
         }
       | string[]
   }): Observable<
-    | (HttpResponse<string[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<string[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13969,8 +13661,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_branch_restriction_policy> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_branch_restriction_policy> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -13988,9 +13680,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     branch: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -14007,8 +13697,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_integration[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_integration[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14030,11 +13720,11 @@ export class GitHubV3RestApiService {
       apps: string[]
     }
   }): Observable<
-    | (HttpResponse<t_integration[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_integration[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14058,11 +13748,11 @@ export class GitHubV3RestApiService {
       apps: string[]
     }
   }): Observable<
-    | (HttpResponse<t_integration[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_integration[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14086,11 +13776,11 @@ export class GitHubV3RestApiService {
       apps: string[]
     }
   }): Observable<
-    | (HttpResponse<t_integration[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_integration[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14111,8 +13801,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14136,11 +13826,11 @@ export class GitHubV3RestApiService {
         }
       | string[]
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14166,11 +13856,11 @@ export class GitHubV3RestApiService {
         }
       | string[]
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14196,11 +13886,11 @@ export class GitHubV3RestApiService {
         }
       | string[]
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14221,8 +13911,8 @@ export class GitHubV3RestApiService {
     repo: string
     branch: string
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14244,11 +13934,11 @@ export class GitHubV3RestApiService {
       users: string[]
     }
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14272,11 +13962,11 @@ export class GitHubV3RestApiService {
       users: string[]
     }
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14300,11 +13990,11 @@ export class GitHubV3RestApiService {
       users: string[]
     }
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14328,13 +14018,13 @@ export class GitHubV3RestApiService {
       new_name: string
     }
   }): Observable<
-    | (HttpResponse<t_branch_with_protection> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_branch_with_protection> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14363,9 +14053,9 @@ export class GitHubV3RestApiService {
           [key: string]: unknown | undefined
         }
   }): Observable<
-    (HttpResponse<t_check_run> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_check_run> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14385,7 +14075,7 @@ export class GitHubV3RestApiService {
     repo: string
     checkRunId: number
   }): Observable<
-    (HttpResponse<t_check_run> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_check_run> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -14458,9 +14148,9 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    (HttpResponse<t_check_run> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_check_run> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14483,13 +14173,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_check_annotation[]> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_check_annotation[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -14508,10 +14194,10 @@ export class GitHubV3RestApiService {
     repo: string
     checkRunId: number
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14532,11 +14218,11 @@ export class GitHubV3RestApiService {
       head_sha: string
     }
   }): Observable<
-    | (HttpResponse<t_check_suite> & { status: 200 })
-    | (HttpResponse<t_check_suite> & { status: 201 })
+    | (HttpResponse<t_check_suite> & {status: 200})
+    | (HttpResponse<t_check_suite> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14561,10 +14247,10 @@ export class GitHubV3RestApiService {
       }[]
     }
   }): Observable<
-    | (HttpResponse<t_check_suite_preference> & { status: 200 })
+    | (HttpResponse<t_check_suite_preference> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14585,7 +14271,7 @@ export class GitHubV3RestApiService {
     repo: string
     checkSuiteId: number
   }): Observable<
-    (HttpResponse<t_check_suite> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_check_suite> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -14611,7 +14297,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         check_runs: t_check_run[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -14639,7 +14325,7 @@ export class GitHubV3RestApiService {
     repo: string
     checkSuiteId: number
   }): Observable<
-    (HttpResponse<t_empty_object> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_empty_object> & {status: 201}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "POST",
@@ -14668,15 +14354,15 @@ export class GitHubV3RestApiService {
     state?: t_code_scanning_alert_state_query
     severity?: t_code_scanning_alert_severity
   }): Observable<
-    | (HttpResponse<t_code_scanning_alert_items[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_alert_items[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -14711,15 +14397,15 @@ export class GitHubV3RestApiService {
     repo: string
     alertNumber: t_alert_number
   }): Observable<
-    | (HttpResponse<t_code_scanning_alert> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_alert> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14744,18 +14430,18 @@ export class GitHubV3RestApiService {
       state: t_code_scanning_alert_set_state
     }
   }): Observable<
-    | (HttpResponse<t_code_scanning_alert> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_alert> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14776,15 +14462,15 @@ export class GitHubV3RestApiService {
     repo: string
     alertNumber: t_alert_number
   }): Observable<
-    | (HttpResponse<t_code_scanning_autofix> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_autofix> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14803,17 +14489,17 @@ export class GitHubV3RestApiService {
     repo: string
     alertNumber: t_alert_number
   }): Observable<
-    | (HttpResponse<t_code_scanning_autofix> & { status: 200 })
-    | (HttpResponse<t_code_scanning_autofix> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_code_scanning_autofix> & {status: 200})
+    | (HttpResponse<t_code_scanning_autofix> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14833,19 +14519,19 @@ export class GitHubV3RestApiService {
     alertNumber: t_alert_number
     requestBody?: t_code_scanning_autofix_commits
   }): Observable<
-    | (HttpResponse<t_code_scanning_autofix_commits_response> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_code_scanning_autofix_commits_response> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14870,14 +14556,14 @@ export class GitHubV3RestApiService {
     ref?: t_code_scanning_ref
     pr?: number
   }): Observable<
-    | (HttpResponse<t_code_scanning_alert_instance[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_alert_instance[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -14912,14 +14598,14 @@ export class GitHubV3RestApiService {
     direction?: "asc" | "desc" | UnknownEnumStringValue
     sort?: "created" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_code_scanning_analysis[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_analysis[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -14953,15 +14639,15 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -14981,18 +14667,18 @@ export class GitHubV3RestApiService {
     analysisId: number
     confirmDelete?: string | null
   }): Observable<
-    | (HttpResponse<t_code_scanning_analysis_deletion> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_analysis_deletion> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ confirm_delete: p["confirmDelete"] })
+    const params = this._queryParams({confirm_delete: p["confirmDelete"]})
 
     return this.httpClient.request<any>(
       "DELETE",
@@ -15010,14 +14696,14 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_code_scanning_codeql_database[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_codeql_database[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15036,15 +14722,15 @@ export class GitHubV3RestApiService {
     repo: string
     language: string
   }): Observable<
-    | (HttpResponse<t_code_scanning_codeql_database> & { status: 200 })
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_codeql_database> & {status: 200})
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15063,14 +14749,14 @@ export class GitHubV3RestApiService {
     repo: string
     language: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15089,17 +14775,17 @@ export class GitHubV3RestApiService {
     repo: string
     requestBody: EmptyObject
   }): Observable<
-    | (HttpResponse<t_code_scanning_variant_analysis> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+    | (HttpResponse<t_code_scanning_variant_analysis> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15120,13 +14806,13 @@ export class GitHubV3RestApiService {
     repo: string
     codeqlVariantAnalysisId: number
   }): Observable<
-    | (HttpResponse<t_code_scanning_variant_analysis> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_variant_analysis> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15147,15 +14833,13 @@ export class GitHubV3RestApiService {
     repoOwner: string
     repoName: string
   }): Observable<
-    | (HttpResponse<t_code_scanning_variant_analysis_repo_task> & {
-        status: 200
-      })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_variant_analysis_repo_task> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15173,14 +14857,14 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_code_scanning_default_setup> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_code_scanning_default_setup> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15199,22 +14883,22 @@ export class GitHubV3RestApiService {
     repo: string
     requestBody: t_code_scanning_default_setup_update
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 200 })
+    | (HttpResponse<t_empty_object> & {status: 200})
     | (HttpResponse<t_code_scanning_default_setup_update_response> & {
         status: 202
       })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15243,19 +14927,19 @@ export class GitHubV3RestApiService {
       validate?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_code_scanning_sarifs_receipt> & { status: 202 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 413 })
+    | (HttpResponse<t_code_scanning_sarifs_receipt> & {status: 202})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 413})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15276,14 +14960,14 @@ export class GitHubV3RestApiService {
     repo: string
     sarifId: string
   }): Observable<
-    | (HttpResponse<t_code_scanning_sarifs_status> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_code_scanning_sarifs_status> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<void> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15304,10 +14988,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<t_code_security_configuration_for_repository> & {
         status: 200
       })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15326,11 +15010,11 @@ export class GitHubV3RestApiService {
     repo: string
     ref?: string
   }): Observable<
-    | (HttpResponse<t_codeowners_errors> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_codeowners_errors> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ ref: p["ref"] })
+    const params = this._queryParams({ref: p["ref"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -15353,17 +15037,14 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         codespaces: t_codespace[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -15398,20 +15079,20 @@ export class GitHubV3RestApiService {
       working_directory?: string
     } | null
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 201 })
-    | (HttpResponse<t_codespace> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_codespace> & {status: 201})
+    | (HttpResponse<t_codespace> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15439,18 +15120,15 @@ export class GitHubV3RestApiService {
           path: string
         }[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -15474,12 +15152,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         machines: t_codespace_machine[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -15512,16 +15190,13 @@ export class GitHubV3RestApiService {
           devcontainer_path: string | null
           location: string
         }
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      ref: p["ref"],
-      client_ip: p["clientIp"],
-    })
+    const params = this._queryParams({ref: p["ref"], client_ip: p["clientIp"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -15543,15 +15218,15 @@ export class GitHubV3RestApiService {
     | (HttpResponse<t_codespaces_permissions_check_for_devcontainer> & {
         status: 200
       })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -15580,13 +15255,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_repo_codespaces_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -15604,7 +15276,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_codespaces_public_key> & { status: 200 })
+    | (HttpResponse<t_codespaces_public_key> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15623,7 +15295,7 @@ export class GitHubV3RestApiService {
     repo: string
     secretName: string
   }): Observable<
-    | (HttpResponse<t_repo_codespaces_secret> & { status: 200 })
+    | (HttpResponse<t_repo_codespaces_secret> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15646,11 +15318,11 @@ export class GitHubV3RestApiService {
       key_id?: string
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15670,9 +15342,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -15698,8 +15368,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_collaborator[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_collaborator[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -15725,8 +15395,8 @@ export class GitHubV3RestApiService {
     repo: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15748,13 +15418,13 @@ export class GitHubV3RestApiService {
       permission?: string
     }
   }): Observable<
-    | (HttpResponse<t_repository_invitation> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_repository_invitation> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15775,9 +15445,9 @@ export class GitHubV3RestApiService {
     repo: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15796,8 +15466,8 @@ export class GitHubV3RestApiService {
     repo: string
     username: string
   }): Observable<
-    | (HttpResponse<t_repository_collaborator_permission> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_repository_collaborator_permission> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15817,12 +15487,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_commit_comment[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_commit_comment[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -15840,8 +15507,8 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
   }): Observable<
-    | (HttpResponse<t_commit_comment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_commit_comment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15863,11 +15530,11 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_commit_comment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_commit_comment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15888,8 +15555,8 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -15920,8 +15587,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_reaction[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_reaction[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -15959,12 +15626,12 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15985,9 +15652,7 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -16011,11 +15676,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_commit[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_commit[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -16045,9 +15710,9 @@ export class GitHubV3RestApiService {
     repo: string
     commitSha: string
   }): Observable<
-    | (HttpResponse<t_branch_short[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_branch_short[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -16068,12 +15733,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_commit_comment[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_commit_comment[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16098,12 +15760,12 @@ export class GitHubV3RestApiService {
       position?: number
     }
   }): Observable<
-    | (HttpResponse<t_commit_comment> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_commit_comment> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16126,14 +15788,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_pull_request_simple[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_pull_request_simple[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16154,22 +15813,19 @@ export class GitHubV3RestApiService {
     perPage?: number
     ref: string
   }): Observable<
-    | (HttpResponse<t_commit> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_commit> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16197,7 +15853,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         check_runs: t_check_run[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -16233,7 +15889,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         check_suites: t_check_suite[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -16262,14 +15918,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_combined_commit_status> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_combined_commit_status> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16290,14 +15943,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_status[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
+    | (HttpResponse<t_status[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16315,8 +15965,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_community_profile> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_community_profile> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -16336,20 +15985,17 @@ export class GitHubV3RestApiService {
     perPage?: number
     basehead: string
   }): Observable<
-    | (HttpResponse<t_commit_comparison> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_commit_comparison> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16374,14 +16020,14 @@ export class GitHubV3RestApiService {
         | t_content_file
         | t_content_symlink
         | t_content_submodule
-      > & { status: 200 })
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      > & {status: 200})
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ ref: p["ref"] })
+    const params = this._queryParams({ref: p["ref"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16416,16 +16062,16 @@ export class GitHubV3RestApiService {
       sha?: string
     }
   }): Observable<
-    | (HttpResponse<t_file_commit> & { status: 200 })
-    | (HttpResponse<t_file_commit> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_file_commit> & {status: 200})
+    | (HttpResponse<t_file_commit> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<t_basic_error | t_repository_rule_violation_error> & {
         status: 409
       })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16459,18 +16105,18 @@ export class GitHubV3RestApiService {
       sha: string
     }
   }): Observable<
-    | (HttpResponse<t_file_commit> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_file_commit> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16493,10 +16139,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_contributor[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_contributor[]> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -16536,12 +16182,12 @@ export class GitHubV3RestApiService {
     first?: number
     last?: number
   }): Observable<
-    | (HttpResponse<t_dependabot_alert[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_dependabot_alert[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -16580,10 +16226,10 @@ export class GitHubV3RestApiService {
     repo: string
     alertNumber: t_alert_number
   }): Observable<
-    | (HttpResponse<t_dependabot_alert> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_dependabot_alert> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -16613,15 +16259,15 @@ export class GitHubV3RestApiService {
       state: "dismissed" | "open" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_dependabot_alert> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_dependabot_alert> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16646,13 +16292,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_dependabot_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16670,7 +16313,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_dependabot_public_key> & { status: 200 })
+    | (HttpResponse<t_dependabot_public_key> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -16689,8 +16332,7 @@ export class GitHubV3RestApiService {
     repo: string
     secretName: string
   }): Observable<
-    | (HttpResponse<t_dependabot_secret> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_dependabot_secret> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -16712,11 +16354,11 @@ export class GitHubV3RestApiService {
       key_id?: string
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16736,9 +16378,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -16756,12 +16396,12 @@ export class GitHubV3RestApiService {
     basehead: string
     name?: string
   }): Observable<
-    | (HttpResponse<t_dependency_graph_diff> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_dependency_graph_diff> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ name: p["name"] })
+    const params = this._queryParams({name: p["name"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16779,9 +16419,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_dependency_graph_spdx_sbom> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_dependency_graph_spdx_sbom> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -16805,10 +16445,10 @@ export class GitHubV3RestApiService {
         id: number
         message: string
         result: string
-      }> & { status: 201 })
+      }> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16834,7 +16474,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_deployment[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_deployment[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       sha: p["sha"],
@@ -16875,15 +16515,15 @@ export class GitHubV3RestApiService {
       transient_environment?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_deployment> & { status: 201 })
+    | (HttpResponse<t_deployment> & {status: 201})
     | (HttpResponse<{
         message?: string
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -16903,8 +16543,8 @@ export class GitHubV3RestApiService {
     repo: string
     deploymentId: number
   }): Observable<
-    | (HttpResponse<t_deployment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_deployment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -16923,9 +16563,9 @@ export class GitHubV3RestApiService {
     repo: string
     deploymentId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -16946,14 +16586,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_deployment_status[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_deployment_status[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -16989,11 +16626,11 @@ export class GitHubV3RestApiService {
       target_url?: string
     }
   }): Observable<
-    | (HttpResponse<t_deployment_status> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_deployment_status> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17015,8 +16652,8 @@ export class GitHubV3RestApiService {
     deploymentId: number
     statusId: number
   }): Observable<
-    | (HttpResponse<t_deployment_status> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_deployment_status> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17040,12 +16677,12 @@ export class GitHubV3RestApiService {
       event_type: string
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17069,13 +16706,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         environments?: t_environment[]
         total_count?: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -17093,7 +16727,7 @@ export class GitHubV3RestApiService {
     repo: string
     environmentName: string
   }): Observable<
-    (HttpResponse<t_environment> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_environment> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -17122,11 +16756,11 @@ export class GitHubV3RestApiService {
       wait_timer?: t_wait_timer
     } | null
   }): Observable<
-    | (HttpResponse<t_environment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 422 })
+    | (HttpResponse<t_environment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17146,9 +16780,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     environmentName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -17170,13 +16802,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         branch_policies: t_deployment_branch_policy[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -17196,12 +16825,12 @@ export class GitHubV3RestApiService {
     environmentName: string
     requestBody: t_deployment_branch_policy_name_pattern_with_type
   }): Observable<
-    | (HttpResponse<t_deployment_branch_policy> & { status: 200 })
-    | (HttpResponse<void> & { status: 303 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_deployment_branch_policy> & {status: 200})
+    | (HttpResponse<void> & {status: 303})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17223,7 +16852,7 @@ export class GitHubV3RestApiService {
     environmentName: string
     branchPolicyId: number
   }): Observable<
-    | (HttpResponse<t_deployment_branch_policy> & { status: 200 })
+    | (HttpResponse<t_deployment_branch_policy> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17244,10 +16873,10 @@ export class GitHubV3RestApiService {
     branchPolicyId: number
     requestBody: t_deployment_branch_policy_name_pattern
   }): Observable<
-    | (HttpResponse<t_deployment_branch_policy> & { status: 200 })
+    | (HttpResponse<t_deployment_branch_policy> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17268,9 +16897,7 @@ export class GitHubV3RestApiService {
     repo: string
     environmentName: string
     branchPolicyId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -17290,7 +16917,7 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         custom_deployment_protection_rules?: t_deployment_protection_rule[]
         total_count?: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17312,10 +16939,10 @@ export class GitHubV3RestApiService {
       integration_id?: number
     }
   }): Observable<
-    | (HttpResponse<t_deployment_protection_rule> & { status: 201 })
+    | (HttpResponse<t_deployment_protection_rule> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17341,13 +16968,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         available_custom_deployment_protection_rule_integrations?: t_custom_deployment_rule_app[]
         total_count?: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -17367,7 +16991,7 @@ export class GitHubV3RestApiService {
     environmentName: string
     protectionRuleId: number
   }): Observable<
-    | (HttpResponse<t_deployment_protection_rule> & { status: 200 })
+    | (HttpResponse<t_deployment_protection_rule> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17386,9 +17010,7 @@ export class GitHubV3RestApiService {
     repo: string
     owner: string
     protectionRuleId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -17410,13 +17032,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_actions_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -17435,8 +17054,7 @@ export class GitHubV3RestApiService {
     repo: string
     environmentName: string
   }): Observable<
-    | (HttpResponse<t_actions_public_key> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_actions_public_key> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -17455,7 +17073,7 @@ export class GitHubV3RestApiService {
     environmentName: string
     secretName: string
   }): Observable<
-    (HttpResponse<t_actions_secret> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_actions_secret> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -17478,11 +17096,11 @@ export class GitHubV3RestApiService {
       key_id: string
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17503,9 +17121,7 @@ export class GitHubV3RestApiService {
     repo: string
     environmentName: string
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -17527,13 +17143,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         total_count: number
         variables: t_actions_variable[]
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -17556,9 +17169,9 @@ export class GitHubV3RestApiService {
       value: string
     }
   }): Observable<
-    (HttpResponse<t_empty_object> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_empty_object> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17580,7 +17193,7 @@ export class GitHubV3RestApiService {
     environmentName: string
     name: string
   }): Observable<
-    (HttpResponse<t_actions_variable> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_actions_variable> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -17602,10 +17215,8 @@ export class GitHubV3RestApiService {
       name?: string
       value?: string
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17626,9 +17237,7 @@ export class GitHubV3RestApiService {
     repo: string
     name: string
     environmentName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -17646,12 +17255,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -17676,8 +17282,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -17706,14 +17312,14 @@ export class GitHubV3RestApiService {
       organization?: string
     } | null
   }): Observable<
-    | (HttpResponse<t_full_repository> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_full_repository> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17736,16 +17342,16 @@ export class GitHubV3RestApiService {
       encoding?: string
     }
   }): Observable<
-    | (HttpResponse<t_short_blob> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_short_blob> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | (HttpResponse<t_validation_error | t_repository_rule_violation_error> & {
         status: 422
       })
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17765,11 +17371,11 @@ export class GitHubV3RestApiService {
     repo: string
     fileSha: string
   }): Observable<
-    | (HttpResponse<t_blob> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_blob> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17803,13 +17409,13 @@ export class GitHubV3RestApiService {
       tree: string
     }
   }): Observable<
-    | (HttpResponse<t_git_commit> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_git_commit> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17829,9 +17435,9 @@ export class GitHubV3RestApiService {
     repo: string
     commitSha: string
   }): Observable<
-    | (HttpResponse<t_git_commit> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_git_commit> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17850,8 +17456,8 @@ export class GitHubV3RestApiService {
     repo: string
     ref: string
   }): Observable<
-    | (HttpResponse<t_git_ref[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_git_ref[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17870,9 +17476,9 @@ export class GitHubV3RestApiService {
     repo: string
     ref: string
   }): Observable<
-    | (HttpResponse<t_git_ref> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_git_ref> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17894,12 +17500,12 @@ export class GitHubV3RestApiService {
       sha: string
     }
   }): Observable<
-    | (HttpResponse<t_git_ref> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_git_ref> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17923,12 +17529,12 @@ export class GitHubV3RestApiService {
       sha: string
     }
   }): Observable<
-    | (HttpResponse<t_git_ref> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_git_ref> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17949,9 +17555,9 @@ export class GitHubV3RestApiService {
     repo: string
     ref: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -17980,12 +17586,12 @@ export class GitHubV3RestApiService {
       type: "commit" | "tree" | "blob" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_git_tag> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_git_tag> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18005,9 +17611,9 @@ export class GitHubV3RestApiService {
     repo: string
     tagSha: string
   }): Observable<
-    | (HttpResponse<t_git_tag> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<t_git_tag> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18041,14 +17647,14 @@ export class GitHubV3RestApiService {
       }[]
     }
   }): Observable<
-    | (HttpResponse<t_git_tree> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_git_tree> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18069,13 +17675,13 @@ export class GitHubV3RestApiService {
     treeSha: string
     recursive?: string
   }): Observable<
-    | (HttpResponse<t_git_tree> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_git_tree> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ recursive: p["recursive"] })
+    const params = this._queryParams({recursive: p["recursive"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -18095,14 +17701,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_hook[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_hook[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -18130,13 +17733,13 @@ export class GitHubV3RestApiService {
       name?: string
     } | null
   }): Observable<
-    | (HttpResponse<t_hook> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18156,8 +17759,8 @@ export class GitHubV3RestApiService {
     repo: string
     hookId: number
   }): Observable<
-    | (HttpResponse<t_hook> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_hook> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18183,12 +17786,12 @@ export class GitHubV3RestApiService {
       remove_events?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_hook> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18209,8 +17812,8 @@ export class GitHubV3RestApiService {
     repo: string
     hookId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18229,7 +17832,7 @@ export class GitHubV3RestApiService {
     repo: string
     hookId: number
   }): Observable<
-    (HttpResponse<t_webhook_config> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_webhook_config> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -18253,9 +17856,9 @@ export class GitHubV3RestApiService {
       url?: t_webhook_config_url
     }
   }): Observable<
-    (HttpResponse<t_webhook_config> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_webhook_config> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18278,9 +17881,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     cursor?: string
   }): Observable<
-    | (HttpResponse<t_hook_delivery_item[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook_delivery_item[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -18306,9 +17909,9 @@ export class GitHubV3RestApiService {
     hookId: number
     deliveryId: number
   }): Observable<
-    | (HttpResponse<t_hook_delivery> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hook_delivery> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18330,9 +17933,9 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18351,8 +17954,8 @@ export class GitHubV3RestApiService {
     repo: string
     hookId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18371,8 +17974,8 @@ export class GitHubV3RestApiService {
     repo: string
     hookId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18390,9 +17993,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_import> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_import> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18416,13 +18019,13 @@ export class GitHubV3RestApiService {
       vcs_username?: string
     }
   }): Observable<
-    | (HttpResponse<t_import> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_import> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18447,11 +18050,11 @@ export class GitHubV3RestApiService {
       vcs_username?: string
     } | null
   }): Observable<
-    | (HttpResponse<t_import> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_import> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18470,8 +18073,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18489,12 +18092,12 @@ export class GitHubV3RestApiService {
     repo: string
     since?: number
   }): Observable<
-    | (HttpResponse<t_porter_author[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_porter_author[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ since: p["since"] })
+    const params = this._queryParams({since: p["since"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -18516,13 +18119,13 @@ export class GitHubV3RestApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_porter_author> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_porter_author> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18542,8 +18145,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_porter_large_file[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_porter_large_file[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18564,12 +18167,12 @@ export class GitHubV3RestApiService {
       use_lfs: "opt_in" | "opt_out" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_import> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 503 })
+    | (HttpResponse<t_import> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18588,9 +18191,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_installation> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_installation> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18607,9 +18210,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_interaction_limit_response | EmptyObject> & {
-        status: 200
-      })
+    | (HttpResponse<t_interaction_limit_response | EmptyObject> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18628,11 +18229,11 @@ export class GitHubV3RestApiService {
     repo: string
     requestBody: t_interaction_limit
   }): Observable<
-    | (HttpResponse<t_interaction_limit_response> & { status: 200 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<t_interaction_limit_response> & {status: 200})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18652,8 +18253,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18673,13 +18274,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_repository_invitation[]> & { status: 200 })
+    | (HttpResponse<t_repository_invitation[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -18706,10 +18304,10 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_repository_invitation> & { status: 200 })
+    | (HttpResponse<t_repository_invitation> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18729,9 +18327,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     invitationId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -18759,10 +18355,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -18812,20 +18408,20 @@ export class GitHubV3RestApiService {
       type?: string | null
     }
   }): Observable<
-    | (HttpResponse<t_issue> & { status: 201 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue> & {status: 201})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18849,9 +18445,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue_comment[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue_comment[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -18879,8 +18475,8 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
   }): Observable<
-    | (HttpResponse<t_issue_comment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_issue_comment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -18902,11 +18498,11 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_issue_comment> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue_comment> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -18926,9 +18522,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     commentId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -18957,8 +18551,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_reaction[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_reaction[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -18996,12 +18590,12 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19022,9 +18616,7 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -19042,14 +18634,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue_event[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue_event[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19067,10 +18656,10 @@ export class GitHubV3RestApiService {
     repo: string
     eventId: number
   }): Observable<
-    | (HttpResponse<t_issue_event> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_issue_event> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19089,11 +18678,11 @@ export class GitHubV3RestApiService {
     repo: string
     issueNumber: number
   }): Observable<
-    | (HttpResponse<t_issue> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_issue> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19136,20 +18725,20 @@ export class GitHubV3RestApiService {
       type?: string | null
     }
   }): Observable<
-    | (HttpResponse<t_issue> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19173,9 +18762,9 @@ export class GitHubV3RestApiService {
       assignees?: string[]
     }
   }): Observable<
-    (HttpResponse<t_issue> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_issue> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19199,9 +18788,9 @@ export class GitHubV3RestApiService {
       assignees?: string[]
     }
   }): Observable<
-    (HttpResponse<t_issue> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_issue> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19223,8 +18812,8 @@ export class GitHubV3RestApiService {
     issueNumber: number
     assignee: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19246,9 +18835,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue_comment[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_issue_comment[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -19277,14 +18866,14 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_issue_comment> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue_comment> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19307,14 +18896,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue_event_for_issue[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_issue_event_for_issue[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19335,16 +18921,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_label[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_label[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19377,14 +18960,14 @@ export class GitHubV3RestApiService {
         }[]
       | string
   }): Observable<
-    | (HttpResponse<t_label[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_label[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19419,14 +19002,14 @@ export class GitHubV3RestApiService {
         }[]
       | string
   }): Observable<
-    | (HttpResponse<t_label[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_label[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19447,10 +19030,10 @@ export class GitHubV3RestApiService {
     repo: string
     issueNumber: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19470,10 +19053,10 @@ export class GitHubV3RestApiService {
     issueNumber: number
     name: string
   }): Observable<
-    | (HttpResponse<t_label[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 301 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_label[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 301})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19500,14 +19083,14 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     } | null
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19528,9 +19111,9 @@ export class GitHubV3RestApiService {
     repo: string
     issueNumber: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19561,9 +19144,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_reaction[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_reaction[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -19601,12 +19184,12 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19627,9 +19210,7 @@ export class GitHubV3RestApiService {
     repo: string
     issueNumber: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -19649,12 +19230,12 @@ export class GitHubV3RestApiService {
       sub_issue_id: number
     }
   }): Observable<
-    | (HttpResponse<t_issue> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_issue> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19677,15 +19258,12 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_issue[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_issue[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19708,14 +19286,14 @@ export class GitHubV3RestApiService {
       sub_issue_id: number
     }
   }): Observable<
-    | (HttpResponse<t_issue> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_issue> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19741,18 +19319,18 @@ export class GitHubV3RestApiService {
       sub_issue_id: number
     }
   }): Observable<
-    | (HttpResponse<t_issue> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_issue> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19775,15 +19353,12 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_timeline_issue_events[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
+    | (HttpResponse<t_timeline_issue_events[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19803,12 +19378,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_deploy_key[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_deploy_key[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19830,11 +19402,11 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    | (HttpResponse<t_deploy_key> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_deploy_key> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19854,8 +19426,8 @@ export class GitHubV3RestApiService {
     repo: string
     keyId: number
   }): Observable<
-    | (HttpResponse<t_deploy_key> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_deploy_key> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19873,9 +19445,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     keyId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -19893,14 +19463,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_label[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_label[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -19922,12 +19489,12 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_label> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_label> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19947,8 +19514,8 @@ export class GitHubV3RestApiService {
     repo: string
     name: string
   }): Observable<
-    | (HttpResponse<t_label> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_label> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -19972,9 +19539,9 @@ export class GitHubV3RestApiService {
       new_name?: string
     }
   }): Observable<
-    (HttpResponse<t_label> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_label> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19994,9 +19561,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     name: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -20012,7 +19577,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    (HttpResponse<t_language> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_language> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -20029,11 +19594,11 @@ export class GitHubV3RestApiService {
     repo: string
     ref?: t_code_scanning_ref
   }): Observable<
-    | (HttpResponse<t_license_content> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_license_content> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ ref: p["ref"] })
+    const params = this._queryParams({ref: p["ref"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -20053,12 +19618,12 @@ export class GitHubV3RestApiService {
       branch: string
     }
   }): Observable<
-    | (HttpResponse<t_merged_upstream> & { status: 200 })
-    | (HttpResponse<void> & { status: 409 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_merged_upstream> & {status: 200})
+    | (HttpResponse<void> & {status: 409})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20082,15 +19647,15 @@ export class GitHubV3RestApiService {
       head: string
     }
   }): Observable<
-    | (HttpResponse<t_commit> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_commit> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20114,8 +19679,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_milestone[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_milestone[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -20147,12 +19712,12 @@ export class GitHubV3RestApiService {
       title: string
     }
   }): Observable<
-    | (HttpResponse<t_milestone> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_milestone> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20172,8 +19737,8 @@ export class GitHubV3RestApiService {
     repo: string
     milestoneNumber: number
   }): Observable<
-    | (HttpResponse<t_milestone> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_milestone> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20198,9 +19763,9 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    (HttpResponse<t_milestone> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_milestone> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20221,8 +19786,8 @@ export class GitHubV3RestApiService {
     repo: string
     milestoneNumber: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20243,12 +19808,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_label[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_label[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -20272,7 +19834,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_thread[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_thread[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       all: p["all"],
@@ -20304,11 +19866,11 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         message?: string
         url?: string
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 205 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 205})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20327,8 +19889,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_page> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_page> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20352,12 +19914,12 @@ export class GitHubV3RestApiService {
       }
     } | null
   }): Observable<
-    | (HttpResponse<t_page> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_page> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20390,13 +19952,13 @@ export class GitHubV3RestApiService {
           }
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20415,10 +19977,10 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20437,12 +19999,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_page_build[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_page_build[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -20459,8 +20018,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_page_build_status> & { status: 201 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_page_build_status> & {status: 201}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "POST",
@@ -20476,7 +20034,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    (HttpResponse<t_page_build> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_page_build> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -20494,7 +20052,7 @@ export class GitHubV3RestApiService {
     repo: string
     buildId: number
   }): Observable<
-    (HttpResponse<t_page_build> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_page_build> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -20518,13 +20076,13 @@ export class GitHubV3RestApiService {
       pages_build_version: string
     }
   }): Observable<
-    | (HttpResponse<t_page_deployment> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_page_deployment> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20545,8 +20103,8 @@ export class GitHubV3RestApiService {
     repo: string
     pagesDeploymentId: number | string
   }): Observable<
-    | (HttpResponse<t_pages_deployment_status> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_pages_deployment_status> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20565,8 +20123,8 @@ export class GitHubV3RestApiService {
     repo: string
     pagesDeploymentId: number | string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20584,11 +20142,11 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_pages_health_check> & { status: 200 })
-    | (HttpResponse<t_empty_object> & { status: 202 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_pages_health_check> & {status: 200})
+    | (HttpResponse<t_empty_object> & {status: 202})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20607,8 +20165,8 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         enabled: boolean
-      }> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20626,8 +20184,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20645,8 +20203,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_scim_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_scim_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20667,12 +20225,12 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_project[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -20700,15 +20258,15 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_project> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 410 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 410})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20727,9 +20285,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_custom_property_value[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_custom_property_value[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20750,13 +20308,13 @@ export class GitHubV3RestApiService {
       properties: t_custom_property_value[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20788,9 +20346,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_pull_request_simple[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_pull_request_simple[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -20828,12 +20386,12 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    | (HttpResponse<t_pull_request> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_pull_request> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20857,7 +20415,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review_comment[]> & { status: 200 })
+    | (HttpResponse<t_pull_request_review_comment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -20884,8 +20442,8 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review_comment> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_pull_request_review_comment> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20907,10 +20465,10 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review_comment> & { status: 200 })
+    | (HttpResponse<t_pull_request_review_comment> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20931,8 +20489,8 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -20963,8 +20521,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_reaction[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_reaction[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -21002,12 +20560,12 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21028,9 +20586,7 @@ export class GitHubV3RestApiService {
     repo: string
     commentId: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -21047,16 +20603,16 @@ export class GitHubV3RestApiService {
     repo: string
     pullNumber: number
   }): Observable<
-    | (HttpResponse<t_pull_request> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 406 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_pull_request> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 406})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21082,12 +20638,12 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    | (HttpResponse<t_pull_request> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_pull_request> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21125,19 +20681,19 @@ export class GitHubV3RestApiService {
       working_directory?: string
     } | null
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 201 })
-    | (HttpResponse<t_codespace> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_codespace> & {status: 201})
+    | (HttpResponse<t_codespace> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21163,7 +20719,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review_comment[]> & { status: 200 })
+    | (HttpResponse<t_pull_request_review_comment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -21203,12 +20759,12 @@ export class GitHubV3RestApiService {
       subject_type?: "line" | "file" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review_comment> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_pull_request_review_comment> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21233,11 +20789,11 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review_comment> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_pull_request_review_comment> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21260,12 +20816,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_commit[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_commit[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21286,20 +20839,17 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_diff_entry[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_diff_entry[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21318,8 +20868,8 @@ export class GitHubV3RestApiService {
     repo: string
     pullNumber: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21344,21 +20894,21 @@ export class GitHubV3RestApiService {
       sha?: string
     } | null
   }): Observable<
-    | (HttpResponse<t_pull_request_merge_result> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_pull_request_merge_result> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         documentation_url?: string
         message?: string
-      }> & { status: 405 })
+      }> & {status: 405})
     | (HttpResponse<{
         documentation_url?: string
         message?: string
-      }> & { status: 409 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 409})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21379,7 +20929,7 @@ export class GitHubV3RestApiService {
     repo: string
     pullNumber: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review_request> & { status: 200 })
+    | (HttpResponse<t_pull_request_review_request> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21402,12 +20952,12 @@ export class GitHubV3RestApiService {
       team_reviewers?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_simple> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_pull_request_simple> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21432,11 +20982,11 @@ export class GitHubV3RestApiService {
       team_reviewers?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_simple> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_pull_request_simple> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21459,13 +21009,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review[]> & { status: 200 })
+    | (HttpResponse<t_pull_request_review[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21498,12 +21045,12 @@ export class GitHubV3RestApiService {
       event?: "APPROVE" | "REQUEST_CHANGES" | "COMMENT" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_pull_request_review> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21525,8 +21072,8 @@ export class GitHubV3RestApiService {
     pullNumber: number
     reviewId: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_pull_request_review> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21549,11 +21096,11 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_pull_request_review> & {status: 200})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21575,9 +21122,9 @@ export class GitHubV3RestApiService {
     pullNumber: number
     reviewId: number
   }): Observable<
-    | (HttpResponse<t_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_pull_request_review> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21599,14 +21146,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_review_comment[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_review_comment[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21630,12 +21174,12 @@ export class GitHubV3RestApiService {
       message: string
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_pull_request_review> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21661,13 +21205,13 @@ export class GitHubV3RestApiService {
       event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_pull_request_review> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_pull_request_review> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21694,12 +21238,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         message?: string
         url?: string
-      }> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21720,13 +21264,13 @@ export class GitHubV3RestApiService {
     repo: string
     ref?: string
   }): Observable<
-    | (HttpResponse<t_content_file> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_content_file> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ ref: p["ref"] })
+    const params = this._queryParams({ref: p["ref"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21745,12 +21289,12 @@ export class GitHubV3RestApiService {
     dir: string
     ref?: string
   }): Observable<
-    | (HttpResponse<t_content_file> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_content_file> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ ref: p["ref"] })
+    const params = this._queryParams({ref: p["ref"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21770,14 +21314,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_release[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_release[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -21805,12 +21346,12 @@ export class GitHubV3RestApiService {
       target_commitish?: string
     }
   }): Observable<
-    | (HttpResponse<t_release> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_release> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21830,9 +21371,9 @@ export class GitHubV3RestApiService {
     repo: string
     assetId: number
   }): Observable<
-    | (HttpResponse<t_release_asset> & { status: 200 })
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_release_asset> & {status: 200})
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21856,9 +21397,9 @@ export class GitHubV3RestApiService {
       state?: string
     }
   }): Observable<
-    (HttpResponse<t_release_asset> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_release_asset> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21878,9 +21419,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     assetId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -21902,11 +21441,11 @@ export class GitHubV3RestApiService {
       target_commitish?: string
     }
   }): Observable<
-    | (HttpResponse<t_release_notes_content> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_release_notes_content> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21926,7 +21465,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    (HttpResponse<t_release> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_release> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -21944,8 +21483,8 @@ export class GitHubV3RestApiService {
     repo: string
     tag: string
   }): Observable<
-    | (HttpResponse<t_release> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_release> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21964,8 +21503,8 @@ export class GitHubV3RestApiService {
     repo: string
     releaseId: number
   }): Observable<
-    | (HttpResponse<t_release> & { status: 200 })
-    | (HttpResponse<void> & { status: 401 })
+    | (HttpResponse<t_release> & {status: 200})
+    | (HttpResponse<void> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -21994,11 +21533,11 @@ export class GitHubV3RestApiService {
       target_commitish?: string
     }
   }): Observable<
-    | (HttpResponse<t_release> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_release> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22018,9 +21557,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     releaseId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -22039,12 +21576,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_release_asset[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_release_asset[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22073,14 +21607,12 @@ export class GitHubV3RestApiService {
       .reposUploadReleaseAsset()
       .build(),
   ): Observable<
-    | (HttpResponse<t_release_asset> & { status: 201 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_release_asset> & {status: 201})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({
-      "Content-Type": "application/octet-stream",
-    })
-    const params = this._queryParams({ name: p["name"], label: p["label"] })
+    const headers = this._headers({"Content-Type": "application/octet-stream"})
+    const params = this._queryParams({name: p["name"], label: p["label"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22112,8 +21644,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_reaction[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_reaction[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -22149,12 +21681,12 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_reaction> & { status: 200 })
-    | (HttpResponse<t_reaction> & { status: 201 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_reaction> & {status: 200})
+    | (HttpResponse<t_reaction> & {status: 201})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22175,9 +21707,7 @@ export class GitHubV3RestApiService {
     repo: string
     releaseId: number
     reactionId: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -22196,13 +21726,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_repository_rule_detailed[]> & { status: 200 })
+    | (HttpResponse<t_repository_rule_detailed[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22224,9 +21751,9 @@ export class GitHubV3RestApiService {
     includesParents?: boolean
     targets?: string
   }): Observable<
-    | (HttpResponse<t_repository_ruleset[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -22259,12 +21786,12 @@ export class GitHubV3RestApiService {
       target?: "branch" | "tag" | "push" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_repository_ruleset> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22294,9 +21821,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_rule_suites> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_rule_suites> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -22325,9 +21852,9 @@ export class GitHubV3RestApiService {
     repo: string
     ruleSuiteId: number
   }): Observable<
-    | (HttpResponse<t_rule_suite> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_rule_suite> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22347,12 +21874,12 @@ export class GitHubV3RestApiService {
     rulesetId: number
     includesParents?: boolean
   }): Observable<
-    | (HttpResponse<t_repository_ruleset> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ includes_parents: p["includesParents"] })
+    const params = this._queryParams({includes_parents: p["includesParents"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22379,12 +21906,12 @@ export class GitHubV3RestApiService {
       target?: "branch" | "tag" | "push" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_repository_ruleset> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_repository_ruleset> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22405,9 +21932,9 @@ export class GitHubV3RestApiService {
     repo: string
     rulesetId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22428,15 +21955,12 @@ export class GitHubV3RestApiService {
     page?: number
     rulesetId: number
   }): Observable<
-    | (HttpResponse<t_ruleset_version[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_ruleset_version[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22456,9 +21980,9 @@ export class GitHubV3RestApiService {
     rulesetId: number
     versionId: number
   }): Observable<
-    | (HttpResponse<t_ruleset_version_with_state> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_ruleset_version_with_state> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22489,13 +22013,13 @@ export class GitHubV3RestApiService {
     isMultiRepo?: boolean
     hideSecret?: boolean
   }): Observable<
-    | (HttpResponse<t_secret_scanning_alert[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_secret_scanning_alert[]> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -22532,17 +22056,17 @@ export class GitHubV3RestApiService {
     alertNumber: t_alert_number
     hideSecret?: boolean
   }): Observable<
-    | (HttpResponse<t_secret_scanning_alert> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_secret_scanning_alert> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<void> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ hide_secret: p["hideSecret"] })
+    const params = this._queryParams({hide_secret: p["hideSecret"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22566,18 +22090,18 @@ export class GitHubV3RestApiService {
       state: t_secret_scanning_alert_state
     }
   }): Observable<
-    | (HttpResponse<t_secret_scanning_alert> & { status: 200 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_secret_scanning_alert> & {status: 200})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22600,19 +22124,16 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_secret_scanning_location[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_secret_scanning_location[]> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22634,18 +22155,18 @@ export class GitHubV3RestApiService {
       reason: t_secret_scanning_push_protection_bypass_reason
     }
   }): Observable<
-    | (HttpResponse<t_secret_scanning_push_protection_bypass> & { status: 200 })
-    | (HttpResponse<void> & { status: 403 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_secret_scanning_push_protection_bypass> & {status: 200})
+    | (HttpResponse<void> & {status: 403})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22665,13 +22186,13 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_secret_scanning_scan_history> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_secret_scanning_scan_history> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22695,9 +22216,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     state?: "triage" | "draft" | "published" | "closed" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_repository_advisory[]> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_repository_advisory[]> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -22726,13 +22247,13 @@ export class GitHubV3RestApiService {
     repo: string
     requestBody: t_repository_advisory_create
   }): Observable<
-    | (HttpResponse<t_repository_advisory> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_repository_advisory> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22753,13 +22274,13 @@ export class GitHubV3RestApiService {
     repo: string
     requestBody: t_private_vulnerability_report_create
   }): Observable<
-    | (HttpResponse<t_repository_advisory> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_repository_advisory> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22780,9 +22301,9 @@ export class GitHubV3RestApiService {
     repo: string
     ghsaId: string
   }): Observable<
-    | (HttpResponse<t_repository_advisory> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_repository_advisory> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22802,13 +22323,13 @@ export class GitHubV3RestApiService {
     ghsaId: string
     requestBody: t_repository_advisory_update
   }): Observable<
-    | (HttpResponse<t_repository_advisory> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_repository_advisory> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -22831,11 +22352,11 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22854,11 +22375,11 @@ export class GitHubV3RestApiService {
     repo: string
     ghsaId: string
   }): Observable<
-    | (HttpResponse<t_full_repository> & { status: 202 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_full_repository> & {status: 202})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22878,14 +22399,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_simple_user[] | t_stargazer[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_simple_user[] | t_stargazer[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -22902,12 +22420,12 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_code_frequency_stat[]> & { status: 200 })
+    | (HttpResponse<t_code_frequency_stat[]> & {status: 200})
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 422 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22925,11 +22443,11 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_commit_activity[]> & { status: 200 })
+    | (HttpResponse<t_commit_activity[]> & {status: 200})
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 204 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22947,11 +22465,11 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_contributor_activity[]> & { status: 200 })
+    | (HttpResponse<t_contributor_activity[]> & {status: 200})
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 204 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22969,8 +22487,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_participation_stats> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_participation_stats> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -22988,8 +22506,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_code_frequency_stat[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_code_frequency_stat[]> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23019,9 +22537,9 @@ export class GitHubV3RestApiService {
       target_url?: string | null
     }
   }): Observable<
-    (HttpResponse<t_status> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_status> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23043,12 +22561,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23065,9 +22580,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_repository_subscription> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_repository_subscription> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23088,10 +22603,10 @@ export class GitHubV3RestApiService {
       subscribed?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_repository_subscription> & { status: 200 })
+    | (HttpResponse<t_repository_subscription> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23109,9 +22624,7 @@ export class GitHubV3RestApiService {
   activityDeleteRepoSubscription(p: {
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`,
@@ -23128,12 +22641,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_tag[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_tag[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23150,9 +22660,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_tag_protection[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_tag_protection[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23173,12 +22683,12 @@ export class GitHubV3RestApiService {
       pattern: string
     }
   }): Observable<
-    | (HttpResponse<t_tag_protection> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_tag_protection> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23199,9 +22709,9 @@ export class GitHubV3RestApiService {
     repo: string
     tagProtectionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23219,9 +22729,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     ref: string
-  }): Observable<
-    (HttpResponse<void> & { status: 302 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 302}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -23239,14 +22747,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23265,14 +22770,11 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_topic> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_topic> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      page: p["page"],
-      per_page: p["perPage"],
-    })
+    const params = this._queryParams({page: p["page"], per_page: p["perPage"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23292,12 +22794,12 @@ export class GitHubV3RestApiService {
       names: string[]
     }
   }): Observable<
-    | (HttpResponse<t_topic> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_topic> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23317,11 +22819,11 @@ export class GitHubV3RestApiService {
     repo: string
     per?: "day" | "week" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_clone_traffic> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_clone_traffic> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ per: p["per"] })
+    const params = this._queryParams({per: p["per"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23338,8 +22840,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_content_traffic[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_content_traffic[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23357,8 +22859,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_referrer_traffic[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_referrer_traffic[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23377,11 +22879,11 @@ export class GitHubV3RestApiService {
     repo: string
     per?: "day" | "week" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_view_traffic> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_view_traffic> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ per: p["per"] })
+    const params = this._queryParams({per: p["per"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23403,10 +22905,9 @@ export class GitHubV3RestApiService {
       team_ids?: number[]
     }
   }): Observable<
-    | (HttpResponse<t_minimal_repository> & { status: 202 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_minimal_repository> & {status: 202}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23425,8 +22926,8 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23443,9 +22944,7 @@ export class GitHubV3RestApiService {
   reposEnableVulnerabilityAlerts(p: {
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "PUT",
       this.config.basePath +
@@ -23460,9 +22959,7 @@ export class GitHubV3RestApiService {
   reposDisableVulnerabilityAlerts(p: {
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -23478,9 +22975,7 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
     ref: string
-  }): Observable<
-    (HttpResponse<void> & { status: 302 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 302}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "GET",
       this.config.basePath +
@@ -23503,9 +22998,9 @@ export class GitHubV3RestApiService {
       private?: boolean
     }
   }): Observable<
-    (HttpResponse<t_full_repository> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_full_repository> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23526,12 +23021,12 @@ export class GitHubV3RestApiService {
       since?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ since: p["since"] })
+    const params = this._queryParams({since: p["since"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -23555,15 +23050,15 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_code_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23596,8 +23091,8 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_commit_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23643,15 +23138,15 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_issue_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23686,11 +23181,11 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_label_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23729,14 +23224,14 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_repo_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23767,8 +23262,8 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_topic_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23799,14 +23294,14 @@ export class GitHubV3RestApiService {
         incomplete_results: boolean
         items: t_user_search_result_item[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -23831,8 +23326,8 @@ export class GitHubV3RestApiService {
   teamsGetLegacy(p: {
     teamId: number
   }): Observable<
-    | (HttpResponse<t_team_full> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team_full> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23859,14 +23354,14 @@ export class GitHubV3RestApiService {
       privacy?: "secret" | "closed" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_team_full> & { status: 200 })
-    | (HttpResponse<t_team_full> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team_full> & {status: 200})
+    | (HttpResponse<t_team_full> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23884,9 +23379,9 @@ export class GitHubV3RestApiService {
   teamsDeleteLegacy(p: {
     teamId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -23905,8 +23400,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team_discussion[]> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       direction: p["direction"],
@@ -23933,9 +23427,9 @@ export class GitHubV3RestApiService {
       title: string
     }
   }): Observable<
-    (HttpResponse<t_team_discussion> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23954,7 +23448,7 @@ export class GitHubV3RestApiService {
     teamId: number
     discussionNumber: number
   }): Observable<
-    (HttpResponse<t_team_discussion> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -23975,9 +23469,9 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    (HttpResponse<t_team_discussion> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_team_discussion> & {status: 200}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -23996,9 +23490,7 @@ export class GitHubV3RestApiService {
   teamsDeleteDiscussionLegacy(p: {
     teamId: number
     discussionNumber: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -24017,7 +23509,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment[]> & { status: 200 })
+    | (HttpResponse<t_team_discussion_comment[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -24045,10 +23537,10 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment> & { status: 201 })
+    | (HttpResponse<t_team_discussion_comment> & {status: 201})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24069,7 +23561,7 @@ export class GitHubV3RestApiService {
     discussionNumber: number
     commentNumber: number
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment> & { status: 200 })
+    | (HttpResponse<t_team_discussion_comment> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24091,10 +23583,10 @@ export class GitHubV3RestApiService {
       body: string
     }
   }): Observable<
-    | (HttpResponse<t_team_discussion_comment> & { status: 200 })
+    | (HttpResponse<t_team_discussion_comment> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24114,9 +23606,7 @@ export class GitHubV3RestApiService {
     teamId: number
     discussionNumber: number
     commentNumber: number
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -24145,7 +23635,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_reaction[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_reaction[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       content: p["content"],
@@ -24182,9 +23672,9 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    (HttpResponse<t_reaction> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_reaction> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24216,7 +23706,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_reaction[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_reaction[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       content: p["content"],
@@ -24252,9 +23742,9 @@ export class GitHubV3RestApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    (HttpResponse<t_reaction> & { status: 201 }) | HttpResponse<unknown>
+    (HttpResponse<t_reaction> & {status: 201}) | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24275,13 +23765,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_organization_invitation[]> & { status: 200 })
+    | (HttpResponse<t_organization_invitation[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -24300,8 +23787,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -24325,8 +23812,8 @@ export class GitHubV3RestApiService {
     teamId: number
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24343,10 +23830,10 @@ export class GitHubV3RestApiService {
     teamId: number
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<void> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<void> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24363,8 +23850,8 @@ export class GitHubV3RestApiService {
     teamId: number
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24381,8 +23868,8 @@ export class GitHubV3RestApiService {
     teamId: number
     username: string
   }): Observable<
-    | (HttpResponse<t_team_membership> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team_membership> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24403,13 +23890,13 @@ export class GitHubV3RestApiService {
       role?: "member" | "maintainer" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_team_membership> & { status: 200 })
-    | (HttpResponse<void> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<t_team_membership> & {status: 200})
+    | (HttpResponse<void> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24429,8 +23916,8 @@ export class GitHubV3RestApiService {
     teamId: number
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 403 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24449,14 +23936,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team_project[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team_project[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -24473,8 +23957,8 @@ export class GitHubV3RestApiService {
     teamId: number
     projectId: number
   }): Observable<
-    | (HttpResponse<t_team_project> & { status: 200 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_team_project> & {status: 200})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24494,16 +23978,16 @@ export class GitHubV3RestApiService {
       permission?: "read" | "write" | "admin" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<void> & {status: 204})
     | (HttpResponse<{
         documentation_url?: string
         message?: string
-      }> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+      }> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24522,9 +24006,9 @@ export class GitHubV3RestApiService {
     teamId: number
     projectId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24542,14 +24026,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -24567,9 +24048,9 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<t_team_repository> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<t_team_repository> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24591,12 +24072,12 @@ export class GitHubV3RestApiService {
       permission?: "pull" | "push" | "admin" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24616,9 +24097,7 @@ export class GitHubV3RestApiService {
     teamId: number
     owner: string
     repo: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath +
@@ -24635,16 +24114,13 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_team[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_team[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -24658,10 +24134,10 @@ export class GitHubV3RestApiService {
   }
 
   usersGetAuthenticated(): Observable<
-    | (HttpResponse<t_private_user | t_public_user> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_private_user | t_public_user> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>("GET", this.config.basePath + `/user`, {
@@ -24684,15 +24160,15 @@ export class GitHubV3RestApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_private_user> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_private_user> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24713,17 +24189,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -24739,11 +24212,11 @@ export class GitHubV3RestApiService {
   usersCheckBlocked(p: {
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24759,12 +24232,12 @@ export class GitHubV3RestApiService {
   usersBlock(p: {
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24780,11 +24253,11 @@ export class GitHubV3RestApiService {
   usersUnblock(p: {
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24807,12 +24280,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         codespaces: t_codespace[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -24871,19 +24344,19 @@ export class GitHubV3RestApiService {
           working_directory?: string
         }
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 201 })
-    | (HttpResponse<t_codespace> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_codespace> & {status: 201})
+    | (HttpResponse<t_codespace> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24907,13 +24380,10 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         secrets: t_codespaces_secret[]
         total_count: number
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -24927,7 +24397,7 @@ export class GitHubV3RestApiService {
   }
 
   codespacesGetPublicKeyForAuthenticatedUser(): Observable<
-    | (HttpResponse<t_codespaces_user_public_key> & { status: 200 })
+    | (HttpResponse<t_codespaces_user_public_key> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -24943,8 +24413,7 @@ export class GitHubV3RestApiService {
   codespacesGetSecretForAuthenticatedUser(p: {
     secretName: string
   }): Observable<
-    | (HttpResponse<t_codespaces_secret> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_codespaces_secret> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -24964,13 +24433,13 @@ export class GitHubV3RestApiService {
       selected_repository_ids?: (number | string)[]
     }
   }): Observable<
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -24987,9 +24456,7 @@ export class GitHubV3RestApiService {
 
   codespacesDeleteSecretForAuthenticatedUser(p: {
     secretName: string
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
     return this.httpClient.request<any>(
       "DELETE",
       this.config.basePath + `/user/codespaces/secrets/${p["secretName"]}`,
@@ -25006,11 +24473,11 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         repositories: t_minimal_repository[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25030,14 +24497,14 @@ export class GitHubV3RestApiService {
       selected_repository_ids: number[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25057,11 +24524,11 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25079,11 +24546,11 @@ export class GitHubV3RestApiService {
     secretName: string
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25100,12 +24567,12 @@ export class GitHubV3RestApiService {
   codespacesGetForAuthenticatedUser(p: {
     codespaceName: string
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_codespace> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25126,13 +24593,13 @@ export class GitHubV3RestApiService {
       recent_folders?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_codespace> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25152,12 +24619,12 @@ export class GitHubV3RestApiService {
   }): Observable<
     | (HttpResponse<{
         [key: string]: unknown | undefined
-      }> & { status: 202 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 202})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25173,12 +24640,12 @@ export class GitHubV3RestApiService {
   codespacesExportForAuthenticatedUser(p: {
     codespaceName: string
   }): Observable<
-    | (HttpResponse<t_codespace_export_details> & { status: 202 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_codespace_export_details> & {status: 202})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25195,8 +24662,8 @@ export class GitHubV3RestApiService {
     codespaceName: string
     exportId: string
   }): Observable<
-    | (HttpResponse<t_codespace_export_details> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_codespace_export_details> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25216,12 +24683,12 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         machines: t_codespace_machine[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25241,14 +24708,14 @@ export class GitHubV3RestApiService {
       private?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_codespace_with_full_repository> & { status: 201 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_codespace_with_full_repository> & {status: 201})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25266,15 +24733,15 @@ export class GitHubV3RestApiService {
   codespacesStartForAuthenticatedUser(p: {
     codespaceName: string
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 402 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_codespace> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 402})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25290,11 +24757,11 @@ export class GitHubV3RestApiService {
   codespacesStopForAuthenticatedUser(p: {
     codespaceName: string
   }): Observable<
-    | (HttpResponse<t_codespace> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_codespace> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25308,7 +24775,7 @@ export class GitHubV3RestApiService {
   }
 
   packagesListDockerMigrationConflictingPackagesForAuthenticatedUser(): Observable<
-    (HttpResponse<t_package[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package[]> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -25325,15 +24792,15 @@ export class GitHubV3RestApiService {
       visibility: "public" | "private" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_email[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_email[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25354,17 +24821,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_email[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_email[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25387,15 +24851,15 @@ export class GitHubV3RestApiService {
         | string
     } = {},
   ): Observable<
-    | (HttpResponse<t_email[]> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_email[]> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25418,15 +24882,15 @@ export class GitHubV3RestApiService {
       | string[]
       | string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25447,16 +24911,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25475,16 +24936,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25500,11 +24958,11 @@ export class GitHubV3RestApiService {
   usersCheckPersonIsFollowedByAuthenticated(p: {
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25520,12 +24978,12 @@ export class GitHubV3RestApiService {
   usersFollow(p: {
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25541,11 +24999,11 @@ export class GitHubV3RestApiService {
   usersUnfollow(p: {
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25564,17 +25022,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_gpg_key[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gpg_key[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25593,15 +25048,15 @@ export class GitHubV3RestApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_gpg_key> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_gpg_key> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25619,11 +25074,11 @@ export class GitHubV3RestApiService {
   usersGetGpgKeyForAuthenticatedUser(p: {
     gpgKeyId: number
   }): Observable<
-    | (HttpResponse<t_gpg_key> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_gpg_key> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25639,12 +25094,12 @@ export class GitHubV3RestApiService {
   usersDeleteGpgKeyForAuthenticatedUser(p: {
     gpgKeyId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25666,16 +25121,13 @@ export class GitHubV3RestApiService {
     | (HttpResponse<{
         installations: t_installation[]
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25697,16 +25149,13 @@ export class GitHubV3RestApiService {
         repositories: t_repository[]
         repository_selection?: string
         total_count: number
-      }> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25724,10 +25173,10 @@ export class GitHubV3RestApiService {
     installationId: number
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25745,11 +25194,11 @@ export class GitHubV3RestApiService {
     installationId: number
     repositoryId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<void> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<void> & {status: 422})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25764,10 +25213,8 @@ export class GitHubV3RestApiService {
   }
 
   interactionsGetRestrictionsForAuthenticatedUser(): Observable<
-    | (HttpResponse<t_interaction_limit_response | EmptyObject> & {
-        status: 200
-      })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<t_interaction_limit_response | EmptyObject> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25783,11 +25230,11 @@ export class GitHubV3RestApiService {
   interactionsSetRestrictionsForAuthenticatedUser(p: {
     requestBody: t_interaction_limit
   }): Observable<
-    | (HttpResponse<t_interaction_limit_response> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_interaction_limit_response> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25803,7 +25250,7 @@ export class GitHubV3RestApiService {
   }
 
   interactionsRemoveRestrictionsForAuthenticatedUser(): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
+    (HttpResponse<void> & {status: 204}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "DELETE",
@@ -25834,9 +25281,9 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_issue[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_issue[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -25867,17 +25314,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_key[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_key[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25896,15 +25340,15 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    | (HttpResponse<t_key> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_key> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25922,11 +25366,11 @@ export class GitHubV3RestApiService {
   usersGetPublicSshKeyForAuthenticatedUser(p: {
     keyId: number
   }): Observable<
-    | (HttpResponse<t_key> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_key> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25942,11 +25386,11 @@ export class GitHubV3RestApiService {
   usersDeletePublicSshKeyForAuthenticatedUser(p: {
     keyId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -25965,16 +25409,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_user_marketplace_purchase[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_user_marketplace_purchase[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -25993,15 +25434,12 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_user_marketplace_purchase[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
+    | (HttpResponse<t_user_marketplace_purchase[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26021,11 +25459,11 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_org_membership[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_org_membership[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -26048,9 +25486,9 @@ export class GitHubV3RestApiService {
   orgsGetMembershipForAuthenticatedUser(p: {
     org: string
   }): Observable<
-    | (HttpResponse<t_org_membership> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_org_membership> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26069,13 +25507,13 @@ export class GitHubV3RestApiService {
       state: "active" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_org_membership> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_org_membership> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26096,16 +25534,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_migration[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_migration[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26131,14 +25566,14 @@ export class GitHubV3RestApiService {
       repositories: string[]
     }
   }): Observable<
-    | (HttpResponse<t_migration> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_migration> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26157,14 +25592,14 @@ export class GitHubV3RestApiService {
     migrationId: number
     exclude?: string[]
   }): Observable<
-    | (HttpResponse<t_migration> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_migration> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ exclude: p["exclude"] })
+    const params = this._queryParams({exclude: p["exclude"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26180,10 +25615,10 @@ export class GitHubV3RestApiService {
   migrationsGetArchiveForAuthenticatedUser(p: {
     migrationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 302 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<void> & {status: 302})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26199,11 +25634,11 @@ export class GitHubV3RestApiService {
   migrationsDeleteArchiveForAuthenticatedUser(p: {
     migrationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26220,11 +25655,11 @@ export class GitHubV3RestApiService {
     migrationId: number
     repoName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26243,14 +25678,11 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26270,16 +25702,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_organization_simple[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_organization_simple[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26305,8 +25734,8 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_package[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 400 })
+    | (HttpResponse<t_package[]> & {status: 200})
+    | (HttpResponse<void> & {status: 400})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -26338,7 +25767,7 @@ export class GitHubV3RestApiService {
       | UnknownEnumStringValue
     packageName: string
   }): Observable<
-    (HttpResponse<t_package> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -26362,10 +25791,10 @@ export class GitHubV3RestApiService {
       | UnknownEnumStringValue
     packageName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26391,13 +25820,13 @@ export class GitHubV3RestApiService {
     packageName: string
     token?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ token: p["token"] })
+    const params = this._queryParams({token: p["token"]})
 
     return this.httpClient.request<any>(
       "POST",
@@ -26425,10 +25854,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     state?: "active" | "deleted" | UnknownEnumStringValue
   }): Observable<
-    | (HttpResponse<t_package_version[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_package_version[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -26461,7 +25890,7 @@ export class GitHubV3RestApiService {
     packageName: string
     packageVersionId: number
   }): Observable<
-    (HttpResponse<t_package_version> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package_version> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -26486,10 +25915,10 @@ export class GitHubV3RestApiService {
     packageName: string
     packageVersionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26515,10 +25944,10 @@ export class GitHubV3RestApiService {
     packageName: string
     packageVersionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26538,14 +25967,14 @@ export class GitHubV3RestApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_project> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error_simple> & { status: 422 })
+    | (HttpResponse<t_project> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error_simple> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26566,17 +25995,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_email[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_email[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26613,11 +26039,11 @@ export class GitHubV3RestApiService {
       before?: string
     } = {},
   ): Observable<
-    | (HttpResponse<t_repository[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_repository[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -26681,16 +26107,16 @@ export class GitHubV3RestApiService {
       team_id?: number
     }
   }): Observable<
-    | (HttpResponse<t_full_repository> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_full_repository> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26711,17 +26137,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_repository_invitation[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_repository_invitation[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26737,11 +26160,11 @@ export class GitHubV3RestApiService {
   reposAcceptInvitationForAuthenticatedUser(p: {
     invitationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26758,11 +26181,11 @@ export class GitHubV3RestApiService {
   reposDeclineInvitationForAuthenticatedUser(p: {
     invitationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_basic_error> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_basic_error> & {status: 409})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26782,17 +26205,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_social_account[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_social_account[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26810,15 +26230,15 @@ export class GitHubV3RestApiService {
       account_urls: string[]
     }
   }): Observable<
-    | (HttpResponse<t_social_account[]> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_social_account[]> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26838,15 +26258,15 @@ export class GitHubV3RestApiService {
       account_urls: string[]
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26867,17 +26287,14 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_ssh_signing_key[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_ssh_signing_key[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -26896,15 +26313,15 @@ export class GitHubV3RestApiService {
       title?: string
     }
   }): Observable<
-    | (HttpResponse<t_ssh_signing_key> & { status: 201 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_ssh_signing_key> & {status: 201})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26922,11 +26339,11 @@ export class GitHubV3RestApiService {
   usersGetSshSigningKeyForAuthenticatedUser(p: {
     sshSigningKeyId: number
   }): Observable<
-    | (HttpResponse<t_ssh_signing_key> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_ssh_signing_key> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26942,11 +26359,11 @@ export class GitHubV3RestApiService {
   usersDeleteSshSigningKeyForAuthenticatedUser(p: {
     sshSigningKeyId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -26967,10 +26384,10 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_starred_repository[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_starred_repository[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -26995,11 +26412,11 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27016,11 +26433,11 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27037,11 +26454,11 @@ export class GitHubV3RestApiService {
     owner: string
     repo: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27060,16 +26477,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27088,16 +26502,13 @@ export class GitHubV3RestApiService {
       page?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_team_full[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_team_full[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27113,8 +26524,8 @@ export class GitHubV3RestApiService {
   usersGetById(p: {
     accountId: number
   }): Observable<
-    | (HttpResponse<t_private_user | t_public_user> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_private_user | t_public_user> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27133,8 +26544,8 @@ export class GitHubV3RestApiService {
       perPage?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_simple_user[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 304 })
+    | (HttpResponse<t_simple_user[]> & {status: 200})
+    | (HttpResponse<void> & {status: 304})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27156,8 +26567,8 @@ export class GitHubV3RestApiService {
   usersGetByUsername(p: {
     username: string
   }): Observable<
-    | (HttpResponse<t_private_user | t_public_user> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_private_user | t_public_user> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27207,10 +26618,10 @@ export class GitHubV3RestApiService {
           next?: string
           previous?: string
         }
-      }> & { status: 200 })
+      }> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const params = this._queryParams({
       per_page: p["perPage"],
       before: p["before"],
@@ -27241,11 +26652,11 @@ export class GitHubV3RestApiService {
           attestation_ids: number[]
         }
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -27265,9 +26676,9 @@ export class GitHubV3RestApiService {
     username: string
     subjectDigest: string
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27285,10 +26696,10 @@ export class GitHubV3RestApiService {
     username: string
     attestationId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27324,10 +26735,10 @@ export class GitHubV3RestApiService {
           bundle_url?: string
           repository_id?: number
         }[]
-      }> & { status: 200 })
-    | (HttpResponse<t_empty_object> & { status: 201 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_empty_object> & {status: 201})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27352,9 +26763,9 @@ export class GitHubV3RestApiService {
   packagesListDockerMigrationConflictingPackagesForUser(p: {
     username: string
   }): Observable<
-    | (HttpResponse<t_package[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_package[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27372,12 +26783,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27396,12 +26804,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27419,12 +26824,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27442,12 +26844,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27465,12 +26864,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_simple_user[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_simple_user[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27487,8 +26883,8 @@ export class GitHubV3RestApiService {
     username: string
     targetUser: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27508,8 +26904,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_base_gist[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_base_gist[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27534,12 +26930,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_gpg_key[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_gpg_key[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27562,9 +26955,9 @@ export class GitHubV3RestApiService {
       | UnknownEnumStringValue
     subjectId?: string
   }): Observable<
-    | (HttpResponse<t_hovercard> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_hovercard> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27586,7 +26979,7 @@ export class GitHubV3RestApiService {
   appsGetUserInstallation(p: {
     username: string
   }): Observable<
-    (HttpResponse<t_installation> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_installation> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -27603,12 +26996,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_key_simple[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_key_simple[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27626,13 +27016,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_organization_simple[]> & { status: 200 })
+    | (HttpResponse<t_organization_simple[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27659,10 +27046,10 @@ export class GitHubV3RestApiService {
     page?: number
     perPage?: number
   }): Observable<
-    | (HttpResponse<t_package[]> & { status: 200 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
+    | (HttpResponse<t_package[]> & {status: 200})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27695,7 +27082,7 @@ export class GitHubV3RestApiService {
     packageName: string
     username: string
   }): Observable<
-    (HttpResponse<t_package> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -27720,10 +27107,10 @@ export class GitHubV3RestApiService {
     packageName: string
     username: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27750,13 +27137,13 @@ export class GitHubV3RestApiService {
     username: string
     token?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ token: p["token"] })
+    const params = this._queryParams({token: p["token"]})
 
     return this.httpClient.request<any>(
       "POST",
@@ -27782,10 +27169,10 @@ export class GitHubV3RestApiService {
     packageName: string
     username: string
   }): Observable<
-    | (HttpResponse<t_package_version[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<t_package_version[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27812,7 +27199,7 @@ export class GitHubV3RestApiService {
     packageVersionId: number
     username: string
   }): Observable<
-    (HttpResponse<t_package_version> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_package_version> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
       "GET",
@@ -27838,10 +27225,10 @@ export class GitHubV3RestApiService {
     username: string
     packageVersionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27868,10 +27255,10 @@ export class GitHubV3RestApiService {
     username: string
     packageVersionId: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_basic_error> & { status: 401 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_basic_error> & {status: 401})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -27891,8 +27278,8 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_project[]> & { status: 200 })
-    | (HttpResponse<t_validation_error> & { status: 422 })
+    | (HttpResponse<t_project[]> & {status: 200})
+    | (HttpResponse<t_validation_error> & {status: 422})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27917,12 +27304,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27940,12 +27324,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_event[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_event[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -27971,7 +27352,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -27996,7 +27377,7 @@ export class GitHubV3RestApiService {
   billingGetGithubActionsBillingUser(p: {
     username: string
   }): Observable<
-    | (HttpResponse<t_actions_billing_usage> & { status: 200 })
+    | (HttpResponse<t_actions_billing_usage> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -28012,7 +27393,7 @@ export class GitHubV3RestApiService {
   billingGetGithubPackagesBillingUser(p: {
     username: string
   }): Observable<
-    | (HttpResponse<t_packages_billing_usage> & { status: 200 })
+    | (HttpResponse<t_packages_billing_usage> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -28029,7 +27410,7 @@ export class GitHubV3RestApiService {
   billingGetSharedStorageBillingUser(p: {
     username: string
   }): Observable<
-    | (HttpResponse<t_combined_billing_usage> & { status: 200 })
+    | (HttpResponse<t_combined_billing_usage> & {status: 200})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -28050,15 +27431,15 @@ export class GitHubV3RestApiService {
     day?: number
     hour?: number
   }): Observable<
-    | (HttpResponse<t_billing_usage_report_user> & { status: 200 })
-    | (HttpResponse<t_scim_error> & { status: 400 })
-    | (HttpResponse<t_basic_error> & { status: 403 })
-    | (HttpResponse<t_basic_error> & { status: 500 })
+    | (HttpResponse<t_billing_usage_report_user> & {status: 200})
+    | (HttpResponse<t_scim_error> & {status: 400})
+    | (HttpResponse<t_basic_error> & {status: 403})
+    | (HttpResponse<t_basic_error> & {status: 500})
     | (HttpResponse<{
         code?: string
         documentation_url?: string
         message?: string
-      }> & { status: 503 })
+      }> & {status: 503})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -28084,12 +27465,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    (HttpResponse<t_social_account[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_social_account[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -28107,13 +27485,9 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_ssh_signing_key[]> & { status: 200 })
-    | HttpResponse<unknown>
+    (HttpResponse<t_ssh_signing_key[]> & {status: 200}) | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -28133,7 +27507,7 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_starred_repository[] | t_repository[]> & { status: 200 })
+    | (HttpResponse<t_starred_repository[] | t_repository[]> & {status: 200})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -28159,13 +27533,10 @@ export class GitHubV3RestApiService {
     perPage?: number
     page?: number
   }): Observable<
-    | (HttpResponse<t_minimal_repository[]> & { status: 200 })
+    | (HttpResponse<t_minimal_repository[]> & {status: 200})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({
-      per_page: p["perPage"],
-      page: p["page"],
-    })
+    const params = this._queryParams({per_page: p["perPage"], page: p["page"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -28179,8 +27550,8 @@ export class GitHubV3RestApiService {
   }
 
   metaGetAllVersions(): Observable<
-    | (HttpResponse<string[]> & { status: 200 })
-    | (HttpResponse<t_basic_error> & { status: 404 })
+    | (HttpResponse<string[]> & {status: 200})
+    | (HttpResponse<t_basic_error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -28194,7 +27565,7 @@ export class GitHubV3RestApiService {
   }
 
   metaGetZen(): Observable<
-    (HttpResponse<string> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<string> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>("GET", this.config.basePath + `/zen`, {
       observe: "response",
@@ -28203,5 +27574,5 @@ export class GitHubV3RestApiService {
   }
 }
 
-export { GitHubV3RestApiService as ApiClient }
-export { GitHubV3RestApiServiceConfig as ApiClientConfig }
+export {GitHubV3RestApiService as ApiClient}
+export {GitHubV3RestApiServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/api.github.com.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ContosoWidgetManagerService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {ContosoWidgetManagerService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class ContosoWidgetManagerModule {}
 
-export { ContosoWidgetManagerModule as ApiModule }
+export {ContosoWidgetManagerModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-core-data-plane-service.tsp/client.service.ts
@@ -20,9 +20,9 @@ import {
   t_WidgetRepairRequest,
   t_WidgetRepairState,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class ContosoWidgetManagerServiceServers {
   static server(url: "{endpoint}/widget" = "{endpoint}/widget"): {
@@ -88,7 +88,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -103,7 +103,7 @@ export class ContosoWidgetManagerService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -132,7 +132,7 @@ export class ContosoWidgetManagerService {
   }): Observable<
     | (HttpResponse<{
         statusString: string
-      }> & { status: 200 })
+      }> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -141,7 +141,7 @@ export class ContosoWidgetManagerService {
     const headers = this._headers({
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -172,13 +172,13 @@ export class ContosoWidgetManagerService {
             id: string
             status: t_Azure_Core_Foundations_OperationState
           }
-      > & { status: 200 })
+      > & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -204,8 +204,8 @@ export class ContosoWidgetManagerService {
     xMsClientRequestId?: t_Azure_Core_uuid
     requestBody: t_WidgetCreateOrUpdate
   }): Observable<
-    | (HttpResponse<t_Widget> & { status: 200 })
-    | (HttpResponse<t_Widget> & { status: 201 })
+    | (HttpResponse<t_Widget> & {status: 200})
+    | (HttpResponse<t_Widget> & {status: 201})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -221,7 +221,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -246,7 +246,7 @@ export class ContosoWidgetManagerService {
     ifModifiedSince?: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_Widget> & { status: 200 })
+    | (HttpResponse<t_Widget> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -259,7 +259,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -288,7 +288,7 @@ export class ContosoWidgetManagerService {
         error?: t_Azure_Core_Foundations_Error
         id: string
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 202 })
+      }> & {status: 202})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -303,7 +303,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "DELETE",
@@ -325,7 +325,7 @@ export class ContosoWidgetManagerService {
     select?: string[]
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_PagedWidget> & { status: 200 })
+    | (HttpResponse<t_PagedWidget> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -363,7 +363,7 @@ export class ContosoWidgetManagerService {
     ifModifiedSince?: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_WidgetAnalytics> & { status: 200 })
+    | (HttpResponse<t_WidgetAnalytics> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -376,7 +376,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -402,8 +402,8 @@ export class ContosoWidgetManagerService {
     xMsClientRequestId?: t_Azure_Core_uuid
     requestBody: t_WidgetAnalyticsCreateOrUpdate
   }): Observable<
-    | (HttpResponse<t_WidgetAnalytics> & { status: 200 })
-    | (HttpResponse<t_WidgetAnalytics> & { status: 201 })
+    | (HttpResponse<t_WidgetAnalytics> & {status: 200})
+    | (HttpResponse<t_WidgetAnalytics> & {status: 201})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -419,7 +419,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -445,13 +445,13 @@ export class ContosoWidgetManagerService {
         id: string
         result?: t_WidgetRepairRequest
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 200 })
+      }> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -484,7 +484,7 @@ export class ContosoWidgetManagerService {
           updatedDateTime: string
         }
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 202 })
+      }> & {status: 202})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -496,7 +496,7 @@ export class ContosoWidgetManagerService {
       "Repeatability-First-Sent": p["repeatabilityFirstSent"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -523,13 +523,13 @@ export class ContosoWidgetManagerService {
         id: string
         result?: t_WidgetPart
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 200 })
+      }> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -555,7 +555,7 @@ export class ContosoWidgetManagerService {
     xMsClientRequestId?: t_Azure_Core_uuid
     requestBody: t_WidgetPart
   }): Observable<
-    | (HttpResponse<void> & { status: 201 })
+    | (HttpResponse<void> & {status: 201})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -571,7 +571,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -592,7 +592,7 @@ export class ContosoWidgetManagerService {
     widgetName: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_PagedWidgetPart> & { status: 200 })
+    | (HttpResponse<t_PagedWidgetPart> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -601,7 +601,7 @@ export class ContosoWidgetManagerService {
     const headers = this._headers({
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -625,7 +625,7 @@ export class ContosoWidgetManagerService {
     ifModifiedSince?: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_WidgetPart> & { status: 200 })
+    | (HttpResponse<t_WidgetPart> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -638,7 +638,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -665,7 +665,7 @@ export class ContosoWidgetManagerService {
     ifModifiedSince?: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<void> & {status: 204})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -680,7 +680,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "DELETE",
@@ -707,7 +707,7 @@ export class ContosoWidgetManagerService {
         error?: t_Azure_Core_Foundations_Error
         id: string
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 202 })
+      }> & {status: 202})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -719,7 +719,7 @@ export class ContosoWidgetManagerService {
       "Repeatability-First-Sent": p["repeatabilityFirstSent"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -745,13 +745,13 @@ export class ContosoWidgetManagerService {
         id: string
         result?: t_Manufacturer
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 200 })
+      }> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -777,8 +777,8 @@ export class ContosoWidgetManagerService {
     xMsClientRequestId?: t_Azure_Core_uuid
     requestBody: t_Manufacturer
   }): Observable<
-    | (HttpResponse<t_Manufacturer> & { status: 200 })
-    | (HttpResponse<t_Manufacturer> & { status: 201 })
+    | (HttpResponse<t_Manufacturer> & {status: 200})
+    | (HttpResponse<t_Manufacturer> & {status: 201})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -794,7 +794,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -819,7 +819,7 @@ export class ContosoWidgetManagerService {
     ifModifiedSince?: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_Manufacturer> & { status: 200 })
+    | (HttpResponse<t_Manufacturer> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -832,7 +832,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -861,7 +861,7 @@ export class ContosoWidgetManagerService {
         error?: t_Azure_Core_Foundations_Error
         id: string
         status: t_Azure_Core_Foundations_OperationState
-      }> & { status: 202 })
+      }> & {status: 202})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -876,7 +876,7 @@ export class ContosoWidgetManagerService {
       "If-Modified-Since": p["ifModifiedSince"],
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "DELETE",
@@ -894,7 +894,7 @@ export class ContosoWidgetManagerService {
     apiVersion: string
     xMsClientRequestId?: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_PagedManufacturer> & { status: 200 })
+    | (HttpResponse<t_PagedManufacturer> & {status: 200})
     | (HttpResponse<t_Azure_Core_Foundations_ErrorResponse> & {
         status: StatusCode
       })
@@ -903,7 +903,7 @@ export class ContosoWidgetManagerService {
     const headers = this._headers({
       "x-ms-client-request-id": p["xMsClientRequestId"],
     })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -918,5 +918,5 @@ export class ContosoWidgetManagerService {
   }
 }
 
-export { ContosoWidgetManagerService as ApiClient }
-export { ContosoWidgetManagerServiceConfig as ApiClientConfig }
+export {ContosoWidgetManagerService as ApiClient}
+export {ContosoWidgetManagerServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { ContosoProviderHubClientService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {ContosoProviderHubClientService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class ContosoProviderHubClientModule {}
 
-export { ContosoProviderHubClientModule as ApiModule }
+export {ContosoProviderHubClientModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/client.service.ts
@@ -12,9 +12,9 @@ import {
   t_MoveResponse,
   t_OperationListResult,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class ContosoProviderHubClientServiceServers {
   static default(): Server<"ContosoProviderHubClientService"> {
@@ -23,7 +23,7 @@ export class ContosoProviderHubClientServiceServers {
 
   static server(
     url: "https://management.azure.com" = "https://management.azure.com",
-  ): { build: () => Server<"ContosoProviderHubClientService"> } {
+  ): {build: () => Server<"ContosoProviderHubClientService">} {
     switch (url) {
       case "https://management.azure.com":
         return {
@@ -82,7 +82,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -97,7 +97,7 @@ export class ContosoProviderHubClientService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -123,13 +123,13 @@ export class ContosoProviderHubClientService {
   operationsList(p: {
     apiVersion: string
   }): Observable<
-    | (HttpResponse<t_OperationListResult> & { status: 200 })
+    | (HttpResponse<t_OperationListResult> & {status: 200})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -149,13 +149,13 @@ export class ContosoProviderHubClientService {
     resourceGroupName: string
     employeeName: string
   }): Observable<
-    | (HttpResponse<t_Employee> & { status: 200 })
+    | (HttpResponse<t_Employee> & {status: 200})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -176,15 +176,15 @@ export class ContosoProviderHubClientService {
     employeeName: string
     requestBody: t_Employee
   }): Observable<
-    | (HttpResponse<t_Employee> & { status: 200 })
-    | (HttpResponse<t_Employee> & { status: 201 })
+    | (HttpResponse<t_Employee> & {status: 200})
+    | (HttpResponse<t_Employee> & {status: 201})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const headers = this._headers({"Content-Type": "application/json"})
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -208,14 +208,14 @@ export class ContosoProviderHubClientService {
     employeeName: string
     requestBody: t_EmployeeUpdate
   }): Observable<
-    | (HttpResponse<t_Employee> & { status: 200 })
+    | (HttpResponse<t_Employee> & {status: 200})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const headers = this._headers({"Content-Type": "application/json"})
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -238,14 +238,14 @@ export class ContosoProviderHubClientService {
     resourceGroupName: string
     employeeName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 202 })
-    | (HttpResponse<void> & { status: 204 })
+    | (HttpResponse<void> & {status: 202})
+    | (HttpResponse<void> & {status: 204})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "DELETE",
@@ -265,14 +265,14 @@ export class ContosoProviderHubClientService {
     resourceGroupName: string
     employeeName: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 404})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "HEAD",
@@ -291,13 +291,13 @@ export class ContosoProviderHubClientService {
     subscriptionId: t_Azure_Core_uuid
     resourceGroupName: string
   }): Observable<
-    | (HttpResponse<t_EmployeeListResult> & { status: 200 })
+    | (HttpResponse<t_EmployeeListResult> & {status: 200})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -315,13 +315,13 @@ export class ContosoProviderHubClientService {
     apiVersion: string
     subscriptionId: t_Azure_Core_uuid
   }): Observable<
-    | (HttpResponse<t_EmployeeListResult> & { status: 200 })
+    | (HttpResponse<t_EmployeeListResult> & {status: 200})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const params = this._queryParams({"api-version": p["apiVersion"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -342,14 +342,14 @@ export class ContosoProviderHubClientService {
     employeeName: string
     requestBody: t_MoveRequest
   }): Observable<
-    | (HttpResponse<t_MoveResponse> & { status: 200 })
+    | (HttpResponse<t_MoveResponse> & {status: 200})
     | (HttpResponse<t_Azure_ResourceManager_CommonTypes_ErrorResponse> & {
         status: StatusCode
       })
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
-    const params = this._queryParams({ "api-version": p["apiVersion"] })
+    const headers = this._headers({"Content-Type": "application/json"})
+    const params = this._queryParams({"api-version": p["apiVersion"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -367,5 +367,5 @@ export class ContosoProviderHubClientService {
   }
 }
 
-export { ContosoProviderHubClientService as ApiClient }
-export { ContosoProviderHubClientServiceConfig as ApiClientConfig }
+export {ContosoProviderHubClientService as ApiClient}
+export {ContosoProviderHubClientServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-angular/src/generated/azure-resource-manager.tsp/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { MyAccountManagementService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {MyAccountManagementService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class MyAccountManagementModule {}
 
-export { MyAccountManagementModule as ApiModule }
+export {MyAccountManagementModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/client.service.ts
@@ -22,9 +22,9 @@ import {
   t_UpdateAppAuthenticatorEnrollmentRequest,
   t_UpdateAuthenticatorEnrollmentRequest,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class MyAccountManagementServiceServers {
   static default(): Server<"MyAccountManagementService"> {
@@ -97,7 +97,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -112,7 +112,7 @@ export class MyAccountManagementService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -138,11 +138,11 @@ export class MyAccountManagementService {
   createAppAuthenticatorEnrollment(p: {
     requestBody: t_AppAuthenticatorEnrollmentRequest
   }): Observable<
-    | (HttpResponse<t_AppAuthenticatorEnrollment> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<t_AppAuthenticatorEnrollment> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -166,9 +166,9 @@ export class MyAccountManagementService {
     challengeId: string
     requestBody: t_PushNotificationVerification
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 400 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 400})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -193,10 +193,10 @@ export class MyAccountManagementService {
     enrollmentId: string
     requestBody: t_UpdateAppAuthenticatorEnrollmentRequest
   }): Observable<
-    | (HttpResponse<t_AppAuthenticatorEnrollment> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<t_AppAuthenticatorEnrollment> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -220,10 +220,10 @@ export class MyAccountManagementService {
   deleteAppAuthenticatorEnrollment(p: {
     enrollmentId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -240,8 +240,8 @@ export class MyAccountManagementService {
   listAppAuthenticatorPendingPushNotificationChallenges(p: {
     enrollmentId: string
   }): Observable<
-    | (HttpResponse<t_PushNotificationChallenge[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_PushNotificationChallenge[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -260,12 +260,12 @@ export class MyAccountManagementService {
       expand?: string
     } = {},
   ): Observable<
-    | (HttpResponse<t_Authenticator[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Authenticator[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -282,13 +282,13 @@ export class MyAccountManagementService {
     authenticatorId: string
     expand?: string
   }): Observable<
-    | (HttpResponse<t_Authenticator> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Authenticator> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -305,10 +305,10 @@ export class MyAccountManagementService {
   listEnrollments(p: {
     authenticatorId: string
   }): Observable<
-    | (HttpResponse<t_AuthenticatorEnrollment[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_AuthenticatorEnrollment[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -326,10 +326,10 @@ export class MyAccountManagementService {
     authenticatorId: string
     enrollmentId: string
   }): Observable<
-    | (HttpResponse<t_AuthenticatorEnrollment> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_AuthenticatorEnrollment> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -348,10 +348,10 @@ export class MyAccountManagementService {
     enrollmentId: string
     requestBody: t_UpdateAuthenticatorEnrollmentRequest
   }): Observable<
-    | (HttpResponse<t_AuthenticatorEnrollment> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<t_AuthenticatorEnrollment> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -373,8 +373,8 @@ export class MyAccountManagementService {
   }
 
   listEmails(): Observable<
-    | (HttpResponse<t_Email[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Email[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -397,14 +397,14 @@ export class MyAccountManagementService {
       state?: string
     }
   }): Observable<
-    | (HttpResponse<t_Email> & { status: 201 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 409 })
+    | (HttpResponse<t_Email> & {status: 201})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -422,8 +422,8 @@ export class MyAccountManagementService {
   getEmail(p: {
     id: string
   }): Observable<
-    | (HttpResponse<t_Email> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Email> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -439,10 +439,10 @@ export class MyAccountManagementService {
   deleteEmail(p: {
     id: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -482,13 +482,13 @@ export class MyAccountManagementService {
           email: string
         }
         status: "VERIFIED" | "UNVERIFIED" | UnknownEnumStringValue
-      }> & { status: 201 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+      }> & {status: 201})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -540,9 +540,9 @@ export class MyAccountManagementService {
           email: string
         }
         status: "VERIFIED" | "UNVERIFIED" | UnknownEnumStringValue
-      }> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 404 })
+      }> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -563,13 +563,13 @@ export class MyAccountManagementService {
       verificationCode: string
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -586,8 +586,8 @@ export class MyAccountManagementService {
   }
 
   listOktaApplications(): Observable<
-    | (HttpResponse<t_OktaApplication[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
+    | (HttpResponse<t_OktaApplication[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -601,8 +601,8 @@ export class MyAccountManagementService {
   }
 
   getOrganization(): Observable<
-    | (HttpResponse<t_Organization> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Organization> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -616,8 +616,8 @@ export class MyAccountManagementService {
   }
 
   getPassword(): Observable<
-    | (HttpResponse<t_PasswordResponse> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_PasswordResponse> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -637,13 +637,13 @@ export class MyAccountManagementService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_PasswordResponse> & { status: 201 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
+    | (HttpResponse<t_PasswordResponse> & {status: 201})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -665,13 +665,13 @@ export class MyAccountManagementService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_PasswordResponse> & { status: 201 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
+    | (HttpResponse<t_PasswordResponse> & {status: 201})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -687,9 +687,9 @@ export class MyAccountManagementService {
   }
 
   deletePassword(): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -703,8 +703,8 @@ export class MyAccountManagementService {
   }
 
   listPhones(): Observable<
-    | (HttpResponse<t_Phone[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Phone[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -726,15 +726,15 @@ export class MyAccountManagementService {
       sendCode?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_Phone> & { status: 201 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 409 })
-    | (HttpResponse<t_Error> & { status: 500 })
+    | (HttpResponse<t_Phone> & {status: 201})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 409})
+    | (HttpResponse<t_Error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -752,9 +752,9 @@ export class MyAccountManagementService {
   getPhone(p: {
     id: string
   }): Observable<
-    | (HttpResponse<t_Phone> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<t_Phone> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -770,10 +770,10 @@ export class MyAccountManagementService {
   deletePhone(p: {
     id: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -802,15 +802,15 @@ export class MyAccountManagementService {
             href: string
           }
         }
-      }> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 500 })
+      }> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 500})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -831,15 +831,15 @@ export class MyAccountManagementService {
       verificationCode: string
     }
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 409 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 409})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -855,8 +855,8 @@ export class MyAccountManagementService {
   }
 
   getProfile(): Observable<
-    | (HttpResponse<t_Profile> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Profile> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -874,12 +874,12 @@ export class MyAccountManagementService {
       profile?: EmptyObject
     }
   }): Observable<
-    | (HttpResponse<t_Profile> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Profile> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -895,8 +895,8 @@ export class MyAccountManagementService {
   }
 
   getProfileSchema(): Observable<
-    | (HttpResponse<t_Schema> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 401 })
+    | (HttpResponse<t_Schema> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 401})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -910,9 +910,9 @@ export class MyAccountManagementService {
   }
 
   deleteSessions(): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -926,5 +926,5 @@ export class MyAccountManagementService {
   }
 }
 
-export { MyAccountManagementService as ApiClient }
-export { MyAccountManagementServiceConfig as ApiClientConfig }
+export {MyAccountManagementService as ApiClient}
+export {MyAccountManagementServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.idp.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { OktaOpenIdConnectOAuth20Service } from "./client.service"
-import { NgModule } from "@angular/core"
+import {OktaOpenIdConnectOAuth20Service} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class OktaOpenIdConnectOAuth20Module {}
 
-export { OktaOpenIdConnectOAuth20Module as ApiModule }
+export {OktaOpenIdConnectOAuth20Module as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/okta.oauth.yaml/client.service.ts
@@ -35,9 +35,9 @@ import {
   t_TokenResponse,
   t_UserInfo,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class OktaOpenIdConnectOAuth20ServiceServers {
   static default(): Server<"OktaOpenIdConnectOAuth20Service"> {
@@ -112,7 +112,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -127,7 +127,7 @@ export class OktaOpenIdConnectOAuth20Service {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -155,11 +155,11 @@ export class OktaOpenIdConnectOAuth20Service {
       clientId?: string
     } = {},
   ): Observable<
-    | (HttpResponse<t_OidcMetadata> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
+    | (HttpResponse<t_OidcMetadata> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ client_id: p["clientId"] })
+    const params = this._queryParams({client_id: p["clientId"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -194,7 +194,7 @@ export class OktaOpenIdConnectOAuth20Service {
     sessionToken?: string
     state: string
   }): Observable<
-    (HttpResponse<t_Error> & { status: 429 }) | HttpResponse<unknown>
+    (HttpResponse<t_Error> & {status: 429}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       acr_values: p["acrValues"],
@@ -233,7 +233,7 @@ export class OktaOpenIdConnectOAuth20Service {
   authorizeWithPost(p: {
     requestBody: t_AuthorizeWithPost
   }): Observable<
-    (HttpResponse<t_Error> & { status: 429 }) | HttpResponse<unknown>
+    (HttpResponse<t_Error> & {status: 429}) | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
@@ -255,10 +255,10 @@ export class OktaOpenIdConnectOAuth20Service {
   bcAuthorize(p: {
     requestBody: t_BackchannelAuthorizeRequest
   }): Observable<
-    | (HttpResponse<t_BackchannelAuthorizeResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_BackchannelAuthorizeResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -281,11 +281,11 @@ export class OktaOpenIdConnectOAuth20Service {
   challenge(p: {
     requestBody: t_ChallengeRequest
   }): Observable<
-    | (HttpResponse<t_ChallengeResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_OAuthError> & { status: 403 })
-    | (HttpResponse<t_OAuthError> & { status: 429 })
+    | (HttpResponse<t_ChallengeResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_OAuthError> & {status: 403})
+    | (HttpResponse<t_OAuthError> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -312,9 +312,9 @@ export class OktaOpenIdConnectOAuth20Service {
       q?: string
     } = {},
   ): Observable<
-    | (HttpResponse<t_Client[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Client[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -337,13 +337,13 @@ export class OktaOpenIdConnectOAuth20Service {
   createClient(p: {
     requestBody: t_Client
   }): Observable<
-    | (HttpResponse<t_Client> & { status: 201 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Client> & {status: 201})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -361,10 +361,10 @@ export class OktaOpenIdConnectOAuth20Service {
   getClient(p: {
     clientId: string
   }): Observable<
-    | (HttpResponse<t_Client> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Client> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -381,14 +381,14 @@ export class OktaOpenIdConnectOAuth20Service {
     clientId: string
     requestBody: t_Client
   }): Observable<
-    | (HttpResponse<t_Client> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Client> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -406,10 +406,10 @@ export class OktaOpenIdConnectOAuth20Service {
   deleteClient(p: {
     clientId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -425,10 +425,10 @@ export class OktaOpenIdConnectOAuth20Service {
   generateNewClientSecret(p: {
     clientId: string
   }): Observable<
-    | (HttpResponse<t_Client> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 404 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_Client> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 404})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -445,10 +445,10 @@ export class OktaOpenIdConnectOAuth20Service {
   deviceAuthorize(p: {
     requestBody: t_DeviceAuthorizeRequest
   }): Observable<
-    | (HttpResponse<t_DeviceAuthorizeResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_DeviceAuthorizeResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -471,13 +471,13 @@ export class OktaOpenIdConnectOAuth20Service {
   globalTokenRevocation(p: {
     requestBody: t_GlobalTokenRevocationRequest
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<void> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<void> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -495,10 +495,10 @@ export class OktaOpenIdConnectOAuth20Service {
   introspect(p: {
     requestBody: t_IntrospectionRequest
   }): Observable<
-    | (HttpResponse<t_IntrospectionResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_IntrospectionResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -523,11 +523,11 @@ export class OktaOpenIdConnectOAuth20Service {
       clientId?: string
     } = {},
   ): Observable<
-    | (HttpResponse<t_OAuthKeys> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_OAuthKeys> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ client_id: p["clientId"] })
+    const params = this._queryParams({client_id: p["clientId"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -545,8 +545,8 @@ export class OktaOpenIdConnectOAuth20Service {
     postLogoutRedirectUri?: string
     state?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -569,8 +569,8 @@ export class OktaOpenIdConnectOAuth20Service {
   logoutWithPost(p: {
     requestBody: t_LogoutWithPost
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -593,11 +593,11 @@ export class OktaOpenIdConnectOAuth20Service {
   oobAuthenticate(p: {
     requestBody: t_OobAuthenticateRequest
   }): Observable<
-    | (HttpResponse<t_OobAuthenticateResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_OAuthError> & { status: 403 })
-    | (HttpResponse<t_OAuthError> & { status: 429 })
+    | (HttpResponse<t_OobAuthenticateResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_OAuthError> & {status: 403})
+    | (HttpResponse<t_OAuthError> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -622,11 +622,11 @@ export class OktaOpenIdConnectOAuth20Service {
       origin?: string
     } = {},
   ): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ Origin: p["origin"] })
+    const headers = this._headers({Origin: p["origin"]})
 
     return this.httpClient.request<any>(
       "OPTIONS",
@@ -642,14 +642,14 @@ export class OktaOpenIdConnectOAuth20Service {
   par(p: {
     requestBody: t_ParRequest
   }): Observable<
-    | (HttpResponse<t_ParResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_OAuthError> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_ParResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_OAuthError> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -667,13 +667,13 @@ export class OktaOpenIdConnectOAuth20Service {
   revoke(p: {
     requestBody: t_RevokeRequest
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -693,11 +693,11 @@ export class OktaOpenIdConnectOAuth20Service {
       origin?: string
     } = {},
   ): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ Origin: p["origin"] })
+    const headers = this._headers({Origin: p["origin"]})
 
     return this.httpClient.request<any>(
       "OPTIONS",
@@ -713,10 +713,10 @@ export class OktaOpenIdConnectOAuth20Service {
   token(p: {
     requestBody: t_TokenRequest
   }): Observable<
-    | (HttpResponse<t_TokenResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_TokenResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -737,10 +737,10 @@ export class OktaOpenIdConnectOAuth20Service {
   }
 
   userinfo(): Observable<
-    | (HttpResponse<t_UserInfo> & { status: 200 })
-    | (HttpResponse<void> & { status: 401 })
-    | (HttpResponse<void> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_UserInfo> & {status: 200})
+    | (HttpResponse<void> & {status: 401})
+    | (HttpResponse<void> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -757,12 +757,12 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     clientId?: string
   }): Observable<
-    | (HttpResponse<t_OAuthMetadata> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<t_OAuthMetadata> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ client_id: p["clientId"] })
+    const params = this._queryParams({client_id: p["clientId"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -780,12 +780,12 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     clientId?: string
   }): Observable<
-    | (HttpResponse<t_OidcMetadata> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 400 })
-    | (HttpResponse<t_Error> & { status: 404 })
+    | (HttpResponse<t_OidcMetadata> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 400})
+    | (HttpResponse<t_Error> & {status: 404})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ client_id: p["clientId"] })
+    const params = this._queryParams({client_id: p["clientId"]})
 
     return this.httpClient.request<any>(
       "GET",
@@ -822,7 +822,7 @@ export class OktaOpenIdConnectOAuth20Service {
     sessionToken?: string
     state: string
   }): Observable<
-    (HttpResponse<t_Error> & { status: 429 }) | HttpResponse<unknown>
+    (HttpResponse<t_Error> & {status: 429}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       acr_values: p["acrValues"],
@@ -863,7 +863,7 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_AuthorizeWithPost
   }): Observable<
-    (HttpResponse<t_Error> & { status: 429 }) | HttpResponse<unknown>
+    (HttpResponse<t_Error> & {status: 429}) | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
@@ -887,10 +887,10 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_BackchannelAuthorizeRequest
   }): Observable<
-    | (HttpResponse<t_BackchannelAuthorizeResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_BackchannelAuthorizeResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -915,11 +915,11 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_ChallengeRequest
   }): Observable<
-    | (HttpResponse<t_ChallengeResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_OAuthError> & { status: 403 })
-    | (HttpResponse<t_OAuthError> & { status: 429 })
+    | (HttpResponse<t_ChallengeResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_OAuthError> & {status: 403})
+    | (HttpResponse<t_OAuthError> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -944,10 +944,10 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_DeviceAuthorizeRequest
   }): Observable<
-    | (HttpResponse<t_DeviceAuthorizeResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_DeviceAuthorizeResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -972,10 +972,10 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_IntrospectionRequest
   }): Observable<
-    | (HttpResponse<t_IntrospectionResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_IntrospectionResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -999,8 +999,8 @@ export class OktaOpenIdConnectOAuth20Service {
   oauthKeysCustomAs(p: {
     authorizationServerId: string
   }): Observable<
-    | (HttpResponse<t_OAuthKeys> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_OAuthKeys> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1019,8 +1019,8 @@ export class OktaOpenIdConnectOAuth20Service {
     postLogoutRedirectUri?: string
     state?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const params = this._queryParams({
@@ -1044,8 +1044,8 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_LogoutWithPost
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1069,11 +1069,11 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_OobAuthenticateRequest
   }): Observable<
-    | (HttpResponse<t_OobAuthenticateResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_OAuthError> & { status: 403 })
-    | (HttpResponse<t_OAuthError> & { status: 429 })
+    | (HttpResponse<t_OobAuthenticateResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_OAuthError> & {status: 403})
+    | (HttpResponse<t_OAuthError> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1098,11 +1098,11 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     origin?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ Origin: p["origin"] })
+    const headers = this._headers({Origin: p["origin"]})
 
     return this.httpClient.request<any>(
       "OPTIONS",
@@ -1119,14 +1119,14 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_ParRequest
   }): Observable<
-    | (HttpResponse<t_ParResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_OAuthError> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_ParResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_OAuthError> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1145,13 +1145,13 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_RevokeRequest
   }): Observable<
-    | (HttpResponse<void> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1170,11 +1170,11 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     origin?: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ Origin: p["origin"] })
+    const headers = this._headers({Origin: p["origin"]})
 
     return this.httpClient.request<any>(
       "OPTIONS",
@@ -1191,10 +1191,10 @@ export class OktaOpenIdConnectOAuth20Service {
     authorizationServerId: string
     requestBody: t_TokenRequest
   }): Observable<
-    | (HttpResponse<t_TokenResponse> & { status: 200 })
-    | (HttpResponse<t_OAuthError> & { status: 400 })
-    | (HttpResponse<t_OAuthError> & { status: 401 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_TokenResponse> & {status: 200})
+    | (HttpResponse<t_OAuthError> & {status: 400})
+    | (HttpResponse<t_OAuthError> & {status: 401})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1217,10 +1217,10 @@ export class OktaOpenIdConnectOAuth20Service {
   userinfoCustomAs(p: {
     authorizationServerId: string
   }): Observable<
-    | (HttpResponse<t_UserInfo> & { status: 200 })
-    | (HttpResponse<void> & { status: 401 })
-    | (HttpResponse<void> & { status: 403 })
-    | (HttpResponse<t_Error> & { status: 429 })
+    | (HttpResponse<t_UserInfo> & {status: 200})
+    | (HttpResponse<void> & {status: 401})
+    | (HttpResponse<void> & {status: 403})
+    | (HttpResponse<t_Error> & {status: 429})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -1235,5 +1235,5 @@ export class OktaOpenIdConnectOAuth20Service {
   }
 }
 
-export { OktaOpenIdConnectOAuth20Service as ApiClient }
-export { OktaOpenIdConnectOAuth20ServiceConfig as ApiClientConfig }
+export {OktaOpenIdConnectOAuth20Service as ApiClient}
+export {OktaOpenIdConnectOAuth20ServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { SwaggerPetstoreService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {SwaggerPetstoreService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class SwaggerPetstoreModule {}
 
-export { SwaggerPetstoreModule as ApiModule }
+export {SwaggerPetstoreModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/petstore-expanded.yaml/client.service.ts
@@ -2,10 +2,10 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { t_Error, t_NewPet, t_Pet } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {t_Error, t_NewPet, t_Pet} from "./models"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class SwaggerPetstoreServiceServers {
   static default(): Server<"SwaggerPetstoreService"> {
@@ -14,7 +14,7 @@ export class SwaggerPetstoreServiceServers {
 
   static server(
     url: "https://petstore.swagger.io/v2" = "https://petstore.swagger.io/v2",
-  ): { build: () => Server<"SwaggerPetstoreService"> } {
+  ): {build: () => Server<"SwaggerPetstoreService">} {
     switch (url) {
       case "https://petstore.swagger.io/v2":
         return {
@@ -73,7 +73,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -88,7 +88,7 @@ export class SwaggerPetstoreService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -117,11 +117,11 @@ export class SwaggerPetstoreService {
       limit?: number
     } = {},
   ): Observable<
-    | (HttpResponse<t_Pet[]> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: StatusCode })
+    | (HttpResponse<t_Pet[]> & {status: 200})
+    | (HttpResponse<t_Error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const params = this._queryParams({ tags: p["tags"], limit: p["limit"] })
+    const params = this._queryParams({tags: p["tags"], limit: p["limit"]})
 
     return this.httpClient.request<any>("GET", this.config.basePath + `/pets`, {
       params,
@@ -133,11 +133,11 @@ export class SwaggerPetstoreService {
   addPet(p: {
     requestBody: t_NewPet
   }): Observable<
-    | (HttpResponse<t_Pet> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: StatusCode })
+    | (HttpResponse<t_Pet> & {status: 200})
+    | (HttpResponse<t_Error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -155,8 +155,8 @@ export class SwaggerPetstoreService {
   findPetById(p: {
     id: number
   }): Observable<
-    | (HttpResponse<t_Pet> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: StatusCode })
+    | (HttpResponse<t_Pet> & {status: 200})
+    | (HttpResponse<t_Error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -172,8 +172,8 @@ export class SwaggerPetstoreService {
   deletePet(p: {
     id: number
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: StatusCode })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -187,5 +187,5 @@ export class SwaggerPetstoreService {
   }
 }
 
-export { SwaggerPetstoreService as ApiClient }
-export { SwaggerPetstoreServiceConfig as ApiClientConfig }
+export {SwaggerPetstoreService as ApiClient}
+export {SwaggerPetstoreServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { StripeApiService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {StripeApiService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class StripeApiModule {}
 
-export { StripeApiModule as ApiModule }
+export {StripeApiModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/client.service.ts
@@ -163,14 +163,14 @@ import {
   t_treasury_transaction_entry,
   t_webhook_endpoint,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class StripeApiServiceServersOperations {
   static postFiles(
     url: "https://files.stripe.com/" = "https://files.stripe.com/",
-  ): { build: () => Server<"postFiles_StripeApiService"> } {
+  ): {build: () => Server<"postFiles_StripeApiService">} {
     switch (url) {
       case "https://files.stripe.com/":
         return {
@@ -186,7 +186,7 @@ export class StripeApiServiceServersOperations {
 
   static getQuotesQuotePdf(
     url: "https://files.stripe.com/" = "https://files.stripe.com/",
-  ): { build: () => Server<"getQuotesQuotePdf_StripeApiService"> } {
+  ): {build: () => Server<"getQuotesQuotePdf_StripeApiService">} {
     switch (url) {
       case "https://files.stripe.com/":
         return {
@@ -269,7 +269,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -284,7 +284,7 @@ export class StripeApiService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -313,14 +313,14 @@ export class StripeApiService {
       requestBody?: EmptyObject
     } = {},
   ): Observable<
-    | (HttpResponse<t_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -350,8 +350,8 @@ export class StripeApiService {
       type: "account_onboarding" | "account_update" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_account_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -505,8 +505,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_account_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -548,8 +548,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1158,8 +1158,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1183,8 +1183,8 @@ export class StripeApiService {
     account: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1209,14 +1209,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1771,8 +1771,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1828,8 +1828,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1854,8 +1854,8 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1882,14 +1882,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -1946,8 +1946,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -1978,14 +1978,14 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2007,14 +2007,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_capability> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_capability> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2039,8 +2039,8 @@ export class StripeApiService {
       requested?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_capability> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_capability> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2075,8 +2075,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2140,8 +2140,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2166,8 +2166,8 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2194,14 +2194,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2258,8 +2258,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2286,8 +2286,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_login_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_login_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2328,8 +2328,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2512,8 +2512,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2538,8 +2538,8 @@ export class StripeApiService {
     person: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2566,14 +2566,14 @@ export class StripeApiService {
     person: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -2746,8 +2746,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2789,8 +2789,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2973,8 +2973,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -2999,8 +2999,8 @@ export class StripeApiService {
     person: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3027,14 +3027,14 @@ export class StripeApiService {
     person: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3207,8 +3207,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_person> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_person> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3236,8 +3236,8 @@ export class StripeApiService {
       reason: string
     }
   }): Observable<
-    | (HttpResponse<t_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3272,8 +3272,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3307,8 +3307,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_apple_pay_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_apple_pay_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3332,8 +3332,8 @@ export class StripeApiService {
     domain: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_apple_pay_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_apple_pay_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3358,14 +3358,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_apple_pay_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_apple_pay_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3404,8 +3404,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3440,14 +3440,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_fee_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_fee_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3477,8 +3477,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_fee_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_fee_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3504,14 +3504,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_application_fee> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_application_fee> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3535,8 +3535,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_application_fee> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_application_fee> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3569,8 +3569,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3607,8 +3607,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_fee_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_fee_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3644,8 +3644,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3685,8 +3685,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_apps_secret> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_apps_secret> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3716,8 +3716,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_apps_secret> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_apps_secret> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3746,8 +3746,8 @@ export class StripeApiService {
     }
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_apps_secret> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_apps_secret> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3779,14 +3779,14 @@ export class StripeApiService {
       requestBody?: EmptyObject
     } = {},
   ): Observable<
-    | (HttpResponse<t_balance> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_balance> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3828,8 +3828,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3866,14 +3866,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3915,8 +3915,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -3953,14 +3953,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -3992,8 +3992,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4038,8 +4038,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_billing_alert> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_alert> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4064,14 +4064,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_billing_alert> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_alert> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4093,8 +4093,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_alert> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_alert> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4120,8 +4120,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_alert> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_alert> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4147,8 +4147,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_alert> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_alert> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4183,8 +4183,8 @@ export class StripeApiService {
     }
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_billing_credit_balance_summary> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_balance_summary> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4224,8 +4224,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4259,14 +4259,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_billing_credit_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4298,8 +4298,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4356,8 +4356,8 @@ export class StripeApiService {
       priority?: number
     }
   }): Observable<
-    | (HttpResponse<t_billing_credit_grant> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_grant> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4382,14 +4382,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_billing_credit_grant> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_grant> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4415,8 +4415,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_billing_credit_grant> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_grant> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4442,8 +4442,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_credit_grant> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_grant> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4469,8 +4469,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_credit_grant> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_credit_grant> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4500,8 +4500,8 @@ export class StripeApiService {
       type: "cancel" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_billing_meter_event_adjustment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter_event_adjustment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4532,8 +4532,8 @@ export class StripeApiService {
       timestamp?: number
     }
   }): Observable<
-    | (HttpResponse<t_billing_meter_event> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter_event> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4568,8 +4568,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4615,8 +4615,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_billing_meter> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4641,14 +4641,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_billing_meter> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -4671,8 +4671,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_meter> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4698,8 +4698,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_meter> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4736,8 +4736,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4774,8 +4774,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_billing_meter> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_meter> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4811,8 +4811,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4939,8 +4939,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_billing_portal_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_portal_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -4965,14 +4965,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_billing_portal_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_portal_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5095,8 +5095,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_billing_portal_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_portal_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5220,8 +5220,8 @@ export class StripeApiService {
       return_url?: string
     }
   }): Observable<
-    | (HttpResponse<t_billing_portal_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_billing_portal_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5266,8 +5266,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5370,8 +5370,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_charge> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_charge> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5405,8 +5405,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5438,14 +5438,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_charge> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_charge> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5494,8 +5494,8 @@ export class StripeApiService {
       transfer_group?: string
     }
   }): Observable<
-    | (HttpResponse<t_charge> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_charge> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5531,8 +5531,8 @@ export class StripeApiService {
       transfer_group?: string
     }
   }): Observable<
-    | (HttpResponse<t_charge> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_charge> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5557,14 +5557,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5675,8 +5675,8 @@ export class StripeApiService {
       submit?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5702,8 +5702,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5745,8 +5745,8 @@ export class StripeApiService {
       reverse_transfer?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_charge> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_charge> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5779,8 +5779,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5832,8 +5832,8 @@ export class StripeApiService {
       reverse_transfer?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5859,14 +5859,14 @@ export class StripeApiService {
     refund: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -5896,8 +5896,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -5948,8 +5948,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7016,8 +7016,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_checkout_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_checkout_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7042,14 +7042,14 @@ export class StripeApiService {
     session: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_checkout_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_checkout_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7147,8 +7147,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_checkout_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_checkout_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7174,8 +7174,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_checkout_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_checkout_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7208,8 +7208,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7250,8 +7250,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7293,8 +7293,8 @@ export class StripeApiService {
       product: string
     }
   }): Observable<
-    | (HttpResponse<t_climate_order> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_climate_order> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7319,14 +7319,14 @@ export class StripeApiService {
     order: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_climate_order> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_climate_order> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7357,8 +7357,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_climate_order> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_climate_order> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7384,8 +7384,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_climate_order> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_climate_order> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7419,8 +7419,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7452,14 +7452,14 @@ export class StripeApiService {
     product: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_climate_product> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_climate_product> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7489,8 +7489,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7522,14 +7522,14 @@ export class StripeApiService {
     supplier: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_climate_supplier> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_climate_supplier> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7550,14 +7550,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_confirmation_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_confirmation_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7588,8 +7588,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7621,14 +7621,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_country_spec> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_country_spec> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7666,8 +7666,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7727,8 +7727,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_coupon> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_coupon> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7752,8 +7752,8 @@ export class StripeApiService {
     coupon: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_coupon> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_coupon> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7778,14 +7778,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_coupon> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_coupon> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -7821,8 +7821,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_coupon> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_coupon> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7866,8 +7866,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -7944,8 +7944,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_credit_note> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_credit_note> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8011,8 +8011,8 @@ export class StripeApiService {
     }
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_credit_note> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_credit_note> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8103,8 +8103,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8157,8 +8157,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8190,14 +8190,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_credit_note> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_credit_note> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8223,8 +8223,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_credit_note> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_credit_note> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8250,8 +8250,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_credit_note> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_credit_note> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8313,8 +8313,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_customer_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8358,8 +8358,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8593,8 +8593,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_customer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8628,8 +8628,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8660,8 +8660,8 @@ export class StripeApiService {
     customer: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_customer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_customer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8686,14 +8686,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_customer | t_deleted_customer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer | t_deleted_customer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8833,8 +8833,8 @@ export class StripeApiService {
       tax_exempt?: "" | "exempt" | "none" | "reverse" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_customer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8867,8 +8867,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8911,8 +8911,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_customer_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -8939,14 +8939,14 @@ export class StripeApiService {
     transaction: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_customer_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -8977,8 +8977,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_customer_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9012,8 +9012,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9084,8 +9084,8 @@ export class StripeApiService {
       source?: string
     }
   }): Observable<
-    | (HttpResponse<t_payment_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9115,7 +9115,7 @@ export class StripeApiService {
     | (HttpResponse<t_payment_source | t_deleted_payment_source> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9142,14 +9142,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_bank_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_bank_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9203,8 +9203,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_card | t_bank_account | t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_card | t_bank_account | t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9233,8 +9233,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_bank_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_bank_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9268,8 +9268,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9340,8 +9340,8 @@ export class StripeApiService {
       source?: string
     }
   }): Observable<
-    | (HttpResponse<t_payment_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9371,7 +9371,7 @@ export class StripeApiService {
     | (HttpResponse<t_payment_source | t_deleted_payment_source> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9397,14 +9397,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9457,8 +9457,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_card | t_bank_account | t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_card | t_bank_account | t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9483,14 +9483,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_cash_balance> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_cash_balance> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9519,8 +9519,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_cash_balance> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_cash_balance> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9553,8 +9553,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9588,14 +9588,14 @@ export class StripeApiService {
     transaction: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_customer_cash_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer_cash_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9616,8 +9616,8 @@ export class StripeApiService {
     customer: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_discount> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_discount> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9642,14 +9642,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_discount> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_discount> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9692,8 +9692,8 @@ export class StripeApiService {
       funding_type: "bank_transfer" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_funding_instructions> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_funding_instructions> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9782,8 +9782,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9818,14 +9818,14 @@ export class StripeApiService {
     paymentMethod: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_method> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -9856,8 +9856,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9929,8 +9929,8 @@ export class StripeApiService {
       source?: string
     }
   }): Observable<
-    | (HttpResponse<t_payment_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9960,7 +9960,7 @@ export class StripeApiService {
     | (HttpResponse<t_payment_source | t_deleted_payment_source> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -9987,14 +9987,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10048,8 +10048,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_card | t_bank_account | t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_card | t_bank_account | t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10078,8 +10078,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_bank_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_bank_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10113,8 +10113,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10445,8 +10445,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10475,8 +10475,8 @@ export class StripeApiService {
       prorate?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10503,14 +10503,14 @@ export class StripeApiService {
     subscriptionExposedId: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10864,8 +10864,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10891,8 +10891,8 @@ export class StripeApiService {
     subscriptionExposedId: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_discount> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_discount> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -10919,14 +10919,14 @@ export class StripeApiService {
     subscriptionExposedId: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_discount> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_discount> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -10956,8 +10956,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11103,8 +11103,8 @@ export class StripeApiService {
       value: string
     }
   }): Observable<
-    | (HttpResponse<t_tax_id> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_id> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11129,8 +11129,8 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_tax_id> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_tax_id> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11157,14 +11157,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_id> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_id> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11205,8 +11205,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11241,14 +11241,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11359,8 +11359,8 @@ export class StripeApiService {
       submit?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11386,8 +11386,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11420,8 +11420,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11454,14 +11454,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_entitlements_active_entitlement> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_entitlements_active_entitlement> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11493,8 +11493,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11533,8 +11533,8 @@ export class StripeApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_entitlements_feature> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_entitlements_feature> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11559,14 +11559,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_entitlements_feature> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_entitlements_feature> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11596,8 +11596,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_entitlements_feature> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_entitlements_feature> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11628,8 +11628,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_ephemeral_key> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_ephemeral_key> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11655,8 +11655,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_ephemeral_key> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_ephemeral_key> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11701,8 +11701,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11738,14 +11738,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_event> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_event> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11775,8 +11775,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11808,14 +11808,14 @@ export class StripeApiService {
     rateId: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_exchange_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_exchange_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -11870,8 +11870,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_external_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_external_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11915,8 +11915,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11959,8 +11959,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_file_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_file_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -11985,14 +11985,14 @@ export class StripeApiService {
     link: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_file_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_file_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12021,8 +12021,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_file_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_file_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12083,8 +12083,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12147,11 +12147,11 @@ export class StripeApiService {
       | Server<"postFiles_StripeApiService">
       | string = StripeApiServiceServers.operations.postFiles().build(),
   ): Observable<
-    | (HttpResponse<t_file> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_file> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "multipart/form-data" })
+    const headers = this._headers({"Content-Type": "multipart/form-data"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>("POST", basePath + `/v1/files`, {
@@ -12167,14 +12167,14 @@ export class StripeApiService {
     file: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_file> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_file> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12209,8 +12209,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12244,14 +12244,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12274,8 +12274,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12310,8 +12310,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12352,8 +12352,8 @@ export class StripeApiService {
       )[]
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12381,8 +12381,8 @@ export class StripeApiService {
       features: ("transactions" | UnknownEnumStringValue)[]
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12410,8 +12410,8 @@ export class StripeApiService {
       features: ("transactions" | UnknownEnumStringValue)[]
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12467,8 +12467,8 @@ export class StripeApiService {
       return_url?: string
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12493,14 +12493,14 @@ export class StripeApiService {
     session: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_financial_connections_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12541,8 +12541,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12577,14 +12577,14 @@ export class StripeApiService {
     transaction: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_financial_connections_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12621,8 +12621,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12675,8 +12675,8 @@ export class StripeApiService {
       url: string
     }
   }): Observable<
-    | (HttpResponse<t_forwarding_request> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_forwarding_request> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12701,14 +12701,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_forwarding_request> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_forwarding_request> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12749,8 +12749,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12786,14 +12786,14 @@ export class StripeApiService {
     report: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_identity_verification_report> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_identity_verification_report> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12839,8 +12839,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12910,8 +12910,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_identity_verification_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_identity_verification_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -12936,14 +12936,14 @@ export class StripeApiService {
     session: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_identity_verification_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_identity_verification_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -12990,8 +12990,8 @@ export class StripeApiService {
       type?: "document" | "id_number" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_identity_verification_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_identity_verification_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13018,8 +13018,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_identity_verification_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_identity_verification_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13046,8 +13046,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_identity_verification_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_identity_verification_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13088,8 +13088,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13124,14 +13124,14 @@ export class StripeApiService {
     invoicePayment: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_invoice_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13162,8 +13162,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13197,8 +13197,8 @@ export class StripeApiService {
     version?: number
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_invoice_rendering_template> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice_rendering_template> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13229,8 +13229,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice_rendering_template> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice_rendering_template> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13257,8 +13257,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice_rendering_template> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice_rendering_template> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13304,8 +13304,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13389,8 +13389,8 @@ export class StripeApiService {
       unit_amount_decimal?: string
     }
   }): Observable<
-    | (HttpResponse<t_invoiceitem> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoiceitem> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13414,8 +13414,8 @@ export class StripeApiService {
     invoiceitem: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_invoiceitem> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_invoiceitem> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13440,14 +13440,14 @@ export class StripeApiService {
     invoiceitem: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_invoiceitem> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoiceitem> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -13513,8 +13513,8 @@ export class StripeApiService {
       unit_amount_decimal?: string
     }
   }): Observable<
-    | (HttpResponse<t_invoiceitem> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoiceitem> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13577,8 +13577,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -13910,8 +13910,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14369,8 +14369,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14404,8 +14404,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14436,8 +14436,8 @@ export class StripeApiService {
     invoice: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14462,14 +14462,14 @@ export class StripeApiService {
     invoice: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -14781,8 +14781,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14920,8 +14920,8 @@ export class StripeApiService {
       }[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14948,8 +14948,8 @@ export class StripeApiService {
       payment_intent?: string
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -14976,8 +14976,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15010,8 +15010,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15148,8 +15148,8 @@ export class StripeApiService {
       tax_rates?: string[] | "" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_line_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_line_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15176,8 +15176,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15209,8 +15209,8 @@ export class StripeApiService {
       source?: string
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15246,8 +15246,8 @@ export class StripeApiService {
       }[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15273,8 +15273,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15412,8 +15412,8 @@ export class StripeApiService {
       }[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15439,8 +15439,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_invoice> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_invoice> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15490,8 +15490,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15527,14 +15527,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -15562,8 +15562,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15596,8 +15596,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15630,8 +15630,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -15678,8 +15678,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -16677,8 +16677,8 @@ export class StripeApiService {
       type?: "company" | "individual" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_cardholder> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_cardholder> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -16703,14 +16703,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_cardholder> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_cardholder> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -17691,8 +17691,8 @@ export class StripeApiService {
       status?: "active" | "inactive" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_cardholder> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_cardholder> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -17741,8 +17741,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -18736,8 +18736,8 @@ export class StripeApiService {
       type: "physical" | "virtual" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -18762,14 +18762,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -19737,8 +19737,8 @@ export class StripeApiService {
       status?: "active" | "canceled" | "inactive" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -19788,8 +19788,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -19949,8 +19949,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_issuing_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -19975,14 +19975,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20126,8 +20126,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20159,8 +20159,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_dispute> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_dispute> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20205,8 +20205,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20258,8 +20258,8 @@ export class StripeApiService {
       transfer_lookup_key?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_issuing_personalization_design> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_personalization_design> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20284,14 +20284,14 @@ export class StripeApiService {
     personalizationDesign: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_personalization_design> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_personalization_design> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20334,8 +20334,8 @@ export class StripeApiService {
       transfer_lookup_key?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_issuing_personalization_design> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_personalization_design> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20372,8 +20372,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20407,14 +20407,14 @@ export class StripeApiService {
     physicalBundle: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_physical_bundle> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_physical_bundle> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20436,14 +20436,14 @@ export class StripeApiService {
     settlement: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_settlement> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_settlement> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20468,8 +20468,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_issuing_settlement> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_settlement> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20516,8 +20516,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20552,14 +20552,14 @@ export class StripeApiService {
     token: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20582,8 +20582,8 @@ export class StripeApiService {
       status: "active" | "deleted" | "suspended" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20628,8 +20628,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20665,14 +20665,14 @@ export class StripeApiService {
     transaction: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_issuing_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20700,8 +20700,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20756,8 +20756,8 @@ export class StripeApiService {
       return_url?: string
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20782,14 +20782,14 @@ export class StripeApiService {
     session: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_financial_connections_session> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_session> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20824,8 +20824,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20859,14 +20859,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -20888,8 +20888,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20923,8 +20923,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20964,8 +20964,8 @@ export class StripeApiService {
       )[]
     }
   }): Observable<
-    | (HttpResponse<t_financial_connections_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_financial_connections_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -20990,14 +20990,14 @@ export class StripeApiService {
     mandate: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_mandate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_mandate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -21036,8 +21036,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -22172,8 +22172,8 @@ export class StripeApiService {
       use_stripe_sdk?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -22207,8 +22207,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -22241,8 +22241,8 @@ export class StripeApiService {
     intent: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -23353,8 +23353,8 @@ export class StripeApiService {
       transfer_group?: string
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -23382,8 +23382,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -23416,8 +23416,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -23457,8 +23457,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -24579,8 +24579,8 @@ export class StripeApiService {
       use_stripe_sdk?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -24616,8 +24616,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -24647,8 +24647,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -24684,8 +24684,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -25210,8 +25210,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payment_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -25236,14 +25236,14 @@ export class StripeApiService {
     paymentLink: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -25742,8 +25742,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payment_link> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_link> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -25776,8 +25776,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -25819,8 +25819,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26117,8 +26117,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_payment_method_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26143,14 +26143,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_method_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26435,8 +26435,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payment_method_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26473,8 +26473,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26510,8 +26510,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_method_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26536,14 +26536,14 @@ export class StripeApiService {
     paymentMethodDomain: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_method_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -26567,8 +26567,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_method_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26595,8 +26595,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_method_domain> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method_domain> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -26682,8 +26682,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27016,8 +27016,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_payment_method> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27042,14 +27042,14 @@ export class StripeApiService {
     paymentMethod: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payment_method> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -27117,8 +27117,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payment_method> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27145,8 +27145,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_method> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27172,8 +27172,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payment_method> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payment_method> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27225,8 +27225,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27272,8 +27272,8 @@ export class StripeApiService {
       statement_descriptor?: string
     }
   }): Observable<
-    | (HttpResponse<t_payout> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payout> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27298,14 +27298,14 @@ export class StripeApiService {
     payout: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_payout> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payout> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -27333,8 +27333,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_payout> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payout> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27360,8 +27360,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_payout> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payout> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27390,8 +27390,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_payout> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_payout> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27435,8 +27435,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27514,8 +27514,8 @@ export class StripeApiService {
       usage_type?: "licensed" | "metered" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_plan> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_plan> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27539,8 +27539,8 @@ export class StripeApiService {
     plan: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_plan> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_plan> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27565,14 +27565,14 @@ export class StripeApiService {
     plan: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_plan> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_plan> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -27604,8 +27604,8 @@ export class StripeApiService {
       trial_period_days?: number
     }
   }): Observable<
-    | (HttpResponse<t_plan> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_plan> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27657,8 +27657,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27775,8 +27775,8 @@ export class StripeApiService {
       unit_amount_decimal?: string
     }
   }): Observable<
-    | (HttpResponse<t_price> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_price> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27810,8 +27810,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27843,14 +27843,14 @@ export class StripeApiService {
     price: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_price> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_price> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -27916,8 +27916,8 @@ export class StripeApiService {
       transfer_lookup_key?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_price> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_price> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -27963,8 +27963,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28072,8 +28072,8 @@ export class StripeApiService {
       url?: string
     }
   }): Observable<
-    | (HttpResponse<t_product> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_product> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28107,8 +28107,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28139,8 +28139,8 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_product> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_product> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28165,14 +28165,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_product> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_product> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -28225,8 +28225,8 @@ export class StripeApiService {
       url?: string | "" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_product> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_product> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28259,8 +28259,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28294,8 +28294,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_product_feature> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_product_feature> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28320,8 +28320,8 @@ export class StripeApiService {
     product: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_product_feature> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_product_feature> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28347,14 +28347,14 @@ export class StripeApiService {
     product: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_product_feature> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_product_feature> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -28396,8 +28396,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28455,8 +28455,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_promotion_code> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_promotion_code> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28481,14 +28481,14 @@ export class StripeApiService {
     promotionCode: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_promotion_code> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_promotion_code> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -28526,8 +28526,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_promotion_code> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_promotion_code> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28569,8 +28569,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28706,8 +28706,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_quote> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_quote> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28732,14 +28732,14 @@ export class StripeApiService {
     quote: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_quote> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_quote> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -28848,8 +28848,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_quote> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_quote> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28875,8 +28875,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_quote> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_quote> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28902,8 +28902,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_quote> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_quote> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28936,8 +28936,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -28972,8 +28972,8 @@ export class StripeApiService {
       expires_at?: number
     }
   }): Observable<
-    | (HttpResponse<t_quote> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_quote> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29006,8 +29006,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29044,14 +29044,14 @@ export class StripeApiService {
       | Server<"getQuotesQuotePdf_StripeApiService">
       | string = StripeApiServiceServers.operations.getQuotesQuotePdf().build(),
   ): Observable<
-    | (HttpResponse<string> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<string> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -29091,8 +29091,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29127,14 +29127,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_radar_early_fraud_warning> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_radar_early_fraud_warning> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -29173,8 +29173,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29211,8 +29211,8 @@ export class StripeApiService {
       value_list: string
     }
   }): Observable<
-    | (HttpResponse<t_radar_value_list_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_radar_value_list_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29236,8 +29236,8 @@ export class StripeApiService {
     item: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_radar_value_list_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_radar_value_list_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29262,14 +29262,14 @@ export class StripeApiService {
     item: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_radar_value_list_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_radar_value_list_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -29309,8 +29309,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29362,8 +29362,8 @@ export class StripeApiService {
       name: string
     }
   }): Observable<
-    | (HttpResponse<t_radar_value_list> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_radar_value_list> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29387,8 +29387,8 @@ export class StripeApiService {
     valueList: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_radar_value_list> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_radar_value_list> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29413,14 +29413,14 @@ export class StripeApiService {
     valueList: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_radar_value_list> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_radar_value_list> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -29447,8 +29447,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_radar_value_list> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_radar_value_list> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29492,8 +29492,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29550,8 +29550,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29576,14 +29576,14 @@ export class StripeApiService {
     refund: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -29611,8 +29611,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29638,8 +29638,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -29681,8 +29681,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -30363,8 +30363,8 @@ export class StripeApiService {
       report_type: string
     }
   }): Observable<
-    | (HttpResponse<t_reporting_report_run> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_reporting_report_run> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -30389,14 +30389,14 @@ export class StripeApiService {
     reportRun: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_reporting_report_run> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_reporting_report_run> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -30423,14 +30423,14 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -30451,14 +30451,14 @@ export class StripeApiService {
     reportType: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_reporting_report_type> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_reporting_report_type> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -30496,8 +30496,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -30530,14 +30530,14 @@ export class StripeApiService {
     review: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_review> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_review> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -30559,8 +30559,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_review> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_review> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -30601,8 +30601,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -30656,8 +30656,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -31253,8 +31253,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_setup_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_setup_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -31280,8 +31280,8 @@ export class StripeApiService {
     intent: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_setup_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_setup_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -31838,8 +31838,8 @@ export class StripeApiService {
       payment_method_types?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_setup_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_setup_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -31870,8 +31870,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_setup_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_setup_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32438,8 +32438,8 @@ export class StripeApiService {
       use_stripe_sdk?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_setup_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_setup_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32468,8 +32468,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_setup_intent> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_setup_intent> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32514,8 +32514,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32599,8 +32599,8 @@ export class StripeApiService {
       type?: "fixed_amount" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_shipping_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_shipping_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32625,14 +32625,14 @@ export class StripeApiService {
     shippingRateToken: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_shipping_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_shipping_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -32680,8 +32680,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_shipping_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_shipping_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32709,8 +32709,8 @@ export class StripeApiService {
       sql?: string
     }
   }): Observable<
-    | (HttpResponse<t_sigma_sigma_api_query> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_sigma_sigma_api_query> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32744,8 +32744,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32777,14 +32777,14 @@ export class StripeApiService {
     scheduledQueryRun: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_scheduled_query_run> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_scheduled_query_run> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -32913,8 +32913,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -32940,8 +32940,8 @@ export class StripeApiService {
     source: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33057,8 +33057,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33084,14 +33084,14 @@ export class StripeApiService {
     source: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_source_mandate_notification> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_source_mandate_notification> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -33121,8 +33121,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33155,14 +33155,14 @@ export class StripeApiService {
     sourceTransaction: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_source_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_source_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -33186,8 +33186,8 @@ export class StripeApiService {
       values: string[]
     }
   }): Observable<
-    | (HttpResponse<t_source> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_source> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33220,8 +33220,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33302,8 +33302,8 @@ export class StripeApiService {
       tax_rates?: string[] | "" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_subscription_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33335,8 +33335,8 @@ export class StripeApiService {
       proration_date?: number
     }
   }): Observable<
-    | (HttpResponse<t_deleted_subscription_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_subscription_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33361,14 +33361,14 @@ export class StripeApiService {
     item: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_subscription_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -33441,8 +33441,8 @@ export class StripeApiService {
       tax_rates?: string[] | "" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_subscription_item> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_item> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33510,8 +33510,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33737,8 +33737,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_subscription_schedule> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_schedule> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -33763,14 +33763,14 @@ export class StripeApiService {
     schedule: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_subscription_schedule> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_schedule> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -33977,8 +33977,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_subscription_schedule> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_schedule> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34006,8 +34006,8 @@ export class StripeApiService {
       prorate?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_subscription_schedule> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_schedule> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34035,8 +34035,8 @@ export class StripeApiService {
       preserve_cancel_date?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_subscription_schedule> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription_schedule> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34117,8 +34117,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34470,8 +34470,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34505,8 +34505,8 @@ export class StripeApiService {
         object: "search_result" | UnknownEnumStringValue
         total_count?: number
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34555,8 +34555,8 @@ export class StripeApiService {
       prorate?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34581,14 +34581,14 @@ export class StripeApiService {
     subscriptionExposedId: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -34942,8 +34942,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34967,8 +34967,8 @@ export class StripeApiService {
     subscriptionExposedId: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_discount> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_discount> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -34998,8 +34998,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -35032,8 +35032,8 @@ export class StripeApiService {
       proration_date?: number
     }
   }): Observable<
-    | (HttpResponse<t_subscription> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_subscription> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -35220,8 +35220,8 @@ export class StripeApiService {
       tax_date?: number
     }
   }): Observable<
-    | (HttpResponse<t_tax_calculation> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_calculation> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -35246,14 +35246,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_calculation> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_calculation> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -35282,8 +35282,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -35331,8 +35331,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -35994,8 +35994,8 @@ export class StripeApiService {
       expires_at?: number
     }
   }): Observable<
-    | (HttpResponse<t_tax_registration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_registration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36020,14 +36020,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_registration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_registration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -36051,8 +36051,8 @@ export class StripeApiService {
       expires_at?: "now" | UnknownEnumStringValue | number | ""
     }
   }): Observable<
-    | (HttpResponse<t_tax_registration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_registration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36078,14 +36078,14 @@ export class StripeApiService {
       requestBody?: EmptyObject
     } = {},
   ): Observable<
-    | (HttpResponse<t_tax_settings> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_settings> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -36126,8 +36126,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_tax_settings> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_settings> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36158,8 +36158,8 @@ export class StripeApiService {
       reference: string
     }
   }): Observable<
-    | (HttpResponse<t_tax_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36205,8 +36205,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_tax_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36231,14 +36231,14 @@ export class StripeApiService {
     transaction: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -36267,8 +36267,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36310,8 +36310,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36343,14 +36343,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_code> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_code> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -36390,8 +36390,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36547,8 +36547,8 @@ export class StripeApiService {
       value: string
     }
   }): Observable<
-    | (HttpResponse<t_tax_id> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_id> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36572,8 +36572,8 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_tax_id> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_tax_id> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36598,14 +36598,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_id> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_id> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -36645,8 +36645,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36708,8 +36708,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_tax_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36734,14 +36734,14 @@ export class StripeApiService {
     taxRate: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_tax_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -36791,8 +36791,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_tax_rate> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_tax_rate> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36827,8 +36827,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -36995,8 +36995,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_terminal_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37020,8 +37020,8 @@ export class StripeApiService {
     configuration: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_terminal_configuration> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_terminal_configuration> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37049,14 +37049,14 @@ export class StripeApiService {
   }): Observable<
     | (HttpResponse<
         t_terminal_configuration | t_deleted_terminal_configuration
-      > & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      > & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -37225,8 +37225,8 @@ export class StripeApiService {
   }): Observable<
     | (HttpResponse<
         t_terminal_configuration | t_deleted_terminal_configuration
-      > & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      > & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37255,8 +37255,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_terminal_connection_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_connection_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37290,8 +37290,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37339,8 +37339,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_terminal_location> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_location> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37364,8 +37364,8 @@ export class StripeApiService {
     location: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_terminal_location> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_terminal_location> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37393,13 +37393,13 @@ export class StripeApiService {
     | (HttpResponse<t_terminal_location | t_deleted_terminal_location> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -37440,7 +37440,7 @@ export class StripeApiService {
     | (HttpResponse<t_terminal_location | t_deleted_terminal_location> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37488,8 +37488,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37534,8 +37534,8 @@ export class StripeApiService {
       registration_code: string
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37559,8 +37559,8 @@ export class StripeApiService {
     reader: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37588,13 +37588,13 @@ export class StripeApiService {
     | (HttpResponse<t_terminal_reader | t_deleted_terminal_reader> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -37626,7 +37626,7 @@ export class StripeApiService {
     | (HttpResponse<t_terminal_reader | t_deleted_terminal_reader> & {
         status: 200
       })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37652,8 +37652,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37712,8 +37712,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37753,8 +37753,8 @@ export class StripeApiService {
       payment_intent: string
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37785,8 +37785,8 @@ export class StripeApiService {
       payment_intent: string
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37827,8 +37827,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37864,8 +37864,8 @@ export class StripeApiService {
       setup_intent: string
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37903,8 +37903,8 @@ export class StripeApiService {
       reverse_transfer?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -37942,8 +37942,8 @@ export class StripeApiService {
       type: "cart" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -38283,8 +38283,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_confirmation_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_confirmation_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -38313,8 +38313,8 @@ export class StripeApiService {
       reference?: string
     }
   }): Observable<
-    | (HttpResponse<t_customer_cash_balance_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_customer_cash_balance_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -38762,8 +38762,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -38871,8 +38871,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -38899,8 +38899,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -38981,8 +38981,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39010,8 +39010,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39040,8 +39040,8 @@ export class StripeApiService {
       is_amount_controllable?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39069,8 +39069,8 @@ export class StripeApiService {
       reverse_amount?: number
     }
   }): Observable<
-    | (HttpResponse<t_issuing_authorization> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_authorization> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39097,8 +39097,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39125,8 +39125,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39153,8 +39153,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39181,8 +39181,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39209,8 +39209,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_card> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_card> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39237,8 +39237,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_personalization_design> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_personalization_design> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39265,8 +39265,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_personalization_design> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_personalization_design> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39316,8 +39316,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_issuing_personalization_design> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_personalization_design> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39352,8 +39352,8 @@ export class StripeApiService {
       transaction_count?: number
     }
   }): Observable<
-    | (HttpResponse<t_issuing_settlement> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_settlement> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39379,8 +39379,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_issuing_settlement> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_settlement> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -39795,8 +39795,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_issuing_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40211,8 +40211,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_issuing_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40240,8 +40240,8 @@ export class StripeApiService {
       refund_amount?: number
     }
   }): Observable<
-    | (HttpResponse<t_issuing_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_issuing_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40268,8 +40268,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_refund> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_refund> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40303,8 +40303,8 @@ export class StripeApiService {
       type?: "card_present" | "interac_present" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40332,8 +40332,8 @@ export class StripeApiService {
       skip_non_required_inputs?: "all" | "none" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40360,8 +40360,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_terminal_reader> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_terminal_reader> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40396,8 +40396,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40431,8 +40431,8 @@ export class StripeApiService {
       name?: string
     }
   }): Observable<
-    | (HttpResponse<t_test_helpers_test_clock> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_test_helpers_test_clock> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40456,8 +40456,8 @@ export class StripeApiService {
     testClock: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_test_helpers_test_clock> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_test_helpers_test_clock> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40482,14 +40482,14 @@ export class StripeApiService {
     testClock: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_test_helpers_test_clock> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_test_helpers_test_clock> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -40512,8 +40512,8 @@ export class StripeApiService {
       frozen_time: number
     }
   }): Observable<
-    | (HttpResponse<t_test_helpers_test_clock> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_test_helpers_test_clock> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40557,8 +40557,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_inbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40585,8 +40585,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_inbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40613,8 +40613,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_inbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40652,8 +40652,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40680,8 +40680,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40708,8 +40708,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40750,8 +40750,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40789,8 +40789,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40817,8 +40817,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40845,8 +40845,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40887,8 +40887,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40927,8 +40927,8 @@ export class StripeApiService {
       network: "ach" | "us_domestic_wire" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_treasury_received_credit> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_received_credit> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -40966,8 +40966,8 @@ export class StripeApiService {
       network: "ach" | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_treasury_received_debit> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_received_debit> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41380,8 +41380,8 @@ export class StripeApiService {
       }
     } = {},
   ): Observable<
-    | (HttpResponse<t_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41406,14 +41406,14 @@ export class StripeApiService {
     token: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_token> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_token> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -41465,8 +41465,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41513,8 +41513,8 @@ export class StripeApiService {
       transfer_group?: string
     }
   }): Observable<
-    | (HttpResponse<t_topup> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_topup> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41539,14 +41539,14 @@ export class StripeApiService {
     topup: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_topup> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_topup> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -41575,8 +41575,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_topup> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_topup> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41602,8 +41602,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_topup> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_topup> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41647,8 +41647,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41693,8 +41693,8 @@ export class StripeApiService {
       transfer_group?: string
     }
   }): Observable<
-    | (HttpResponse<t_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41727,8 +41727,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41770,8 +41770,8 @@ export class StripeApiService {
       refund_application_fee?: boolean
     }
   }): Observable<
-    | (HttpResponse<t_transfer_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_transfer_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41796,14 +41796,14 @@ export class StripeApiService {
     transfer: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -41832,8 +41832,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41859,14 +41859,14 @@ export class StripeApiService {
     transfer: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_transfer_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_transfer_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -41896,8 +41896,8 @@ export class StripeApiService {
         | UnknownEnumStringValue
     }
   }): Observable<
-    | (HttpResponse<t_transfer_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_transfer_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41933,8 +41933,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41973,8 +41973,8 @@ export class StripeApiService {
       received_credit: string
     }
   }): Observable<
-    | (HttpResponse<t_treasury_credit_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_credit_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -41999,14 +41999,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_credit_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_credit_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42039,8 +42039,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42080,8 +42080,8 @@ export class StripeApiService {
       received_debit: string
     }
   }): Observable<
-    | (HttpResponse<t_treasury_debit_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_debit_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42106,14 +42106,14 @@ export class StripeApiService {
     expand?: string[]
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_debit_reversal> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_debit_reversal> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42153,8 +42153,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42234,8 +42234,8 @@ export class StripeApiService {
       supported_currencies: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_financial_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_financial_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42260,14 +42260,14 @@ export class StripeApiService {
     financialAccount: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_financial_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_financial_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42340,8 +42340,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_financial_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_financial_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42373,8 +42373,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_financial_account> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_financial_account> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42400,14 +42400,14 @@ export class StripeApiService {
     financialAccount: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_financial_account_features> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_financial_account_features> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42465,8 +42465,8 @@ export class StripeApiService {
       }
     }
   }): Observable<
-    | (HttpResponse<t_treasury_financial_account_features> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_financial_account_features> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42506,8 +42506,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42550,8 +42550,8 @@ export class StripeApiService {
       statement_descriptor?: string
     }
   }): Observable<
-    | (HttpResponse<t_treasury_inbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42576,14 +42576,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_inbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42605,8 +42605,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_inbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_inbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42656,8 +42656,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42748,8 +42748,8 @@ export class StripeApiService {
       statement_descriptor?: string
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42774,14 +42774,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42803,8 +42803,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_payment> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_payment> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42844,8 +42844,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42900,8 +42900,8 @@ export class StripeApiService {
       statement_descriptor?: string
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -42926,14 +42926,14 @@ export class StripeApiService {
     outboundTransfer: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -42956,8 +42956,8 @@ export class StripeApiService {
       expand?: string[]
     }
   }): Observable<
-    | (HttpResponse<t_treasury_outbound_transfer> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_outbound_transfer> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43001,8 +43001,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43037,14 +43037,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_received_credit> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_received_credit> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -43074,8 +43074,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43109,14 +43109,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_received_debit> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_received_debit> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -43163,8 +43163,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43201,14 +43201,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_transaction_entry> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_transaction_entry> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -43257,8 +43257,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43295,14 +43295,14 @@ export class StripeApiService {
     id: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_treasury_transaction> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_treasury_transaction> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -43332,8 +43332,8 @@ export class StripeApiService {
         has_more: boolean
         object: "list" | UnknownEnumStringValue
         url: string
-      }> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+      }> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43735,8 +43735,8 @@ export class StripeApiService {
       url: string
     }
   }): Observable<
-    | (HttpResponse<t_webhook_endpoint> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_webhook_endpoint> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43760,8 +43760,8 @@ export class StripeApiService {
     webhookEndpoint: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_deleted_webhook_endpoint> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_deleted_webhook_endpoint> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -43786,14 +43786,14 @@ export class StripeApiService {
     webhookEndpoint: string
     requestBody?: EmptyObject
   }): Observable<
-    | (HttpResponse<t_webhook_endpoint> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_webhook_endpoint> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
       "Content-Type": "application/x-www-form-urlencoded",
     })
-    const params = this._queryParams({ expand: p["expand"] })
+    const params = this._queryParams({expand: p["expand"]})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -44070,8 +44070,8 @@ export class StripeApiService {
       url?: string
     }
   }): Observable<
-    | (HttpResponse<t_webhook_endpoint> & { status: 200 })
-    | (HttpResponse<t_error> & { status: StatusCode })
+    | (HttpResponse<t_webhook_endpoint> & {status: 200})
+    | (HttpResponse<t_error> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     const headers = this._headers({
@@ -44092,5 +44092,5 @@ export class StripeApiService {
   }
 }
 
-export { StripeApiService as ApiClient }
-export { StripeApiServiceConfig as ApiClientConfig }
+export {StripeApiService as ApiClient}
+export {StripeApiServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-angular/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-angular/src/generated/stripe.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/api.module.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/api.module.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { TodoListsExampleApiService } from "./client.service"
-import { NgModule } from "@angular/core"
+import {TodoListsExampleApiService} from "./client.service"
+import {NgModule} from "@angular/core"
 
 @NgModule({
   imports: [],
@@ -13,4 +13,4 @@ import { NgModule } from "@angular/core"
 })
 export class TodoListsExampleApiModule {}
 
-export { TodoListsExampleApiModule as ApiModule }
+export {TodoListsExampleApiModule as ApiModule}

--- a/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
+++ b/integration-tests/typescript-angular/src/generated/todo-lists.yaml/client.service.ts
@@ -9,9 +9,9 @@ import {
   t_TodoList,
   t_UnknownObject,
 } from "./models"
-import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
-import { Observable } from "rxjs"
+import {HttpClient, HttpParams, HttpResponse} from "@angular/common/http"
+import {Injectable} from "@angular/core"
+import {Observable} from "rxjs"
 
 export class TodoListsExampleApiServiceServersOperations {
   static listAttachments(url?: "{schema}://{tenant}.attachments.example.com"): {
@@ -189,7 +189,7 @@ export type QueryParams = {
     | QueryParams[]
 }
 
-export type Server<T> = string & { __server__: T }
+export type Server<T> = string & {__server__: T}
 
 @Injectable({
   providedIn: "root",
@@ -204,7 +204,7 @@ export class TodoListsExampleApiService {
     headers: Record<string, string | undefined>,
   ): Record<string, string> {
     return Object.fromEntries(
-      Object.entries({ ...this.config.defaultHeaders, ...headers }).filter(
+      Object.entries({...this.config.defaultHeaders, ...headers}).filter(
         (it): it is [string, string] => it[1] !== undefined,
       ),
     )
@@ -234,7 +234,7 @@ export class TodoListsExampleApiService {
       tags?: string[]
     } = {},
   ): Observable<
-    (HttpResponse<t_TodoList[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_TodoList[]> & {status: 200}) | HttpResponse<unknown>
   > {
     const params = this._queryParams({
       created: p["created"],
@@ -252,9 +252,9 @@ export class TodoListsExampleApiService {
   getTodoListById(p: {
     listId: string
   }): Observable<
-    | (HttpResponse<t_TodoList> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: StatusCode4xx })
-    | (HttpResponse<void> & { status: StatusCode })
+    | (HttpResponse<t_TodoList> & {status: 200})
+    | (HttpResponse<t_Error> & {status: StatusCode4xx})
+    | (HttpResponse<void> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -271,12 +271,12 @@ export class TodoListsExampleApiService {
     listId: string
     requestBody: t_CreateUpdateTodoList
   }): Observable<
-    | (HttpResponse<t_TodoList> & { status: 200 })
-    | (HttpResponse<t_Error> & { status: StatusCode4xx })
-    | (HttpResponse<void> & { status: StatusCode })
+    | (HttpResponse<t_TodoList> & {status: 200})
+    | (HttpResponse<t_Error> & {status: StatusCode4xx})
+    | (HttpResponse<void> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -294,9 +294,9 @@ export class TodoListsExampleApiService {
   deleteTodoListById(p: {
     listId: string
   }): Observable<
-    | (HttpResponse<void> & { status: 204 })
-    | (HttpResponse<t_Error> & { status: StatusCode4xx })
-    | (HttpResponse<void> & { status: StatusCode })
+    | (HttpResponse<void> & {status: 204})
+    | (HttpResponse<t_Error> & {status: StatusCode4xx})
+    | (HttpResponse<void> & {status: StatusCode})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -317,11 +317,11 @@ export class TodoListsExampleApiService {
         content: string
         createdAt: string
         id: string
-      }> & { status: 200 })
+      }> & {status: 200})
     | (HttpResponse<{
         code: string
         message: string
-      }> & { status: StatusCode5xx })
+      }> & {status: StatusCode5xx})
     | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>(
@@ -341,10 +341,8 @@ export class TodoListsExampleApiService {
       content: string
       id: string
     }
-  }): Observable<
-    (HttpResponse<void> & { status: 204 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "application/json" })
+  }): Observable<(HttpResponse<void> & {status: 204}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "application/json"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>(
@@ -366,7 +364,7 @@ export class TodoListsExampleApiService {
       .listAttachments()
       .build(),
   ): Observable<
-    (HttpResponse<t_UnknownObject[]> & { status: 200 }) | HttpResponse<unknown>
+    (HttpResponse<t_UnknownObject[]> & {status: 200}) | HttpResponse<unknown>
   > {
     return this.httpClient.request<any>("GET", basePath + `/attachments`, {
       observe: "response",
@@ -385,10 +383,8 @@ export class TodoListsExampleApiService {
       | string = TodoListsExampleApiServiceServers.operations
       .uploadAttachment()
       .build(),
-  ): Observable<
-    (HttpResponse<void> & { status: 202 }) | HttpResponse<unknown>
-  > {
-    const headers = this._headers({ "Content-Type": "multipart/form-data" })
+  ): Observable<(HttpResponse<void> & {status: 202}) | HttpResponse<unknown>> {
+    const headers = this._headers({"Content-Type": "multipart/form-data"})
     const body = p["requestBody"]
 
     return this.httpClient.request<any>("POST", basePath + `/attachments`, {
@@ -400,5 +396,5 @@ export class TodoListsExampleApiService {
   }
 }
 
-export { TodoListsExampleApiService as ApiClient }
-export { TodoListsExampleApiServiceConfig as ApiClientConfig }
+export {TodoListsExampleApiService as ApiClient}
+export {TodoListsExampleApiServiceConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/client.ts
@@ -339,12 +339,12 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class GitHubV3RestApiServersOperations {
   static reposUploadReleaseAsset(
     url: "https://uploads.github.com" = "https://uploads.github.com",
-  ): { build: () => Server<"reposUploadReleaseAsset_GitHubV3RestApi"> } {
+  ): {build: () => Server<"reposUploadReleaseAsset_GitHubV3RestApi">} {
     switch (url) {
       case "https://uploads.github.com":
         return {
@@ -402,7 +402,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -469,7 +469,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -488,7 +488,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -504,7 +504,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -533,7 +533,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -549,7 +549,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -569,7 +569,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_webhook_config>> {
     const url = `/app/hook/config`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -578,7 +578,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -594,12 +594,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_hook_delivery_item[]>> {
     const url = `/app/hook/deliveries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], cursor: p["cursor"] })
+    const query = this._query({per_page: p["perPage"], cursor: p["cursor"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -618,7 +618,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -641,7 +641,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -657,12 +657,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_integration_installation_request[]>> {
     const url = `/app/installation-requests`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -690,7 +690,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -709,7 +709,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -728,7 +728,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -748,7 +748,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_installation_token>> {
     const url = `/app/installations/${p["installationId"]}/access_tokens`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -757,7 +757,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -776,7 +776,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -795,7 +795,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -813,7 +813,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/applications/${p["clientId"]}/grant`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -822,7 +822,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -840,7 +840,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_authorization>> {
     const url = `/applications/${p["clientId"]}/token`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -849,7 +849,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -867,7 +867,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_authorization>> {
     const url = `/applications/${p["clientId"]}/token`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -876,7 +876,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -894,7 +894,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/applications/${p["clientId"]}/token`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -903,7 +903,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -926,7 +926,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_authorization>> {
     const url = `/applications/${p["clientId"]}/token/scoped`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -935,7 +935,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -954,7 +954,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -973,7 +973,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -990,12 +990,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_classroom_accepted_assignment[]>> {
     const url = `/assignments/${p["assignmentId"]}/accepted_assignments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1014,7 +1014,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1030,12 +1030,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_classroom[]>> {
     const url = `/classrooms`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1054,7 +1054,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1071,12 +1071,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_classroom_assignment[]>> {
     const url = `/classrooms/${p["classroomId"]}/assignments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1092,7 +1092,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1111,7 +1111,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1132,7 +1132,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/credentials/revoke`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1141,7 +1141,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1161,7 +1161,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1188,7 +1188,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1266,7 +1266,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_security_configuration>> {
     const url = `/enterprises/${p["enterprise"]}/code-security/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1275,7 +1275,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1294,7 +1294,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1314,7 +1314,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1393,7 +1393,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_security_configuration>> {
     const url = `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1402,7 +1402,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1422,7 +1422,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1445,7 +1445,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}/attach`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1454,7 +1454,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1494,7 +1494,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}/defaults`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1503,7 +1503,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1533,7 +1533,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1582,7 +1582,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1627,7 +1627,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1643,12 +1643,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1664,7 +1664,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1690,7 +1690,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1717,7 +1717,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_simple>> {
     const url = `/gists`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1726,7 +1726,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1752,7 +1752,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1778,7 +1778,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1797,7 +1797,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1825,7 +1825,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_simple>> {
     const url = `/gists/${p["gistId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1834,7 +1834,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1853,7 +1853,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1870,12 +1870,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_comment[]>> {
     const url = `/gists/${p["gistId"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1893,7 +1893,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_comment>> {
     const url = `/gists/${p["gistId"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1902,7 +1902,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1922,7 +1922,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1941,7 +1941,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_comment>> {
     const url = `/gists/${p["gistId"]}/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1950,7 +1950,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1970,7 +1970,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1987,12 +1987,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_commit[]>> {
     const url = `/gists/${p["gistId"]}/commits`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2009,12 +2009,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gist_simple[]>> {
     const url = `/gists/${p["gistId"]}/forks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2033,7 +2033,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2052,7 +2052,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2071,7 +2071,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2090,7 +2090,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2110,7 +2110,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2126,7 +2126,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2145,7 +2145,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2167,12 +2167,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/installation/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2188,7 +2188,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2239,7 +2239,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2265,7 +2265,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2284,7 +2284,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2303,7 +2303,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<string>> {
     const url = `/markdown`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2312,7 +2312,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2326,17 +2326,14 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<string>> {
     const url = `/markdown/raw`
-    const headers = this._headers(
-      { "Content-Type": "text/plain" },
-      opts.headers,
-    )
+    const headers = this._headers({"Content-Type": "text/plain"}, opts.headers)
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2355,7 +2352,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2371,12 +2368,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_marketplace_listing_plan[]>> {
     const url = `/marketplace_listing/plans`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2405,7 +2402,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2424,7 +2421,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2440,12 +2437,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_marketplace_listing_plan[]>> {
     const url = `/marketplace_listing/stubbed/plans`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2474,7 +2471,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2490,7 +2487,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2508,12 +2505,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/networks/${p["owner"]}/${p["repo"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2545,7 +2542,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2568,7 +2565,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/notifications`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2577,7 +2574,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2596,7 +2593,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2615,7 +2612,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PATCH",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2634,7 +2631,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2653,7 +2650,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2671,7 +2668,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_thread_subscription>> {
     const url = `/notifications/threads/${p["threadId"]}/subscription`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2680,7 +2677,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2699,7 +2696,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2714,12 +2711,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<string>> {
     const url = `/octocat`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ s: p["s"] })
+    const query = this._query({s: p["s"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2735,12 +2732,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_simple[]>> {
     const url = `/organizations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"], per_page: p["perPage"] })
+    const query = this._query({since: p["since"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2757,12 +2754,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dependabot_repository_access_details>> {
     const url = `/organizations/${p["org"]}/dependabot/repository-access`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2781,7 +2778,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/organizations/${p["org"]}/dependabot/repository-access`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2790,7 +2787,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2808,7 +2805,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/organizations/${p["org"]}/dependabot/repository-access/default-level`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2817,7 +2814,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2846,7 +2843,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2865,7 +2862,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2922,7 +2919,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_full>> {
     const url = `/orgs/${p["org"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2931,7 +2928,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2954,7 +2951,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2973,7 +2970,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2995,12 +2992,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/cache/usage-by-repository`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3022,12 +3019,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/hosted-runners`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3055,7 +3052,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_actions_hosted_runner>> {
     const url = `/orgs/${p["org"]}/actions/hosted-runners`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3064,7 +3061,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3088,7 +3085,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3112,7 +3109,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3131,7 +3128,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3155,7 +3152,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3179,7 +3176,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3199,7 +3196,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3221,7 +3218,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_actions_hosted_runner>> {
     const url = `/orgs/${p["org"]}/actions/hosted-runners/${p["hostedRunnerId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3230,7 +3227,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3250,7 +3247,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3269,7 +3266,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3285,7 +3282,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/orgs/${p["org"]}/actions/oidc/customization/sub`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3294,7 +3291,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3313,7 +3310,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3332,7 +3329,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/permissions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3341,7 +3338,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3363,12 +3360,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/permissions/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3386,7 +3383,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/permissions/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3395,7 +3392,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3415,7 +3412,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3435,7 +3432,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3454,7 +3451,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3470,7 +3467,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/permissions/selected-actions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3479,7 +3476,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3498,7 +3495,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3514,7 +3511,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/permissions/workflow`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3523,7 +3520,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3555,7 +3552,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3582,7 +3579,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_runner_groups_org>> {
     const url = `/orgs/${p["org"]}/actions/runner-groups`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3591,7 +3588,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3611,7 +3608,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3637,7 +3634,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_runner_groups_org>> {
     const url = `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3646,7 +3643,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3666,7 +3663,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3689,12 +3686,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/hosted-runners`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3717,12 +3714,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3741,7 +3738,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3750,7 +3747,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3771,7 +3768,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3792,7 +3789,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3815,12 +3812,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/runners`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3839,7 +3836,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/runners`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3848,7 +3845,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3869,7 +3866,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3890,7 +3887,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3922,7 +3919,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3941,7 +3938,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3967,7 +3964,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/runners/generate-jitconfig`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3976,7 +3973,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3995,7 +3992,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4014,7 +4011,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4034,7 +4031,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4054,7 +4051,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4079,7 +4076,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4103,7 +4100,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4112,7 +4109,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4136,7 +4133,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4145,7 +4142,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4170,7 +4167,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4196,7 +4193,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4218,12 +4215,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4242,7 +4239,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4262,7 +4259,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4284,7 +4281,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4293,7 +4290,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4313,7 +4310,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4336,12 +4333,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4360,7 +4357,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4369,7 +4366,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4390,7 +4387,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4411,7 +4408,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4433,12 +4430,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4459,7 +4456,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/orgs/${p["org"]}/actions/variables`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4468,7 +4465,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4488,7 +4485,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4512,7 +4509,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/variables/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4521,7 +4518,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4541,7 +4538,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4564,12 +4561,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/actions/variables/${p["name"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4588,7 +4585,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/actions/variables/${p["name"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4597,7 +4594,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4618,7 +4615,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4639,7 +4636,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4700,7 +4697,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/attestations/bulk-list`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const query = this._query({
@@ -4714,7 +4711,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url + query,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4736,7 +4733,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/attestations/delete-request`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4745,7 +4742,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4765,7 +4762,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4785,7 +4782,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4839,7 +4836,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4856,12 +4853,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/orgs/${p["org"]}/blocks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4881,7 +4878,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4901,7 +4898,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4921,7 +4918,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4957,7 +4954,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4985,7 +4982,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_campaign_summary>> {
     const url = `/orgs/${p["org"]}/campaigns`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4994,7 +4991,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5014,7 +5011,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5039,7 +5036,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_campaign_summary>> {
     const url = `/orgs/${p["org"]}/campaigns/${p["campaignNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5048,7 +5045,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5068,7 +5065,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5109,7 +5106,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5138,7 +5135,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5229,7 +5226,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_security_configuration>> {
     const url = `/orgs/${p["org"]}/code-security/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5238,7 +5235,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5257,7 +5254,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5275,7 +5272,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/code-security/configurations/detach`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5284,7 +5281,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5304,7 +5301,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5398,7 +5395,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5407,7 +5404,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5427,7 +5424,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5457,7 +5454,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}/attach`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5466,7 +5463,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5506,7 +5503,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}/defaults`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5515,7 +5512,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5545,7 +5542,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5567,12 +5564,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/codespaces`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5596,7 +5593,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/codespaces/access`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5605,7 +5602,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5623,7 +5620,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/codespaces/access/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5632,7 +5629,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5650,7 +5647,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/codespaces/access/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5659,7 +5656,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5681,12 +5678,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/codespaces/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5705,7 +5702,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5725,7 +5722,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5747,7 +5744,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5756,7 +5753,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5776,7 +5773,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5799,12 +5796,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5823,7 +5820,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5832,7 +5829,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5853,7 +5850,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5874,7 +5871,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5893,7 +5890,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5915,12 +5912,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/copilot/billing/seats`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5942,7 +5939,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/copilot/billing/selected_teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5951,7 +5948,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5973,7 +5970,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/copilot/billing/selected_teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5982,7 +5979,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6004,7 +6001,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/copilot/billing/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6013,7 +6010,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6035,7 +6032,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/copilot/billing/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6044,7 +6041,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6073,7 +6070,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6122,7 +6119,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6144,12 +6141,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/dependabot/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6168,7 +6165,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6188,7 +6185,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6210,7 +6207,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6219,7 +6216,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6239,7 +6236,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6262,12 +6259,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6286,7 +6283,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6295,7 +6292,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6316,7 +6313,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6337,7 +6334,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6356,7 +6353,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6373,12 +6370,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/orgs/${p["org"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6395,12 +6392,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_invitation[]>> {
     const url = `/orgs/${p["org"]}/failed_invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6417,12 +6414,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_org_hook[]>> {
     const url = `/orgs/${p["org"]}/hooks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6450,7 +6447,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_org_hook>> {
     const url = `/orgs/${p["org"]}/hooks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6459,7 +6456,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6479,7 +6476,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6508,7 +6505,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_org_hook>> {
     const url = `/orgs/${p["org"]}/hooks/${p["hookId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6517,7 +6514,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6537,7 +6534,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6557,7 +6554,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6579,7 +6576,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_webhook_config>> {
     const url = `/orgs/${p["org"]}/hooks/${p["hookId"]}/config`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6588,7 +6585,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6606,12 +6603,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_hook_delivery_item[]>> {
     const url = `/orgs/${p["org"]}/hooks/${p["hookId"]}/deliveries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], cursor: p["cursor"] })
+    const query = this._query({per_page: p["perPage"], cursor: p["cursor"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6632,7 +6629,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6657,7 +6654,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6677,7 +6674,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6728,7 +6725,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6770,7 +6767,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6795,7 +6792,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6821,7 +6818,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6854,7 +6851,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6881,7 +6878,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6909,7 +6906,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6944,7 +6941,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6987,7 +6984,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7006,7 +7003,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7028,12 +7025,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/installations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7052,7 +7049,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7068,7 +7065,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_interaction_limit_response>> {
     const url = `/orgs/${p["org"]}/interaction-limits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -7077,7 +7074,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7096,7 +7093,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7131,7 +7128,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7160,7 +7157,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_invitation>> {
     const url = `/orgs/${p["org"]}/invitations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -7169,7 +7166,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7189,7 +7186,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7207,12 +7204,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/orgs/${p["org"]}/invitations/${p["invitationId"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7231,7 +7228,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7247,7 +7244,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue_type>> {
     const url = `/orgs/${p["org"]}/issue-types`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -7256,7 +7253,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7273,7 +7270,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue_type>> {
     const url = `/orgs/${p["org"]}/issue-types/${p["issueTypeId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -7282,7 +7279,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7302,7 +7299,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7348,7 +7345,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7377,7 +7374,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7397,7 +7394,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7417,7 +7414,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7440,12 +7437,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/members/${p["username"]}/codespaces`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7470,7 +7467,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7491,7 +7488,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7511,7 +7508,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7531,7 +7528,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7550,7 +7547,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_org_membership>> {
     const url = `/orgs/${p["org"]}/memberships/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -7559,7 +7556,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7579,7 +7576,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7606,7 +7603,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7632,7 +7629,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_migration>> {
     const url = `/orgs/${p["org"]}/migrations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -7641,7 +7638,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7658,12 +7655,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_migration>> {
     const url = `/orgs/${p["org"]}/migrations/${p["migrationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ exclude: p["exclude"] })
+    const query = this._query({exclude: p["exclude"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7683,7 +7680,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7703,7 +7700,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7724,7 +7721,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7742,12 +7739,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/orgs/${p["org"]}/migrations/${p["migrationId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7771,7 +7768,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7791,7 +7788,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7812,7 +7809,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7833,7 +7830,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7853,7 +7850,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7874,7 +7871,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7895,7 +7892,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7915,7 +7912,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7933,12 +7930,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_role_assignment[]>> {
     const url = `/orgs/${p["org"]}/organization-roles/${p["roleId"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7956,12 +7953,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_user_role_assignment[]>> {
     const url = `/orgs/${p["org"]}/organization-roles/${p["roleId"]}/users`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -7988,7 +7985,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8007,7 +8004,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<EmptyObject> | AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/outside_collaborators/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8016,7 +8013,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8036,7 +8033,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8072,7 +8069,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8100,7 +8097,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8128,7 +8125,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8153,12 +8150,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}/restore`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ token: p["token"] })
+    const query = this._query({token: p["token"]})
 
     return this._request({
       url: url + query,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8194,7 +8191,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8223,7 +8220,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8252,7 +8249,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8281,7 +8278,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8324,7 +8321,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8348,7 +8345,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/personal-access-token-requests`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8357,7 +8354,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8377,7 +8374,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/personal-access-token-requests/${p["patRequestId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8386,7 +8383,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8404,12 +8401,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/orgs/${p["org"]}/personal-access-token-requests/${p["patRequestId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8450,7 +8447,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8473,7 +8470,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/personal-access-tokens`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8482,7 +8479,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8501,7 +8498,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/personal-access-tokens/${p["patId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8510,7 +8507,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8528,12 +8525,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/orgs/${p["org"]}/personal-access-tokens/${p["patId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8555,12 +8552,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/private-registries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8590,7 +8587,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/private-registries`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8599,7 +8596,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8623,7 +8620,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8643,7 +8640,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8677,7 +8674,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/private-registries/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8686,7 +8683,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8706,7 +8703,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8733,7 +8730,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8752,7 +8749,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project>> {
     const url = `/orgs/${p["org"]}/projects`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8761,7 +8758,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8780,7 +8777,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8798,7 +8795,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_custom_property[]>> {
     const url = `/orgs/${p["org"]}/properties/schema`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8807,7 +8804,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8827,7 +8824,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8844,7 +8841,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_custom_property>> {
     const url = `/orgs/${p["org"]}/properties/schema/${p["customPropertyName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8853,7 +8850,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8873,7 +8870,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8900,7 +8897,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8919,7 +8916,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/properties/values`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8928,7 +8925,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8945,12 +8942,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/orgs/${p["org"]}/public_members`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8970,7 +8967,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8990,7 +8987,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9010,7 +9007,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9053,7 +9050,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9107,7 +9104,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_full_repository>> {
     const url = `/orgs/${p["org"]}/repos`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9116,7 +9113,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9143,7 +9140,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9168,7 +9165,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_ruleset>> {
     const url = `/orgs/${p["org"]}/rulesets`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9177,7 +9174,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9217,7 +9214,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9237,7 +9234,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9257,7 +9254,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9283,7 +9280,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_ruleset>> {
     const url = `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9292,7 +9289,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9312,7 +9309,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9330,12 +9327,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ruleset_version[]>> {
     const url = `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}/history`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9356,7 +9353,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9403,7 +9400,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9441,7 +9438,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9460,7 +9457,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9480,7 +9477,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9500,7 +9497,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9519,7 +9516,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9538,7 +9535,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9557,7 +9554,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9579,12 +9576,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/orgs/${p["org"]}/settings/network-configurations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9606,7 +9603,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_network_configuration>> {
     const url = `/orgs/${p["org"]}/settings/network-configurations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9615,7 +9612,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9635,7 +9632,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9658,7 +9655,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_network_configuration>> {
     const url = `/orgs/${p["org"]}/settings/network-configurations/${p["networkConfigurationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9667,7 +9664,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9687,7 +9684,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9707,7 +9704,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9737,7 +9734,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9754,12 +9751,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/orgs/${p["org"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9790,7 +9787,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_full>> {
     const url = `/orgs/${p["org"]}/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9799,7 +9796,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9819,7 +9816,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9851,7 +9848,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_full>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9860,7 +9857,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9880,7 +9877,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9910,7 +9907,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9931,7 +9928,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9940,7 +9937,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9961,7 +9958,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9982,7 +9979,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9991,7 +9988,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10012,7 +10009,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10041,7 +10038,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10061,7 +10058,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion_comment>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10070,7 +10067,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10092,7 +10089,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10113,7 +10110,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion_comment>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10122,7 +10119,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10144,7 +10141,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10183,7 +10180,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10213,7 +10210,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10222,7 +10219,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10245,7 +10242,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10283,7 +10280,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10312,7 +10309,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10321,7 +10318,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10343,7 +10340,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10361,12 +10358,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_invitation[]>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10394,7 +10391,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10415,7 +10412,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10435,7 +10432,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_membership>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10444,7 +10441,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10465,7 +10462,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10483,12 +10480,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_project[]>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10509,7 +10506,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10531,7 +10528,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10540,7 +10537,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10561,7 +10558,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10579,12 +10576,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10606,7 +10603,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10627,7 +10624,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10636,7 +10633,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10658,7 +10655,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10676,12 +10673,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/orgs/${p["org"]}/teams/${p["teamSlug"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10711,7 +10708,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/orgs/${p["org"]}/${p["securityProduct"]}/${p["enablement"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10720,7 +10717,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10739,7 +10736,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10758,7 +10755,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project_card>> {
     const url = `/projects/columns/cards/${p["cardId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10767,7 +10764,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10786,7 +10783,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10805,7 +10802,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<EmptyObject>> {
     const url = `/projects/columns/cards/${p["cardId"]}/moves`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10814,7 +10811,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10833,7 +10830,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10851,7 +10848,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project_column>> {
     const url = `/projects/columns/${p["columnId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10860,7 +10857,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10879,7 +10876,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10910,7 +10907,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10933,7 +10930,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project_card>> {
     const url = `/projects/columns/${p["columnId"]}/cards`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10942,7 +10939,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10960,7 +10957,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<EmptyObject>> {
     const url = `/projects/columns/${p["columnId"]}/moves`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10969,7 +10966,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10988,7 +10985,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11012,7 +11009,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project>> {
     const url = `/projects/${p["projectId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11021,7 +11018,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11040,7 +11037,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11067,7 +11064,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11088,7 +11085,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/projects/${p["projectId"]}/collaborators/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11097,7 +11094,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11117,7 +11114,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11137,7 +11134,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11154,12 +11151,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project_column[]>> {
     const url = `/projects/${p["projectId"]}/columns`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11177,7 +11174,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project_column>> {
     const url = `/projects/${p["projectId"]}/columns`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11186,7 +11183,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11202,7 +11199,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11222,7 +11219,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11306,7 +11303,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_full_repository>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11315,7 +11312,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11335,7 +11332,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11368,7 +11365,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11389,7 +11386,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11410,7 +11407,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11432,7 +11429,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11452,7 +11449,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11490,7 +11487,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11508,12 +11505,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_actions_cache_list>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/caches`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ key: p["key"], ref: p["ref"] })
+    const query = this._query({key: p["key"], ref: p["ref"]})
 
     return this._request({
       url: url + query,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11534,7 +11531,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11555,7 +11552,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11576,7 +11573,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11596,7 +11593,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/jobs/${p["jobId"]}/rerun`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11605,7 +11602,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11625,7 +11622,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11645,7 +11642,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/oidc/customization/sub`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11654,7 +11651,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11677,12 +11674,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/organization-secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11705,12 +11702,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/organization-variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11730,7 +11727,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11750,7 +11747,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/permissions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11759,7 +11756,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11779,7 +11776,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11796,7 +11793,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/access`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11805,7 +11802,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11825,7 +11822,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11842,7 +11839,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/selected-actions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11851,7 +11848,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11871,7 +11868,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11888,7 +11885,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/workflow`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11897,7 +11894,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11930,7 +11927,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11950,7 +11947,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11977,7 +11974,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runners/generate-jitconfig`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11986,7 +11983,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12006,7 +12003,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12026,7 +12023,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12047,7 +12044,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12068,7 +12065,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12094,7 +12091,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12119,7 +12116,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12128,7 +12125,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12153,7 +12150,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12162,7 +12159,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12188,7 +12185,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12215,7 +12212,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12277,7 +12274,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12295,14 +12292,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_workflow_run>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({
-      exclude_pull_requests: p["excludePullRequests"],
-    })
+    const query = this._query({exclude_pull_requests: p["excludePullRequests"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12323,7 +12318,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12344,7 +12339,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12365,7 +12360,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12399,7 +12394,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12418,14 +12413,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_workflow_run>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/attempts/${p["attemptNumber"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({
-      exclude_pull_requests: p["excludePullRequests"],
-    })
+    const query = this._query({exclude_pull_requests: p["excludePullRequests"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12450,12 +12443,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/attempts/${p["attemptNumber"]}/jobs`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12477,7 +12470,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12498,7 +12491,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12518,7 +12511,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/deployment_protection_rule`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12527,7 +12520,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12548,7 +12541,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12582,7 +12575,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12603,7 +12596,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12624,7 +12617,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12645,7 +12638,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12667,7 +12660,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deployment[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/pending_deployments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12676,7 +12669,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12696,7 +12689,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/rerun`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12705,7 +12698,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12725,7 +12718,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/rerun-failed-jobs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12734,7 +12727,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12755,7 +12748,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12778,12 +12771,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12803,7 +12796,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12824,7 +12817,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12845,7 +12838,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12854,7 +12847,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12875,7 +12868,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12898,12 +12891,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12923,7 +12916,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/variables`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12932,7 +12925,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12953,7 +12946,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12974,7 +12967,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/variables/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12983,7 +12976,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13004,7 +12997,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13027,12 +13020,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/workflows`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13053,7 +13046,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13074,7 +13067,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13099,7 +13092,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}/dispatches`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13108,7 +13101,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13129,7 +13122,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13192,7 +13185,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13213,7 +13206,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13264,7 +13257,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13282,12 +13275,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/assignees`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13308,7 +13301,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13343,7 +13336,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/attestations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13352,7 +13345,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13407,7 +13400,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13427,7 +13420,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13448,7 +13441,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_autolink>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/autolinks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13457,7 +13450,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13478,7 +13471,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13499,7 +13492,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13519,7 +13512,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13539,7 +13532,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13559,7 +13552,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13587,7 +13580,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13608,7 +13601,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13629,7 +13622,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13691,7 +13684,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_protected_branch>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13700,7 +13693,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13721,7 +13714,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13742,7 +13735,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13763,7 +13756,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13784,7 +13777,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13805,7 +13798,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13842,7 +13835,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_protected_branch_pull_request_review>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13851,7 +13844,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13872,7 +13865,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13893,7 +13886,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13914,7 +13907,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13935,7 +13928,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13956,7 +13949,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13983,7 +13976,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_status_check_policy>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13992,7 +13985,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14013,7 +14006,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14034,7 +14027,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14056,7 +14049,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<string[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14065,7 +14058,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14087,7 +14080,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<string[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14096,7 +14089,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14118,7 +14111,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<string[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14127,7 +14120,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14148,7 +14141,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14169,7 +14162,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14190,7 +14183,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14210,7 +14203,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_integration[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14219,7 +14212,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14239,7 +14232,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_integration[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14248,7 +14241,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14268,7 +14261,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_integration[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14277,7 +14270,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14298,7 +14291,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14320,7 +14313,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14329,7 +14322,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14351,7 +14344,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14360,7 +14353,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14382,7 +14375,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14391,7 +14384,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14412,7 +14405,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14432,7 +14425,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14441,7 +14434,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14461,7 +14454,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14470,7 +14463,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14490,7 +14483,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14499,7 +14492,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14519,7 +14512,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_branch_with_protection>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/rename`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14528,7 +14521,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14553,7 +14546,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_check_run>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/check-runs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14562,7 +14555,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14583,7 +14576,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14669,7 +14662,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_check_run>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14678,7 +14671,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14697,12 +14690,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_check_annotation[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}/annotations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14723,7 +14716,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14742,7 +14735,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_check_suite>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/check-suites`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14751,7 +14744,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14775,7 +14768,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_check_suite_preference>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/check-suites/preferences`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14784,7 +14777,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14805,7 +14798,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14843,7 +14836,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14864,7 +14857,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14910,7 +14903,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14931,7 +14924,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14954,7 +14947,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_scanning_alert>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14963,7 +14956,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14984,7 +14977,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15005,7 +14998,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15023,7 +15016,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_scanning_autofix_commits_response>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}/autofix/commits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15032,7 +15025,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15063,7 +15056,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15103,7 +15096,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15128,7 +15121,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15146,12 +15139,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_scanning_analysis_deletion>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/analyses/${p["analysisId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ confirm_delete: p["confirmDelete"] })
+    const query = this._query({confirm_delete: p["confirmDelete"]})
 
     return this._request({
       url: url + query,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15171,7 +15164,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15192,7 +15185,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15213,7 +15206,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15230,7 +15223,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_scanning_variant_analysis>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/variant-analyses`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15239,7 +15232,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15260,7 +15253,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15283,7 +15276,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15303,7 +15296,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15323,7 +15316,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/default-setup`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15332,7 +15325,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15357,7 +15350,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_code_scanning_sarifs_receipt>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/code-scanning/sarifs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15366,7 +15359,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15387,7 +15380,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15410,7 +15403,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15427,12 +15420,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_codeowners_errors>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codeowners/errors`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15455,12 +15448,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codespaces`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15497,7 +15490,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_codespace>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codespaces`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15506,7 +15499,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15533,12 +15526,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codespaces/devcontainers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15571,7 +15564,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15599,12 +15592,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codespaces/new`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"], client_ip: p["clientIp"] })
+    const query = this._query({ref: p["ref"], client_ip: p["clientIp"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15630,7 +15623,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15653,12 +15646,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15678,7 +15671,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15699,7 +15692,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15720,7 +15713,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15729,7 +15722,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15750,7 +15743,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15786,7 +15779,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15807,7 +15800,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15827,7 +15820,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_invitation> | AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15836,7 +15829,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15857,7 +15850,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15878,7 +15871,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15896,12 +15889,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit_comment[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15922,7 +15915,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15942,7 +15935,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15951,7 +15944,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15972,7 +15965,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16010,7 +16003,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16039,7 +16032,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16048,7 +16041,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16070,7 +16063,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16108,7 +16101,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16129,7 +16122,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16148,12 +16141,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit_comment[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16176,7 +16169,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16185,7 +16178,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16204,12 +16197,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_simple[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/pulls`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16228,12 +16221,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16273,7 +16266,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16309,7 +16302,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16328,12 +16321,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_combined_commit_status>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}/status`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16352,12 +16345,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_status[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}/statuses`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16377,7 +16370,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16396,12 +16389,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit_comparison>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/compare/${p["basehead"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16426,12 +16419,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16468,7 +16461,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file_commit>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16477,7 +16470,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16511,7 +16504,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file_commit>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16520,7 +16513,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16548,7 +16541,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16602,7 +16595,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16623,7 +16616,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16654,7 +16647,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dependabot_alert>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/dependabot/alerts/${p["alertNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16663,7 +16656,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16686,12 +16679,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16711,7 +16704,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16732,7 +16725,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16753,7 +16746,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16762,7 +16755,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16783,7 +16776,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16801,12 +16794,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dependency_graph_diff>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/dependency-graph/compare/${p["basehead"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ name: p["name"] })
+    const query = this._query({name: p["name"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16826,7 +16819,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16850,7 +16843,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/dependency-graph/snapshots`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16859,7 +16852,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16893,7 +16886,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16932,7 +16925,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/deployments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16941,7 +16934,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16962,7 +16955,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16983,7 +16976,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17002,12 +16995,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deployment_status[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17041,7 +17034,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deployment_status>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17050,7 +17043,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17072,7 +17065,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17096,7 +17089,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/dispatches`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17105,7 +17098,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17128,12 +17121,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17154,7 +17147,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17187,7 +17180,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_environment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17196,7 +17189,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17217,7 +17210,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17241,12 +17234,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17264,7 +17257,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deployment_branch_policy>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17273,7 +17266,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17295,7 +17288,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17314,7 +17307,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deployment_branch_policy>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies/${p["branchPolicyId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17323,7 +17316,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17345,7 +17338,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17373,7 +17366,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17393,7 +17386,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deployment_protection_rule>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17402,7 +17395,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17428,12 +17421,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules/apps`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17455,7 +17448,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17477,7 +17470,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17501,12 +17494,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17527,7 +17520,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17549,7 +17542,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17571,7 +17564,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17580,7 +17573,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17602,7 +17595,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17626,12 +17619,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17652,7 +17645,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17661,7 +17654,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17683,7 +17676,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17705,7 +17698,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17714,7 +17707,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17736,7 +17729,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17754,12 +17747,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17792,7 +17785,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17813,7 +17806,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_full_repository>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/forks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17822,7 +17815,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17842,7 +17835,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_short_blob>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/blobs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17851,7 +17844,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17872,7 +17865,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17908,7 +17901,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_git_commit>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/commits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17917,7 +17910,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17938,7 +17931,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17959,7 +17952,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17980,7 +17973,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18000,7 +17993,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_git_ref>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/refs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18009,7 +18002,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18030,7 +18023,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_git_ref>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/refs/${p["ref"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18039,7 +18032,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18060,7 +18053,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18089,7 +18082,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_git_tag>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/tags`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18098,7 +18091,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18119,7 +18112,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18156,7 +18149,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_git_tree>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/trees`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18165,7 +18158,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18183,12 +18176,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_git_tree>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/git/trees/${p["treeSha"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ recursive: p["recursive"] })
+    const query = this._query({recursive: p["recursive"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18206,12 +18199,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_hook[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/hooks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18240,7 +18233,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_hook>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/hooks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18249,7 +18242,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18270,7 +18263,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18294,7 +18287,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_hook>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18303,7 +18296,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18324,7 +18317,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18345,7 +18338,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18368,7 +18361,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_webhook_config>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/config`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18377,7 +18370,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18396,12 +18389,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_hook_delivery_item[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/deliveries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], cursor: p["cursor"] })
+    const query = this._query({per_page: p["perPage"], cursor: p["cursor"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18423,7 +18416,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18449,7 +18442,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18470,7 +18463,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18491,7 +18484,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18511,7 +18504,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18542,7 +18535,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_import>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/import`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18551,7 +18544,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18581,7 +18574,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_import>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/import`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18590,7 +18583,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18610,7 +18603,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18627,12 +18620,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_porter_author[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/import/authors`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"] })
+    const query = this._query({since: p["since"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18653,7 +18646,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_porter_author>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/import/authors/${p["authorId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18662,7 +18655,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18682,7 +18675,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18701,7 +18694,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_import>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/import/lfs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18710,7 +18703,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18730,7 +18723,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18750,7 +18743,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18767,7 +18760,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_interaction_limit_response>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18776,7 +18769,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18796,7 +18789,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18814,12 +18807,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_invitation[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18848,7 +18841,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_invitation>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/invitations/${p["invitationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18857,7 +18850,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18878,7 +18871,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18924,7 +18917,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18959,7 +18952,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18968,7 +18961,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19000,7 +18993,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19021,7 +19014,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19041,7 +19034,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19050,7 +19043,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19071,7 +19064,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19109,7 +19102,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19138,7 +19131,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19147,7 +19140,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19169,7 +19162,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19187,12 +19180,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue_event[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19213,7 +19206,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19234,7 +19227,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19280,7 +19273,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19289,7 +19282,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19309,7 +19302,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19318,7 +19311,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19338,7 +19331,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19347,7 +19340,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19369,7 +19362,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19398,7 +19391,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19418,7 +19411,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19427,7 +19420,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19446,12 +19439,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue_event_for_issue[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19470,12 +19463,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19508,7 +19501,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19517,7 +19510,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19550,7 +19543,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19559,7 +19552,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19580,7 +19573,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19602,7 +19595,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19630,7 +19623,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/lock`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19639,7 +19632,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19660,7 +19653,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19698,7 +19691,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19727,7 +19720,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19736,7 +19729,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19758,7 +19751,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19778,7 +19771,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issue`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19787,7 +19780,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19806,12 +19799,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issues`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19832,7 +19825,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issues`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19841,7 +19834,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19863,7 +19856,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issue>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issues/priority`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19872,7 +19865,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19891,12 +19884,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_timeline_issue_events[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/timeline`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19914,12 +19907,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deploy_key[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19940,7 +19933,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deploy_key>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19949,7 +19942,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19970,7 +19963,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19991,7 +19984,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20009,12 +20002,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/labels`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20035,7 +20028,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20044,7 +20037,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20065,7 +20058,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20087,7 +20080,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20096,7 +20089,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20117,7 +20110,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20137,7 +20130,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20154,12 +20147,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_license_content>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/license`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20178,7 +20171,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_merged_upstream>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/merge-upstream`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20187,7 +20180,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20208,7 +20201,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit> | AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/merges`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20217,7 +20210,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20249,7 +20242,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20271,7 +20264,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_milestone>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/milestones`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20280,7 +20273,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20301,7 +20294,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20324,7 +20317,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_milestone>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20333,7 +20326,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20354,7 +20347,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20373,12 +20366,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_label[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}/labels`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20412,7 +20405,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20437,7 +20430,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/notifications`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20446,7 +20439,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20466,7 +20459,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20493,7 +20486,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_page>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pages`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20502,7 +20495,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20537,7 +20530,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pages`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20546,7 +20539,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20566,7 +20559,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20584,12 +20577,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_page_build[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pages/builds`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20609,7 +20602,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20629,7 +20622,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20650,7 +20643,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20673,7 +20666,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_page_deployment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pages/deployments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20682,7 +20675,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20703,7 +20696,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20724,7 +20717,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20746,7 +20739,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20770,7 +20763,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20790,7 +20783,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20810,7 +20803,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20838,7 +20831,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20858,7 +20851,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/projects`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20867,7 +20860,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20887,7 +20880,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20906,7 +20899,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/properties/values`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20915,7 +20908,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20956,7 +20949,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20982,7 +20975,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20991,7 +20984,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21023,7 +21016,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21044,7 +21037,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21064,7 +21057,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21073,7 +21066,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21094,7 +21087,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21132,7 +21125,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21161,7 +21154,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21170,7 +21163,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21192,7 +21185,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21213,7 +21206,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21237,7 +21230,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21246,7 +21239,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21283,7 +21276,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_codespace>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/codespaces`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21292,7 +21285,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21325,7 +21318,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21356,7 +21349,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21365,7 +21358,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21386,7 +21379,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review_comment>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/comments/${p["commentId"]}/replies`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21395,7 +21388,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21414,12 +21407,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_commit[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/commits`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21438,12 +21431,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_diff_entry[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/files`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21464,7 +21457,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21489,7 +21482,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_merge_result>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/merge`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21498,7 +21491,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21519,7 +21512,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21540,7 +21533,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_simple>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21549,7 +21542,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21570,7 +21563,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_simple>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21579,7 +21572,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21598,12 +21591,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21638,7 +21631,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21647,7 +21640,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21669,7 +21662,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21690,7 +21683,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21699,7 +21692,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21721,7 +21714,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21741,12 +21734,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_review_comment[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21768,7 +21761,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/dismissals`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21777,7 +21770,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21803,7 +21796,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_pull_request_review>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/events`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21812,7 +21805,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21837,7 +21830,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/update-branch`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21846,7 +21839,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21863,12 +21856,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_content_file>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/readme`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21886,12 +21879,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_content_file>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/readme/${p["dir"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21909,12 +21902,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21943,7 +21936,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21952,7 +21945,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21973,7 +21966,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21995,7 +21988,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release_asset>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22004,7 +21997,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22025,7 +22018,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22047,7 +22040,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release_notes_content>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases/generate-notes`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22056,7 +22049,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22076,7 +22069,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22097,7 +22090,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22118,7 +22111,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22147,7 +22140,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22156,7 +22149,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22177,7 +22170,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22196,12 +22189,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release_asset[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/assets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22226,10 +22219,10 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_release_asset>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/assets`
     const headers = this._headers(
-      { "Content-Type": "application/octet-stream" },
+      {"Content-Type": "application/octet-stream"},
       opts.headers,
     )
-    const query = this._query({ name: p["name"], label: p["label"] })
+    const query = this._query({name: p["name"], label: p["label"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
@@ -22237,7 +22230,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       method: "POST",
       data: body,
       baseURL: basePath,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22273,7 +22266,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22300,7 +22293,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22309,7 +22302,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22331,7 +22324,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22350,12 +22343,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_rule_detailed[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/rules/branches/${p["branch"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22385,7 +22378,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22411,7 +22404,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_ruleset>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/rulesets`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22420,7 +22413,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22459,7 +22452,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22480,7 +22473,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22498,12 +22491,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_ruleset>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ includes_parents: p["includesParents"] })
+    const query = this._query({includes_parents: p["includesParents"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22530,7 +22523,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_ruleset>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22539,7 +22532,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22560,7 +22553,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22579,12 +22572,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ruleset_version[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}/history`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22606,7 +22599,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22654,7 +22647,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22672,12 +22665,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_secret_scanning_alert>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ hide_secret: p["hideSecret"] })
+    const query = this._query({hide_secret: p["hideSecret"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22701,7 +22694,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_secret_scanning_alert>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22710,7 +22703,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22729,12 +22722,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_secret_scanning_location[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/alerts/${p["alertNumber"]}/locations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22754,7 +22747,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_secret_scanning_push_protection_bypass>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/push-protection-bypasses`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22763,7 +22756,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22783,7 +22776,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22822,7 +22815,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22839,7 +22832,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_advisory>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/security-advisories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22848,7 +22841,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22865,7 +22858,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_advisory>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/security-advisories/reports`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22874,7 +22867,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22895,7 +22888,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22913,7 +22906,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_advisory>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/security-advisories/${p["ghsaId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22922,7 +22915,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22947,7 +22940,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22968,7 +22961,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22986,12 +22979,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[] | t_stargazer[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/stargazers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23017,7 +23010,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23043,7 +23036,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23069,7 +23062,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23089,7 +23082,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23109,7 +23102,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23137,7 +23130,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_status>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/statuses/${p["sha"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23146,7 +23139,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23164,12 +23157,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/subscribers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23189,7 +23182,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23209,7 +23202,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_subscription>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/subscription`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23218,7 +23211,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23238,7 +23231,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23256,12 +23249,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tag[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/tags`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23281,7 +23274,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23300,7 +23293,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tag_protection>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/tags/protection`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23309,7 +23302,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23330,7 +23323,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23351,7 +23344,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23369,12 +23362,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23392,12 +23385,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_topic>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/topics`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23416,7 +23409,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_topic>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/topics`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23425,7 +23418,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23442,12 +23435,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_clone_traffic>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/traffic/clones`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per: p["per"] })
+    const query = this._query({per: p["per"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23467,7 +23460,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23487,7 +23480,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23504,12 +23497,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_view_traffic>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/traffic/views`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per: p["per"] })
+    const query = this._query({per: p["per"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23530,7 +23523,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository>> {
     const url = `/repos/${p["owner"]}/${p["repo"]}/transfer`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23539,7 +23532,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23559,7 +23552,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23579,7 +23572,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23599,7 +23592,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23620,7 +23613,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23643,7 +23636,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_full_repository>> {
     const url = `/repos/${p["templateOwner"]}/${p["templateRepo"]}/generate`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23652,7 +23645,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23667,12 +23660,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"] })
+    const query = this._query({since: p["since"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23708,7 +23701,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23744,7 +23737,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23794,7 +23787,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23832,7 +23825,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23873,7 +23866,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23905,7 +23898,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23941,7 +23934,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23960,7 +23953,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23991,7 +23984,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_full>> {
     const url = `/teams/${p["teamId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24000,7 +23993,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24019,7 +24012,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24046,7 +24039,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24066,7 +24059,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion>> {
     const url = `/teams/${p["teamId"]}/discussions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24075,7 +24068,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24095,7 +24088,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24115,7 +24108,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion>> {
     const url = `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24124,7 +24117,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24144,7 +24137,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24172,7 +24165,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24191,7 +24184,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion_comment>> {
     const url = `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24200,7 +24193,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24221,7 +24214,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24241,7 +24234,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_discussion_comment>> {
     const url = `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24250,7 +24243,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24271,7 +24264,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24309,7 +24302,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24338,7 +24331,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24347,7 +24340,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24384,7 +24377,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24412,7 +24405,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reaction>> {
     const url = `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24421,7 +24414,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24438,12 +24431,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_invitation[]>> {
     const url = `/teams/${p["teamId"]}/invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24470,7 +24463,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24490,7 +24483,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24510,7 +24503,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24530,7 +24523,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24550,7 +24543,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24569,7 +24562,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_membership>> {
     const url = `/teams/${p["teamId"]}/memberships/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24578,7 +24571,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24598,7 +24591,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24615,12 +24608,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_project[]>> {
     const url = `/teams/${p["teamId"]}/projects`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24640,7 +24633,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24661,7 +24654,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/teams/${p["teamId"]}/projects/${p["projectId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24670,7 +24663,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24690,7 +24683,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24707,12 +24700,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/teams/${p["teamId"]}/repos`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24733,7 +24726,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24755,7 +24748,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24764,7 +24757,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24785,7 +24778,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24802,12 +24795,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team[]>> {
     const url = `/teams/${p["teamId"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24823,7 +24816,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24847,7 +24840,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_private_user>> {
     const url = `/user`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -24856,7 +24849,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24872,12 +24865,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/user/blocks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24896,7 +24889,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24915,7 +24908,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24934,7 +24927,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -24965,7 +24958,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25022,7 +25015,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_codespace>> {
     const url = `/user/codespaces`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25031,7 +25024,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25052,12 +25045,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/user/codespaces/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25073,7 +25066,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25092,7 +25085,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25112,7 +25105,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_empty_object> | AxiosResponse<void>> {
     const url = `/user/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25121,7 +25114,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25140,7 +25133,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25164,7 +25157,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25182,7 +25175,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/user/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25191,7 +25184,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25211,7 +25204,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25231,7 +25224,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25250,7 +25243,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25270,7 +25263,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_codespace>> {
     const url = `/user/codespaces/${p["codespaceName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25279,7 +25272,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25302,7 +25295,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25321,7 +25314,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25341,7 +25334,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25365,7 +25358,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25384,7 +25377,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_codespace_with_full_repository>> {
     const url = `/user/codespaces/${p["codespaceName"]}/publish`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25393,7 +25386,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25412,7 +25405,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25431,7 +25424,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25447,7 +25440,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25464,7 +25457,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_email[]>> {
     const url = `/user/email/visibility`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25473,7 +25466,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25489,12 +25482,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_email[]>> {
     const url = `/user/emails`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25514,7 +25507,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_email[]>> {
     const url = `/user/emails`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25523,7 +25516,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25543,7 +25536,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/user/emails`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25552,7 +25545,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25568,12 +25561,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/user/followers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25589,12 +25582,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/user/following`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25613,7 +25606,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25632,7 +25625,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25651,7 +25644,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25667,12 +25660,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gpg_key[]>> {
     const url = `/user/gpg_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25690,7 +25683,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gpg_key>> {
     const url = `/user/gpg_keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25699,7 +25692,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25718,7 +25711,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25737,7 +25730,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25758,12 +25751,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/user/installations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25786,12 +25779,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/user/installations/${p["installationId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25811,7 +25804,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25831,7 +25824,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25850,7 +25843,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25865,7 +25858,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_interaction_limit_response>> {
     const url = `/user/interaction-limits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25874,7 +25867,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25890,7 +25883,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25933,7 +25926,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25949,12 +25942,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_key[]>> {
     const url = `/user/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25972,7 +25965,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_key>> {
     const url = `/user/keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25981,7 +25974,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26000,7 +25993,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26019,7 +26012,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26035,12 +26028,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_user_marketplace_purchase[]>> {
     const url = `/user/marketplace_purchases`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26056,12 +26049,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_user_marketplace_purchase[]>> {
     const url = `/user/marketplace_purchases/stubbed`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26087,7 +26080,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26106,7 +26099,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26124,7 +26117,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_org_membership>> {
     const url = `/user/memberships/orgs/${p["org"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26133,7 +26126,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26149,12 +26142,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_migration[]>> {
     const url = `/user/migrations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26179,7 +26172,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_migration>> {
     const url = `/user/migrations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26188,7 +26181,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26204,12 +26197,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_migration>> {
     const url = `/user/migrations/${p["migrationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ exclude: p["exclude"] })
+    const query = this._query({exclude: p["exclude"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26228,7 +26221,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26247,7 +26240,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26267,7 +26260,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26284,12 +26277,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/user/migrations/${p["migrationId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26305,12 +26298,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_simple[]>> {
     const url = `/user/orgs`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26345,7 +26338,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26372,7 +26365,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26399,7 +26392,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26423,12 +26416,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/user/packages/${p["packageType"]}/${p["packageName"]}/restore`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ token: p["token"] })
+    const query = this._query({token: p["token"]})
 
     return this._request({
       url: url + query,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26463,7 +26456,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26491,7 +26484,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26519,7 +26512,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26547,7 +26540,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26565,7 +26558,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_project>> {
     const url = `/user/projects`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26574,7 +26567,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26590,12 +26583,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_email[]>> {
     const url = `/user/public_emails`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26644,7 +26637,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26691,7 +26684,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_full_repository>> {
     const url = `/user/repos`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26700,7 +26693,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26716,12 +26709,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_repository_invitation[]>> {
     const url = `/user/repository_invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26740,7 +26733,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PATCH",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26759,7 +26752,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26775,12 +26768,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_social_account[]>> {
     const url = `/user/social_accounts`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26797,7 +26790,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_social_account[]>> {
     const url = `/user/social_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26806,7 +26799,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26823,7 +26816,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/user/social_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26832,7 +26825,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26848,12 +26841,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ssh_signing_key[]>> {
     const url = `/user/ssh_signing_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26871,7 +26864,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ssh_signing_key>> {
     const url = `/user/ssh_signing_keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -26880,7 +26873,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26899,7 +26892,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26918,7 +26911,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26946,7 +26939,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26966,7 +26959,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -26986,7 +26979,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "PUT",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27006,7 +26999,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27022,12 +27015,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/user/subscriptions`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27043,12 +27036,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_team_full[]>> {
     const url = `/user/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27067,7 +27060,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27083,12 +27076,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/users`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"], per_page: p["perPage"] })
+    const query = this._query({since: p["since"], per_page: p["perPage"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27107,7 +27100,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27168,7 +27161,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   > {
     const url = `/users/${p["username"]}/attestations/bulk-list`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const query = this._query({
@@ -27182,7 +27175,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url + query,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27204,7 +27197,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/users/${p["username"]}/attestations/delete-request`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -27213,7 +27206,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27233,7 +27226,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27253,7 +27246,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27309,7 +27302,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27328,7 +27321,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27345,12 +27338,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/users/${p["username"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27368,12 +27361,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/users/${p["username"]}/events/orgs/${p["org"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27390,12 +27383,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/users/${p["username"]}/events/public`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27412,12 +27405,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/users/${p["username"]}/followers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27434,12 +27427,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_simple_user[]>> {
     const url = `/users/${p["username"]}/following`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27459,7 +27452,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27486,7 +27479,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27503,12 +27496,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_gpg_key[]>> {
     const url = `/users/${p["username"]}/gpg_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27538,7 +27531,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27557,7 +27550,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27574,12 +27567,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_key_simple[]>> {
     const url = `/users/${p["username"]}/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27596,12 +27589,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_organization_simple[]>> {
     const url = `/users/${p["username"]}/orgs`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27637,7 +27630,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27665,7 +27658,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27693,7 +27686,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27718,12 +27711,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}/restore`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ token: p["token"] })
+    const query = this._query({token: p["token"]})
 
     return this._request({
       url: url + query,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27751,7 +27744,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27780,7 +27773,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27809,7 +27802,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27838,7 +27831,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27865,7 +27858,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27882,12 +27875,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/users/${p["username"]}/received_events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27904,12 +27897,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event[]>> {
     const url = `/users/${p["username"]}/received_events/public`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27945,7 +27938,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27964,7 +27957,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27983,7 +27976,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28002,7 +27995,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28031,7 +28024,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28048,12 +28041,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_social_account[]>> {
     const url = `/users/${p["username"]}/social_accounts`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28070,12 +28063,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ssh_signing_key[]>> {
     const url = `/users/${p["username"]}/ssh_signing_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28104,7 +28097,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28121,12 +28114,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_minimal_repository[]>> {
     const url = `/users/${p["username"]}/subscriptions`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28142,7 +28135,7 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28158,12 +28151,12 @@ export class GitHubV3RestApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { GitHubV3RestApi as ApiClient }
-export type { GitHubV3RestApiConfig as ApiClientConfig }
+export {GitHubV3RestApi as ApiClient}
+export type {GitHubV3RestApiConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/api.github.com.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -24,7 +24,7 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class ContosoWidgetManagerServers {
   static server(url: "{endpoint}/widget" = "{endpoint}/widget"): {
@@ -70,15 +70,15 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   > {
     const url = `/service-status`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -109,12 +109,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   > {
     const url = `/widgets/${p["widgetName"]}/operations/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -150,14 +150,14 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -187,12 +187,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -232,12 +232,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -257,7 +257,7 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_PagedWidget>> {
     const url = `/widgets`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
     const query = this._query({
@@ -271,7 +271,7 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -301,12 +301,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -342,14 +342,14 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -373,12 +373,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   > {
     const url = `/widgets/${p["widgetId"]}/repairs/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -421,14 +421,14 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -453,12 +453,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   > {
     const url = `/widgets/${p["widgetName"]}/parts/${p["widgetPartName"]}/operations/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -494,14 +494,14 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -518,15 +518,15 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_PagedWidgetPart>> {
     const url = `/widgets/${p["widgetName"]}/parts`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -557,12 +557,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -597,12 +597,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -636,14 +636,14 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -667,12 +667,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   > {
     const url = `/manufacturers/${p["manufacturerId"]}/operations/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -708,14 +708,14 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -745,12 +745,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -790,12 +790,12 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -811,20 +811,20 @@ export class ContosoWidgetManager extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_PagedManufacturer>> {
     const url = `/manufacturers`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { ContosoWidgetManager as ApiClient }
-export type { ContosoWidgetManagerConfig as ApiClientConfig }
+export {ContosoWidgetManager as ApiClient}
+export type {ContosoWidgetManagerConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/client.ts
@@ -16,7 +16,7 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class ContosoProviderHubClientServers {
   static default(): Server<"ContosoProviderHubClient"> {
@@ -25,7 +25,7 @@ export class ContosoProviderHubClientServers {
 
   static server(
     url: "https://management.azure.com" = "https://management.azure.com",
-  ): { build: () => Server<"ContosoProviderHubClient"> } {
+  ): {build: () => Server<"ContosoProviderHubClient">} {
     switch (url) {
       case "https://management.azure.com":
         return {
@@ -58,12 +58,12 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OperationListResult>> {
     const url = `/providers/Microsoft.ContosoProviderHub/operations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -81,12 +81,12 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Employee>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -105,17 +105,17 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Employee>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -134,17 +134,17 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Employee>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -162,12 +162,12 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -185,12 +185,12 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "HEAD",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -207,12 +207,12 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_EmployeeListResult>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -228,12 +228,12 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_EmployeeListResult>> {
     const url = `/subscriptions/${p["subscriptionId"]}/providers/Microsoft.ContosoProviderHub/employees`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -252,22 +252,22 @@ export class ContosoProviderHubClient extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_MoveResponse>> {
     const url = `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}/move`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { ContosoProviderHubClient as ApiClient }
-export type { ContosoProviderHubClientConfig as ApiClientConfig }
+export {ContosoProviderHubClient as ApiClient}
+export type {ContosoProviderHubClientConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-axios/src/generated/azure-resource-manager.tsp/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.idp.yaml/client.ts
@@ -26,7 +26,7 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class MyAccountManagementServers {
   static default(): Server<"MyAccountManagement"> {
@@ -73,7 +73,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_AppAuthenticatorEnrollment>> {
     const url = `/idp/myaccount/app-authenticators`
     const headers = this._headers(
-      { "Content-Type": "application/json, okta-version=1.0.0" },
+      {"Content-Type": "application/json, okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -82,7 +82,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -98,7 +98,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/idp/myaccount/app-authenticators/challenge/${p["challengeId"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/json;okta-version=1.0.0" },
+      {"Content-Type": "application/json;okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -107,7 +107,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -123,7 +123,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_AppAuthenticatorEnrollment>> {
     const url = `/idp/myaccount/app-authenticators/${p["enrollmentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/merge-patch+json;okta-version=1.0.0" },
+      {"Content-Type": "application/merge-patch+json;okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -132,7 +132,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -151,7 +151,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -170,7 +170,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -185,12 +185,12 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Authenticator[]>> {
     const url = `/idp/myaccount/authenticators`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -206,12 +206,12 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Authenticator>> {
     const url = `/idp/myaccount/authenticators/${p["authenticatorId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -230,7 +230,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -250,7 +250,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -267,7 +267,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_AuthenticatorEnrollment>> {
     const url = `/idp/myaccount/authenticators/${p["authenticatorId"]}/enrollments/${p["enrollmentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/merge-patch+json;okta-version=1.0.0" },
+      {"Content-Type": "application/merge-patch+json;okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -276,7 +276,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "PATCH",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -292,7 +292,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -314,7 +314,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Email>> {
     const url = `/idp/myaccount/emails`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -323,7 +323,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -342,7 +342,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -361,7 +361,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -402,7 +402,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   > {
     const url = `/idp/myaccount/emails/${p["id"]}/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -411,7 +411,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -466,7 +466,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -485,7 +485,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/idp/myaccount/emails/${p["id"]}/challenge/${p["challengeId"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -494,7 +494,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -510,7 +510,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -526,7 +526,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -542,7 +542,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -561,7 +561,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_PasswordResponse>> {
     const url = `/idp/myaccount/password`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -570,7 +570,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -589,7 +589,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_PasswordResponse>> {
     const url = `/idp/myaccount/password`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -598,7 +598,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -614,7 +614,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -630,7 +630,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -651,7 +651,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Phone>> {
     const url = `/idp/myaccount/phones`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -660,7 +660,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -679,7 +679,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -698,7 +698,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -732,7 +732,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   > {
     const url = `/idp/myaccount/phones/${p["id"]}/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -741,7 +741,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -759,7 +759,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/idp/myaccount/phones/${p["id"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -768,7 +768,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -784,7 +784,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -801,7 +801,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Profile>> {
     const url = `/idp/myaccount/profile`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -810,7 +810,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -826,7 +826,7 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -842,12 +842,12 @@ export class MyAccountManagement extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { MyAccountManagement as ApiClient }
-export type { MyAccountManagementConfig as ApiClientConfig }
+export {MyAccountManagement as ApiClient}
+export type {MyAccountManagementConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.idp.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/okta.oauth.yaml/client.ts
@@ -38,7 +38,7 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class OktaOpenIdConnectOAuth20Servers {
   static default(): Server<"OktaOpenIdConnectOAuth20"> {
@@ -85,12 +85,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OidcMetadata>> {
     const url = `/.well-known/openid-configuration`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -150,7 +150,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -165,7 +165,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -174,7 +174,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -189,7 +189,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_BackchannelAuthorizeResponse>> {
     const url = `/oauth2/v1/bc/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -198,7 +198,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -213,7 +213,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ChallengeResponse>> {
     const url = `/oauth2/v1/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -222,7 +222,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -239,16 +239,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Client[]>> {
     const url = `/oauth2/v1/clients`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({
-      after: p["after"],
-      limit: p["limit"],
-      q: p["q"],
-    })
+    const query = this._query({after: p["after"], limit: p["limit"], q: p["q"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -263,7 +259,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Client>> {
     const url = `/oauth2/v1/clients`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -272,7 +268,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -291,7 +287,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -307,7 +303,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Client>> {
     const url = `/oauth2/v1/clients/${p["clientId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -316,7 +312,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -335,7 +331,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -354,7 +350,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "POST",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -369,7 +365,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_DeviceAuthorizeResponse>> {
     const url = `/oauth2/v1/device/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -378,7 +374,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -393,7 +389,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/global-token-revocation`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -402,7 +398,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -417,7 +413,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_IntrospectionResponse>> {
     const url = `/oauth2/v1/introspect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -426,7 +422,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -441,12 +437,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OAuthKeys>> {
     const url = `/oauth2/v1/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -472,7 +468,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -487,7 +483,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/logout`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -496,7 +492,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -511,7 +507,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OobAuthenticateResponse>> {
     const url = `/oauth2/v1/oob-authenticate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -520,7 +516,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -534,12 +530,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/par`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
     return this._request({
       url: url,
       method: "OPTIONS",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -554,7 +550,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ParResponse>> {
     const url = `/oauth2/v1/par`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -563,7 +559,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -578,7 +574,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/revoke`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -587,7 +583,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -601,12 +597,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/v1/token`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
     return this._request({
       url: url,
       method: "OPTIONS",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -621,7 +617,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_TokenResponse>> {
     const url = `/oauth2/v1/token`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -630,7 +626,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -646,7 +642,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -662,12 +658,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OAuthMetadata>> {
     const url = `/oauth2/${p["authorizationServerId"]}/.well-known/oauth-authorization-server`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -683,12 +679,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OidcMetadata>> {
     const url = `/oauth2/${p["authorizationServerId"]}/.well-known/openid-configuration`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -749,7 +745,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -765,7 +761,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -774,7 +770,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -790,7 +786,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_BackchannelAuthorizeResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/bc/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -799,7 +795,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -815,7 +811,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ChallengeResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -824,7 +820,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -840,7 +836,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_DeviceAuthorizeResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/device/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -849,7 +845,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -865,7 +861,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_IntrospectionResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/introspect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -874,7 +870,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -893,7 +889,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -920,7 +916,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -936,7 +932,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/logout`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -945,7 +941,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -961,7 +957,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_OobAuthenticateResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/oob-authenticate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -970,7 +966,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -985,12 +981,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/par`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
     return this._request({
       url: url,
       method: "OPTIONS",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1006,7 +1002,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ParResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/par`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1015,7 +1011,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1031,7 +1027,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/revoke`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1040,7 +1036,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1055,12 +1051,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     opts: AxiosRequestConfig = {},
   ): Promise<AxiosResponse<void>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/token`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
     return this._request({
       url: url,
       method: "OPTIONS",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1076,7 +1072,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_TokenResponse>> {
     const url = `/oauth2/${p["authorizationServerId"]}/v1/token`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1085,7 +1081,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1104,12 +1100,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { OktaOpenIdConnectOAuth20 as ApiClient }
-export type { OktaOpenIdConnectOAuth20Config as ApiClientConfig }
+export {OktaOpenIdConnectOAuth20 as ApiClient}
+export type {OktaOpenIdConnectOAuth20Config as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/petstore-expanded.yaml/client.ts
@@ -2,13 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { t_NewPet, t_Pet } from "./models"
+import {t_NewPet, t_Pet} from "./models"
 import {
   AbstractAxiosClient,
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class SwaggerPetstoreServers {
   static default(): Server<"SwaggerPetstore"> {
@@ -17,7 +17,7 @@ export class SwaggerPetstoreServers {
 
   static server(
     url: "https://petstore.swagger.io/v2" = "https://petstore.swagger.io/v2",
-  ): { build: () => Server<"SwaggerPetstore"> } {
+  ): {build: () => Server<"SwaggerPetstore">} {
     switch (url) {
       case "https://petstore.swagger.io/v2":
         return {
@@ -51,12 +51,12 @@ export class SwaggerPetstore extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Pet[]>> {
     const url = `/pets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ tags: p["tags"], limit: p["limit"] })
+    const query = this._query({tags: p["tags"], limit: p["limit"]})
 
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -71,7 +71,7 @@ export class SwaggerPetstore extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_Pet>> {
     const url = `/pets`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -80,7 +80,7 @@ export class SwaggerPetstore extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -99,7 +99,7 @@ export class SwaggerPetstore extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -118,12 +118,12 @@ export class SwaggerPetstore extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { SwaggerPetstore as ApiClient }
-export type { SwaggerPetstoreConfig as ApiClientConfig }
+export {SwaggerPetstore as ApiClient}
+export type {SwaggerPetstoreConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/client.ts
@@ -167,12 +167,12 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class StripeApiServersOperations {
   static postFiles(
     url: "https://files.stripe.com/" = "https://files.stripe.com/",
-  ): { build: () => Server<"postFiles_StripeApi"> } {
+  ): {build: () => Server<"postFiles_StripeApi">} {
     switch (url) {
       case "https://files.stripe.com/":
         return {
@@ -188,7 +188,7 @@ export class StripeApiServersOperations {
 
   static getQuotesQuotePdf(
     url: "https://files.stripe.com/" = "https://files.stripe.com/",
-  ): { build: () => Server<"getQuotesQuotePdf_StripeApi"> } {
+  ): {build: () => Server<"getQuotesQuotePdf_StripeApi">} {
     switch (url) {
       case "https://files.stripe.com/":
         return {
@@ -246,17 +246,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/account`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -290,7 +290,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account_link>> {
     const url = `/v1/account_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -299,7 +299,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -513,7 +513,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account_session>> {
     const url = `/v1/account_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -522,7 +522,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -556,7 +556,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -572,7 +572,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1440,7 +1440,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1449,7 +1449,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1465,7 +1465,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_account>> {
     const url = `/v1/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -1474,7 +1474,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -1491,17 +1491,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2307,7 +2307,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2316,7 +2316,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2375,7 +2375,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/bank_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2384,7 +2384,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2401,7 +2401,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_external_account>> {
     const url = `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2410,7 +2410,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2428,17 +2428,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2492,7 +2492,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2501,7 +2501,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2525,17 +2525,17 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/accounts/${p["account"]}/capabilities`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2553,17 +2553,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_capability>> {
     const url = `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2583,7 +2583,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_capability>> {
     const url = `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2592,7 +2592,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2620,7 +2620,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/accounts/${p["account"]}/external_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -2636,7 +2636,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2695,7 +2695,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/external_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2704,7 +2704,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2721,7 +2721,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_external_account>> {
     const url = `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2730,7 +2730,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2748,17 +2748,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2812,7 +2812,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2821,7 +2821,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2839,7 +2839,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_login_link>> {
     const url = `/v1/accounts/${p["account"]}/login_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -2848,7 +2848,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -2883,7 +2883,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/accounts/${p["account"]}/people`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -2899,7 +2899,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3116,7 +3116,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/people`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3125,7 +3125,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3142,7 +3142,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_person>> {
     const url = `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3151,7 +3151,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3169,17 +3169,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3397,7 +3397,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3406,7 +3406,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3441,7 +3441,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/accounts/${p["account"]}/persons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3457,7 +3457,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3674,7 +3674,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/persons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3683,7 +3683,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3700,7 +3700,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_person>> {
     const url = `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3709,7 +3709,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3727,17 +3727,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3955,7 +3955,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_person>> {
     const url = `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3964,7 +3964,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -3983,7 +3983,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_account>> {
     const url = `/v1/accounts/${p["account"]}/reject`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -3992,7 +3992,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4019,7 +4019,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/apple_pay/domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4035,7 +4035,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4053,7 +4053,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_apple_pay_domain>> {
     const url = `/v1/apple_pay/domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4062,7 +4062,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4078,7 +4078,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_apple_pay_domain>> {
     const url = `/v1/apple_pay/domains/${p["domain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4087,7 +4087,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4104,17 +4104,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_apple_pay_domain>> {
     const url = `/v1/apple_pay/domains/${p["domain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4149,7 +4149,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/application_fees`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4166,7 +4166,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4184,17 +4184,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_fee_refund>> {
     const url = `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4222,7 +4222,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_fee_refund>> {
     const url = `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4231,7 +4231,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4248,17 +4248,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_application_fee>> {
     const url = `/v1/application_fees/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4278,7 +4278,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_application_fee>> {
     const url = `/v1/application_fees/${p["id"]}/refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4287,7 +4287,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4314,7 +4314,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/application_fees/${p["id"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4329,7 +4329,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4353,7 +4353,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_fee_refund>> {
     const url = `/v1/application_fees/${p["id"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4362,7 +4362,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4392,7 +4392,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/apps/secrets`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4408,7 +4408,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4432,7 +4432,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_apps_secret>> {
     const url = `/v1/apps/secrets`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4441,7 +4441,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4463,7 +4463,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_apps_secret>> {
     const url = `/v1/apps/secrets/delete`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4472,7 +4472,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4493,7 +4493,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_apps_secret>> {
     const url = `/v1/apps/secrets/find`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4507,7 +4507,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4523,17 +4523,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_balance>> {
     const url = `/v1/balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4571,7 +4571,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/balance/history`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4591,7 +4591,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4608,17 +4608,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_balance_transaction>> {
     const url = `/v1/balance/history/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4656,7 +4656,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4676,7 +4676,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4693,17 +4693,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_balance_transaction>> {
     const url = `/v1/balance_transactions/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4731,7 +4731,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/billing/alerts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4748,7 +4748,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4780,7 +4780,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_alert>> {
     const url = `/v1/billing/alerts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4789,7 +4789,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4806,17 +4806,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_alert>> {
     const url = `/v1/billing/alerts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4834,7 +4834,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_alert>> {
     const url = `/v1/billing/alerts/${p["id"]}/activate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4843,7 +4843,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4861,7 +4861,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_alert>> {
     const url = `/v1/billing/alerts/${p["id"]}/archive`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4870,7 +4870,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4888,7 +4888,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_alert>> {
     const url = `/v1/billing/alerts/${p["id"]}/deactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -4897,7 +4897,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4928,7 +4928,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_balance_summary>> {
     const url = `/v1/billing/credit_balance_summary`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4942,7 +4942,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -4970,7 +4970,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/billing/credit_balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4987,7 +4987,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5004,17 +5004,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_balance_transaction>> {
     const url = `/v1/billing/credit_balance_transactions/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5041,7 +5041,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/billing/credit_grants`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5057,7 +5057,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5104,7 +5104,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_grant>> {
     const url = `/v1/billing/credit_grants`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5113,7 +5113,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5130,17 +5130,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_grant>> {
     const url = `/v1/billing/credit_grants/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5164,7 +5164,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_grant>> {
     const url = `/v1/billing/credit_grants/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5173,7 +5173,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5191,7 +5191,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_grant>> {
     const url = `/v1/billing/credit_grants/${p["id"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5200,7 +5200,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5218,7 +5218,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_credit_grant>> {
     const url = `/v1/billing/credit_grants/${p["id"]}/void`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5227,7 +5227,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5251,7 +5251,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter_event_adjustment>> {
     const url = `/v1/billing/meter_event_adjustments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5260,7 +5260,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5283,7 +5283,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter_event>> {
     const url = `/v1/billing/meter_events`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5292,7 +5292,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5319,7 +5319,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/billing/meters`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5335,7 +5335,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5371,7 +5371,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter>> {
     const url = `/v1/billing/meters`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5380,7 +5380,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5397,17 +5397,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter>> {
     const url = `/v1/billing/meters/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5426,7 +5426,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter>> {
     const url = `/v1/billing/meters/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5435,7 +5435,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5453,7 +5453,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter>> {
     const url = `/v1/billing/meters/${p["id"]}/deactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5462,7 +5462,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5493,7 +5493,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/billing/meters/${p["id"]}/event_summaries`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5512,7 +5512,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5530,7 +5530,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_meter>> {
     const url = `/v1/billing/meters/${p["id"]}/reactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5539,7 +5539,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5567,7 +5567,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/billing_portal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5584,7 +5584,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5733,7 +5733,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_portal_configuration>> {
     const url = `/v1/billing_portal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5742,7 +5742,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5759,17 +5759,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_portal_configuration>> {
     const url = `/v1/billing_portal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -5941,7 +5941,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_portal_configuration>> {
     const url = `/v1/billing_portal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -5950,7 +5950,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6086,7 +6086,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_billing_portal_session>> {
     const url = `/v1/billing_portal/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6095,7 +6095,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6132,7 +6132,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/charges`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6151,7 +6151,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6250,7 +6250,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_charge>> {
     const url = `/v1/charges`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6259,7 +6259,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6287,7 +6287,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/charges/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6302,7 +6302,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6319,17 +6319,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_charge>> {
     const url = `/v1/charges/${p["charge"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6381,7 +6381,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_charge>> {
     const url = `/v1/charges/${p["charge"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6390,7 +6390,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6420,7 +6420,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_charge>> {
     const url = `/v1/charges/${p["charge"]}/capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6429,7 +6429,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6446,17 +6446,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/charges/${p["charge"]}/dispute`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6676,7 +6676,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/charges/${p["charge"]}/dispute`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6685,7 +6685,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6703,7 +6703,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/charges/${p["charge"]}/dispute/close`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6712,7 +6712,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6752,7 +6752,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_charge>> {
     const url = `/v1/charges/${p["charge"]}/refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6761,7 +6761,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6788,7 +6788,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/charges/${p["charge"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6803,7 +6803,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6846,7 +6846,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/charges/${p["charge"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6855,7 +6855,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6873,17 +6873,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6911,7 +6911,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -6920,7 +6920,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -6962,7 +6962,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/checkout/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6984,7 +6984,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8397,7 +8397,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_checkout_session>> {
     const url = `/v1/checkout/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8406,7 +8406,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8423,17 +8423,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_checkout_session>> {
     const url = `/v1/checkout/sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8559,7 +8559,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_checkout_session>> {
     const url = `/v1/checkout/sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8568,7 +8568,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8586,7 +8586,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_checkout_session>> {
     const url = `/v1/checkout/sessions/${p["session"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8595,7 +8595,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8622,7 +8622,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/checkout/sessions/${p["session"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8637,7 +8637,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8663,7 +8663,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/climate/orders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8678,7 +8678,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8709,7 +8709,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_climate_order>> {
     const url = `/v1/climate/orders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8718,7 +8718,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8735,17 +8735,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_climate_order>> {
     const url = `/v1/climate/orders/${p["order"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8777,7 +8777,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_climate_order>> {
     const url = `/v1/climate/orders/${p["order"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8786,7 +8786,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8804,7 +8804,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_climate_order>> {
     const url = `/v1/climate/orders/${p["order"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -8813,7 +8813,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8839,7 +8839,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/climate/products`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8854,7 +8854,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8871,17 +8871,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_climate_product>> {
     const url = `/v1/climate/products/${p["product"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8907,7 +8907,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/climate/suppliers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8922,7 +8922,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8939,17 +8939,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_climate_supplier>> {
     const url = `/v1/climate/suppliers/${p["supplier"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -8966,17 +8966,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_confirmation_token>> {
     const url = `/v1/confirmation_tokens/${p["confirmationToken"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9002,7 +9002,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/country_specs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9017,7 +9017,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9034,17 +9034,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_country_spec>> {
     const url = `/v1/country_specs/${p["country"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9078,7 +9078,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/coupons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9094,7 +9094,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9145,7 +9145,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_coupon>> {
     const url = `/v1/coupons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9154,7 +9154,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9170,7 +9170,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_coupon>> {
     const url = `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9179,7 +9179,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9196,17 +9196,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_coupon>> {
     const url = `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9243,7 +9243,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_coupon>> {
     const url = `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9252,7 +9252,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9288,7 +9288,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/credit_notes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9306,7 +9306,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9384,7 +9384,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9393,7 +9393,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9454,7 +9454,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes/preview`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9479,7 +9479,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9550,7 +9550,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/credit_notes/preview/lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9578,7 +9578,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9605,7 +9605,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/credit_notes/${p["creditNote"]}/lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9620,7 +9620,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9637,17 +9637,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9671,7 +9671,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9680,7 +9680,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9698,7 +9698,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_credit_note>> {
     const url = `/v1/credit_notes/${p["id"]}/void`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9707,7 +9707,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9771,7 +9771,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer_session>> {
     const url = `/v1/customer_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -9780,7 +9780,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -9816,7 +9816,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9834,7 +9834,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10080,7 +10080,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer>> {
     const url = `/v1/customers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10089,7 +10089,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10117,7 +10117,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10132,7 +10132,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10148,7 +10148,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_customer>> {
     const url = `/v1/customers/${p["customer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10157,7 +10157,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10174,17 +10174,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer | t_deleted_customer>> {
     const url = `/v1/customers/${p["customer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10356,7 +10356,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer>> {
     const url = `/v1/customers/${p["customer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10365,7 +10365,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10392,7 +10392,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10407,7 +10407,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10437,7 +10437,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer_balance_transaction>> {
     const url = `/v1/customers/${p["customer"]}/balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10446,7 +10446,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10464,17 +10464,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer_balance_transaction>> {
     const url = `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10503,7 +10503,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer_balance_transaction>> {
     const url = `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10512,7 +10512,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10539,7 +10539,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/bank_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10554,7 +10554,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10619,7 +10619,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/bank_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10628,7 +10628,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10647,7 +10647,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source | t_deleted_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10656,7 +10656,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10674,17 +10674,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_bank_account>> {
     const url = `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10742,7 +10742,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_card | t_bank_account | t_source>> {
     const url = `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10751,7 +10751,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10771,7 +10771,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_bank_account>> {
     const url = `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10780,7 +10780,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10807,7 +10807,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10822,7 +10822,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10887,7 +10887,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10896,7 +10896,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10915,7 +10915,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source | t_deleted_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -10924,7 +10924,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -10942,17 +10942,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_card>> {
     const url = `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11010,7 +11010,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_card | t_bank_account | t_source>> {
     const url = `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11019,7 +11019,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11036,17 +11036,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_cash_balance>> {
     const url = `/v1/customers/${p["customer"]}/cash_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11076,7 +11076,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_cash_balance>> {
     const url = `/v1/customers/${p["customer"]}/cash_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11085,7 +11085,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11112,7 +11112,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/cash_balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11127,7 +11127,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11145,17 +11145,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer_cash_balance_transaction>> {
     const url = `/v1/customers/${p["customer"]}/cash_balance_transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11171,7 +11171,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_discount>> {
     const url = `/v1/customers/${p["customer"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11180,7 +11180,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11197,17 +11197,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_discount>> {
     const url = `/v1/customers/${p["customer"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11250,7 +11250,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_funding_instructions>> {
     const url = `/v1/customers/${p["customer"]}/funding_instructions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11259,7 +11259,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11341,7 +11341,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/payment_methods`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11358,7 +11358,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11376,17 +11376,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/customers/${p["customer"]}/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11414,7 +11414,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/sources`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11430,7 +11430,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11495,7 +11495,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/sources`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11504,7 +11504,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11523,7 +11523,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source | t_deleted_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11532,7 +11532,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11550,17 +11550,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_source>> {
     const url = `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11618,7 +11618,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_card | t_bank_account | t_source>> {
     const url = `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11627,7 +11627,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11647,7 +11647,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_bank_account>> {
     const url = `/v1/customers/${p["customer"]}/sources/${p["id"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -11656,7 +11656,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -11683,7 +11683,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11698,7 +11698,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12148,7 +12148,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12157,7 +12157,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12178,7 +12178,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12187,7 +12187,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12205,17 +12205,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12710,7 +12710,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12719,7 +12719,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12736,7 +12736,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_discount>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12745,7 +12745,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12763,17 +12763,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_discount>> {
     const url = `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12800,7 +12800,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/customers/${p["customer"]}/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -12815,7 +12815,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12946,7 +12946,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_id>> {
     const url = `/v1/customers/${p["customer"]}/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12955,7 +12955,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12972,7 +12972,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_tax_id>> {
     const url = `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -12981,7 +12981,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -12999,17 +12999,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_id>> {
     const url = `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13045,7 +13045,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/disputes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13063,7 +13063,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13080,17 +13080,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13310,7 +13310,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13319,7 +13319,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13337,7 +13337,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_dispute>> {
     const url = `/v1/disputes/${p["dispute"]}/close`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13346,7 +13346,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13373,7 +13373,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/entitlements/active_entitlements`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13389,7 +13389,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13406,17 +13406,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_entitlements_active_entitlement>> {
     const url = `/v1/entitlements/active_entitlements/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13444,7 +13444,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/entitlements/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13461,7 +13461,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13485,7 +13485,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_entitlements_feature>> {
     const url = `/v1/entitlements/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13494,7 +13494,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13511,17 +13511,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_entitlements_feature>> {
     const url = `/v1/entitlements/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13550,7 +13550,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_entitlements_feature>> {
     const url = `/v1/entitlements/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13559,7 +13559,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13580,7 +13580,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ephemeral_key>> {
     const url = `/v1/ephemeral_keys`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13589,7 +13589,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13607,7 +13607,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_ephemeral_key>> {
     const url = `/v1/ephemeral_keys/${p["key"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13616,7 +13616,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13653,7 +13653,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/events`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13672,7 +13672,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13689,17 +13689,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_event>> {
     const url = `/v1/events/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13725,7 +13725,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/exchange_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13740,7 +13740,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13757,17 +13757,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_exchange_rate>> {
     const url = `/v1/exchange_rates/${p["rateId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13820,7 +13820,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_external_account>> {
     const url = `/v1/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13829,7 +13829,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13865,7 +13865,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/file_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13883,7 +13883,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13911,7 +13911,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file_link>> {
     const url = `/v1/file_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13920,7 +13920,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13937,17 +13937,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file_link>> {
     const url = `/v1/file_links/${p["link"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -13975,7 +13975,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file_link>> {
     const url = `/v1/file_links/${p["link"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -13984,7 +13984,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14037,7 +14037,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/files`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14054,7 +14054,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14103,7 +14103,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file>> {
     const url = `/v1/files`
     const headers = this._headers(
-      { "Content-Type": "multipart/form-data" },
+      {"Content-Type": "multipart/form-data"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14113,7 +14113,7 @@ export class StripeApi extends AbstractAxiosClient {
       method: "POST",
       data: body,
       baseURL: basePath,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14130,17 +14130,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_file>> {
     const url = `/v1/files/${p["file"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14171,7 +14171,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/financial_connections/accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14188,7 +14188,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14205,17 +14205,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/financial_connections/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14233,7 +14233,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/financial_connections/accounts/${p["account"]}/disconnect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14242,7 +14242,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14270,7 +14270,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/financial_connections/accounts/${p["account"]}/owners`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14286,7 +14286,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14310,7 +14310,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/financial_connections/accounts/${p["account"]}/refresh`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14319,7 +14319,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14338,7 +14338,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/financial_connections/accounts/${p["account"]}/subscribe`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14347,7 +14347,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14366,7 +14366,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/financial_connections/accounts/${p["account"]}/unsubscribe`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14375,7 +14375,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14428,7 +14428,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_session>> {
     const url = `/v1/financial_connections/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14437,7 +14437,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14454,17 +14454,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_session>> {
     const url = `/v1/financial_connections/sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14502,7 +14502,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/financial_connections/transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14520,7 +14520,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14537,17 +14537,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_transaction>> {
     const url = `/v1/financial_connections/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14579,7 +14579,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/forwarding/requests`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14595,7 +14595,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14638,7 +14638,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_forwarding_request>> {
     const url = `/v1/forwarding/requests`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14647,7 +14647,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14664,17 +14664,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_forwarding_request>> {
     const url = `/v1/forwarding/requests/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14711,7 +14711,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/identity/verification_reports`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14730,7 +14730,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14747,17 +14747,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_identity_verification_report>> {
     const url = `/v1/identity/verification_reports/${p["report"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14799,7 +14799,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/identity/verification_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14818,7 +14818,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14880,7 +14880,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_identity_verification_session>> {
     const url = `/v1/identity/verification_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14889,7 +14889,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14906,17 +14906,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_identity_verification_session>> {
     const url = `/v1/identity/verification_sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14969,7 +14969,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_identity_verification_session>> {
     const url = `/v1/identity/verification_sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -14978,7 +14978,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -14996,7 +14996,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_identity_verification_session>> {
     const url = `/v1/identity/verification_sessions/${p["session"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15005,7 +15005,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15023,7 +15023,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_identity_verification_session>> {
     const url = `/v1/identity/verification_sessions/${p["session"]}/redact`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15032,7 +15032,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15064,7 +15064,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/invoice_payments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -15082,7 +15082,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15099,17 +15099,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice_payment>> {
     const url = `/v1/invoice_payments/${p["invoicePayment"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15136,7 +15136,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/invoice_rendering_templates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -15152,7 +15152,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15170,17 +15170,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice_rendering_template>> {
     const url = `/v1/invoice_rendering_templates/${p["template"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"], version: p["version"] })
+    const query = this._query({expand: p["expand"], version: p["version"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15198,7 +15198,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice_rendering_template>> {
     const url = `/v1/invoice_rendering_templates/${p["template"]}/archive`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15207,7 +15207,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15225,7 +15225,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice_rendering_template>> {
     const url = `/v1/invoice_rendering_templates/${p["template"]}/unarchive`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15234,7 +15234,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15271,7 +15271,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/invoiceitems`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -15290,7 +15290,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15368,7 +15368,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoiceitem>> {
     const url = `/v1/invoiceitems`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15377,7 +15377,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15393,7 +15393,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_invoiceitem>> {
     const url = `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15402,7 +15402,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15419,17 +15419,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoiceitem>> {
     const url = `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15504,7 +15504,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoiceitem>> {
     const url = `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -15513,7 +15513,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -15568,7 +15568,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/invoices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -15589,7 +15589,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16019,7 +16019,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16028,7 +16028,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16619,7 +16619,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/create_preview`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16628,7 +16628,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16656,7 +16656,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/invoices/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -16671,7 +16671,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16687,7 +16687,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -16696,7 +16696,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -16713,17 +16713,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17156,7 +17156,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17165,7 +17165,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17329,7 +17329,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/add_lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17338,7 +17338,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17357,7 +17357,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/attach_payment`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17366,7 +17366,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17385,7 +17385,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/finalize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17394,7 +17394,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17421,7 +17421,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/invoices/${p["invoice"]}/lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -17436,7 +17436,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17589,7 +17589,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_line_item>> {
     const url = `/v1/invoices/${p["invoice"]}/lines/${p["lineItemId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17598,7 +17598,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17616,7 +17616,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/mark_uncollectible`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17625,7 +17625,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17649,7 +17649,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/pay`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17658,7 +17658,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17689,7 +17689,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/remove_lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17698,7 +17698,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17716,7 +17716,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/send`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17725,7 +17725,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17889,7 +17889,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/update_lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17898,7 +17898,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17916,7 +17916,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_invoice>> {
     const url = `/v1/invoices/${p["invoice"]}/void`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -17925,7 +17925,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -17967,7 +17967,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/authorizations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -17986,7 +17986,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18003,17 +18003,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/issuing/authorizations/${p["authorization"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18040,7 +18040,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/issuing/authorizations/${p["authorization"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18049,7 +18049,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18077,7 +18077,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/issuing/authorizations/${p["authorization"]}/approve`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18086,7 +18086,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18113,7 +18113,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/issuing/authorizations/${p["authorization"]}/decline`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -18122,7 +18122,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -18160,7 +18160,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/cardholders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -18180,7 +18180,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19181,7 +19181,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_cardholder>> {
     const url = `/v1/issuing/cardholders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -19190,7 +19190,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -19207,17 +19207,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_cardholder>> {
     const url = `/v1/issuing/cardholders/${p["cardholder"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20219,7 +20219,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_cardholder>> {
     const url = `/v1/issuing/cardholders/${p["cardholder"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -20228,7 +20228,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -20269,7 +20269,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -20292,7 +20292,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21284,7 +21284,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/issuing/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -21293,7 +21293,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -21310,17 +21310,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/issuing/cards/${p["card"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22313,7 +22313,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/issuing/cards/${p["card"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22322,7 +22322,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22364,7 +22364,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/disputes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -22382,7 +22382,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22635,7 +22635,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_dispute>> {
     const url = `/v1/issuing/disputes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22644,7 +22644,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22661,17 +22661,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_dispute>> {
     const url = `/v1/issuing/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22923,7 +22923,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_dispute>> {
     const url = `/v1/issuing/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22932,7 +22932,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -22959,7 +22959,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_dispute>> {
     const url = `/v1/issuing/disputes/${p["dispute"]}/submit`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -22968,7 +22968,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23005,7 +23005,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/personalization_designs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23023,7 +23023,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23063,7 +23063,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/issuing/personalization_designs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23072,7 +23072,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23089,17 +23089,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23152,7 +23152,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23161,7 +23161,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23189,7 +23189,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/physical_bundles`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23206,7 +23206,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23223,17 +23223,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_physical_bundle>> {
     const url = `/v1/issuing/physical_bundles/${p["physicalBundle"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23250,17 +23250,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_settlement>> {
     const url = `/v1/issuing/settlements/${p["settlement"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23283,7 +23283,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_settlement>> {
     const url = `/v1/issuing/settlements/${p["settlement"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23292,7 +23292,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23333,7 +23333,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23351,7 +23351,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23368,17 +23368,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_token>> {
     const url = `/v1/issuing/tokens/${p["token"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23397,7 +23397,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_token>> {
     const url = `/v1/issuing/tokens/${p["token"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23406,7 +23406,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23443,7 +23443,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/issuing/transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23462,7 +23462,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23479,17 +23479,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_transaction>> {
     const url = `/v1/issuing/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23516,7 +23516,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_transaction>> {
     const url = `/v1/issuing/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23525,7 +23525,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23578,7 +23578,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_session>> {
     const url = `/v1/link_account_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23587,7 +23587,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23604,17 +23604,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_session>> {
     const url = `/v1/link_account_sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23645,7 +23645,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/linked_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23662,7 +23662,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23679,17 +23679,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/linked_accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23707,7 +23707,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/linked_accounts/${p["account"]}/disconnect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23716,7 +23716,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23744,7 +23744,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/linked_accounts/${p["account"]}/owners`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23760,7 +23760,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23784,7 +23784,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_financial_connections_account>> {
     const url = `/v1/linked_accounts/${p["account"]}/refresh`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -23793,7 +23793,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23810,17 +23810,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_mandate>> {
     const url = `/v1/mandates/${p["mandate"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -23855,7 +23855,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23872,7 +23872,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25480,7 +25480,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -25489,7 +25489,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25517,7 +25517,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_intents/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -25532,7 +25532,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -25550,7 +25550,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -25563,7 +25563,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27136,7 +27136,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -27145,7 +27145,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27165,7 +27165,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}/apply_customer_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -27174,7 +27174,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27201,7 +27201,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -27210,7 +27210,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -27247,7 +27247,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}/capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -27256,7 +27256,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28846,7 +28846,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}/confirm`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -28855,7 +28855,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28887,7 +28887,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}/increment_authorization`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -28896,7 +28896,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28917,7 +28917,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_intent>> {
     const url = `/v1/payment_intents/${p["intent"]}/verify_microdeposits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -28926,7 +28926,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -28953,7 +28953,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -28969,7 +28969,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -29584,7 +29584,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_link>> {
     const url = `/v1/payment_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -29593,7 +29593,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -29610,17 +29610,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_link>> {
     const url = `/v1/payment_links/${p["paymentLink"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -30220,7 +30220,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_link>> {
     const url = `/v1/payment_links/${p["paymentLink"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -30229,7 +30229,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -30256,7 +30256,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_links/${p["paymentLink"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -30271,7 +30271,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -30298,7 +30298,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_method_configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -30314,7 +30314,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -30905,7 +30905,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_configuration>> {
     const url = `/v1/payment_method_configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -30914,7 +30914,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -30931,17 +30931,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_configuration>> {
     const url = `/v1/payment_method_configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31533,7 +31533,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_configuration>> {
     const url = `/v1/payment_method_configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -31542,7 +31542,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31570,7 +31570,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_method_domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31587,7 +31587,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31606,7 +31606,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_domain>> {
     const url = `/v1/payment_method_domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -31615,7 +31615,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31632,17 +31632,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_domain>> {
     const url = `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31661,7 +31661,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_domain>> {
     const url = `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -31670,7 +31670,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31688,7 +31688,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method_domain>> {
     const url = `/v1/payment_method_domains/${p["paymentMethodDomain"]}/validate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -31697,7 +31697,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -31774,7 +31774,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payment_methods`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31791,7 +31791,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32163,7 +32163,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/payment_methods`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32172,7 +32172,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32189,17 +32189,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32282,7 +32282,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32291,7 +32291,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32310,7 +32310,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/payment_methods/${p["paymentMethod"]}/attach`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32319,7 +32319,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32337,7 +32337,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payment_method>> {
     const url = `/v1/payment_methods/${p["paymentMethod"]}/detach`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32346,7 +32346,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32390,7 +32390,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/payouts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -32409,7 +32409,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32440,7 +32440,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payout>> {
     const url = `/v1/payouts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32449,7 +32449,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32466,17 +32466,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payout>> {
     const url = `/v1/payouts/${p["payout"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32503,7 +32503,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payout>> {
     const url = `/v1/payouts/${p["payout"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32512,7 +32512,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32530,7 +32530,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payout>> {
     const url = `/v1/payouts/${p["payout"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32539,7 +32539,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32562,7 +32562,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_payout>> {
     const url = `/v1/payouts/${p["payout"]}/reverse`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32571,7 +32571,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32607,7 +32607,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/plans`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -32625,7 +32625,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32703,7 +32703,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_plan>> {
     const url = `/v1/plans`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32712,7 +32712,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32728,7 +32728,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_plan>> {
     const url = `/v1/plans/${p["plan"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32737,7 +32737,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32754,17 +32754,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_plan>> {
     const url = `/v1/plans/${p["plan"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32795,7 +32795,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_plan>> {
     const url = `/v1/plans/${p["plan"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -32804,7 +32804,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -32852,7 +32852,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/prices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -32874,7 +32874,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33001,7 +33001,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_price>> {
     const url = `/v1/prices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33010,7 +33010,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33038,7 +33038,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/prices/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33053,7 +33053,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33070,17 +33070,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_price>> {
     const url = `/v1/prices/${p["price"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33153,7 +33153,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_price>> {
     const url = `/v1/prices/${p["price"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33162,7 +33162,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33200,7 +33200,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/products`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33220,7 +33220,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33339,7 +33339,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_product>> {
     const url = `/v1/products`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33348,7 +33348,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33376,7 +33376,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/products/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33391,7 +33391,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33407,7 +33407,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_product>> {
     const url = `/v1/products/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33416,7 +33416,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33433,17 +33433,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_product>> {
     const url = `/v1/products/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33501,7 +33501,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_product>> {
     const url = `/v1/products/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33510,7 +33510,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33537,7 +33537,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/products/${p["product"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33552,7 +33552,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33571,7 +33571,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_product_feature>> {
     const url = `/v1/products/${p["product"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33580,7 +33580,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33597,7 +33597,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_product_feature>> {
     const url = `/v1/products/${p["product"]}/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33606,7 +33606,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33624,17 +33624,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_product_feature>> {
     const url = `/v1/products/${p["product"]}/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33672,7 +33672,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/promotion_codes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33692,7 +33692,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33736,7 +33736,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_promotion_code>> {
     const url = `/v1/promotion_codes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33745,7 +33745,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33762,17 +33762,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_promotion_code>> {
     const url = `/v1/promotion_codes/${p["promotionCode"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33813,7 +33813,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_promotion_code>> {
     const url = `/v1/promotion_codes/${p["promotionCode"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -33822,7 +33822,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -33856,7 +33856,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/quotes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33874,7 +33874,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34029,7 +34029,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34038,7 +34038,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34055,17 +34055,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes/${p["quote"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34210,7 +34210,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes/${p["quote"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34219,7 +34219,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34237,7 +34237,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes/${p["quote"]}/accept`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34246,7 +34246,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34264,7 +34264,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes/${p["quote"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34273,7 +34273,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34300,7 +34300,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/quotes/${p["quote"]}/computed_upfront_line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34315,7 +34315,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34334,7 +34334,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_quote>> {
     const url = `/v1/quotes/${p["quote"]}/finalize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34343,7 +34343,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34370,7 +34370,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/quotes/${p["quote"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34385,7 +34385,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34405,10 +34405,10 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<string>> {
     const url = `/v1/quotes/${p["quote"]}/pdf`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
@@ -34416,7 +34416,7 @@ export class StripeApi extends AbstractAxiosClient {
       method: "GET",
       data: body,
       baseURL: basePath,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34452,7 +34452,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/radar/early_fraud_warnings`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34470,7 +34470,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34487,17 +34487,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_radar_early_fraud_warning>> {
     const url = `/v1/radar/early_fraud_warnings/${p["earlyFraudWarning"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34533,7 +34533,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/radar/value_list_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34551,7 +34551,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34570,7 +34570,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_radar_value_list_item>> {
     const url = `/v1/radar/value_list_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34579,7 +34579,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34595,7 +34595,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_radar_value_list_item>> {
     const url = `/v1/radar/value_list_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34604,7 +34604,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34621,17 +34621,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_radar_value_list_item>> {
     const url = `/v1/radar/value_list_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34667,7 +34667,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/radar/value_lists`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34685,7 +34685,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34724,7 +34724,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_radar_value_list>> {
     const url = `/v1/radar/value_lists`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34733,7 +34733,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34749,7 +34749,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_radar_value_list>> {
     const url = `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34758,7 +34758,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34775,17 +34775,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_radar_value_list>> {
     const url = `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34810,7 +34810,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_radar_value_list>> {
     const url = `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34819,7 +34819,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34855,7 +34855,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34873,7 +34873,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34916,7 +34916,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34925,7 +34925,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34942,17 +34942,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -34979,7 +34979,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -34988,7 +34988,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35006,7 +35006,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/refunds/${p["refund"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -35015,7 +35015,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35049,7 +35049,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/reporting/report_runs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -35065,7 +35065,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35738,7 +35738,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reporting_report_run>> {
     const url = `/v1/reporting/report_runs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -35747,7 +35747,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35764,17 +35764,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reporting_report_run>> {
     const url = `/v1/reporting/report_runs/${p["reportRun"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35797,17 +35797,17 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/reporting/report_types`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35824,17 +35824,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_reporting_report_type>> {
     const url = `/v1/reporting/report_types/${p["reportType"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35868,7 +35868,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/reviews`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -35884,7 +35884,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35901,17 +35901,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_review>> {
     const url = `/v1/reviews/${p["review"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35929,7 +35929,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_review>> {
     const url = `/v1/reviews/${p["review"]}/approve`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -35938,7 +35938,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -35973,7 +35973,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/setup_attempts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -35990,7 +35990,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -36027,7 +36027,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/setup_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -36046,7 +36046,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -36795,7 +36795,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -36804,7 +36804,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -36822,7 +36822,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -36835,7 +36835,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -37548,7 +37548,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -37557,7 +37557,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -37583,7 +37583,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents/${p["intent"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -37592,7 +37592,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38320,7 +38320,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents/${p["intent"]}/confirm`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -38329,7 +38329,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38350,7 +38350,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_setup_intent>> {
     const url = `/v1/setup_intents/${p["intent"]}/verify_microdeposits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -38359,7 +38359,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38395,7 +38395,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/shipping_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -38413,7 +38413,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38492,7 +38492,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_shipping_rate>> {
     const url = `/v1/shipping_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -38501,7 +38501,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38518,17 +38518,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_shipping_rate>> {
     const url = `/v1/shipping_rates/${p["shippingRateToken"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38580,7 +38580,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_shipping_rate>> {
     const url = `/v1/shipping_rates/${p["shippingRateToken"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -38589,7 +38589,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38609,7 +38609,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_sigma_sigma_api_query>> {
     const url = `/v1/sigma/saved_queries/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -38618,7 +38618,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38644,7 +38644,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/sigma/scheduled_query_runs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -38659,7 +38659,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38676,17 +38676,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_scheduled_query_run>> {
     const url = `/v1/sigma/scheduled_query_runs/${p["scheduledQueryRun"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38844,7 +38844,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_source>> {
     const url = `/v1/sources`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -38853,7 +38853,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -38871,7 +38871,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_source>> {
     const url = `/v1/sources/${p["source"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -38884,7 +38884,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39019,7 +39019,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_source>> {
     const url = `/v1/sources/${p["source"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -39028,7 +39028,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39046,17 +39046,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_source_mandate_notification>> {
     const url = `/v1/sources/${p["source"]}/mandate_notifications/${p["mandateNotification"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39083,7 +39083,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/sources/${p["source"]}/source_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39098,7 +39098,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39116,17 +39116,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_source_transaction>> {
     const url = `/v1/sources/${p["source"]}/source_transactions/${p["sourceTransaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39145,7 +39145,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_source>> {
     const url = `/v1/sources/${p["source"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -39154,7 +39154,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39181,7 +39181,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/subscription_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39197,7 +39197,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39286,7 +39286,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_item>> {
     const url = `/v1/subscription_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -39295,7 +39295,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39322,7 +39322,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_subscription_item>> {
     const url = `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -39331,7 +39331,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39348,17 +39348,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_item>> {
     const url = `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39452,7 +39452,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_item>> {
     const url = `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -39461,7 +39461,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39521,7 +39521,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/subscription_schedules`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39542,7 +39542,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39820,7 +39820,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_schedule>> {
     const url = `/v1/subscription_schedules`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -39829,7 +39829,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -39846,17 +39846,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_schedule>> {
     const url = `/v1/subscription_schedules/${p["schedule"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40135,7 +40135,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_schedule>> {
     const url = `/v1/subscription_schedules/${p["schedule"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -40144,7 +40144,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40164,7 +40164,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_schedule>> {
     const url = `/v1/subscription_schedules/${p["schedule"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -40173,7 +40173,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40192,7 +40192,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription_schedule>> {
     const url = `/v1/subscription_schedules/${p["schedule"]}/release`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -40201,7 +40201,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40273,7 +40273,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40297,7 +40297,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40763,7 +40763,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -40772,7 +40772,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40800,7 +40800,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/subscriptions/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40815,7 +40815,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40854,7 +40854,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -40863,7 +40863,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -40880,17 +40880,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41386,7 +41386,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -41395,7 +41395,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41411,7 +41411,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_discount>> {
     const url = `/v1/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -41420,7 +41420,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41441,7 +41441,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions/${p["subscription"]}/migrate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -41450,7 +41450,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41480,7 +41480,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_subscription>> {
     const url = `/v1/subscriptions/${p["subscription"]}/resume`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -41489,7 +41489,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41691,7 +41691,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_calculation>> {
     const url = `/v1/tax/calculations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -41700,7 +41700,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41717,17 +41717,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_calculation>> {
     const url = `/v1/tax/calculations/${p["calculation"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41754,7 +41754,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/tax/calculations/${p["calculation"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -41769,7 +41769,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -41801,7 +41801,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/tax/registrations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -41817,7 +41817,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42723,7 +42723,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_registration>> {
     const url = `/v1/tax/registrations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -42732,7 +42732,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42749,17 +42749,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_registration>> {
     const url = `/v1/tax/registrations/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42779,7 +42779,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_registration>> {
     const url = `/v1/tax/registrations/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -42788,7 +42788,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42804,17 +42804,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_settings>> {
     const url = `/v1/tax/settings`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42856,7 +42856,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_settings>> {
     const url = `/v1/tax/settings`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -42865,7 +42865,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42890,7 +42890,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_transaction>> {
     const url = `/v1/tax/transactions/create_from_calculation`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -42899,7 +42899,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42945,7 +42945,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_transaction>> {
     const url = `/v1/tax/transactions/create_reversal`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -42954,7 +42954,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -42971,17 +42971,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_transaction>> {
     const url = `/v1/tax/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43008,7 +43008,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/tax/transactions/${p["transaction"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -43023,7 +43023,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43049,7 +43049,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/tax_codes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -43064,7 +43064,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43081,17 +43081,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_code>> {
     const url = `/v1/tax_codes/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43127,7 +43127,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -43143,7 +43143,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43285,7 +43285,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_id>> {
     const url = `/v1/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -43294,7 +43294,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43310,7 +43310,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_tax_id>> {
     const url = `/v1/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -43319,7 +43319,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43336,17 +43336,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_id>> {
     const url = `/v1/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43382,7 +43382,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/tax_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -43400,7 +43400,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43449,7 +43449,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_rate>> {
     const url = `/v1/tax_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -43458,7 +43458,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43475,17 +43475,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_rate>> {
     const url = `/v1/tax_rates/${p["taxRate"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43537,7 +43537,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_tax_rate>> {
     const url = `/v1/tax_rates/${p["taxRate"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -43546,7 +43546,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43573,7 +43573,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/terminal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -43589,7 +43589,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43793,7 +43793,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_configuration>> {
     const url = `/v1/terminal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -43802,7 +43802,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43818,7 +43818,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_terminal_configuration>> {
     const url = `/v1/terminal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -43827,7 +43827,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -43846,17 +43846,17 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/terminal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44085,7 +44085,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/terminal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44094,7 +44094,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44112,7 +44112,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_connection_token>> {
     const url = `/v1/terminal/connection_tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44121,7 +44121,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44147,7 +44147,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/terminal/locations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -44162,7 +44162,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44198,7 +44198,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_location>> {
     const url = `/v1/terminal/locations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44207,7 +44207,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44223,7 +44223,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_terminal_location>> {
     const url = `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44232,7 +44232,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44249,17 +44249,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_location | t_deleted_terminal_location>> {
     const url = `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44300,7 +44300,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_location | t_deleted_terminal_location>> {
     const url = `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44309,7 +44309,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44349,7 +44349,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/terminal/readers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -44368,7 +44368,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44397,7 +44397,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44406,7 +44406,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44422,7 +44422,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44431,7 +44431,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44448,17 +44448,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader | t_deleted_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44486,7 +44486,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader | t_deleted_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44495,7 +44495,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44513,7 +44513,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/cancel_action`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44522,7 +44522,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44582,7 +44582,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/collect_inputs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44591,7 +44591,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44629,7 +44629,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/collect_payment_method`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44638,7 +44638,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44662,7 +44662,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/confirm_payment_intent`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44671,7 +44671,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44710,7 +44710,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/process_payment_intent`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44719,7 +44719,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44748,7 +44748,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/process_setup_intent`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44757,7 +44757,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44790,7 +44790,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/refund_payment`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44799,7 +44799,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -44830,7 +44830,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/terminal/readers/${p["reader"]}/set_reader_display`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -44839,7 +44839,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -45233,7 +45233,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_confirmation_token>> {
     const url = `/v1/test_helpers/confirmation_tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -45242,7 +45242,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -45263,7 +45263,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_customer_cash_balance_transaction>> {
     const url = `/v1/test_helpers/customers/${p["customer"]}/fund_cash_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -45272,7 +45272,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -45770,7 +45770,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -45779,7 +45779,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -45915,7 +45915,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -45924,7 +45924,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -45942,7 +45942,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -45951,7 +45951,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46049,7 +46049,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/finalize_amount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46058,7 +46058,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46077,7 +46077,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/fraud_challenges/respond`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46086,7 +46086,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46106,7 +46106,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/increment`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46115,7 +46115,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46134,7 +46134,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_authorization>> {
     const url = `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/reverse`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46143,7 +46143,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46161,7 +46161,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/deliver`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46170,7 +46170,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46188,7 +46188,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46197,7 +46197,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46215,7 +46215,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46224,7 +46224,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46242,7 +46242,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/ship`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46251,7 +46251,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46269,7 +46269,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_card>> {
     const url = `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/submit`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46278,7 +46278,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46296,7 +46296,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/test_helpers/issuing/personalization_designs/${p["personalizationDesign"]}/activate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46305,7 +46305,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46323,7 +46323,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/test_helpers/issuing/personalization_designs/${p["personalizationDesign"]}/deactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46332,7 +46332,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46377,7 +46377,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_personalization_design>> {
     const url = `/v1/test_helpers/issuing/personalization_designs/${p["personalizationDesign"]}/reject`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46386,7 +46386,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46412,7 +46412,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_settlement>> {
     const url = `/v1/test_helpers/issuing/settlements`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46421,7 +46421,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46439,7 +46439,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_settlement>> {
     const url = `/v1/test_helpers/issuing/settlements/${p["settlement"]}/complete`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46448,7 +46448,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -46895,7 +46895,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_transaction>> {
     const url = `/v1/test_helpers/issuing/transactions/create_force_capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -46904,7 +46904,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47351,7 +47351,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_transaction>> {
     const url = `/v1/test_helpers/issuing/transactions/create_unlinked_refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47360,7 +47360,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47379,7 +47379,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_issuing_transaction>> {
     const url = `/v1/test_helpers/issuing/transactions/${p["transaction"]}/refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47388,7 +47388,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47406,7 +47406,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_refund>> {
     const url = `/v1/test_helpers/refunds/${p["refund"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47415,7 +47415,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47447,7 +47447,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/test_helpers/terminal/readers/${p["reader"]}/present_payment_method`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47456,7 +47456,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47477,7 +47477,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/test_helpers/terminal/readers/${p["reader"]}/succeed_input_collection`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47486,7 +47486,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47504,7 +47504,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_terminal_reader>> {
     const url = `/v1/test_helpers/terminal/readers/${p["reader"]}/timeout_input_collection`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47513,7 +47513,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47539,7 +47539,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/test_helpers/test_clocks`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -47554,7 +47554,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47573,7 +47573,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_test_helpers_test_clock>> {
     const url = `/v1/test_helpers/test_clocks`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47582,7 +47582,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47598,7 +47598,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_test_helpers_test_clock>> {
     const url = `/v1/test_helpers/test_clocks/${p["testClock"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47607,7 +47607,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47624,17 +47624,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_test_helpers_test_clock>> {
     const url = `/v1/test_helpers/test_clocks/${p["testClock"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47653,7 +47653,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_test_helpers_test_clock>> {
     const url = `/v1/test_helpers/test_clocks/${p["testClock"]}/advance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47662,7 +47662,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47702,7 +47702,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47711,7 +47711,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47729,7 +47729,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47738,7 +47738,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47756,7 +47756,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/succeed`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47765,7 +47765,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47798,7 +47798,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/test_helpers/treasury/outbound_payments/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47807,7 +47807,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47825,7 +47825,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47834,7 +47834,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47852,7 +47852,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/post`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47861,7 +47861,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47898,7 +47898,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47907,7 +47907,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47940,7 +47940,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47949,7 +47949,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47967,7 +47967,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -47976,7 +47976,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -47994,7 +47994,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}/post`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48003,7 +48003,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48040,7 +48040,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48049,7 +48049,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48083,7 +48083,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_received_credit>> {
     const url = `/v1/test_helpers/treasury/received_credits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48092,7 +48092,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48126,7 +48126,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_received_debit>> {
     const url = `/v1/test_helpers/treasury/received_debits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48135,7 +48135,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48674,7 +48674,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_token>> {
     const url = `/v1/tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48683,7 +48683,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48700,17 +48700,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_token>> {
     const url = `/v1/tokens/${p["token"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48758,7 +48758,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/topups`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -48776,7 +48776,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48808,7 +48808,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_topup>> {
     const url = `/v1/topups`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48817,7 +48817,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48834,17 +48834,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_topup>> {
     const url = `/v1/topups/${p["topup"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48872,7 +48872,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_topup>> {
     const url = `/v1/topups/${p["topup"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48881,7 +48881,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48899,7 +48899,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_topup>> {
     const url = `/v1/topups/${p["topup"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -48908,7 +48908,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48944,7 +48944,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -48962,7 +48962,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -48993,7 +48993,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_transfer>> {
     const url = `/v1/transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49002,7 +49002,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49029,7 +49029,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/transfers/${p["id"]}/reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -49044,7 +49044,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49074,7 +49074,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_transfer_reversal>> {
     const url = `/v1/transfers/${p["id"]}/reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49083,7 +49083,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49100,17 +49100,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_transfer>> {
     const url = `/v1/transfers/${p["transfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49138,7 +49138,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_transfer>> {
     const url = `/v1/transfers/${p["transfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49147,7 +49147,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49165,17 +49165,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_transfer_reversal>> {
     const url = `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49203,7 +49203,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_transfer_reversal>> {
     const url = `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49212,7 +49212,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49241,7 +49241,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/credit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -49259,7 +49259,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49282,7 +49282,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_credit_reversal>> {
     const url = `/v1/treasury/credit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49291,7 +49291,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49308,17 +49308,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_credit_reversal>> {
     const url = `/v1/treasury/credit_reversals/${p["creditReversal"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49348,7 +49348,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/debit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -49367,7 +49367,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49390,7 +49390,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_debit_reversal>> {
     const url = `/v1/treasury/debit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49399,7 +49399,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49416,17 +49416,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_debit_reversal>> {
     const url = `/v1/treasury/debit_reversals/${p["debitReversal"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49461,7 +49461,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/financial_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -49478,7 +49478,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49577,7 +49577,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_financial_account>> {
     const url = `/v1/treasury/financial_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49586,7 +49586,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49603,17 +49603,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_financial_account>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49722,7 +49722,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_financial_account>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49731,7 +49731,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49759,7 +49759,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_financial_account>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}/close`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49768,7 +49768,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49785,17 +49785,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_financial_account_features>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49874,7 +49874,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_financial_account_features>> {
     const url = `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49883,7 +49883,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49916,7 +49916,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/inbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -49933,7 +49933,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49961,7 +49961,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/treasury/inbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -49970,7 +49970,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -49987,17 +49987,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/treasury/inbound_transfers/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50015,7 +50015,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_inbound_transfer>> {
     const url = `/v1/treasury/inbound_transfers/${p["inboundTransfer"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -50024,7 +50024,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50067,7 +50067,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/outbound_payments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50086,7 +50086,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50188,7 +50188,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/treasury/outbound_payments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -50197,7 +50197,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50214,17 +50214,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/treasury/outbound_payments/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50242,7 +50242,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_payment>> {
     const url = `/v1/treasury/outbound_payments/${p["id"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -50251,7 +50251,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50285,7 +50285,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/outbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50302,7 +50302,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50355,7 +50355,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/treasury/outbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -50364,7 +50364,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50381,17 +50381,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50409,7 +50409,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_outbound_transfer>> {
     const url = `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -50418,7 +50418,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50455,7 +50455,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/received_credits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50473,7 +50473,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50490,17 +50490,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_received_credit>> {
     const url = `/v1/treasury/received_credits/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50528,7 +50528,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/received_debits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50545,7 +50545,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50562,17 +50562,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_received_debit>> {
     const url = `/v1/treasury/received_debits/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50617,7 +50617,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/transaction_entries`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50637,7 +50637,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50654,17 +50654,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_transaction_entry>> {
     const url = `/v1/treasury/transaction_entries/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50714,7 +50714,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/treasury/transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50734,7 +50734,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50751,17 +50751,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_treasury_transaction>> {
     const url = `/v1/treasury/transactions/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -50787,7 +50787,7 @@ export class StripeApi extends AbstractAxiosClient {
   > {
     const url = `/v1/webhook_endpoints`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -50802,7 +50802,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -51195,7 +51195,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_webhook_endpoint>> {
     const url = `/v1/webhook_endpoints`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -51204,7 +51204,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -51220,7 +51220,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_deleted_webhook_endpoint>> {
     const url = `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -51229,7 +51229,7 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "DELETE",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -51246,17 +51246,17 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_webhook_endpoint>> {
     const url = `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._request({
       url: url + query,
       method: "GET",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -51534,7 +51534,7 @@ export class StripeApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_webhook_endpoint>> {
     const url = `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -51543,12 +51543,12 @@ export class StripeApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { StripeApi as ApiClient }
-export type { StripeApiConfig as ApiClientConfig }
+export {StripeApi as ApiClient}
+export type {StripeApiConfig as ApiClientConfig}

--- a/integration-tests/typescript-axios/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-axios/src/generated/stripe.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-axios/src/generated/todo-lists.yaml/client.ts
@@ -13,7 +13,7 @@ import {
   AbstractAxiosConfig,
   Server,
 } from "@nahkies/typescript-axios-runtime/main"
-import { AxiosRequestConfig, AxiosResponse } from "axios"
+import {AxiosRequestConfig, AxiosResponse} from "axios"
 
 export class TodoListsExampleApiServersOperations {
   static listAttachments(url?: "{schema}://{tenant}.attachments.example.com"): {
@@ -173,7 +173,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
     return this._request({
       url: url + query,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -192,7 +192,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -208,7 +208,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<t_TodoList>> {
     const url = `/list/${p["listId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -217,7 +217,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
       url: url,
       method: "PUT",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -236,7 +236,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "DELETE",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -262,7 +262,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
     return this._request({
       url: url,
       method: "GET",
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -282,7 +282,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/list/${p["listId"]}/items`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -291,7 +291,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
       url: url,
       method: "POST",
       data: body,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -313,7 +313,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
       url: url,
       method: "GET",
       baseURL: basePath,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
@@ -335,7 +335,7 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
   ): Promise<AxiosResponse<void>> {
     const url = `/attachments`
     const headers = this._headers(
-      { "Content-Type": "multipart/form-data" },
+      {"Content-Type": "multipart/form-data"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
@@ -345,12 +345,12 @@ export class TodoListsExampleApi extends AbstractAxiosClient {
       method: "POST",
       data: body,
       baseURL: basePath,
-      ...(timeout ? { timeout } : {}),
+      ...(timeout ? {timeout} : {}),
       ...opts,
       headers,
     })
   }
 }
 
-export { TodoListsExampleApi as ApiClient }
-export type { TodoListsExampleApiConfig as ApiClientConfig }
+export {TodoListsExampleApi as ApiClient}
+export type {TodoListsExampleApiConfig as ApiClientConfig}

--- a/integration-tests/typescript-express/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/api.github.com.yaml/generated.ts
@@ -2167,8 +2167,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type MetaRootResponder = {
   with200(): ExpressRuntimeResponse<t_root>
@@ -21814,7 +21814,7 @@ export function createRouter(implementation: Implementation): Router {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof ExpressRuntimeResponse
           ? response.unpack()
           : response
@@ -21918,7 +21918,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21993,7 +21993,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22053,7 +22053,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22071,7 +22071,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsCreateFromManifestParamSchema = z.object({ code: z.string() })
+  const appsCreateFromManifestParamSchema = z.object({code: z.string()})
 
   const appsCreateFromManifestResponseBodyValidator = responseValidationFactory(
     [
@@ -22146,7 +22146,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22199,7 +22199,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22265,7 +22265,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22342,7 +22342,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22415,7 +22415,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22491,7 +22491,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22576,7 +22576,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22602,7 +22602,7 @@ export function createRouter(implementation: Implementation): Router {
   const appsListInstallationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     outdated: z.string().optional(),
   })
 
@@ -22647,7 +22647,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22716,7 +22716,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22785,7 +22785,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22879,7 +22879,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22954,7 +22954,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23024,7 +23024,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23042,7 +23042,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsDeleteAuthorizationParamSchema = z.object({ client_id: z.string() })
+  const appsDeleteAuthorizationParamSchema = z.object({client_id: z.string()})
 
   const appsDeleteAuthorizationRequestBodySchema = z.object({
     access_token: z.string(),
@@ -23100,7 +23100,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23118,9 +23118,9 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsCheckTokenParamSchema = z.object({ client_id: z.string() })
+  const appsCheckTokenParamSchema = z.object({client_id: z.string()})
 
-  const appsCheckTokenRequestBodySchema = z.object({ access_token: z.string() })
+  const appsCheckTokenRequestBodySchema = z.object({access_token: z.string()})
 
   const appsCheckTokenResponseBodyValidator = responseValidationFactory(
     [
@@ -23177,7 +23177,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23195,9 +23195,9 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsResetTokenParamSchema = z.object({ client_id: z.string() })
+  const appsResetTokenParamSchema = z.object({client_id: z.string()})
 
-  const appsResetTokenRequestBodySchema = z.object({ access_token: z.string() })
+  const appsResetTokenRequestBodySchema = z.object({access_token: z.string()})
 
   const appsResetTokenResponseBodyValidator = responseValidationFactory(
     [
@@ -23250,7 +23250,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23268,11 +23268,9 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsDeleteTokenParamSchema = z.object({ client_id: z.string() })
+  const appsDeleteTokenParamSchema = z.object({client_id: z.string()})
 
-  const appsDeleteTokenRequestBodySchema = z.object({
-    access_token: z.string(),
-  })
+  const appsDeleteTokenRequestBodySchema = z.object({access_token: z.string()})
 
   const appsDeleteTokenResponseBodyValidator = responseValidationFactory(
     [
@@ -23325,7 +23323,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23343,7 +23341,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsScopeTokenParamSchema = z.object({ client_id: z.string() })
+  const appsScopeTokenParamSchema = z.object({client_id: z.string()})
 
   const appsScopeTokenRequestBodySchema = z.object({
     access_token: z.string(),
@@ -23417,7 +23415,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23435,7 +23433,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsGetBySlugParamSchema = z.object({ app_slug: z.string() })
+  const appsGetBySlugParamSchema = z.object({app_slug: z.string()})
 
   const appsGetBySlugResponseBodyValidator = responseValidationFactory(
     [
@@ -23488,7 +23486,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23558,7 +23556,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23639,7 +23637,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23716,7 +23714,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23780,7 +23778,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23849,7 +23847,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23930,7 +23928,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23997,7 +23995,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24020,7 +24018,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codesOfConductGetConductCodeParamSchema = z.object({ key: z.string() })
+  const codesOfConductGetConductCodeParamSchema = z.object({key: z.string()})
 
   const codesOfConductGetConductCodeResponseBodyValidator =
     responseValidationFactory(
@@ -24074,7 +24072,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24151,7 +24149,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24214,7 +24212,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24306,7 +24304,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24350,9 +24348,7 @@ export function createRouter(implementation: Implementation): Router {
         .optional()
         .default("disabled"),
       dependency_graph_autosubmit_action_options: z
-        .object({
-          labeled_runners: PermissiveBoolean.optional().default(false),
-        })
+        .object({labeled_runners: PermissiveBoolean.optional().default(false)})
         .optional(),
       dependabot_alerts: z
         .enum(["enabled", "disabled", "not_set"])
@@ -24474,7 +24470,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24498,7 +24494,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codeSecurityGetDefaultConfigurationsForEnterpriseParamSchema = z.object(
-    { enterprise: z.string() },
+    {enterprise: z.string()},
   )
 
   const codeSecurityGetDefaultConfigurationsForEnterpriseResponseBodyValidator =
@@ -24551,7 +24547,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24643,7 +24639,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24682,7 +24678,7 @@ export function createRouter(implementation: Implementation): Router {
       .enum(["enabled", "disabled", "not_set"])
       .optional(),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional() })
+      .object({labeled_runners: PermissiveBoolean.optional()})
       .optional(),
     dependabot_alerts: z.enum(["enabled", "disabled", "not_set"]).optional(),
     dependabot_security_updates: z
@@ -24793,7 +24789,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24887,7 +24883,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -24987,7 +24983,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25011,7 +25007,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codeSecuritySetConfigurationAsDefaultForEnterpriseParamSchema =
-    z.object({ enterprise: z.string(), configuration_id: z.coerce.number() })
+    z.object({enterprise: z.string(), configuration_id: z.coerce.number()})
 
   const codeSecuritySetConfigurationAsDefaultForEnterpriseRequestBodySchema =
     z.object({
@@ -25095,7 +25091,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25119,7 +25115,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codeSecurityGetRepositoriesForEnterpriseConfigurationParamSchema =
-    z.object({ enterprise: z.string(), configuration_id: z.coerce.number() })
+    z.object({enterprise: z.string(), configuration_id: z.coerce.number()})
 
   const codeSecurityGetRepositoriesForEnterpriseConfigurationQuerySchema =
     z.object({
@@ -25193,7 +25189,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25306,7 +25302,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25423,7 +25419,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25518,7 +25514,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25573,7 +25569,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25592,7 +25588,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const gistsListQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -25648,7 +25644,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25668,7 +25664,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const gistsCreateRequestBodySchema = z.object({
     description: z.string().optional(),
-    files: z.record(z.object({ content: z.string() })),
+    files: z.record(z.object({content: z.string()})),
     public: z
       .union([
         PermissiveBoolean.default(false),
@@ -25736,7 +25732,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25755,7 +25751,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const gistsListPublicQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -25815,7 +25811,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25834,7 +25830,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const gistsListStarredQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -25894,7 +25890,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25912,7 +25908,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsGetParamSchema = z.object({ gist_id: z.string() })
+  const gistsGetParamSchema = z.object({gist_id: z.string()})
 
   const gistsGetResponseBodyValidator = responseValidationFactory(
     [
@@ -25992,7 +25988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26010,7 +26006,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsUpdateParamSchema = z.object({ gist_id: z.string() })
+  const gistsUpdateParamSchema = z.object({gist_id: z.string()})
 
   const gistsUpdateRequestBodySchema = z
     .object({
@@ -26083,7 +26079,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26101,7 +26097,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsDeleteParamSchema = z.object({ gist_id: z.string() })
+  const gistsDeleteParamSchema = z.object({gist_id: z.string()})
 
   const gistsDeleteResponseBodyValidator = responseValidationFactory(
     [
@@ -26158,7 +26154,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26176,7 +26172,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsListCommentsParamSchema = z.object({ gist_id: z.string() })
+  const gistsListCommentsParamSchema = z.object({gist_id: z.string()})
 
   const gistsListCommentsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -26242,7 +26238,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26260,7 +26256,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsCreateCommentParamSchema = z.object({ gist_id: z.string() })
+  const gistsCreateCommentParamSchema = z.object({gist_id: z.string()})
 
   const gistsCreateCommentRequestBodySchema = z.object({
     body: z.string().max(65535),
@@ -26325,7 +26321,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26426,7 +26422,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26504,7 +26500,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26582,7 +26578,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26600,7 +26596,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsListCommitsParamSchema = z.object({ gist_id: z.string() })
+  const gistsListCommitsParamSchema = z.object({gist_id: z.string()})
 
   const gistsListCommitsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -26666,7 +26662,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26684,7 +26680,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsListForksParamSchema = z.object({ gist_id: z.string() })
+  const gistsListForksParamSchema = z.object({gist_id: z.string()})
 
   const gistsListForksQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -26750,7 +26746,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26768,7 +26764,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsForkParamSchema = z.object({ gist_id: z.string() })
+  const gistsForkParamSchema = z.object({gist_id: z.string()})
 
   const gistsForkResponseBodyValidator = responseValidationFactory(
     [
@@ -26829,7 +26825,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26847,7 +26843,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsCheckIsStarredParamSchema = z.object({ gist_id: z.string() })
+  const gistsCheckIsStarredParamSchema = z.object({gist_id: z.string()})
 
   const gistsCheckIsStarredResponseBodyValidator = responseValidationFactory(
     [
@@ -26904,7 +26900,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26922,7 +26918,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsStarParamSchema = z.object({ gist_id: z.string() })
+  const gistsStarParamSchema = z.object({gist_id: z.string()})
 
   const gistsStarResponseBodyValidator = responseValidationFactory(
     [
@@ -26979,7 +26975,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26997,7 +26993,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsUnstarParamSchema = z.object({ gist_id: z.string() })
+  const gistsUnstarParamSchema = z.object({gist_id: z.string()})
 
   const gistsUnstarResponseBodyValidator = responseValidationFactory(
     [
@@ -27054,7 +27050,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27132,7 +27128,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27194,7 +27190,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27212,7 +27208,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gitignoreGetTemplateParamSchema = z.object({ name: z.string() })
+  const gitignoreGetTemplateParamSchema = z.object({name: z.string()})
 
   const gitignoreGetTemplateResponseBodyValidator = responseValidationFactory(
     [
@@ -27261,7 +27257,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27357,7 +27353,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27415,7 +27411,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27450,7 +27446,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     collab: PermissiveBoolean.optional(),
     orgs: PermissiveBoolean.optional(),
     owned: PermissiveBoolean.optional(),
@@ -27514,7 +27510,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27586,7 +27582,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27606,7 +27602,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const licensesGetParamSchema = z.object({ license: z.string() })
+  const licensesGetParamSchema = z.object({license: z.string()})
 
   const licensesGetResponseBodyValidator = responseValidationFactory(
     [
@@ -27663,7 +27659,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27734,7 +27730,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27801,7 +27797,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27875,7 +27871,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27954,7 +27950,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28043,7 +28039,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28123,7 +28119,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28198,7 +28194,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28279,7 +28275,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28342,7 +28338,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28440,7 +28436,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28466,8 +28462,8 @@ export function createRouter(implementation: Implementation): Router {
   const activityListNotificationsForAuthenticatedUserQuerySchema = z.object({
     all: PermissiveBoolean.optional().default(false),
     participating: PermissiveBoolean.optional().default(false),
-    since: z.string().datetime({ offset: true }).optional(),
-    before: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
+    before: z.string().datetime({offset: true}).optional(),
     page: z.coerce.number().optional().default(1),
     per_page: z.coerce.number().optional().default(50),
   })
@@ -28538,7 +28534,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28563,7 +28559,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const activityMarkNotificationsAsReadRequestBodySchema = z
     .object({
-      last_read_at: z.string().datetime({ offset: true }).optional(),
+      last_read_at: z.string().datetime({offset: true}).optional(),
       read: PermissiveBoolean.optional(),
     })
     .optional()
@@ -28571,7 +28567,7 @@ export function createRouter(implementation: Implementation): Router {
   const activityMarkNotificationsAsReadResponseBodyValidator =
     responseValidationFactory(
       [
-        ["202", z.object({ message: z.string().optional() })],
+        ["202", z.object({message: z.string().optional()})],
         ["205", z.undefined()],
         ["304", z.undefined()],
         ["401", s_basic_error],
@@ -28630,7 +28626,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28650,9 +28646,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const activityGetThreadParamSchema = z.object({
-    thread_id: z.coerce.number(),
-  })
+  const activityGetThreadParamSchema = z.object({thread_id: z.coerce.number()})
 
   const activityGetThreadResponseBodyValidator = responseValidationFactory(
     [
@@ -28709,7 +28703,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28783,7 +28777,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28844,7 +28838,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28863,7 +28857,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const activityGetThreadSubscriptionForAuthenticatedUserParamSchema = z.object(
-    { thread_id: z.coerce.number() },
+    {thread_id: z.coerce.number()},
   )
 
   const activityGetThreadSubscriptionForAuthenticatedUserResponseBodyValidator =
@@ -28928,7 +28922,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28956,7 +28950,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const activitySetThreadSubscriptionRequestBodySchema = z
-    .object({ ignored: PermissiveBoolean.optional().default(false) })
+    .object({ignored: PermissiveBoolean.optional().default(false)})
     .optional()
 
   const activitySetThreadSubscriptionResponseBodyValidator =
@@ -29019,7 +29013,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29099,7 +29093,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29119,7 +29113,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const metaGetOctocatQuerySchema = z.object({ s: z.string().optional() })
+  const metaGetOctocatQuerySchema = z.object({s: z.string().optional()})
 
   const metaGetOctocatResponseBodyValidator = responseValidationFactory(
     [["200", z.string()]],
@@ -29162,7 +29156,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29232,7 +29226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29317,7 +29311,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29408,7 +29402,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29501,7 +29495,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29616,7 +29610,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29639,7 +29633,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsGetParamSchema = z.object({ org: z.string() })
+  const orgsGetParamSchema = z.object({org: z.string()})
 
   const orgsGetResponseBodyValidator = responseValidationFactory(
     [
@@ -29688,7 +29682,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29706,7 +29700,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsUpdateParamSchema = z.object({ org: z.string() })
+  const orgsUpdateParamSchema = z.object({org: z.string()})
 
   const orgsUpdateRequestBodySchema = z
     .object({
@@ -29816,7 +29810,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29834,7 +29828,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsDeleteParamSchema = z.object({ org: z.string() })
+  const orgsDeleteParamSchema = z.object({org: z.string()})
 
   const orgsDeleteResponseBodyValidator = responseValidationFactory(
     [
@@ -29889,7 +29883,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29955,7 +29949,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30052,7 +30046,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30075,9 +30069,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsListHostedRunnersForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const actionsListHostedRunnersForOrgParamSchema = z.object({org: z.string()})
 
   const actionsListHostedRunnersForOrgQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -30141,7 +30133,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30161,9 +30153,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsCreateHostedRunnerForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const actionsCreateHostedRunnerForOrgParamSchema = z.object({org: z.string()})
 
   const actionsCreateHostedRunnerForOrgRequestBodySchema = z.object({
     name: z.string(),
@@ -30220,7 +30210,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30303,7 +30293,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30389,7 +30379,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30460,7 +30450,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30546,7 +30536,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30632,7 +30622,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30699,7 +30689,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30774,7 +30764,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30838,7 +30828,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30901,7 +30891,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30993,7 +30983,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31070,7 +31060,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31152,7 +31142,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31176,7 +31166,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsListSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsListSelectedRepositoriesEnabledGithubActionsOrganizationQuerySchema =
     z.object({
@@ -31247,7 +31237,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31271,10 +31261,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationRequestBodySchema =
-    z.object({ selected_repository_ids: z.array(z.coerce.number()) })
+    z.object({selected_repository_ids: z.array(z.coerce.number())})
 
   const actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationResponseBodyValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -31325,7 +31315,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31349,7 +31339,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsEnableSelectedRepositoryGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string(), repository_id: z.coerce.number() })
+    z.object({org: z.string(), repository_id: z.coerce.number()})
 
   const actionsEnableSelectedRepositoryGithubActionsOrganizationResponseBodyValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -31396,7 +31386,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31420,7 +31410,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsDisableSelectedRepositoryGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string(), repository_id: z.coerce.number() })
+    z.object({org: z.string(), repository_id: z.coerce.number()})
 
   const actionsDisableSelectedRepositoryGithubActionsOrganizationResponseBodyValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -31467,7 +31457,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31539,7 +31529,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31618,7 +31608,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31642,7 +31632,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsOrganizationResponseBodyValidator =
     responseValidationFactory(
@@ -31694,7 +31684,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31718,7 +31708,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationRequestBodySchema =
     s_actions_set_default_workflow_permissions.optional()
@@ -31772,7 +31762,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31868,7 +31858,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31958,7 +31948,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32031,7 +32021,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32117,7 +32107,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32190,7 +32180,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32286,7 +32276,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32310,7 +32300,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsListRepoAccessToSelfHostedRunnerGroupInOrgParamSchema = z.object(
-    { org: z.string(), runner_group_id: z.coerce.number() },
+    {org: z.string(), runner_group_id: z.coerce.number()},
   )
 
   const actionsListRepoAccessToSelfHostedRunnerGroupInOrgQuerySchema = z.object(
@@ -32383,7 +32373,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32412,7 +32402,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsSetRepoAccessToSelfHostedRunnerGroupInOrgRequestBodySchema =
-    z.object({ selected_repository_ids: z.array(z.coerce.number()) })
+    z.object({selected_repository_ids: z.array(z.coerce.number())})
 
   const actionsSetRepoAccessToSelfHostedRunnerGroupInOrgResponseBodyValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -32463,7 +32453,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32537,7 +32527,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32612,7 +32602,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32708,7 +32698,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32789,7 +32779,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32863,7 +32853,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32937,7 +32927,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33027,7 +33017,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33096,7 +33086,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33133,7 +33123,7 @@ export function createRouter(implementation: Implementation): Router {
   const actionsGenerateRunnerJitconfigForOrgResponseBodyValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ runner: s_runner, encoded_jit_config: z.string() })],
+        ["201", z.object({runner: s_runner, encoded_jit_config: z.string()})],
         ["404", s_basic_error],
         ["409", s_basic_error],
         ["422", s_validation_error_simple],
@@ -33199,7 +33189,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33271,7 +33261,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33294,9 +33284,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsCreateRemoveTokenForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const actionsCreateRemoveTokenForOrgParamSchema = z.object({org: z.string()})
 
   const actionsCreateRemoveTokenForOrgResponseBodyValidator =
     responseValidationFactory([["201", s_authentication_token]], undefined)
@@ -33337,7 +33325,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33401,7 +33389,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33480,7 +33468,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33571,7 +33559,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33600,7 +33588,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsAddCustomLabelsToSelfHostedRunnerForOrgRequestBodySchema =
-    z.object({ labels: z.array(z.string()).min(1).max(100) })
+    z.object({labels: z.array(z.string()).min(1).max(100)})
 
   const actionsAddCustomLabelsToSelfHostedRunnerForOrgResponseBodyValidator =
     responseValidationFactory(
@@ -33673,7 +33661,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33702,7 +33690,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsSetCustomLabelsForSelfHostedRunnerForOrgRequestBodySchema =
-    z.object({ labels: z.array(z.string()).min(0).max(100) })
+    z.object({labels: z.array(z.string()).min(0).max(100)})
 
   const actionsSetCustomLabelsForSelfHostedRunnerForOrgResponseBodyValidator =
     responseValidationFactory(
@@ -33775,7 +33763,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33799,7 +33787,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgParamSchema =
-    z.object({ org: z.string(), runner_id: z.coerce.number() })
+    z.object({org: z.string(), runner_id: z.coerce.number()})
 
   const actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgResponseBodyValidator =
     responseValidationFactory(
@@ -33864,7 +33852,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33888,11 +33876,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsRemoveCustomLabelFromSelfHostedRunnerForOrgParamSchema =
-    z.object({
-      org: z.string(),
-      runner_id: z.coerce.number(),
-      name: z.string(),
-    })
+    z.object({org: z.string(), runner_id: z.coerce.number(), name: z.string()})
 
   const actionsRemoveCustomLabelFromSelfHostedRunnerForOrgResponseBodyValidator =
     responseValidationFactory(
@@ -33961,7 +33945,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33984,7 +33968,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsListOrgSecretsParamSchema = z.object({ org: z.string() })
+  const actionsListOrgSecretsParamSchema = z.object({org: z.string()})
 
   const actionsListOrgSecretsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -34047,7 +34031,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34065,7 +34049,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsGetOrgPublicKeyParamSchema = z.object({ org: z.string() })
+  const actionsGetOrgPublicKeyParamSchema = z.object({org: z.string()})
 
   const actionsGetOrgPublicKeyResponseBodyValidator = responseValidationFactory(
     [["200", s_actions_public_key]],
@@ -34108,7 +34092,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34174,7 +34158,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34262,7 +34246,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34328,7 +34312,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34419,7 +34403,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34494,7 +34478,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34571,7 +34555,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34654,7 +34638,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34677,7 +34661,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsListOrgVariablesParamSchema = z.object({ org: z.string() })
+  const actionsListOrgVariablesParamSchema = z.object({org: z.string()})
 
   const actionsListOrgVariablesQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(10),
@@ -34741,7 +34725,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34759,7 +34743,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const actionsCreateOrgVariableParamSchema = z.object({ org: z.string() })
+  const actionsCreateOrgVariableParamSchema = z.object({org: z.string()})
 
   const actionsCreateOrgVariableRequestBodySchema = z.object({
     name: z.string(),
@@ -34811,7 +34795,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34877,7 +34861,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34950,7 +34934,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35012,7 +34996,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35107,7 +35091,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35197,7 +35181,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35274,7 +35258,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35357,7 +35341,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35380,7 +35364,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListAttestationsBulkParamSchema = z.object({ org: z.string() })
+  const orgsListAttestationsBulkParamSchema = z.object({org: z.string()})
 
   const orgsListAttestationsBulkQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -35515,7 +35499,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35533,11 +35517,11 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsDeleteAttestationsBulkParamSchema = z.object({ org: z.string() })
+  const orgsDeleteAttestationsBulkParamSchema = z.object({org: z.string()})
 
   const orgsDeleteAttestationsBulkRequestBodySchema = z.union([
-    z.object({ subject_digests: z.array(z.string()).min(1).max(1024) }),
-    z.object({ attestation_ids: z.array(z.coerce.number()).min(1).max(1024) }),
+    z.object({subject_digests: z.array(z.string()).min(1).max(1024)}),
+    z.object({attestation_ids: z.array(z.coerce.number()).min(1).max(1024)}),
   ])
 
   const orgsDeleteAttestationsBulkResponseBodyValidator =
@@ -35592,7 +35576,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35675,7 +35659,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35759,7 +35743,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35879,7 +35863,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35897,7 +35881,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListBlockedUsersParamSchema = z.object({ org: z.string() })
+  const orgsListBlockedUsersParamSchema = z.object({org: z.string()})
 
   const orgsListBlockedUsersQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -35949,7 +35933,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36019,7 +36003,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36089,7 +36073,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36153,7 +36137,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36171,7 +36155,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const campaignsListOrgCampaignsParamSchema = z.object({ org: z.string() })
+  const campaignsListOrgCampaignsParamSchema = z.object({org: z.string()})
 
   const campaignsListOrgCampaignsQuerySchema = z.object({
     page: z.coerce.number().optional().default(1),
@@ -36251,7 +36235,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36269,14 +36253,14 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const campaignsCreateCampaignParamSchema = z.object({ org: z.string() })
+  const campaignsCreateCampaignParamSchema = z.object({org: z.string()})
 
   const campaignsCreateCampaignRequestBodySchema = z.object({
     name: z.string().min(1).max(50),
     description: z.string().min(1).max(255),
     managers: z.array(z.string()).max(10).optional(),
     team_managers: z.array(z.string()).max(10).optional(),
-    ends_at: z.string().datetime({ offset: true }),
+    ends_at: z.string().datetime({offset: true}),
     contact_link: z.string().nullable().optional(),
     code_scanning_alerts: z
       .array(
@@ -36368,7 +36352,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36458,7 +36442,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36488,7 +36472,7 @@ export function createRouter(implementation: Implementation): Router {
     description: z.string().min(1).max(255).optional(),
     managers: z.array(z.string()).max(10).optional(),
     team_managers: z.array(z.string()).max(10).optional(),
-    ends_at: z.string().datetime({ offset: true }).optional(),
+    ends_at: z.string().datetime({offset: true}).optional(),
     contact_link: z.string().nullable().optional(),
     state: s_campaign_state.optional(),
   })
@@ -36568,7 +36552,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36654,7 +36638,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36672,7 +36656,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codeScanningListAlertsForOrgParamSchema = z.object({ org: z.string() })
+  const codeScanningListAlertsForOrgParamSchema = z.object({org: z.string()})
 
   const codeScanningListAlertsForOrgQuerySchema = z.object({
     tool_name: s_code_scanning_analysis_tool_name.optional(),
@@ -36756,7 +36740,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36845,7 +36829,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36868,9 +36852,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codeSecurityCreateConfigurationParamSchema = z.object({
-    org: z.string(),
-  })
+  const codeSecurityCreateConfigurationParamSchema = z.object({org: z.string()})
 
   const codeSecurityCreateConfigurationRequestBodySchema = z.object({
     name: z.string(),
@@ -36888,7 +36870,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional()
       .default("disabled"),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional().default(false) })
+      .object({labeled_runners: PermissiveBoolean.optional().default(false)})
       .optional(),
     dependabot_alerts: z
       .enum(["enabled", "disabled", "not_set"])
@@ -37005,7 +36987,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37093,7 +37075,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37116,9 +37098,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codeSecurityDetachConfigurationParamSchema = z.object({
-    org: z.string(),
-  })
+  const codeSecurityDetachConfigurationParamSchema = z.object({org: z.string()})
 
   const codeSecurityDetachConfigurationRequestBodySchema = z.object({
     selected_repository_ids: z
@@ -37192,7 +37172,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37275,7 +37255,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37311,7 +37291,7 @@ export function createRouter(implementation: Implementation): Router {
       .enum(["enabled", "disabled", "not_set"])
       .optional(),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional() })
+      .object({labeled_runners: PermissiveBoolean.optional()})
       .optional(),
     dependabot_alerts: z.enum(["enabled", "disabled", "not_set"]).optional(),
     dependabot_security_updates: z
@@ -37417,7 +37397,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37502,7 +37482,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37583,7 +37563,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37689,7 +37669,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37788,7 +37768,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37811,7 +37791,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codespacesListInOrganizationParamSchema = z.object({ org: z.string() })
+  const codespacesListInOrganizationParamSchema = z.object({org: z.string()})
 
   const codespacesListInOrganizationQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -37895,7 +37875,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37915,7 +37895,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codespacesSetCodespacesAccessParamSchema = z.object({ org: z.string() })
+  const codespacesSetCodespacesAccessParamSchema = z.object({org: z.string()})
 
   const codespacesSetCodespacesAccessRequestBodySchema = z.object({
     visibility: z.enum([
@@ -37995,7 +37975,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38091,7 +38071,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38196,7 +38176,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38219,7 +38199,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codespacesListOrgSecretsParamSchema = z.object({ org: z.string() })
+  const codespacesListOrgSecretsParamSchema = z.object({org: z.string()})
 
   const codespacesListOrgSecretsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -38283,7 +38263,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38301,7 +38281,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const codespacesGetOrgPublicKeyParamSchema = z.object({ org: z.string() })
+  const codespacesGetOrgPublicKeyParamSchema = z.object({org: z.string()})
 
   const codespacesGetOrgPublicKeyResponseBodyValidator =
     responseValidationFactory([["200", s_codespaces_public_key]], undefined)
@@ -38342,7 +38322,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38406,7 +38386,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38503,7 +38483,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38579,7 +38559,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38674,7 +38654,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38768,7 +38748,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38859,7 +38839,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38950,7 +38930,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39049,7 +39029,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39072,7 +39052,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const copilotListCopilotSeatsParamSchema = z.object({ org: z.string() })
+  const copilotListCopilotSeatsParamSchema = z.object({org: z.string()})
 
   const copilotListCopilotSeatsQuerySchema = z.object({
     page: z.coerce.number().optional().default(1),
@@ -39152,7 +39132,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39170,9 +39150,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const copilotAddCopilotSeatsForTeamsParamSchema = z.object({
-    org: z.string(),
-  })
+  const copilotAddCopilotSeatsForTeamsParamSchema = z.object({org: z.string()})
 
   const copilotAddCopilotSeatsForTeamsRequestBodySchema = z.object({
     selected_teams: z.array(z.string()).min(1),
@@ -39181,7 +39159,7 @@ export function createRouter(implementation: Implementation): Router {
   const copilotAddCopilotSeatsForTeamsResponseBodyValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ seats_created: z.coerce.number() })],
+        ["201", z.object({seats_created: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -39248,7 +39226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39279,7 +39257,7 @@ export function createRouter(implementation: Implementation): Router {
   const copilotCancelCopilotSeatAssignmentForTeamsResponseBodyValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ seats_cancelled: z.coerce.number() })],
+        ["200", z.object({seats_cancelled: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -39352,7 +39330,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39375,9 +39353,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const copilotAddCopilotSeatsForUsersParamSchema = z.object({
-    org: z.string(),
-  })
+  const copilotAddCopilotSeatsForUsersParamSchema = z.object({org: z.string()})
 
   const copilotAddCopilotSeatsForUsersRequestBodySchema = z.object({
     selected_usernames: z.array(z.string()).min(1),
@@ -39386,7 +39362,7 @@ export function createRouter(implementation: Implementation): Router {
   const copilotAddCopilotSeatsForUsersResponseBodyValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ seats_created: z.coerce.number() })],
+        ["201", z.object({seats_created: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -39453,7 +39429,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39484,7 +39460,7 @@ export function createRouter(implementation: Implementation): Router {
   const copilotCancelCopilotSeatAssignmentForUsersResponseBodyValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ seats_cancelled: z.coerce.number() })],
+        ["200", z.object({seats_cancelled: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -39557,7 +39533,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39663,7 +39639,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39686,7 +39662,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const dependabotListAlertsForOrgParamSchema = z.object({ org: z.string() })
+  const dependabotListAlertsForOrgParamSchema = z.object({org: z.string()})
 
   const dependabotListAlertsForOrgQuerySchema = z.object({
     state: z.string().optional(),
@@ -39778,7 +39754,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39798,7 +39774,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const dependabotListOrgSecretsParamSchema = z.object({ org: z.string() })
+  const dependabotListOrgSecretsParamSchema = z.object({org: z.string()})
 
   const dependabotListOrgSecretsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -39862,7 +39838,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39880,7 +39856,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const dependabotGetOrgPublicKeyParamSchema = z.object({ org: z.string() })
+  const dependabotGetOrgPublicKeyParamSchema = z.object({org: z.string()})
 
   const dependabotGetOrgPublicKeyResponseBodyValidator =
     responseValidationFactory([["200", s_dependabot_public_key]], undefined)
@@ -39921,7 +39897,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39987,7 +39963,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40076,7 +40052,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40143,7 +40119,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40234,7 +40210,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40315,7 +40291,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40398,7 +40374,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40481,7 +40457,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40505,7 +40481,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const packagesListDockerMigrationConflictingPackagesForOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const packagesListDockerMigrationConflictingPackagesForOrganizationResponseBodyValidator =
     responseValidationFactory(
@@ -40565,7 +40541,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40588,7 +40564,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const activityListPublicOrgEventsParamSchema = z.object({ org: z.string() })
+  const activityListPublicOrgEventsParamSchema = z.object({org: z.string()})
 
   const activityListPublicOrgEventsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -40638,7 +40614,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40658,7 +40634,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListFailedInvitationsParamSchema = z.object({ org: z.string() })
+  const orgsListFailedInvitationsParamSchema = z.object({org: z.string()})
 
   const orgsListFailedInvitationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -40717,7 +40693,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40735,7 +40711,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListWebhooksParamSchema = z.object({ org: z.string() })
+  const orgsListWebhooksParamSchema = z.object({org: z.string()})
 
   const orgsListWebhooksQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -40793,7 +40769,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40811,7 +40787,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsCreateWebhookParamSchema = z.object({ org: z.string() })
+  const orgsCreateWebhookParamSchema = z.object({org: z.string()})
 
   const orgsCreateWebhookRequestBodySchema = z.object({
     name: z.string(),
@@ -40882,7 +40858,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40952,7 +40928,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41046,7 +41022,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41116,7 +41092,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41178,7 +41154,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41255,7 +41231,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41341,7 +41317,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41416,7 +41392,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41494,7 +41470,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41566,7 +41542,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41665,7 +41641,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41685,7 +41661,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const apiInsightsGetSubjectStatsParamSchema = z.object({ org: z.string() })
+  const apiInsightsGetSubjectStatsParamSchema = z.object({org: z.string()})
 
   const apiInsightsGetSubjectStatsQuerySchema = z.object({
     min_timestamp: z.string(),
@@ -41758,7 +41734,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41778,7 +41754,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const apiInsightsGetSummaryStatsParamSchema = z.object({ org: z.string() })
+  const apiInsightsGetSummaryStatsParamSchema = z.object({org: z.string()})
 
   const apiInsightsGetSummaryStatsQuerySchema = z.object({
     min_timestamp: z.string(),
@@ -41831,7 +41807,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41907,7 +41883,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41990,7 +41966,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42013,7 +41989,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const apiInsightsGetTimeStatsParamSchema = z.object({ org: z.string() })
+  const apiInsightsGetTimeStatsParamSchema = z.object({org: z.string()})
 
   const apiInsightsGetTimeStatsQuerySchema = z.object({
     min_timestamp: z.string(),
@@ -42064,7 +42040,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42136,7 +42112,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42217,7 +42193,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42310,7 +42286,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42328,7 +42304,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsGetOrgInstallationParamSchema = z.object({ org: z.string() })
+  const appsGetOrgInstallationParamSchema = z.object({org: z.string()})
 
   const appsGetOrgInstallationResponseBodyValidator = responseValidationFactory(
     [["200", s_installation]],
@@ -42371,7 +42347,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42389,7 +42365,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListAppInstallationsParamSchema = z.object({ org: z.string() })
+  const orgsListAppInstallationsParamSchema = z.object({org: z.string()})
 
   const orgsListAppInstallationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -42453,7 +42429,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42519,7 +42495,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42600,7 +42576,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42672,7 +42648,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42695,7 +42671,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListPendingInvitationsParamSchema = z.object({ org: z.string() })
+  const orgsListPendingInvitationsParamSchema = z.object({org: z.string()})
 
   const orgsListPendingInvitationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -42768,7 +42744,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42788,7 +42764,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsCreateInvitationParamSchema = z.object({ org: z.string() })
+  const orgsCreateInvitationParamSchema = z.object({org: z.string()})
 
   const orgsCreateInvitationRequestBodySchema = z
     .object({
@@ -42857,7 +42833,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42931,7 +42907,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43011,7 +42987,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43029,7 +43005,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListIssueTypesParamSchema = z.object({ org: z.string() })
+  const orgsListIssueTypesParamSchema = z.object({org: z.string()})
 
   const orgsListIssueTypesResponseBodyValidator = responseValidationFactory(
     [
@@ -43078,7 +43054,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43096,7 +43072,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsCreateIssueTypeParamSchema = z.object({ org: z.string() })
+  const orgsCreateIssueTypeParamSchema = z.object({org: z.string()})
 
   const orgsCreateIssueTypeRequestBodySchema = s_organization_create_issue_type
 
@@ -43155,7 +43131,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43235,7 +43211,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43309,7 +43285,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43327,7 +43303,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const issuesListForOrgParamSchema = z.object({ org: z.string() })
+  const issuesListForOrgParamSchema = z.object({org: z.string()})
 
   const issuesListForOrgQuerySchema = z.object({
     filter: z
@@ -43342,7 +43318,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -43398,7 +43374,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43416,7 +43392,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListMembersParamSchema = z.object({ org: z.string() })
+  const orgsListMembersParamSchema = z.object({org: z.string()})
 
   const orgsListMembersQuerySchema = z.object({
     filter: z
@@ -43479,7 +43455,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43554,7 +43530,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43626,7 +43602,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43731,7 +43707,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43826,7 +43802,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43916,7 +43892,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44005,7 +43981,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44085,7 +44061,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44109,7 +44085,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const orgsSetMembershipForUserRequestBodySchema = z
-    .object({ role: z.enum(["admin", "member"]).optional().default("member") })
+    .object({role: z.enum(["admin", "member"]).optional().default("member")})
     .optional()
 
   const orgsSetMembershipForUserResponseBodyValidator =
@@ -44168,7 +44144,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44243,7 +44219,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44263,7 +44239,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const migrationsListForOrgParamSchema = z.object({ org: z.string() })
+  const migrationsListForOrgParamSchema = z.object({org: z.string()})
 
   const migrationsListForOrgQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -44321,7 +44297,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44339,7 +44315,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const migrationsStartForOrgParamSchema = z.object({ org: z.string() })
+  const migrationsStartForOrgParamSchema = z.object({org: z.string()})
 
   const migrationsStartForOrgRequestBodySchema = z.object({
     repositories: z.array(z.string()),
@@ -44408,7 +44384,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44492,7 +44468,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44563,7 +44539,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44636,7 +44612,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44710,7 +44686,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44792,7 +44768,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44810,7 +44786,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListOrgRolesParamSchema = z.object({ org: z.string() })
+  const orgsListOrgRolesParamSchema = z.object({org: z.string()})
 
   const orgsListOrgRolesResponseBodyValidator = responseValidationFactory(
     [
@@ -44872,7 +44848,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -44934,7 +44910,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45010,7 +44986,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45075,7 +45051,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45137,7 +45113,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45213,7 +45189,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45278,7 +45254,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45352,7 +45328,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45435,7 +45411,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45518,7 +45494,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45536,7 +45512,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListOutsideCollaboratorsParamSchema = z.object({ org: z.string() })
+  const orgsListOutsideCollaboratorsParamSchema = z.object({org: z.string()})
 
   const orgsListOutsideCollaboratorsQuerySchema = z.object({
     filter: z
@@ -45590,7 +45566,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45616,7 +45592,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const orgsConvertMemberToOutsideCollaboratorRequestBodySchema = z
-    .object({ async: PermissiveBoolean.optional().default(false) })
+    .object({async: PermissiveBoolean.optional().default(false)})
     .optional()
 
   const orgsConvertMemberToOutsideCollaboratorResponseBodyValidator =
@@ -45685,7 +45661,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45770,7 +45746,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45868,7 +45844,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45943,7 +45919,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46035,7 +46011,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46132,7 +46108,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46241,7 +46217,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46323,7 +46299,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46416,7 +46392,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46509,7 +46485,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46532,7 +46508,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListPatGrantRequestsParamSchema = z.object({ org: z.string() })
+  const orgsListPatGrantRequestsParamSchema = z.object({org: z.string()})
 
   const orgsListPatGrantRequestsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -46547,8 +46523,8 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
     repository: z.string().optional(),
     permission: z.string().optional(),
-    last_used_before: z.string().datetime({ offset: true }).optional(),
-    last_used_after: z.string().datetime({ offset: true }).optional(),
+    last_used_before: z.string().datetime({offset: true}).optional(),
+    last_used_after: z.string().datetime({offset: true}).optional(),
     token_id: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
@@ -46623,7 +46599,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46717,7 +46693,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46811,7 +46787,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46899,7 +46875,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46922,7 +46898,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListPatGrantsParamSchema = z.object({ org: z.string() })
+  const orgsListPatGrantsParamSchema = z.object({org: z.string()})
 
   const orgsListPatGrantsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -46937,8 +46913,8 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
     repository: z.string().optional(),
     permission: z.string().optional(),
-    last_used_before: z.string().datetime({ offset: true }).optional(),
-    last_used_after: z.string().datetime({ offset: true }).optional(),
+    last_used_before: z.string().datetime({offset: true}).optional(),
+    last_used_after: z.string().datetime({offset: true}).optional(),
     token_id: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
@@ -47012,7 +46988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47030,7 +47006,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsUpdatePatAccessesParamSchema = z.object({ org: z.string() })
+  const orgsUpdatePatAccessesParamSchema = z.object({org: z.string()})
 
   const orgsUpdatePatAccessesRequestBodySchema = z.object({
     action: z.enum(["revoke"]),
@@ -47102,7 +47078,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47192,7 +47168,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47280,7 +47256,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47380,7 +47356,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47490,7 +47466,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47520,7 +47496,7 @@ export function createRouter(implementation: Implementation): Router {
   const privateRegistriesGetOrgPublicKeyResponseBodyValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ key_id: z.string(), key: z.string() })],
+        ["200", z.object({key_id: z.string(), key: z.string()})],
         ["404", s_basic_error],
       ],
       undefined,
@@ -47568,7 +47544,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47649,7 +47625,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47758,7 +47734,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47844,7 +47820,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47867,7 +47843,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsListForOrgParamSchema = z.object({ org: z.string() })
+  const projectsListForOrgParamSchema = z.object({org: z.string()})
 
   const projectsListForOrgQuerySchema = z.object({
     state: z.enum(["open", "closed", "all"]).optional().default("open"),
@@ -47926,7 +47902,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47944,7 +47920,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsCreateForOrgParamSchema = z.object({ org: z.string() })
+  const projectsCreateForOrgParamSchema = z.object({org: z.string()})
 
   const projectsCreateForOrgRequestBodySchema = z.object({
     name: z.string(),
@@ -48018,7 +47994,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48036,7 +48012,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsGetAllCustomPropertiesParamSchema = z.object({ org: z.string() })
+  const orgsGetAllCustomPropertiesParamSchema = z.object({org: z.string()})
 
   const orgsGetAllCustomPropertiesResponseBodyValidator =
     responseValidationFactory(
@@ -48090,7 +48066,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48174,7 +48150,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48253,7 +48229,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48335,7 +48311,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48412,7 +48388,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48504,7 +48480,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48603,7 +48579,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48626,7 +48602,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListPublicMembersParamSchema = z.object({ org: z.string() })
+  const orgsListPublicMembersParamSchema = z.object({org: z.string()})
 
   const orgsListPublicMembersQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -48678,7 +48654,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48749,7 +48725,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48828,7 +48804,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48901,7 +48877,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48924,7 +48900,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposListForOrgParamSchema = z.object({ org: z.string() })
+  const reposListForOrgParamSchema = z.object({org: z.string()})
 
   const reposListForOrgQuerySchema = z.object({
     type: z
@@ -48985,7 +48961,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49003,7 +48979,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposCreateInOrgParamSchema = z.object({ org: z.string() })
+  const reposCreateInOrgParamSchema = z.object({org: z.string()})
 
   const reposCreateInOrgRequestBodySchema = z.object({
     name: z.string(),
@@ -49092,7 +49068,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49110,7 +49086,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposGetOrgRulesetsParamSchema = z.object({ org: z.string() })
+  const reposGetOrgRulesetsParamSchema = z.object({org: z.string()})
 
   const reposGetOrgRulesetsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -49173,7 +49149,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49191,7 +49167,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposCreateOrgRulesetParamSchema = z.object({ org: z.string() })
+  const reposCreateOrgRulesetParamSchema = z.object({org: z.string()})
 
   const reposCreateOrgRulesetRequestBodySchema = z.object({
     name: z.string(),
@@ -49260,7 +49236,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49278,7 +49254,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposGetOrgRuleSuitesParamSchema = z.object({ org: z.string() })
+  const reposGetOrgRuleSuitesParamSchema = z.object({org: z.string()})
 
   const reposGetOrgRuleSuitesQuerySchema = z.object({
     ref: z.string().optional(),
@@ -49351,7 +49327,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49425,7 +49401,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49499,7 +49475,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49588,7 +49564,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49662,7 +49638,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49746,7 +49722,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49822,7 +49798,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49840,9 +49816,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const secretScanningListAlertsForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const secretScanningListAlertsForOrgParamSchema = z.object({org: z.string()})
 
   const secretScanningListAlertsForOrgQuerySchema = z.object({
     state: z.enum(["open", "resolved"]).optional(),
@@ -49929,7 +49903,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50027,7 +50001,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50050,7 +50024,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListSecurityManagerTeamsParamSchema = z.object({ org: z.string() })
+  const orgsListSecurityManagerTeamsParamSchema = z.object({org: z.string()})
 
   const orgsListSecurityManagerTeamsResponseBodyValidator =
     responseValidationFactory([["200", z.array(s_team_simple)]], undefined)
@@ -50091,7 +50065,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50155,7 +50129,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50219,7 +50193,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50282,7 +50256,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50348,7 +50322,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50414,7 +50388,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50509,7 +50483,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50592,7 +50566,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50665,7 +50639,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50749,7 +50723,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50822,7 +50796,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50895,7 +50869,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50996,7 +50970,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51016,7 +50990,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsListParamSchema = z.object({ org: z.string() })
+  const teamsListParamSchema = z.object({org: z.string()})
 
   const teamsListQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -51074,7 +51048,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51092,7 +51066,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsCreateParamSchema = z.object({ org: z.string() })
+  const teamsCreateParamSchema = z.object({org: z.string()})
 
   const teamsCreateRequestBodySchema = z.object({
     name: z.string(),
@@ -51162,7 +51136,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51232,7 +51206,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51331,7 +51305,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51395,7 +51369,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51468,7 +51442,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51540,7 +51514,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51605,7 +51579,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51630,7 +51604,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const teamsUpdateDiscussionInOrgRequestBodySchema = z
-    .object({ title: z.string().optional(), body: z.string().optional() })
+    .object({title: z.string().optional(), body: z.string().optional()})
     .optional()
 
   const teamsUpdateDiscussionInOrgResponseBodyValidator =
@@ -51676,7 +51650,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51741,7 +51715,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51819,7 +51793,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51892,7 +51866,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51961,7 +51935,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52035,7 +52009,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52104,7 +52078,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52200,7 +52174,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52302,7 +52276,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52378,7 +52352,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52467,7 +52441,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52567,7 +52541,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52636,7 +52610,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52712,7 +52686,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52788,7 +52762,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52860,7 +52834,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52954,7 +52928,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53031,7 +53005,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53109,7 +53083,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53187,7 +53161,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53217,7 +53191,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const teamsAddOrUpdateProjectPermissionsInOrgRequestBodySchema = z
-    .object({ permission: z.enum(["read", "write", "admin"]).optional() })
+    .object({permission: z.enum(["read", "write", "admin"]).optional()})
     .nullable()
     .optional()
 
@@ -53288,7 +53262,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53356,7 +53330,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53429,7 +53403,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53506,7 +53480,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53537,7 +53511,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const teamsAddOrUpdateRepoPermissionsInOrgRequestBodySchema = z
-    .object({ permission: z.string().optional() })
+    .object({permission: z.string().optional()})
     .optional()
 
   const teamsAddOrUpdateRepoPermissionsInOrgResponseBodyValidator =
@@ -53589,7 +53563,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53660,7 +53634,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53733,7 +53707,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53766,7 +53740,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const orgsEnableOrDisableSecurityProductOnAllOrgReposRequestBodySchema = z
-    .object({ query_suite: z.enum(["default", "extended"]).optional() })
+    .object({query_suite: z.enum(["default", "extended"]).optional()})
     .optional()
 
   const orgsEnableOrDisableSecurityProductOnAllOrgReposResponseBodyValidator =
@@ -53827,7 +53801,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53850,7 +53824,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsGetCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsGetCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsGetCardResponseBodyValidator = responseValidationFactory(
     [
@@ -53911,7 +53885,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53929,7 +53903,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsUpdateCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsUpdateCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsUpdateCardRequestBodySchema = z
     .object({
@@ -54005,7 +53979,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54023,7 +53997,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsDeleteCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsDeleteCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsDeleteCardResponseBodyValidator = responseValidationFactory(
     [
@@ -54095,7 +54069,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54113,7 +54087,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsMoveCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsMoveCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsMoveCardRequestBodySchema = z.object({
     position: z.string().regex(new RegExp("^(?:top|bottom|after:\\d+)$")),
@@ -54239,7 +54213,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54257,9 +54231,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsGetColumnParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsGetColumnParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsGetColumnResponseBodyValidator = responseValidationFactory(
     [
@@ -54320,7 +54292,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54342,7 +54314,7 @@ export function createRouter(implementation: Implementation): Router {
     column_id: z.coerce.number(),
   })
 
-  const projectsUpdateColumnRequestBodySchema = z.object({ name: z.string() })
+  const projectsUpdateColumnRequestBodySchema = z.object({name: z.string()})
 
   const projectsUpdateColumnResponseBodyValidator = responseValidationFactory(
     [
@@ -54403,7 +54375,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54480,7 +54452,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54498,9 +54470,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsListCardsParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsListCardsParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsListCardsQuerySchema = z.object({
     archived_state: z
@@ -54570,7 +54540,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54588,13 +54558,11 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsCreateCardParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsCreateCardParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsCreateCardRequestBodySchema = z.union([
-    z.object({ note: z.string().nullable() }),
-    z.object({ content_id: z.coerce.number(), content_type: z.string() }),
+    z.object({note: z.string().nullable()}),
+    z.object({content_id: z.coerce.number(), content_type: z.string()}),
   ])
 
   const projectsCreateCardResponseBodyValidator = responseValidationFactory(
@@ -54691,7 +54659,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54709,9 +54677,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsMoveColumnParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsMoveColumnParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsMoveColumnRequestBodySchema = z.object({
     position: z.string().regex(new RegExp("^(?:first|last|after:\\d+)$")),
@@ -54780,7 +54746,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54798,7 +54764,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsGetParamSchema = z.object({ project_id: z.coerce.number() })
+  const projectsGetParamSchema = z.object({project_id: z.coerce.number()})
 
   const projectsGetResponseBodyValidator = responseValidationFactory(
     [
@@ -54855,7 +54821,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54873,7 +54839,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsUpdateParamSchema = z.object({ project_id: z.coerce.number() })
+  const projectsUpdateParamSchema = z.object({project_id: z.coerce.number()})
 
   const projectsUpdateRequestBodySchema = z
     .object({
@@ -54969,7 +54935,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54987,7 +54953,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsDeleteParamSchema = z.object({ project_id: z.coerce.number() })
+  const projectsDeleteParamSchema = z.object({project_id: z.coerce.number()})
 
   const projectsDeleteResponseBodyValidator = responseValidationFactory(
     [
@@ -55063,7 +55029,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55159,7 +55125,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55260,7 +55226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55347,7 +55313,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55438,7 +55404,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55526,7 +55492,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55548,7 +55514,7 @@ export function createRouter(implementation: Implementation): Router {
     project_id: z.coerce.number(),
   })
 
-  const projectsCreateColumnRequestBodySchema = z.object({ name: z.string() })
+  const projectsCreateColumnRequestBodySchema = z.object({name: z.string()})
 
   const projectsCreateColumnResponseBodyValidator = responseValidationFactory(
     [
@@ -55613,7 +55579,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55678,7 +55644,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55696,7 +55662,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposGetParamSchema = z.object({ owner: z.string(), repo: z.string() })
+  const reposGetParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposGetResponseBodyValidator = responseValidationFactory(
     [
@@ -55753,7 +55719,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55771,10 +55737,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposUpdateParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const reposUpdateParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposUpdateRequestBodySchema = z
     .object({
@@ -55786,20 +55749,18 @@ export function createRouter(implementation: Implementation): Router {
       security_and_analysis: z
         .object({
           advanced_security: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
-          code_security: z.object({ status: z.string().optional() }).optional(),
-          secret_scanning: z
-            .object({ status: z.string().optional() })
-            .optional(),
+          code_security: z.object({status: z.string().optional()}).optional(),
+          secret_scanning: z.object({status: z.string().optional()}).optional(),
           secret_scanning_push_protection: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
           secret_scanning_ai_detection: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
           secret_scanning_non_provider_patterns: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
         })
         .nullable()
@@ -55894,7 +55855,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55912,10 +55873,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposDeleteParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const reposDeleteParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposDeleteResponseBodyValidator = responseValidationFactory(
     [
@@ -55985,7 +55943,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56071,7 +56029,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56138,7 +56096,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56203,7 +56161,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56276,7 +56234,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56343,7 +56301,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56423,7 +56381,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56496,7 +56454,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56561,7 +56519,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56626,7 +56584,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56697,7 +56655,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56727,9 +56685,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsReRunJobForWorkflowRunRequestBodySchema = z
-    .object({
-      enable_debug_logging: PermissiveBoolean.optional().default(false),
-    })
+    .object({enable_debug_logging: PermissiveBoolean.optional().default(false)})
     .nullable()
     .optional()
 
@@ -56785,7 +56741,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56862,7 +56818,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56955,7 +56911,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57045,7 +57001,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57141,7 +57097,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57219,7 +57175,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57302,7 +57258,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57380,7 +57336,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57460,7 +57416,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57527,7 +57483,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57601,7 +57557,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57625,7 +57581,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsRepositoryResponseBodyValidator =
     responseValidationFactory(
@@ -57677,7 +57633,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57701,7 +57657,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryRequestBodySchema =
     s_actions_set_default_workflow_permissions
@@ -57764,7 +57720,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57855,7 +57811,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57931,7 +57887,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57969,7 +57925,7 @@ export function createRouter(implementation: Implementation): Router {
   const actionsGenerateRunnerJitconfigForRepoResponseBodyValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ runner: s_runner, encoded_jit_config: z.string() })],
+        ["201", z.object({runner: s_runner, encoded_jit_config: z.string()})],
         ["404", s_basic_error],
         ["409", s_basic_error],
         ["422", s_validation_error_simple],
@@ -58035,7 +57991,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58108,7 +58064,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58175,7 +58131,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58240,7 +58196,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58323,7 +58279,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58415,7 +58371,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58445,7 +58401,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsAddCustomLabelsToSelfHostedRunnerForRepoRequestBodySchema =
-    z.object({ labels: z.array(z.string()).min(1).max(100) })
+    z.object({labels: z.array(z.string()).min(1).max(100)})
 
   const actionsAddCustomLabelsToSelfHostedRunnerForRepoResponseBodyValidator =
     responseValidationFactory(
@@ -58518,7 +58474,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58548,7 +58504,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsSetCustomLabelsForSelfHostedRunnerForRepoRequestBodySchema =
-    z.object({ labels: z.array(z.string()).min(0).max(100) })
+    z.object({labels: z.array(z.string()).min(0).max(100)})
 
   const actionsSetCustomLabelsForSelfHostedRunnerForRepoResponseBodyValidator =
     responseValidationFactory(
@@ -58621,7 +58577,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58714,7 +58670,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58812,7 +58768,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58864,7 +58820,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    created: z.string().datetime({ offset: true }).optional(),
+    created: z.string().datetime({offset: true}).optional(),
     exclude_pull_requests: PermissiveBoolean.optional().default(false),
     check_suite_id: z.coerce.number().optional(),
     head_sha: z.string().optional(),
@@ -58927,7 +58883,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59002,7 +58958,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59065,7 +59021,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59131,7 +59087,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59207,7 +59163,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59294,7 +59250,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59368,7 +59324,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59405,7 +59361,7 @@ export function createRouter(implementation: Implementation): Router {
       [
         [
           "200",
-          z.object({ total_count: z.coerce.number(), jobs: z.array(s_job) }),
+          z.object({total_count: z.coerce.number(), jobs: z.array(s_job)}),
         ],
         ["404", s_basic_error],
       ],
@@ -59464,7 +59420,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59539,7 +59495,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59616,7 +59572,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59688,7 +59644,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59762,7 +59718,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59799,7 +59755,7 @@ export function createRouter(implementation: Implementation): Router {
       [
         [
           "200",
-          z.object({ total_count: z.coerce.number(), jobs: z.array(s_job) }),
+          z.object({total_count: z.coerce.number(), jobs: z.array(s_job)}),
         ],
       ],
       undefined,
@@ -59848,7 +59804,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59913,7 +59869,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59991,7 +59947,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60059,7 +60015,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60143,7 +60099,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60173,9 +60129,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsReRunWorkflowRequestBodySchema = z
-    .object({
-      enable_debug_logging: PermissiveBoolean.optional().default(false),
-    })
+    .object({enable_debug_logging: PermissiveBoolean.optional().default(false)})
     .nullable()
     .optional()
 
@@ -60224,7 +60178,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60249,9 +60203,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const actionsReRunWorkflowFailedJobsRequestBodySchema = z
-    .object({
-      enable_debug_logging: PermissiveBoolean.optional().default(false),
-    })
+    .object({enable_debug_logging: PermissiveBoolean.optional().default(false)})
     .nullable()
     .optional()
 
@@ -60298,7 +60250,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60363,7 +60315,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60449,7 +60401,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60511,7 +60463,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60576,7 +60528,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60663,7 +60615,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60728,7 +60680,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60813,7 +60765,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60884,7 +60836,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60949,7 +60901,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61021,7 +60973,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61084,7 +61036,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61169,7 +61121,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61234,7 +61186,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61299,7 +61251,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61371,7 +61323,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61438,7 +61390,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61486,7 +61438,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    created: z.string().datetime({ offset: true }).optional(),
+    created: z.string().datetime({offset: true}).optional(),
     exclude_pull_requests: PermissiveBoolean.optional().default(false),
     check_suite_id: z.coerce.number().optional(),
     head_sha: z.string().optional(),
@@ -61549,7 +61501,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61612,7 +61564,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61706,7 +61658,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61785,7 +61737,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61857,7 +61809,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61892,7 +61844,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const reposCreateAttestationResponseBodyValidator = responseValidationFactory(
     [
-      ["201", z.object({ id: z.coerce.number().optional() })],
+      ["201", z.object({id: z.coerce.number().optional()})],
       ["403", s_basic_error],
       ["422", s_validation_error],
     ],
@@ -61947,7 +61899,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62066,7 +62018,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62130,7 +62082,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62210,7 +62162,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62281,7 +62233,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62352,7 +62304,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62425,7 +62377,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62489,7 +62441,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62556,7 +62508,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62641,7 +62593,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62716,7 +62668,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62788,7 +62740,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62926,7 +62878,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63000,7 +62952,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63070,7 +63022,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63140,7 +63092,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63214,7 +63166,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63284,7 +63236,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63396,7 +63348,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63479,7 +63431,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63558,7 +63510,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63643,7 +63595,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63726,7 +63678,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63803,7 +63755,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63835,10 +63787,7 @@ export function createRouter(implementation: Implementation): Router {
       contexts: z.array(z.string()).optional(),
       checks: z
         .array(
-          z.object({
-            context: z.string(),
-            app_id: z.coerce.number().optional(),
-          }),
+          z.object({context: z.string(), app_id: z.coerce.number().optional()}),
         )
         .optional(),
     })
@@ -63900,7 +63849,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63965,7 +63914,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64039,7 +63988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64066,7 +64015,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposAddStatusCheckContextsRequestBodySchema = z
-    .union([z.object({ contexts: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({contexts: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposAddStatusCheckContextsResponseBodyValidator =
@@ -64129,7 +64078,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64156,7 +64105,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposSetStatusCheckContextsRequestBodySchema = z
-    .union([z.object({ contexts: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({contexts: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposSetStatusCheckContextsResponseBodyValidator =
@@ -64215,7 +64164,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64242,7 +64191,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposRemoveStatusCheckContextsRequestBodySchema = z.union([
-    z.object({ contexts: z.array(z.string()) }),
+    z.object({contexts: z.array(z.string())}),
     z.array(z.string()),
   ])
 
@@ -64302,7 +64251,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64376,7 +64325,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64441,7 +64390,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64521,7 +64470,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64606,7 +64555,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64688,7 +64637,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64770,7 +64719,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64850,7 +64799,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64880,7 +64829,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposAddTeamAccessRestrictionsRequestBodySchema = z
-    .union([z.object({ teams: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({teams: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposAddTeamAccessRestrictionsResponseBodyValidator =
@@ -64935,7 +64884,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64962,7 +64911,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposSetTeamAccessRestrictionsRequestBodySchema = z
-    .union([z.object({ teams: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({teams: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposSetTeamAccessRestrictionsResponseBodyValidator =
@@ -65017,7 +64966,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65044,7 +64993,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposRemoveTeamAccessRestrictionsRequestBodySchema = z.union([
-    z.object({ teams: z.array(z.string()) }),
+    z.object({teams: z.array(z.string())}),
     z.array(z.string()),
   ])
 
@@ -65100,7 +65049,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65183,7 +65132,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65268,7 +65217,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65350,7 +65299,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65432,7 +65381,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65461,7 +65410,7 @@ export function createRouter(implementation: Implementation): Router {
     branch: z.string(),
   })
 
-  const reposRenameBranchRequestBodySchema = z.object({ new_name: z.string() })
+  const reposRenameBranchRequestBodySchema = z.object({new_name: z.string()})
 
   const reposRenameBranchResponseBodyValidator = responseValidationFactory(
     [
@@ -65522,7 +65471,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65546,9 +65495,9 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const checksCreateRequestBodySchema = z.union([
-    z.intersection(z.object({ status: z.object({}) }), z.record(z.unknown())),
+    z.intersection(z.object({status: z.object({})}), z.record(z.unknown())),
     z.intersection(
-      z.object({ status: z.object({}).optional() }),
+      z.object({status: z.object({}).optional()}),
       z.record(z.unknown()),
     ),
   ])
@@ -65598,7 +65547,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65663,7 +65612,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65691,7 +65640,7 @@ export function createRouter(implementation: Implementation): Router {
     name: z.string().optional(),
     details_url: z.string().optional(),
     external_id: z.string().optional(),
-    started_at: z.string().datetime({ offset: true }).optional(),
+    started_at: z.string().datetime({offset: true}).optional(),
     status: z
       .enum([
         "queued",
@@ -65714,7 +65663,7 @@ export function createRouter(implementation: Implementation): Router {
         "timed_out",
       ])
       .optional(),
-    completed_at: z.string().datetime({ offset: true }).optional(),
+    completed_at: z.string().datetime({offset: true}).optional(),
     output: z
       .object({
         title: z.string().optional(),
@@ -65804,7 +65753,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65878,7 +65827,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65957,7 +65906,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65980,7 +65929,7 @@ export function createRouter(implementation: Implementation): Router {
     repo: z.string(),
   })
 
-  const checksCreateSuiteRequestBodySchema = z.object({ head_sha: z.string() })
+  const checksCreateSuiteRequestBodySchema = z.object({head_sha: z.string()})
 
   const checksCreateSuiteResponseBodyValidator = responseValidationFactory(
     [
@@ -66033,7 +65982,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66110,7 +66059,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66177,7 +66126,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66265,7 +66214,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66330,7 +66279,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66445,7 +66394,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66541,7 +66490,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66647,7 +66596,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66741,7 +66690,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66844,7 +66793,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66952,7 +66901,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67056,7 +67005,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67164,7 +67113,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67263,7 +67212,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67368,7 +67317,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67462,7 +67411,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67561,7 +67510,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67654,7 +67603,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67758,7 +67707,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67852,7 +67801,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67951,7 +67900,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68048,7 +67997,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68161,7 +68110,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68191,7 +68140,7 @@ export function createRouter(implementation: Implementation): Router {
     ref: s_code_scanning_ref_full,
     sarif: s_code_scanning_analysis_sarif_file,
     checkout_uri: z.string().optional(),
-    started_at: z.string().datetime({ offset: true }).optional(),
+    started_at: z.string().datetime({offset: true}).optional(),
     tool_name: z.string().optional(),
     validate: PermissiveBoolean.optional(),
   })
@@ -68277,7 +68226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68369,7 +68318,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68460,7 +68409,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68543,7 +68492,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68650,7 +68599,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68785,7 +68734,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68809,7 +68758,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codespacesListDevcontainersInRepositoryForAuthenticatedUserParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const codespacesListDevcontainersInRepositoryForAuthenticatedUserQuerySchema =
     z.object({
@@ -68910,7 +68859,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69027,7 +68976,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69145,7 +69094,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69265,7 +69214,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69355,7 +69304,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69417,7 +69366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69482,7 +69431,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69570,7 +69519,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69638,7 +69587,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69723,7 +69672,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69794,7 +69743,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69819,7 +69768,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const reposAddCollaboratorRequestBodySchema = z
-    .object({ permission: z.string().optional().default("push") })
+    .object({permission: z.string().optional().default("push")})
     .optional()
 
   const reposAddCollaboratorResponseBodyValidator = responseValidationFactory(
@@ -69881,7 +69830,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69957,7 +69906,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70031,7 +69980,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70107,7 +70056,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70180,7 +70129,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70204,9 +70153,7 @@ export function createRouter(implementation: Implementation): Router {
     comment_id: z.coerce.number(),
   })
 
-  const reposUpdateCommitCommentRequestBodySchema = z.object({
-    body: z.string(),
-  })
+  const reposUpdateCommitCommentRequestBodySchema = z.object({body: z.string()})
 
   const reposUpdateCommitCommentResponseBodyValidator =
     responseValidationFactory(
@@ -70260,7 +70207,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70332,7 +70279,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70425,7 +70372,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70520,7 +70467,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70586,7 +70533,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70616,8 +70563,8 @@ export function createRouter(implementation: Implementation): Router {
     path: z.string().optional(),
     author: z.string().optional(),
     committer: z.string().optional(),
-    since: z.string().datetime({ offset: true }).optional(),
-    until: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
+    until: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -70685,7 +70632,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70761,7 +70708,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70835,7 +70782,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70924,7 +70871,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71011,7 +70958,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71123,7 +71070,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71212,7 +71159,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71299,7 +71246,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71380,7 +71327,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71463,7 +71410,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71527,7 +71474,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71628,7 +71575,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71652,7 +71599,7 @@ export function createRouter(implementation: Implementation): Router {
     path: z.string(),
   })
 
-  const reposGetContentQuerySchema = z.object({ ref: z.string().optional() })
+  const reposGetContentQuerySchema = z.object({ref: z.string().optional()})
 
   const reposGetContentResponseBodyValidator = responseValidationFactory(
     [
@@ -71730,7 +71677,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71841,7 +71788,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71872,10 +71819,10 @@ export function createRouter(implementation: Implementation): Router {
     sha: z.string(),
     branch: z.string().optional(),
     committer: z
-      .object({ name: z.string().optional(), email: z.string().optional() })
+      .object({name: z.string().optional(), email: z.string().optional()})
       .optional(),
     author: z
-      .object({ name: z.string().optional(), email: z.string().optional() })
+      .object({name: z.string().optional(), email: z.string().optional()})
       .optional(),
   })
 
@@ -71953,7 +71900,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72041,7 +71988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72154,7 +72101,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72235,7 +72182,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72340,7 +72287,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72425,7 +72372,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72487,7 +72434,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72552,7 +72499,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72640,7 +72587,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72708,7 +72655,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72794,7 +72741,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72869,7 +72816,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72961,7 +72908,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73043,7 +72990,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73083,7 +73030,7 @@ export function createRouter(implementation: Implementation): Router {
   const reposCreateDeploymentResponseBodyValidator = responseValidationFactory(
     [
       ["201", s_deployment],
-      ["202", z.object({ message: z.string().optional() })],
+      ["202", z.object({message: z.string().optional()})],
       ["409", z.undefined()],
       ["422", s_validation_error],
     ],
@@ -73141,7 +73088,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73212,7 +73159,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73287,7 +73234,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73368,7 +73315,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73464,7 +73411,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73539,7 +73486,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73623,7 +73570,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73708,7 +73655,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73773,7 +73720,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73867,7 +73814,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73932,7 +73879,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74018,7 +73965,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74106,7 +74053,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74175,7 +74122,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74248,7 +74195,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74317,7 +74264,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74409,7 +74356,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74488,7 +74435,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74589,7 +74536,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74667,7 +74614,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74742,7 +74689,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74833,7 +74780,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74898,7 +74845,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74964,7 +74911,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75060,7 +75007,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75129,7 +75076,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75217,7 +75164,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75291,7 +75238,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75357,7 +75304,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75432,7 +75379,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75498,7 +75445,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75573,7 +75520,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75656,7 +75603,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75751,7 +75698,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75844,7 +75791,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75927,7 +75874,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75958,14 +75905,14 @@ export function createRouter(implementation: Implementation): Router {
       .object({
         name: z.string(),
         email: z.string(),
-        date: z.string().datetime({ offset: true }).optional(),
+        date: z.string().datetime({offset: true}).optional(),
       })
       .optional(),
     committer: z
       .object({
         name: z.string().optional(),
         email: z.string().optional(),
-        date: z.string().datetime({ offset: true }).optional(),
+        date: z.string().datetime({offset: true}).optional(),
       })
       .optional(),
     signature: z.string().optional(),
@@ -76030,7 +75977,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76105,7 +76052,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76176,7 +76123,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76251,7 +76198,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76334,7 +76281,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76418,7 +76365,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76493,7 +76440,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76525,7 +76472,7 @@ export function createRouter(implementation: Implementation): Router {
       .object({
         name: z.string(),
         email: z.string(),
-        date: z.string().datetime({ offset: true }).optional(),
+        date: z.string().datetime({offset: true}).optional(),
       })
       .optional(),
   })
@@ -76585,7 +76532,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76660,7 +76607,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76761,7 +76708,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76785,7 +76732,7 @@ export function createRouter(implementation: Implementation): Router {
     tree_sha: z.string(),
   })
 
-  const gitGetTreeQuerySchema = z.object({ recursive: z.string().optional() })
+  const gitGetTreeQuerySchema = z.object({recursive: z.string().optional()})
 
   const gitGetTreeResponseBodyValidator = responseValidationFactory(
     [
@@ -76846,7 +76793,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76925,7 +76872,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77024,7 +76971,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77095,7 +77042,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77182,7 +77129,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77253,7 +77200,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77316,7 +77263,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77394,7 +77341,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77481,7 +77428,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77560,7 +77507,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77639,7 +77586,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77712,7 +77659,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77783,7 +77730,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77858,7 +77805,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77948,7 +77895,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78032,7 +77979,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78102,7 +78049,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78185,7 +78132,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78212,7 +78159,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const migrationsMapCommitAuthorRequestBodySchema = z
-    .object({ email: z.string().optional(), name: z.string().optional() })
+    .object({email: z.string().optional(), name: z.string().optional()})
     .optional()
 
   const migrationsMapCommitAuthorResponseBodyValidator =
@@ -78275,7 +78222,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78346,7 +78293,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78429,7 +78376,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78506,7 +78453,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78573,7 +78520,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78656,7 +78603,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78738,7 +78685,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78816,7 +78763,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78893,7 +78840,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78958,7 +78905,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78994,7 +78941,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -79058,7 +79005,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79185,7 +79132,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79211,7 +79158,7 @@ export function createRouter(implementation: Implementation): Router {
   const issuesListCommentsForRepoQuerySchema = z.object({
     sort: z.enum(["created", "updated"]).optional().default("created"),
     direction: z.enum(["asc", "desc"]).optional(),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -79272,7 +79219,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79343,7 +79290,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79367,7 +79314,7 @@ export function createRouter(implementation: Implementation): Router {
     comment_id: z.coerce.number(),
   })
 
-  const issuesUpdateCommentRequestBodySchema = z.object({ body: z.string() })
+  const issuesUpdateCommentRequestBodySchema = z.object({body: z.string()})
 
   const issuesUpdateCommentResponseBodyValidator = responseValidationFactory(
     [
@@ -79420,7 +79367,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79485,7 +79432,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79578,7 +79525,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79673,7 +79620,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79739,7 +79686,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79821,7 +79768,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79900,7 +79847,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79983,7 +79930,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80118,7 +80065,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80143,7 +80090,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const issuesAddAssigneesRequestBodySchema = z
-    .object({ assignees: z.array(z.string()).optional() })
+    .object({assignees: z.array(z.string()).optional()})
     .optional()
 
   const issuesAddAssigneesResponseBodyValidator = responseValidationFactory(
@@ -80191,7 +80138,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80264,7 +80211,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80337,7 +80284,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80367,7 +80314,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const issuesListCommentsQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -80427,7 +80374,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80451,7 +80398,7 @@ export function createRouter(implementation: Implementation): Router {
     issue_number: z.coerce.number(),
   })
 
-  const issuesCreateCommentRequestBodySchema = z.object({ body: z.string() })
+  const issuesCreateCommentRequestBodySchema = z.object({body: z.string()})
 
   const issuesCreateCommentResponseBodyValidator = responseValidationFactory(
     [
@@ -80516,7 +80463,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80596,7 +80543,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80685,7 +80632,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80711,15 +80658,15 @@ export function createRouter(implementation: Implementation): Router {
 
   const issuesAddLabelsRequestBodySchema = z
     .union([
-      z.object({ labels: z.array(z.string()).min(1).optional() }),
+      z.object({labels: z.array(z.string()).min(1).optional()}),
       z.array(z.string()).min(1),
       z.object({
         labels: z
-          .array(z.object({ name: z.string() }))
+          .array(z.object({name: z.string()}))
           .min(1)
           .optional(),
       }),
-      z.array(z.object({ name: z.string() })).min(1),
+      z.array(z.object({name: z.string()})).min(1),
       z.string(),
     ])
     .optional()
@@ -80787,7 +80734,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80813,15 +80760,15 @@ export function createRouter(implementation: Implementation): Router {
 
   const issuesSetLabelsRequestBodySchema = z
     .union([
-      z.object({ labels: z.array(z.string()).min(1).optional() }),
+      z.object({labels: z.array(z.string()).min(1).optional()}),
       z.array(z.string()).min(1),
       z.object({
         labels: z
-          .array(z.object({ name: z.string() }))
+          .array(z.object({name: z.string()}))
           .min(1)
           .optional(),
       }),
-      z.array(z.object({ name: z.string() })).min(1),
+      z.array(z.object({name: z.string()})).min(1),
       z.string(),
     ])
     .optional()
@@ -80889,7 +80836,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80968,7 +80915,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81048,7 +80995,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81144,7 +81091,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81219,7 +81166,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81315,7 +81262,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81408,7 +81355,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81472,7 +81419,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81555,7 +81502,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81639,7 +81586,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81731,7 +81678,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81836,7 +81783,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81923,7 +81870,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81998,7 +81945,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82078,7 +82025,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82149,7 +82096,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82214,7 +82161,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82294,7 +82241,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82378,7 +82325,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82449,7 +82396,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82526,7 +82473,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82591,7 +82538,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82655,7 +82602,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82733,7 +82680,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82756,7 +82703,7 @@ export function createRouter(implementation: Implementation): Router {
     repo: z.string(),
   })
 
-  const reposMergeUpstreamRequestBodySchema = z.object({ branch: z.string() })
+  const reposMergeUpstreamRequestBodySchema = z.object({branch: z.string()})
 
   const reposMergeUpstreamResponseBodyValidator = responseValidationFactory(
     [
@@ -82813,7 +82760,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82831,10 +82778,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposMergeParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const reposMergeParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposMergeRequestBodySchema = z.object({
     base: z.string(),
@@ -82909,7 +82853,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82991,7 +82935,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83018,7 +82962,7 @@ export function createRouter(implementation: Implementation): Router {
     title: z.string(),
     state: z.enum(["open", "closed"]).optional().default("open"),
     description: z.string().optional(),
-    due_on: z.string().datetime({ offset: true }).optional(),
+    due_on: z.string().datetime({offset: true}).optional(),
   })
 
   const issuesCreateMilestoneResponseBodyValidator = responseValidationFactory(
@@ -83076,7 +83020,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83147,7 +83091,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83176,7 +83120,7 @@ export function createRouter(implementation: Implementation): Router {
       title: z.string().optional(),
       state: z.enum(["open", "closed"]).optional().default("open"),
       description: z.string().optional(),
-      due_on: z.string().datetime({ offset: true }).optional(),
+      due_on: z.string().datetime({offset: true}).optional(),
     })
     .optional()
 
@@ -83225,7 +83169,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83296,7 +83240,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83368,7 +83312,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83389,15 +83333,15 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const activityListRepoNotificationsForAuthenticatedUserParamSchema = z.object(
-    { owner: z.string(), repo: z.string() },
+    {owner: z.string(), repo: z.string()},
   )
 
   const activityListRepoNotificationsForAuthenticatedUserQuerySchema = z.object(
     {
       all: PermissiveBoolean.optional().default(false),
       participating: PermissiveBoolean.optional().default(false),
-      since: z.string().datetime({ offset: true }).optional(),
-      before: z.string().datetime({ offset: true }).optional(),
+      since: z.string().datetime({offset: true}).optional(),
+      before: z.string().datetime({offset: true}).optional(),
       per_page: z.coerce.number().optional().default(30),
       page: z.coerce.number().optional().default(1),
     },
@@ -83452,7 +83396,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83481,7 +83425,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const activityMarkRepoNotificationsAsReadRequestBodySchema = z
-    .object({ last_read_at: z.string().datetime({ offset: true }).optional() })
+    .object({last_read_at: z.string().datetime({offset: true}).optional()})
     .optional()
 
   const activityMarkRepoNotificationsAsReadResponseBodyValidator =
@@ -83545,7 +83489,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83620,7 +83564,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83710,7 +83654,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83740,7 +83684,7 @@ export function createRouter(implementation: Implementation): Router {
     source: z
       .union([
         z.enum(["gh-pages", "master", "master /docs"]),
-        z.object({ branch: z.string(), path: z.enum(["/", "/docs"]) }),
+        z.object({branch: z.string(), path: z.enum(["/", "/docs"])}),
       ])
       .optional(),
   })
@@ -83811,7 +83755,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83894,7 +83838,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83967,7 +83911,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84031,7 +83975,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84093,7 +84037,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84158,7 +84102,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84249,7 +84193,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84323,7 +84267,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84395,7 +84339,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84480,7 +84424,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84506,7 +84450,7 @@ export function createRouter(implementation: Implementation): Router {
   const reposCheckPrivateVulnerabilityReportingResponseBodyValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ enabled: PermissiveBoolean })],
+        ["200", z.object({enabled: PermissiveBoolean})],
         ["422", s_scim_error],
       ],
       undefined,
@@ -84559,7 +84503,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84641,7 +84585,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84723,7 +84667,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84824,7 +84768,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84919,7 +84863,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84994,7 +84938,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85089,7 +85033,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85112,7 +85056,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const pullsListParamSchema = z.object({ owner: z.string(), repo: z.string() })
+  const pullsListParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const pullsListQuerySchema = z.object({
     state: z.enum(["open", "closed", "all"]).optional().default("open"),
@@ -85182,7 +85126,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85200,10 +85144,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const pullsCreateParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const pullsCreateParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const pullsCreateRequestBodySchema = z.object({
     title: z.string().optional(),
@@ -85271,7 +85212,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85297,7 +85238,7 @@ export function createRouter(implementation: Implementation): Router {
   const pullsListReviewCommentsForRepoQuerySchema = z.object({
     sort: z.enum(["created", "updated", "created_at"]).optional(),
     direction: z.enum(["asc", "desc"]).optional(),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -85350,7 +85291,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85425,7 +85366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85449,9 +85390,7 @@ export function createRouter(implementation: Implementation): Router {
     comment_id: z.coerce.number(),
   })
 
-  const pullsUpdateReviewCommentRequestBodySchema = z.object({
-    body: z.string(),
-  })
+  const pullsUpdateReviewCommentRequestBodySchema = z.object({body: z.string()})
 
   const pullsUpdateReviewCommentResponseBodyValidator =
     responseValidationFactory(
@@ -85501,7 +85440,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85573,7 +85512,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85672,7 +85611,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85776,7 +85715,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85851,7 +85790,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85954,7 +85893,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86043,7 +85982,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86169,7 +86108,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86201,7 +86140,7 @@ export function createRouter(implementation: Implementation): Router {
   const pullsListReviewCommentsQuerySchema = z.object({
     sort: z.enum(["created", "updated"]).optional().default("created"),
     direction: z.enum(["asc", "desc"]).optional(),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -86254,7 +86193,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86349,7 +86288,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86432,7 +86371,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86508,7 +86447,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86607,7 +86546,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86678,7 +86617,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86797,7 +86736,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86865,7 +86804,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86953,7 +86892,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87034,7 +86973,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87110,7 +87049,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87210,7 +87149,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87282,7 +87221,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87307,7 +87246,7 @@ export function createRouter(implementation: Implementation): Router {
     review_id: z.coerce.number(),
   })
 
-  const pullsUpdateReviewRequestBodySchema = z.object({ body: z.string() })
+  const pullsUpdateReviewRequestBodySchema = z.object({body: z.string()})
 
   const pullsUpdateReviewResponseBodyValidator = responseValidationFactory(
     [
@@ -87360,7 +87299,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87437,7 +87376,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87519,7 +87458,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87606,7 +87545,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87695,7 +87634,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87720,7 +87659,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const pullsUpdateBranchRequestBodySchema = z
-    .object({ expected_head_sha: z.string().optional() })
+    .object({expected_head_sha: z.string().optional()})
     .nullable()
     .optional()
 
@@ -87728,10 +87667,7 @@ export function createRouter(implementation: Implementation): Router {
     [
       [
         "202",
-        z.object({
-          message: z.string().optional(),
-          url: z.string().optional(),
-        }),
+        z.object({message: z.string().optional(), url: z.string().optional()}),
       ],
       ["403", s_basic_error],
       ["422", s_validation_error],
@@ -87788,7 +87724,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87811,7 +87747,7 @@ export function createRouter(implementation: Implementation): Router {
     repo: z.string(),
   })
 
-  const reposGetReadmeQuerySchema = z.object({ ref: z.string().optional() })
+  const reposGetReadmeQuerySchema = z.object({ref: z.string().optional()})
 
   const reposGetReadmeResponseBodyValidator = responseValidationFactory(
     [
@@ -87872,7 +87808,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87956,7 +87892,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88035,7 +87971,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88125,7 +88061,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88200,7 +88136,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88275,7 +88211,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88338,7 +88274,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88420,7 +88356,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88484,7 +88420,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88555,7 +88491,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88626,7 +88562,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88717,7 +88653,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88782,7 +88718,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88856,7 +88792,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88943,7 +88879,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89027,7 +88963,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89111,7 +89047,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89175,7 +89111,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89249,7 +89185,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89334,7 +89270,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89421,7 +89357,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89514,7 +89450,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89589,7 +89525,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89672,7 +89608,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89762,7 +89698,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89837,7 +89773,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -89922,7 +89858,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90001,7 +89937,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90109,7 +90045,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90209,7 +90145,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90314,7 +90250,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90410,7 +90346,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90526,7 +90462,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90619,7 +90555,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90718,7 +90654,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90815,7 +90751,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90839,7 +90775,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const securityAdvisoriesCreatePrivateVulnerabilityReportParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const securityAdvisoriesCreatePrivateVulnerabilityReportRequestBodySchema =
     s_private_vulnerability_report_create
@@ -90910,7 +90846,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -90997,7 +90933,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91095,7 +91031,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91119,7 +91055,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const securityAdvisoriesCreateRepositoryAdvisoryCveRequestParamSchema =
-    z.object({ owner: z.string(), repo: z.string(), ghsa_id: z.string() })
+    z.object({owner: z.string(), repo: z.string(), ghsa_id: z.string()})
 
   const securityAdvisoriesCreateRepositoryAdvisoryCveRequestResponseBodyValidator =
     responseValidationFactory(
@@ -91189,7 +91125,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91278,7 +91214,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91362,7 +91298,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91445,7 +91381,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91524,7 +91460,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91603,7 +91539,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91674,7 +91610,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91746,7 +91682,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91820,7 +91756,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91891,7 +91827,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -91968,7 +91904,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92043,7 +91979,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92107,7 +92043,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92182,7 +92118,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92256,7 +92192,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92339,7 +92275,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92415,7 +92351,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92478,7 +92414,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92559,7 +92495,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92638,7 +92574,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92720,7 +92656,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92798,7 +92734,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92868,7 +92804,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -92938,7 +92874,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93016,7 +92952,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93090,7 +93026,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93161,7 +93097,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93225,7 +93161,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93289,7 +93225,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93354,7 +93290,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93430,7 +93366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93503,7 +93439,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93610,7 +93546,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93694,7 +93630,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93817,7 +93753,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -93916,7 +93852,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94021,7 +93957,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94103,7 +94039,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94206,7 +94142,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94224,7 +94160,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsGetLegacyParamSchema = z.object({ team_id: z.coerce.number() })
+  const teamsGetLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsGetLegacyResponseBodyValidator = responseValidationFactory(
     [
@@ -94273,7 +94209,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94291,7 +94227,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsUpdateLegacyParamSchema = z.object({ team_id: z.coerce.number() })
+  const teamsUpdateLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsUpdateLegacyRequestBodySchema = z.object({
     name: z.string(),
@@ -94367,7 +94303,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94385,7 +94321,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsDeleteLegacyParamSchema = z.object({ team_id: z.coerce.number() })
+  const teamsDeleteLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsDeleteLegacyResponseBodyValidator = responseValidationFactory(
     [
@@ -94438,7 +94374,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94509,7 +94445,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94582,7 +94518,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94646,7 +94582,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94670,7 +94606,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const teamsUpdateDiscussionLegacyRequestBodySchema = z
-    .object({ title: z.string().optional(), body: z.string().optional() })
+    .object({title: z.string().optional(), body: z.string().optional()})
     .optional()
 
   const teamsUpdateDiscussionLegacyResponseBodyValidator =
@@ -94716,7 +94652,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94780,7 +94716,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94857,7 +94793,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -94932,7 +94868,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95000,7 +94936,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95073,7 +95009,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95141,7 +95077,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95236,7 +95172,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95328,7 +95264,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95422,7 +95358,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95512,7 +95448,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95590,7 +95526,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95674,7 +95610,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95744,7 +95680,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95822,7 +95758,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95893,7 +95829,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -95964,7 +95900,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96061,7 +95997,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96137,7 +96073,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96221,7 +96157,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96298,7 +96234,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96327,7 +96263,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const teamsAddOrUpdateProjectPermissionsLegacyRequestBodySchema = z
-    .object({ permission: z.enum(["read", "write", "admin"]).optional() })
+    .object({permission: z.enum(["read", "write", "admin"]).optional()})
     .optional()
 
   const teamsAddOrUpdateProjectPermissionsLegacyResponseBodyValidator =
@@ -96405,7 +96341,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96485,7 +96421,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96503,9 +96439,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsListReposLegacyParamSchema = z.object({
-    team_id: z.coerce.number(),
-  })
+  const teamsListReposLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsListReposLegacyQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -96563,7 +96497,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96639,7 +96573,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96669,7 +96603,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const teamsAddOrUpdateRepoPermissionsLegacyRequestBodySchema = z
-    .object({ permission: z.enum(["pull", "push", "admin"]).optional() })
+    .object({permission: z.enum(["pull", "push", "admin"]).optional()})
     .optional()
 
   const teamsAddOrUpdateRepoPermissionsLegacyResponseBodyValidator =
@@ -96734,7 +96668,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96804,7 +96738,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96822,9 +96756,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const teamsListChildLegacyParamSchema = z.object({
-    team_id: z.coerce.number(),
-  })
+  const teamsListChildLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsListChildLegacyQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -96890,7 +96822,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -96961,7 +96893,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97056,7 +96988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97139,7 +97071,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97162,7 +97094,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersCheckBlockedParamSchema = z.object({ username: z.string() })
+  const usersCheckBlockedParamSchema = z.object({username: z.string()})
 
   const usersCheckBlockedResponseBodyValidator = responseValidationFactory(
     [
@@ -97223,7 +97155,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97241,7 +97173,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersBlockParamSchema = z.object({ username: z.string() })
+  const usersBlockParamSchema = z.object({username: z.string()})
 
   const usersBlockResponseBodyValidator = responseValidationFactory(
     [
@@ -97306,7 +97238,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97324,7 +97256,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersUnblockParamSchema = z.object({ username: z.string() })
+  const usersUnblockParamSchema = z.object({username: z.string()})
 
   const usersUnblockResponseBodyValidator = responseValidationFactory(
     [
@@ -97385,7 +97317,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97482,7 +97414,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97619,7 +97551,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97706,7 +97638,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97773,7 +97705,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97845,7 +97777,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -97869,7 +97801,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codespacesCreateOrUpdateSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string() })
+    z.object({secret_name: z.string()})
 
   const codespacesCreateOrUpdateSecretForAuthenticatedUserRequestBodySchema =
     z.object({
@@ -97953,7 +97885,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98025,7 +97957,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98049,7 +97981,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codespacesListRepositoriesForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string() })
+    z.object({secret_name: z.string()})
 
   const codespacesListRepositoriesForSecretForAuthenticatedUserResponseBodyValidator =
     responseValidationFactory(
@@ -98126,7 +98058,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98150,10 +98082,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codespacesSetRepositoriesForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string() })
+    z.object({secret_name: z.string()})
 
   const codespacesSetRepositoriesForSecretForAuthenticatedUserRequestBodySchema =
-    z.object({ selected_repository_ids: z.array(z.coerce.number()) })
+    z.object({selected_repository_ids: z.array(z.coerce.number())})
 
   const codespacesSetRepositoriesForSecretForAuthenticatedUserResponseBodyValidator =
     responseValidationFactory(
@@ -98225,7 +98157,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98249,7 +98181,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codespacesAddRepositoryForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string(), repository_id: z.coerce.number() })
+    z.object({secret_name: z.string(), repository_id: z.coerce.number()})
 
   const codespacesAddRepositoryForSecretForAuthenticatedUserResponseBodyValidator =
     responseValidationFactory(
@@ -98317,7 +98249,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98341,7 +98273,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const codespacesRemoveRepositoryForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string(), repository_id: z.coerce.number() })
+    z.object({secret_name: z.string(), repository_id: z.coerce.number()})
 
   const codespacesRemoveRepositoryForSecretForAuthenticatedUserResponseBodyValidator =
     responseValidationFactory(
@@ -98409,7 +98341,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98500,7 +98432,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98601,7 +98533,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98700,7 +98632,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98797,7 +98729,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98879,7 +98811,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -98985,7 +98917,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99089,7 +99021,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99192,7 +99124,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99279,7 +99211,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99343,7 +99275,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99367,7 +99299,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const usersSetPrimaryEmailVisibilityForAuthenticatedUserRequestBodySchema =
-    z.object({ visibility: z.enum(["public", "private"]) })
+    z.object({visibility: z.enum(["public", "private"])})
 
   const usersSetPrimaryEmailVisibilityForAuthenticatedUserResponseBodyValidator =
     responseValidationFactory(
@@ -99439,7 +99371,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99527,7 +99459,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99552,7 +99484,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const usersAddEmailForAuthenticatedUserRequestBodySchema = z
     .union([
-      z.object({ emails: z.array(z.string()).min(1) }),
+      z.object({emails: z.array(z.string()).min(1)}),
       z.array(z.string()).min(1),
       z.string(),
     ])
@@ -99622,7 +99554,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99646,7 +99578,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const usersDeleteEmailForAuthenticatedUserRequestBodySchema = z.union([
-    z.object({ emails: z.array(z.string()).min(1) }),
+    z.object({emails: z.array(z.string()).min(1)}),
     z.array(z.string()).min(1),
     z.string(),
   ])
@@ -99721,7 +99653,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99811,7 +99743,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99901,7 +99833,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -99994,7 +99926,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100017,7 +99949,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersFollowParamSchema = z.object({ username: z.string() })
+  const usersFollowParamSchema = z.object({username: z.string()})
 
   const usersFollowResponseBodyValidator = responseValidationFactory(
     [
@@ -100082,7 +100014,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100100,7 +100032,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersUnfollowParamSchema = z.object({ username: z.string() })
+  const usersUnfollowParamSchema = z.object({username: z.string()})
 
   const usersUnfollowResponseBodyValidator = responseValidationFactory(
     [
@@ -100161,7 +100093,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100250,7 +100182,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100348,7 +100280,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100435,7 +100367,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100532,7 +100464,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100631,7 +100563,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100740,7 +100672,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100830,7 +100762,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -100925,7 +100857,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101000,7 +100932,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101080,7 +101012,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101144,7 +101076,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101179,7 +101111,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -101236,7 +101168,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101327,7 +101259,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101431,7 +101363,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101524,7 +101456,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101617,7 +101549,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101709,7 +101641,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101797,7 +101729,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101892,7 +101824,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -101977,7 +101909,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102074,7 +102006,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102158,7 +102090,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102253,7 +102185,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102359,7 +102291,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102448,7 +102380,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102541,7 +102473,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102635,7 +102567,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102725,7 +102657,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102809,7 +102741,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102897,7 +102829,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -102977,7 +102909,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103074,7 +103006,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103179,7 +103111,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103288,7 +103220,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103369,7 +103301,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103467,7 +103399,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103567,7 +103499,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103655,7 +103587,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103749,7 +103681,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103789,8 +103721,8 @@ export function createRouter(implementation: Implementation): Router {
     direction: z.enum(["asc", "desc"]).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    since: z.string().datetime({ offset: true }).optional(),
-    before: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
+    before: z.string().datetime({offset: true}).optional(),
   })
 
   const reposListForAuthenticatedUserResponseBodyValidator =
@@ -103853,7 +103785,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -103971,7 +103903,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104062,7 +103994,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104155,7 +104087,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104248,7 +104180,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104342,7 +104274,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104439,7 +104371,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104463,7 +104395,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const usersDeleteSocialAccountForAuthenticatedUserRequestBodySchema =
-    z.object({ account_urls: z.array(z.string()) })
+    z.object({account_urls: z.array(z.string())})
 
   const usersDeleteSocialAccountForAuthenticatedUserResponseBodyValidator =
     responseValidationFactory(
@@ -104535,7 +104467,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104629,7 +104561,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104734,7 +104666,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104827,7 +104759,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -104920,7 +104852,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105012,7 +104944,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105106,7 +105038,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105200,7 +105132,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105294,7 +105226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105384,7 +105316,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105468,7 +105400,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105488,7 +105420,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersGetByIdParamSchema = z.object({ account_id: z.coerce.number() })
+  const usersGetByIdParamSchema = z.object({account_id: z.coerce.number()})
 
   const usersGetByIdResponseBodyValidator = responseValidationFactory(
     [
@@ -105539,7 +105471,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105609,7 +105541,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105627,7 +105559,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersGetByUsernameParamSchema = z.object({ username: z.string() })
+  const usersGetByUsernameParamSchema = z.object({username: z.string()})
 
   const usersGetByUsernameResponseBodyValidator = responseValidationFactory(
     [
@@ -105678,7 +105610,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105696,9 +105628,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersListAttestationsBulkParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListAttestationsBulkParamSchema = z.object({username: z.string()})
 
   const usersListAttestationsBulkQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -105833,7 +105763,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105856,8 +105786,8 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const usersDeleteAttestationsBulkRequestBodySchema = z.union([
-    z.object({ subject_digests: z.array(z.string()).min(1).max(1024) }),
-    z.object({ attestation_ids: z.array(z.coerce.number()).min(1).max(1024) }),
+    z.object({subject_digests: z.array(z.string()).min(1).max(1024)}),
+    z.object({attestation_ids: z.array(z.coerce.number()).min(1).max(1024)}),
   ])
 
   const usersDeleteAttestationsBulkResponseBodyValidator =
@@ -105912,7 +105842,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -105995,7 +105925,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106079,7 +106009,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106211,7 +106141,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106230,7 +106160,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const packagesListDockerMigrationConflictingPackagesForUserParamSchema =
-    z.object({ username: z.string() })
+    z.object({username: z.string()})
 
   const packagesListDockerMigrationConflictingPackagesForUserResponseBodyValidator =
     responseValidationFactory(
@@ -106290,7 +106220,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106371,7 +106301,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106453,7 +106383,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106528,7 +106458,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106548,9 +106478,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersListFollowersForUserParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListFollowersForUserParamSchema = z.object({username: z.string()})
 
   const usersListFollowersForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -106600,7 +106528,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106618,9 +106546,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersListFollowingForUserParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListFollowingForUserParamSchema = z.object({username: z.string()})
 
   const usersListFollowingForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -106670,7 +106596,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106741,7 +106667,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106761,10 +106687,10 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const gistsListForUserParamSchema = z.object({ username: z.string() })
+  const gistsListForUserParamSchema = z.object({username: z.string()})
 
   const gistsListForUserQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -106820,7 +106746,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106838,7 +106764,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersListGpgKeysForUserParamSchema = z.object({ username: z.string() })
+  const usersListGpgKeysForUserParamSchema = z.object({username: z.string()})
 
   const usersListGpgKeysForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -106888,7 +106814,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106906,7 +106832,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersGetContextForUserParamSchema = z.object({ username: z.string() })
+  const usersGetContextForUserParamSchema = z.object({username: z.string()})
 
   const usersGetContextForUserQuerySchema = z.object({
     subject_type: z
@@ -106970,7 +106896,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -106988,7 +106914,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const appsGetUserInstallationParamSchema = z.object({ username: z.string() })
+  const appsGetUserInstallationParamSchema = z.object({username: z.string()})
 
   const appsGetUserInstallationResponseBodyValidator =
     responseValidationFactory([["200", s_installation]], undefined)
@@ -107029,7 +106955,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107047,9 +106973,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const usersListPublicKeysForUserParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListPublicKeysForUserParamSchema = z.object({username: z.string()})
 
   const usersListPublicKeysForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -107099,7 +107023,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107119,7 +107043,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const orgsListForUserParamSchema = z.object({ username: z.string() })
+  const orgsListForUserParamSchema = z.object({username: z.string()})
 
   const orgsListForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -107171,7 +107095,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107267,7 +107191,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107339,7 +107263,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107426,7 +107350,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107523,7 +107447,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107619,7 +107543,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107695,7 +107619,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107785,7 +107709,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107884,7 +107808,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -107907,7 +107831,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const projectsListForUserParamSchema = z.object({ username: z.string() })
+  const projectsListForUserParamSchema = z.object({username: z.string()})
 
   const projectsListForUserQuerySchema = z.object({
     state: z.enum(["open", "closed", "all"]).optional().default("open"),
@@ -107966,7 +107890,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108036,7 +107960,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108117,7 +108041,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108140,7 +108064,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const reposListForUserParamSchema = z.object({ username: z.string() })
+  const reposListForUserParamSchema = z.object({username: z.string()})
 
   const reposListForUserQuerySchema = z.object({
     type: z.enum(["all", "owner", "member"]).optional().default("owner"),
@@ -108198,7 +108122,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108259,7 +108183,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108325,7 +108249,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108391,7 +108315,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108506,7 +108430,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108581,7 +108505,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108653,7 +108577,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108737,7 +108661,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108812,7 +108736,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108875,7 +108799,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -108930,7 +108854,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-express/src/generated/api.github.com.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_actions_billing_usage = {
   included_minutes: number

--- a/integration-tests/typescript-express/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/api.github.com.yaml/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -44,8 +44,8 @@ export const s_actions_cache_list = z.object({
       ref: z.string().optional(),
       key: z.string().optional(),
       version: z.string().optional(),
-      last_accessed_at: z.string().datetime({ offset: true }).optional(),
-      created_at: z.string().datetime({ offset: true }).optional(),
+      last_accessed_at: z.string().datetime({offset: true}).optional(),
+      created_at: z.string().datetime({offset: true}).optional(),
       size_in_bytes: z.coerce.number().optional(),
     }),
   ),
@@ -101,15 +101,15 @@ export const s_actions_public_key = z.object({
 
 export const s_actions_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_actions_variable = z.object({
   name: z.string(),
   value: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_actions_workflow_access_to_repository = z.object({
@@ -127,17 +127,17 @@ export const s_actor = z.object({
 
 export const s_alert_auto_dismissed_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
   .nullable()
 
-export const s_alert_created_at = z.string().datetime({ offset: true })
+export const s_alert_created_at = z.string().datetime({offset: true})
 
 export const s_alert_dismissed_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
   .nullable()
 
-export const s_alert_fixed_at = z.string().datetime({ offset: true }).nullable()
+export const s_alert_fixed_at = z.string().datetime({offset: true}).nullable()
 
 export const s_alert_html_url = z.string()
 
@@ -145,7 +145,7 @@ export const s_alert_instances_url = z.string()
 
 export const s_alert_number = z.coerce.number()
 
-export const s_alert_updated_at = z.string().datetime({ offset: true })
+export const s_alert_updated_at = z.string().datetime({offset: true})
 
 export const s_alert_url = z.string()
 
@@ -309,9 +309,9 @@ export const s_artifact = z.object({
   url: z.string(),
   archive_download_url: z.string(),
   expired: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  expires_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  expires_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   digest: z.string().nullable().optional(),
   workflow_run: z
     .object({
@@ -499,7 +499,7 @@ export const s_branch_restriction_policy = z.object({
 
 export const s_branch_short = z.object({
   name: z.string(),
-  commit: z.object({ sha: z.string(), url: z.string() }),
+  commit: z.object({sha: z.string(), url: z.string()}),
   protected: PermissiveBoolean,
 })
 
@@ -644,7 +644,7 @@ export const s_code_scanning_analysis_commit_sha = z
 
 export const s_code_scanning_analysis_created_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
 
 export const s_code_scanning_analysis_deletion = z.object({
   next_analysis_url: z.string().nullable(),
@@ -666,7 +666,7 @@ export const s_code_scanning_analysis_tool_version = z.string().nullable()
 export const s_code_scanning_analysis_url = z.string()
 
 export const s_code_scanning_autofix_commits = z
-  .object({ target_ref: z.string().optional(), message: z.string().optional() })
+  .object({target_ref: z.string().optional(), message: z.string().optional()})
   .nullable()
 
 export const s_code_scanning_autofix_commits_response = z.object({
@@ -678,7 +678,7 @@ export const s_code_scanning_autofix_description = z.string().nullable()
 
 export const s_code_scanning_autofix_started_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
 
 export const s_code_scanning_autofix_status = z.enum([
   "pending",
@@ -710,7 +710,7 @@ export const s_code_scanning_default_setup = z.object({
   runner_label: z.string().nullable().optional(),
   query_suite: z.enum(["default", "extended"]).optional(),
   threat_model: z.enum(["remote", "remote_and_local"]).optional(),
-  updated_at: z.string().datetime({ offset: true }).nullable().optional(),
+  updated_at: z.string().datetime({offset: true}).nullable().optional(),
   schedule: z.enum(["weekly"]).nullable().optional(),
 })
 
@@ -779,7 +779,7 @@ export const s_code_scanning_variant_analysis_repository = z.object({
   full_name: z.string(),
   private: PermissiveBoolean,
   stargazers_count: z.coerce.number(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_code_scanning_variant_analysis_status = z.enum([
@@ -804,7 +804,7 @@ export const s_code_security_configuration = z.object({
     .enum(["enabled", "disabled", "not_set"])
     .optional(),
   dependency_graph_autosubmit_action_options: z
-    .object({ labeled_runners: PermissiveBoolean.optional() })
+    .object({labeled_runners: PermissiveBoolean.optional()})
     .optional(),
   dependabot_alerts: z.enum(["enabled", "disabled", "not_set"]).optional(),
   dependabot_security_updates: z
@@ -864,8 +864,8 @@ export const s_code_security_configuration = z.object({
   enforcement: z.enum(["enforced", "unenforced"]).optional(),
   url: z.string().optional(),
   html_url: z.string().optional(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_codeowners_errors = z.object({
@@ -884,7 +884,7 @@ export const s_codeowners_errors = z.object({
 
 export const s_codespace_export_details = z.object({
   state: z.string().nullable().optional(),
-  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  completed_at: z.string().datetime({offset: true}).nullable().optional(),
   branch: z.string().nullable().optional(),
   sha: z.string().nullable().optional(),
   id: z.string().optional(),
@@ -904,8 +904,8 @@ export const s_codespace_machine = z.object({
 
 export const s_codespaces_org_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -925,8 +925,8 @@ export const s_codespaces_public_key = z.object({
 
 export const s_codespaces_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string(),
 })
@@ -1311,8 +1311,8 @@ export const s_dependabot_public_key = z.object({
 
 export const s_dependabot_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_dependency_graph_diff = z.array(
@@ -1462,8 +1462,8 @@ export const s_enterprise = z.object({
   node_id: z.string(),
   name: z.string(),
   slug: z.string(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   avatar_url: z.string(),
 })
 
@@ -1479,8 +1479,8 @@ export const s_enterprise_team = z.object({
   group_name: z.string().nullable().optional(),
   html_url: z.string(),
   members_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_file_commit = z.object({
@@ -1525,7 +1525,7 @@ export const s_file_commit = z.object({
       .optional(),
     message: z.string().optional(),
     tree: z
-      .object({ url: z.string().optional(), sha: z.string().optional() })
+      .object({url: z.string().optional(), sha: z.string().optional()})
       .optional(),
     parents: z
       .array(
@@ -1553,19 +1553,19 @@ export const s_git_commit = z.object({
   node_id: z.string(),
   url: z.string(),
   author: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   committer: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   message: z.string(),
-  tree: z.object({ sha: z.string(), url: z.string() }),
+  tree: z.object({sha: z.string(), url: z.string()}),
   parents: z.array(
-    z.object({ sha: z.string(), url: z.string(), html_url: z.string() }),
+    z.object({sha: z.string(), url: z.string(), html_url: z.string()}),
   ),
   verification: z.object({
     verified: PermissiveBoolean,
@@ -1650,8 +1650,8 @@ export const s_gpg_key = z.object({
   can_encrypt_comms: PermissiveBoolean,
   can_encrypt_storage: PermissiveBoolean,
   can_certify: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }),
-  expires_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  expires_at: z.string().datetime({offset: true}).nullable(),
   revoked: PermissiveBoolean,
   raw_key: z.string().nullable(),
 })
@@ -1659,7 +1659,7 @@ export const s_gpg_key = z.object({
 export const s_hook_delivery = z.object({
   id: z.coerce.number(),
   guid: z.string(),
-  delivered_at: z.string().datetime({ offset: true }),
+  delivered_at: z.string().datetime({offset: true}),
   redelivery: PermissiveBoolean,
   duration: z.coerce.number(),
   status: z.string(),
@@ -1668,7 +1668,7 @@ export const s_hook_delivery = z.object({
   action: z.string().nullable(),
   installation_id: z.coerce.number().nullable(),
   repository_id: z.coerce.number().nullable(),
-  throttled_at: z.string().datetime({ offset: true }).nullable().optional(),
+  throttled_at: z.string().datetime({offset: true}).nullable().optional(),
   url: z.string().optional(),
   request: z.object({
     headers: z.record(z.unknown()).nullable(),
@@ -1683,7 +1683,7 @@ export const s_hook_delivery = z.object({
 export const s_hook_delivery_item = z.object({
   id: z.coerce.number(),
   guid: z.string(),
-  delivered_at: z.string().datetime({ offset: true }),
+  delivered_at: z.string().datetime({offset: true}),
   redelivery: PermissiveBoolean,
   duration: z.coerce.number(),
   status: z.string(),
@@ -1692,7 +1692,7 @@ export const s_hook_delivery_item = z.object({
   action: z.string().nullable(),
   installation_id: z.coerce.number().nullable(),
   repository_id: z.coerce.number().nullable(),
-  throttled_at: z.string().datetime({ offset: true }).nullable().optional(),
+  throttled_at: z.string().datetime({offset: true}).nullable().optional(),
 })
 
 export const s_hook_response = z.object({
@@ -1702,7 +1702,7 @@ export const s_hook_response = z.object({
 })
 
 export const s_hovercard = z.object({
-  contexts: z.array(z.object({ message: z.string(), octicon: z.string() })),
+  contexts: z.array(z.object({message: z.string(), octicon: z.string()})),
 })
 
 export const s_import = z.object({
@@ -1782,7 +1782,7 @@ export const s_issue_event_label = z.object({
   color: z.string().nullable(),
 })
 
-export const s_issue_event_milestone = z.object({ title: z.string() })
+export const s_issue_event_milestone = z.object({title: z.string()})
 
 export const s_issue_event_project_card = z.object({
   url: z.string(),
@@ -1793,10 +1793,7 @@ export const s_issue_event_project_card = z.object({
   previous_column_name: z.string().optional(),
 })
 
-export const s_issue_event_rename = z.object({
-  from: z.string(),
-  to: z.string(),
-})
+export const s_issue_event_rename = z.object({from: z.string(), to: z.string()})
 
 export const s_issue_type = z
   .object({
@@ -1817,8 +1814,8 @@ export const s_issue_type = z
       ])
       .nullable()
       .optional(),
-    created_at: z.string().datetime({ offset: true }).optional(),
-    updated_at: z.string().datetime({ offset: true }).optional(),
+    created_at: z.string().datetime({offset: true}).optional(),
+    updated_at: z.string().datetime({offset: true}).optional(),
     is_enabled: PermissiveBoolean.optional(),
   })
   .nullable()
@@ -1851,9 +1848,9 @@ export const s_job = z.object({
       "action_required",
     ])
     .nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  started_at: z.string().datetime({ offset: true }),
-  completed_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  started_at: z.string().datetime({offset: true}),
+  completed_at: z.string().datetime({offset: true}).nullable(),
   name: z.string(),
   steps: z
     .array(
@@ -1862,12 +1859,8 @@ export const s_job = z.object({
         conclusion: z.string().nullable(),
         name: z.string(),
         number: z.coerce.number(),
-        started_at: z.string().datetime({ offset: true }).nullable().optional(),
-        completed_at: z
-          .string()
-          .datetime({ offset: true })
-          .nullable()
-          .optional(),
+        started_at: z.string().datetime({offset: true}).nullable().optional(),
+        completed_at: z.string().datetime({offset: true}).nullable().optional(),
       }),
     )
     .optional(),
@@ -1886,7 +1879,7 @@ export const s_key = z.object({
   id: z.coerce.number(),
   url: z.string(),
   title: z.string(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   verified: PermissiveBoolean,
   read_only: PermissiveBoolean,
 })
@@ -1894,7 +1887,7 @@ export const s_key = z.object({
 export const s_key_simple = z.object({
   id: z.coerce.number(),
   key: z.string(),
-  created_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_label = z.object({
@@ -1934,9 +1927,9 @@ export const s_license_simple = z.object({
   html_url: z.string().optional(),
 })
 
-export const s_link = z.object({ href: z.string() })
+export const s_link = z.object({href: z.string()})
 
-export const s_link_with_type = z.object({ href: z.string(), type: z.string() })
+export const s_link_with_type = z.object({href: z.string(), type: z.string()})
 
 export const s_marketplace_account = z.object({
   url: z.string(),
@@ -1979,7 +1972,7 @@ export const s_network_configuration = z.object({
   name: z.string(),
   compute_service: z.enum(["none", "actions", "codespaces"]).optional(),
   network_settings_ids: z.array(z.string()).optional(),
-  created_on: z.string().datetime({ offset: true }).nullable(),
+  created_on: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_network_settings = z.object({
@@ -2001,7 +1994,7 @@ export const s_nullable_actions_hosted_runner_pool_image = z
 
 export const s_nullable_alert_updated_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
   .nullable()
 
 export const s_nullable_code_of_conduct_simple = z
@@ -2062,7 +2055,7 @@ export const s_nullable_collaborator = z
   .nullable()
 
 export const s_nullable_community_health_file = z
-  .object({ url: z.string(), html_url: z.string() })
+  .object({url: z.string(), html_url: z.string()})
   .nullable()
 
 export const s_nullable_git_user = z
@@ -2106,12 +2099,10 @@ export const s_nullable_simple_commit = z
     id: z.string(),
     tree_id: z.string(),
     message: z.string(),
-    timestamp: z.string().datetime({ offset: true }),
-    author: z
-      .object({ name: z.string(), email: z.string().email() })
-      .nullable(),
+    timestamp: z.string().datetime({offset: true}),
+    author: z.object({name: z.string(), email: z.string().email()}).nullable(),
     committer: z
-      .object({ name: z.string(), email: z.string().email() })
+      .object({name: z.string(), email: z.string().email()})
       .nullable(),
   })
   .nullable()
@@ -2184,8 +2175,8 @@ export const s_org_hook = z.object({
     content_type: z.string().optional(),
     secret: z.string().optional(),
   }),
-  updated_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
   type: z.string(),
 })
 
@@ -2194,8 +2185,8 @@ export const s_org_private_registry_configuration = z.object({
   registry_type: z.enum(["maven_repository", "nuget_feed", "goproxy_server"]),
   username: z.string().nullable().optional(),
   visibility: z.enum(["all", "private", "selected"]),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_org_private_registry_configuration_with_selected_repositories =
@@ -2205,14 +2196,14 @@ export const s_org_private_registry_configuration_with_selected_repositories =
     username: z.string().optional(),
     visibility: z.enum(["all", "private", "selected"]),
     selected_repository_ids: z.array(z.coerce.number()).optional(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
   })
 
 export const s_organization_actions_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -2220,8 +2211,8 @@ export const s_organization_actions_secret = z.object({
 export const s_organization_actions_variable = z.object({
   name: z.string(),
   value: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -2247,8 +2238,8 @@ export const s_organization_create_issue_type = z.object({
 
 export const s_organization_dependabot_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -2329,9 +2320,9 @@ export const s_organization_full = z.object({
   secret_scanning_push_protection_custom_link_enabled:
     PermissiveBoolean.optional(),
   secret_scanning_push_protection_custom_link: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  archived_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  archived_at: z.string().datetime({offset: true}).nullable(),
   deploy_keys_enabled_for_repositories: PermissiveBoolean.optional(),
 })
 
@@ -2377,9 +2368,9 @@ export const s_package_version = z.object({
   html_url: z.string().optional(),
   license: z.string().optional(),
   description: z.string().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  deleted_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  deleted_at: z.string().datetime({offset: true}).optional(),
   metadata: z
     .object({
       package_type: z.enum([
@@ -2390,8 +2381,8 @@ export const s_package_version = z.object({
         "nuget",
         "container",
       ]),
-      container: z.object({ tags: z.array(z.string()) }).optional(),
-      docker: z.object({ tag: z.array(z.string()).optional() }).optional(),
+      container: z.object({tags: z.array(z.string())}).optional(),
+      docker: z.object({tag: z.array(z.string()).optional()}).optional(),
     })
     .optional(),
 })
@@ -2584,8 +2575,8 @@ export const s_private_user = z.object({
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
   following: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   private_gists: z.coerce.number(),
   total_private_repos: z.coerce.number(),
   owned_private_repos: z.coerce.number(),
@@ -2611,8 +2602,8 @@ export const s_project_column = z.object({
   id: z.coerce.number(),
   node_id: z.string(),
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_protected_branch_admin_enforced = z.object({
@@ -2625,7 +2616,7 @@ export const s_protected_branch_required_status_check = z.object({
   enforcement_level: z.string().optional(),
   contexts: z.array(z.string()),
   checks: z.array(
-    z.object({ context: z.string(), app_id: z.coerce.number().nullable() }),
+    z.object({context: z.string(), app_id: z.coerce.number().nullable()}),
   ),
   contexts_url: z.string().optional(),
   strict: PermissiveBoolean.optional(),
@@ -2670,8 +2661,8 @@ export const s_public_user = z.object({
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
   following: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   plan: z
     .object({
       collaborators: z.coerce.number(),
@@ -2700,20 +2691,12 @@ export const s_pull_request_minimal = z.object({
   head: z.object({
     ref: z.string(),
     sha: z.string(),
-    repo: z.object({
-      id: z.coerce.number(),
-      url: z.string(),
-      name: z.string(),
-    }),
+    repo: z.object({id: z.coerce.number(), url: z.string(), name: z.string()}),
   }),
   base: z.object({
     ref: z.string(),
     sha: z.string(),
-    repo: z.object({
-      id: z.coerce.number(),
-      url: z.string(),
-      name: z.string(),
-    }),
+    repo: z.object({id: z.coerce.number(), url: z.string(), name: z.string()}),
   }),
 })
 
@@ -2756,8 +2739,8 @@ export const s_release_notes_content = z.object({
 
 export const s_repo_codespaces_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_repository_rule_branch_name_pattern = z.object({
@@ -2808,13 +2791,9 @@ export const s_repository_rule_committer_email_pattern = z.object({
     .optional(),
 })
 
-export const s_repository_rule_creation = z.object({
-  type: z.enum(["creation"]),
-})
+export const s_repository_rule_creation = z.object({type: z.enum(["creation"])})
 
-export const s_repository_rule_deletion = z.object({
-  type: z.enum(["deletion"]),
-})
+export const s_repository_rule_deletion = z.object({type: z.enum(["deletion"])})
 
 export const s_repository_rule_enforcement = z.enum([
   "disabled",
@@ -2825,28 +2804,26 @@ export const s_repository_rule_enforcement = z.enum([
 export const s_repository_rule_file_extension_restriction = z.object({
   type: z.enum(["file_extension_restriction"]),
   parameters: z
-    .object({ restricted_file_extensions: z.array(z.string()) })
+    .object({restricted_file_extensions: z.array(z.string())})
     .optional(),
 })
 
 export const s_repository_rule_file_path_restriction = z.object({
   type: z.enum(["file_path_restriction"]),
-  parameters: z
-    .object({ restricted_file_paths: z.array(z.string()) })
-    .optional(),
+  parameters: z.object({restricted_file_paths: z.array(z.string())}).optional(),
 })
 
 export const s_repository_rule_max_file_path_length = z.object({
   type: z.enum(["max_file_path_length"]),
   parameters: z
-    .object({ max_file_path_length: z.coerce.number().min(1).max(32767) })
+    .object({max_file_path_length: z.coerce.number().min(1).max(32767)})
     .optional(),
 })
 
 export const s_repository_rule_max_file_size = z.object({
   type: z.enum(["max_file_size"]),
   parameters: z
-    .object({ max_file_size: z.coerce.number().min(1).max(100) })
+    .object({max_file_size: z.coerce.number().min(1).max(100)})
     .optional(),
 })
 
@@ -2913,7 +2890,7 @@ export const s_repository_rule_pull_request = z.object({
 export const s_repository_rule_required_deployments = z.object({
   type: z.enum(["required_deployments"]),
   parameters: z
-    .object({ required_deployment_environments: z.array(z.string()) })
+    .object({required_deployment_environments: z.array(z.string())})
     .optional(),
 })
 
@@ -2946,7 +2923,7 @@ export const s_repository_rule_tag_name_pattern = z.object({
 export const s_repository_rule_update = z.object({
   type: z.enum(["update"]),
   parameters: z
-    .object({ update_allows_fetch_and_merge: PermissiveBoolean })
+    .object({update_allows_fetch_and_merge: PermissiveBoolean})
     .optional(),
 })
 
@@ -2996,7 +2973,7 @@ export const s_repository_subscription = z.object({
   subscribed: PermissiveBoolean,
   ignored: PermissiveBoolean,
   reason: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   url: z.string(),
   repository_url: z.string(),
 })
@@ -3057,7 +3034,7 @@ export const s_rule_suite = z.object({
   ref: z.string().optional(),
   repository_id: z.coerce.number().optional(),
   repository_name: z.string().optional(),
-  pushed_at: z.string().datetime({ offset: true }).optional(),
+  pushed_at: z.string().datetime({offset: true}).optional(),
   result: z.enum(["pass", "fail", "bypass"]).optional(),
   evaluation_result: z.enum(["pass", "fail", "bypass"]).nullable().optional(),
   rule_evaluations: z
@@ -3091,7 +3068,7 @@ export const s_rule_suites = z.array(
     ref: z.string().optional(),
     repository_id: z.coerce.number().optional(),
     repository_name: z.string().optional(),
-    pushed_at: z.string().datetime({ offset: true }).optional(),
+    pushed_at: z.string().datetime({offset: true}).optional(),
     result: z.enum(["pass", "fail", "bypass"]).optional(),
     evaluation_result: z.enum(["pass", "fail", "bypass"]).optional(),
   }),
@@ -3103,7 +3080,7 @@ export const s_ruleset_version = z.object({
     id: z.coerce.number().optional(),
     type: z.string().optional(),
   }),
-  updated_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_runner_application = z.object({
@@ -3252,8 +3229,8 @@ export const s_secret_scanning_push_protection_bypass_reason = z.enum([
 export const s_secret_scanning_scan = z.object({
   type: z.string().optional(),
   status: z.string().optional(),
-  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
-  started_at: z.string().datetime({ offset: true }).nullable().optional(),
+  completed_at: z.string().datetime({offset: true}).nullable().optional(),
+  started_at: z.string().datetime({offset: true}).nullable().optional(),
 })
 
 export const s_security_advisory_credit_types = z.enum([
@@ -3295,25 +3272,25 @@ export const s_security_advisory_epss = z
 export const s_security_and_analysis = z
   .object({
     advanced_security: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     code_security: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     dependabot_security_updates: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning_push_protection: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning_non_provider_patterns: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning_ai_detection: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
   })
   .nullable()
@@ -3326,7 +3303,7 @@ export const s_selected_actions = z.object({
 
 export const s_selected_actions_url = z.string()
 
-export const s_short_blob = z.object({ url: z.string(), sha: z.string() })
+export const s_short_blob = z.object({url: z.string(), sha: z.string()})
 
 export const s_simple_classroom = z.object({
   id: z.coerce.number(),
@@ -3364,11 +3341,9 @@ export const s_simple_commit = z.object({
   id: z.string(),
   tree_id: z.string(),
   message: z.string(),
-  timestamp: z.string().datetime({ offset: true }),
-  author: z.object({ name: z.string(), email: z.string().email() }).nullable(),
-  committer: z
-    .object({ name: z.string(), email: z.string().email() })
-    .nullable(),
+  timestamp: z.string().datetime({offset: true}),
+  author: z.object({name: z.string(), email: z.string().email()}).nullable(),
+  committer: z.object({name: z.string(), email: z.string().email()}).nullable(),
 })
 
 export const s_simple_commit_status = z.object({
@@ -3381,8 +3356,8 @@ export const s_simple_commit_status = z.object({
   required: PermissiveBoolean.nullable().optional(),
   avatar_url: z.string().nullable(),
   url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_simple_user = z.object({
@@ -3419,7 +3394,7 @@ export const s_ssh_signing_key = z.object({
   key: z.string(),
   id: z.coerce.number(),
   title: z.string(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
 })
 
 export const s_status_check_policy = z.object({
@@ -3427,7 +3402,7 @@ export const s_status_check_policy = z.object({
   strict: PermissiveBoolean,
   contexts: z.array(z.string()),
   checks: z.array(
-    z.object({ context: z.string(), app_id: z.coerce.number().nullable() }),
+    z.object({context: z.string(), app_id: z.coerce.number().nullable()}),
   ),
   contexts_url: z.string(),
 })
@@ -3440,7 +3415,7 @@ export const s_sub_issues_summary = z.object({
 
 export const s_tag = z.object({
   name: z.string(),
-  commit: z.object({ sha: z.string(), url: z.string() }),
+  commit: z.object({sha: z.string(), url: z.string()}),
   zipball_url: z.string(),
   tarball_url: z.string(),
   node_id: z.string(),
@@ -3487,7 +3462,7 @@ export const s_team_organization = z.object({
   followers: z.coerce.number(),
   following: z.coerce.number(),
   html_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   type: z.string(),
   total_private_repos: z.coerce.number().optional(),
   owned_private_repos: z.coerce.number().optional(),
@@ -3517,8 +3492,8 @@ export const s_team_organization = z.object({
   members_can_fork_private_repositories:
     PermissiveBoolean.nullable().optional(),
   web_commit_signoff_required: PermissiveBoolean.optional(),
-  updated_at: z.string().datetime({ offset: true }),
-  archived_at: z.string().datetime({ offset: true }).nullable(),
+  updated_at: z.string().datetime({offset: true}),
+  archived_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_team_simple = z.object({
@@ -3541,7 +3516,7 @@ export const s_thread_subscription = z.object({
   subscribed: PermissiveBoolean,
   ignored: PermissiveBoolean,
   reason: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
   url: z.string(),
   thread_url: z.string().optional(),
   repository_url: z.string().optional(),
@@ -3553,19 +3528,19 @@ export const s_timeline_committed_event = z.object({
   node_id: z.string(),
   url: z.string(),
   author: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   committer: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   message: z.string(),
-  tree: z.object({ sha: z.string(), url: z.string() }),
+  tree: z.object({sha: z.string(), url: z.string()}),
   parents: z.array(
-    z.object({ sha: z.string(), url: z.string(), html_url: z.string() }),
+    z.object({sha: z.string(), url: z.string(), html_url: z.string()}),
   ),
   verification: z.object({
     verified: PermissiveBoolean,
@@ -3577,10 +3552,10 @@ export const s_timeline_committed_event = z.object({
   html_url: z.string(),
 })
 
-export const s_topic = z.object({ names: z.array(z.string()) })
+export const s_topic = z.object({names: z.array(z.string())})
 
 export const s_traffic = z.object({
-  timestamp: z.string().datetime({ offset: true }),
+  timestamp: z.string().datetime({offset: true}),
   uniques: z.coerce.number(),
   count: z.coerce.number(),
 })
@@ -3647,12 +3622,12 @@ export const s_workflow = z.object({
     "disabled_inactivity",
     "disabled_manually",
   ]),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   html_url: z.string(),
   badge_url: z.string(),
-  deleted_at: z.string().datetime({ offset: true }).optional(),
+  deleted_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_workflow_run_usage = z.object({
@@ -3705,9 +3680,9 @@ export const s_workflow_run_usage = z.object({
 
 export const s_workflow_usage = z.object({
   billable: z.object({
-    UBUNTU: z.object({ total_ms: z.coerce.number().optional() }).optional(),
-    MACOS: z.object({ total_ms: z.coerce.number().optional() }).optional(),
-    WINDOWS: z.object({ total_ms: z.coerce.number().optional() }).optional(),
+    UBUNTU: z.object({total_ms: z.coerce.number().optional()}).optional(),
+    MACOS: z.object({total_ms: z.coerce.number().optional()}).optional(),
+    WINDOWS: z.object({total_ms: z.coerce.number().optional()}).optional(),
   }),
 })
 
@@ -3727,7 +3702,7 @@ export const s_actions_hosted_runner = z.object({
   maximum_runners: z.coerce.number().optional().default(10),
   public_ip_enabled: PermissiveBoolean,
   public_ips: z.array(s_public_ip).optional(),
-  last_active_on: z.string().datetime({ offset: true }).nullable().optional(),
+  last_active_on: z.string().datetime({offset: true}).nullable().optional(),
 })
 
 export const s_actions_organization_permissions = z.object({
@@ -3756,7 +3731,7 @@ export const s_activity = z.object({
   before: z.string(),
   after: z.string(),
   ref: z.string(),
-  timestamp: z.string().datetime({ offset: true }),
+  timestamp: z.string().datetime({offset: true}),
   activity_type: z.enum([
     "push",
     "force_push",
@@ -3797,8 +3772,8 @@ export const s_base_gist = z.object({
     }),
   ),
   public: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   description: z.string().nullable(),
   comments: z.coerce.number(),
   comments_enabled: PermissiveBoolean.optional(),
@@ -3831,7 +3806,7 @@ export const s_code_scanning_alert_instance = z.object({
   category: s_code_scanning_analysis_category.optional(),
   state: s_code_scanning_alert_state.optional(),
   commit_sha: z.string().optional(),
-  message: z.object({ text: z.string().optional() }).optional(),
+  message: z.object({text: z.string().optional()}).optional(),
   location: s_code_scanning_alert_location.optional(),
   html_url: z.string().optional(),
   classifications: z.array(s_code_scanning_alert_classification).optional(),
@@ -3856,8 +3831,8 @@ export const s_code_scanning_codeql_database = z.object({
   uploader: s_simple_user,
   content_type: z.string(),
   size: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   commit_oid: z.string().nullable().optional(),
 })
@@ -3907,7 +3882,7 @@ export const s_commit = z.object({
     committer: s_nullable_git_user,
     message: z.string(),
     comment_count: z.coerce.number(),
-    tree: z.object({ sha: z.string(), url: z.string() }),
+    tree: z.object({sha: z.string(), url: z.string()}),
     verification: s_verification.optional(),
   }),
   author: z.union([s_simple_user, s_empty_object]).nullable(),
@@ -3940,8 +3915,8 @@ export const s_commit_comment = z.object({
   line: z.coerce.number().nullable(),
   commit_id: z.string(),
   user: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   author_association: s_author_association,
   reactions: s_reaction_rollup.optional(),
 })
@@ -3959,7 +3934,7 @@ export const s_community_profile = z.object({
     issue_template: s_nullable_community_health_file,
     pull_request_template: s_nullable_community_health_file,
   }),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   content_reports_enabled: PermissiveBoolean.optional(),
 })
 
@@ -4011,7 +3986,7 @@ export const s_dependabot_alert_security_vulnerability = z.object({
   package: s_dependabot_alert_package,
   severity: z.enum(["low", "medium", "high", "critical"]),
   vulnerable_version_range: z.string(),
-  first_patched_version: z.object({ identifier: z.string() }).nullable(),
+  first_patched_version: z.object({identifier: z.string()}).nullable(),
 })
 
 export const s_dependency = z.object({
@@ -4037,8 +4012,8 @@ export const s_environment_approvals = z.object({
       name: z.string().optional(),
       url: z.string().optional(),
       html_url: z.string().optional(),
-      created_at: z.string().datetime({ offset: true }).optional(),
-      updated_at: z.string().datetime({ offset: true }).optional(),
+      created_at: z.string().datetime({offset: true}).optional(),
+      updated_at: z.string().datetime({offset: true}).optional(),
     }),
   ),
   state: z.enum(["approved", "rejected", "pending"]),
@@ -4077,8 +4052,8 @@ export const s_gist_comment = z.object({
   url: z.string(),
   body: z.string().max(65535),
   user: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   author_association: s_author_association,
 })
 
@@ -4091,13 +4066,13 @@ export const s_gist_commit = z.object({
     additions: z.coerce.number().optional(),
     deletions: z.coerce.number().optional(),
   }),
-  committed_at: z.string().datetime({ offset: true }),
+  committed_at: z.string().datetime({offset: true}),
 })
 
 export const s_gist_history = z.object({
   user: s_nullable_simple_user.optional(),
   version: z.string().optional(),
-  committed_at: z.string().datetime({ offset: true }).optional(),
+  committed_at: z.string().datetime({offset: true}).optional(),
   change_status: z
     .object({
       total: z.coerce.number().optional(),
@@ -4114,8 +4089,8 @@ export const s_git_tag = z.object({
   sha: z.string(),
   url: z.string(),
   message: z.string(),
-  tagger: z.object({ date: z.string(), email: z.string(), name: z.string() }),
-  object: z.object({ sha: z.string(), type: z.string(), url: z.string() }),
+  tagger: z.object({date: z.string(), email: z.string(), name: z.string()}),
+  object: z.object({sha: z.string(), type: z.string(), url: z.string()}),
   verification: s_verification.optional(),
 })
 
@@ -4132,14 +4107,14 @@ export const s_installation = z.object({
   target_type: z.string(),
   permissions: s_app_permissions,
   events: z.array(z.string()),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   single_file_name: z.string().nullable(),
   has_multiple_single_files: PermissiveBoolean.optional(),
   single_file_paths: z.array(z.string()).optional(),
   app_slug: z.string(),
   suspended_by: s_nullable_simple_user,
-  suspended_at: z.string().datetime({ offset: true }).nullable(),
+  suspended_at: z.string().datetime({offset: true}).nullable(),
   contact_email: z.string().nullable().optional(),
 })
 
@@ -4154,8 +4129,8 @@ export const s_integration = z
     description: z.string().nullable(),
     external_url: z.string(),
     html_url: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
     permissions: z.intersection(
       z.object({
         issues: z.string().optional(),
@@ -4176,7 +4151,7 @@ export const s_integration_installation_request = z.object({
   node_id: z.string().optional(),
   account: z.union([s_simple_user, s_enterprise]),
   requester: s_simple_user,
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
 })
 
 export const s_interaction_limit = z.object({
@@ -4187,7 +4162,7 @@ export const s_interaction_limit = z.object({
 export const s_interaction_limit_response = z.object({
   limit: s_interaction_group,
   origin: z.string(),
-  expires_at: z.string().datetime({ offset: true }),
+  expires_at: z.string().datetime({offset: true}),
 })
 
 export const s_label_search_result_item = z.object({
@@ -4264,10 +4239,10 @@ export const s_milestone = z.object({
   creator: s_nullable_simple_user,
   open_issues: z.coerce.number(),
   closed_issues: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  due_on: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  due_on: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_minimal_repository = z.object({
@@ -4341,9 +4316,9 @@ export const s_minimal_repository = z.object({
   archived: PermissiveBoolean.optional(),
   disabled: PermissiveBoolean.optional(),
   visibility: z.string().optional(),
-  pushed_at: z.string().datetime({ offset: true }).nullable().optional(),
-  created_at: z.string().datetime({ offset: true }).nullable().optional(),
-  updated_at: z.string().datetime({ offset: true }).nullable().optional(),
+  pushed_at: z.string().datetime({offset: true}).nullable().optional(),
+  created_at: z.string().datetime({offset: true}).nullable().optional(),
+  updated_at: z.string().datetime({offset: true}).nullable().optional(),
   permissions: z
     .object({
       admin: PermissiveBoolean.optional(),
@@ -4389,8 +4364,8 @@ export const s_nullable_integration = z
     description: z.string().nullable(),
     external_url: z.string(),
     html_url: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
     permissions: z.intersection(
       z.object({
         issues: z.string().optional(),
@@ -4420,10 +4395,10 @@ export const s_nullable_milestone = z
     creator: s_nullable_simple_user,
     open_issues: z.coerce.number(),
     closed_issues: z.coerce.number(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
-    closed_at: z.string().datetime({ offset: true }).nullable(),
-    due_on: z.string().datetime({ offset: true }).nullable(),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
+    closed_at: z.string().datetime({offset: true}).nullable(),
+    due_on: z.string().datetime({offset: true}).nullable(),
   })
   .nullable()
 
@@ -4499,9 +4474,9 @@ export const s_nullable_minimal_repository = z
     archived: PermissiveBoolean.optional(),
     disabled: PermissiveBoolean.optional(),
     visibility: z.string().optional(),
-    pushed_at: z.string().datetime({ offset: true }).nullable().optional(),
-    created_at: z.string().datetime({ offset: true }).nullable().optional(),
-    updated_at: z.string().datetime({ offset: true }).nullable().optional(),
+    pushed_at: z.string().datetime({offset: true}).nullable().optional(),
+    created_at: z.string().datetime({offset: true}).nullable().optional(),
+    updated_at: z.string().datetime({offset: true}).nullable().optional(),
     permissions: z
       .object({
         admin: PermissiveBoolean.optional(),
@@ -4620,9 +4595,9 @@ export const s_nullable_repository = z
     archived: PermissiveBoolean.default(false),
     disabled: PermissiveBoolean,
     visibility: z.string().optional().default("public"),
-    pushed_at: z.string().datetime({ offset: true }).nullable(),
-    created_at: z.string().datetime({ offset: true }).nullable(),
-    updated_at: z.string().datetime({ offset: true }).nullable(),
+    pushed_at: z.string().datetime({offset: true}).nullable(),
+    created_at: z.string().datetime({offset: true}).nullable(),
+    updated_at: z.string().datetime({offset: true}).nullable(),
     allow_rebase_merge: PermissiveBoolean.optional().default(true),
     temp_clone_token: z.string().optional(),
     allow_squash_merge: PermissiveBoolean.optional().default(true),
@@ -4743,9 +4718,7 @@ export const s_org_membership = z.object({
   organization_url: z.string(),
   organization: s_organization_simple,
   user: s_nullable_simple_user,
-  permissions: z
-    .object({ can_create_repository: PermissiveBoolean })
-    .optional(),
+  permissions: z.object({can_create_repository: PermissiveBoolean}).optional(),
 })
 
 export const s_org_repo_custom_property_values = z.object({
@@ -4821,8 +4794,8 @@ export const s_organization_role = z.object({
     .optional(),
   permissions: z.array(z.string()),
   organization: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_page = z.object({
@@ -4835,7 +4808,7 @@ export const s_page = z.object({
     .optional(),
   pending_domain_unverified_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   custom_404: PermissiveBoolean.default(false),
@@ -4850,12 +4823,12 @@ export const s_page = z.object({
 export const s_page_build = z.object({
   url: z.string(),
   status: z.string(),
-  error: z.object({ message: z.string().nullable() }),
+  error: z.object({message: z.string().nullable()}),
   pusher: s_nullable_simple_user,
   commit: z.string(),
   duration: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_private_vulnerability_report_create = z.object({
@@ -4893,8 +4866,8 @@ export const s_project = z.object({
   number: z.coerce.number(),
   state: z.string(),
   creator: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   organization_permission: z
     .enum(["read", "write", "admin", "none"])
     .optional(),
@@ -4907,8 +4880,8 @@ export const s_project_card = z.object({
   node_id: z.string(),
   note: z.string().nullable(),
   creator: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   archived: PermissiveBoolean.optional(),
   column_name: z.string().optional(),
   project_id: z.string().optional(),
@@ -4931,10 +4904,10 @@ export const s_pull_request_review = z.object({
   html_url: z.string(),
   pull_request_url: z.string(),
   _links: z.object({
-    html: z.object({ href: z.string() }),
-    pull_request: z.object({ href: z.string() }),
+    html: z.object({href: z.string()}),
+    pull_request: z.object({href: z.string()}),
   }),
-  submitted_at: z.string().datetime({ offset: true }).optional(),
+  submitted_at: z.string().datetime({offset: true}).optional(),
   commit_id: z.string().nullable(),
   body_html: z.string().optional(),
   body_text: z.string().optional(),
@@ -4955,15 +4928,15 @@ export const s_pull_request_review_comment = z.object({
   in_reply_to_id: z.coerce.number().optional(),
   user: s_simple_user,
   body: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   html_url: z.string(),
   pull_request_url: z.string(),
   author_association: s_author_association,
   _links: z.object({
-    self: z.object({ href: z.string() }),
-    html: z.object({ href: z.string() }),
-    pull_request: z.object({ href: z.string() }),
+    self: z.object({href: z.string()}),
+    html: z.object({href: z.string()}),
+    pull_request: z.object({href: z.string()}),
   }),
   start_line: z.coerce.number().nullable().optional(),
   original_start_line: z.coerce.number().nullable().optional(),
@@ -5009,7 +4982,7 @@ export const s_reaction = z.object({
     "rocket",
     "eyes",
   ]),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
 })
 
 export const s_release_asset = z.object({
@@ -5024,8 +4997,8 @@ export const s_release_asset = z.object({
   size: z.coerce.number(),
   digest: z.string().nullable(),
   download_count: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   uploader: s_nullable_simple_user,
 })
 
@@ -5040,9 +5013,9 @@ export const s_repo_search_result_item = z.object({
   description: z.string().nullable(),
   fork: PermissiveBoolean,
   url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  pushed_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  pushed_at: z.string().datetime({offset: true}),
   homepage: z.string().nullable(),
   size: z.coerce.number(),
   stargazers_count: z.coerce.number(),
@@ -5211,9 +5184,9 @@ export const s_repository = z.object({
   archived: PermissiveBoolean.default(false),
   disabled: PermissiveBoolean,
   visibility: z.string().optional().default("public"),
-  pushed_at: z.string().datetime({ offset: true }).nullable(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  pushed_at: z.string().datetime({offset: true}).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   allow_rebase_merge: PermissiveBoolean.optional().default(true),
   temp_clone_token: z.string().optional(),
   allow_squash_merge: PermissiveBoolean.optional().default(true),
@@ -5263,7 +5236,7 @@ export const s_repository_advisory_create = z.object({
   cwe_ids: z.array(z.string()).nullable().optional(),
   credits: z
     .array(
-      z.object({ login: z.string(), type: s_security_advisory_credit_types }),
+      z.object({login: z.string(), type: s_security_advisory_credit_types}),
     )
     .nullable()
     .optional(),
@@ -5298,7 +5271,7 @@ export const s_repository_advisory_update = z.object({
   cwe_ids: z.array(z.string()).nullable().optional(),
   credits: z
     .array(
-      z.object({ login: z.string(), type: s_security_advisory_credit_types }),
+      z.object({login: z.string(), type: s_security_advisory_credit_types}),
     )
     .nullable()
     .optional(),
@@ -5408,12 +5381,12 @@ export const s_review_comment = z.object({
   in_reply_to_id: z.coerce.number().optional(),
   user: s_nullable_simple_user,
   body: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   html_url: z.string(),
   pull_request_url: z.string(),
   author_association: s_author_association,
-  _links: z.object({ self: s_link, html: s_link, pull_request: s_link }),
+  _links: z.object({self: s_link, html: s_link, pull_request: s_link}),
   body_text: z.string().optional(),
   body_html: z.string().optional(),
   reactions: s_reaction_rollup.optional(),
@@ -5427,7 +5400,7 @@ export const s_review_comment = z.object({
 })
 
 export const s_ruleset_version_with_state = s_ruleset_version.merge(
-  z.object({ state: z.object({}) }),
+  z.object({state: z.object({})}),
 )
 
 export const s_runner = z.object({
@@ -5480,7 +5453,7 @@ export const s_secret_scanning_location = z.object({
 
 export const s_secret_scanning_push_protection_bypass = z.object({
   reason: s_secret_scanning_push_protection_bypass_reason.optional(),
-  expire_at: z.string().datetime({ offset: true }).nullable().optional(),
+  expire_at: z.string().datetime({offset: true}).nullable().optional(),
   token_type: z.string().optional(),
 })
 
@@ -5517,7 +5490,7 @@ export const s_simple_classroom_assignment = z.object({
   submitted: z.coerce.number(),
   passing: z.coerce.number(),
   language: z.string(),
-  deadline: z.string().datetime({ offset: true }).nullable(),
+  deadline: z.string().datetime({offset: true}).nullable(),
   classroom: s_simple_classroom,
 })
 
@@ -5571,7 +5544,7 @@ export const s_simple_repository = z.object({
 })
 
 export const s_stargazer = z.object({
-  starred_at: z.string().datetime({ offset: true }),
+  starred_at: z.string().datetime({offset: true}),
   user: s_nullable_simple_user,
 })
 
@@ -5621,8 +5594,8 @@ export const s_team_discussion = z.object({
   body_version: z.string(),
   comments_count: z.coerce.number(),
   comments_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  last_edited_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  last_edited_at: z.string().datetime({offset: true}).nullable(),
   html_url: z.string(),
   node_id: z.string(),
   number: z.coerce.number(),
@@ -5630,7 +5603,7 @@ export const s_team_discussion = z.object({
   private: PermissiveBoolean,
   team_url: z.string(),
   title: z.string(),
-  updated_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   reactions: s_reaction_rollup.optional(),
 })
@@ -5640,13 +5613,13 @@ export const s_team_discussion_comment = z.object({
   body: z.string(),
   body_html: z.string(),
   body_version: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  last_edited_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  last_edited_at: z.string().datetime({offset: true}).nullable(),
   discussion_url: z.string(),
   html_url: z.string(),
   node_id: z.string(),
   number: z.coerce.number(),
-  updated_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   reactions: s_reaction_rollup.optional(),
 })
@@ -5669,8 +5642,8 @@ export const s_team_full = z.object({
   parent: s_nullable_team_simple.optional(),
   members_count: z.coerce.number(),
   repos_count: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   organization: s_team_organization,
   ldap_dn: z.string().optional(),
 })
@@ -5780,9 +5753,9 @@ export const s_team_repository = z.object({
   archived: PermissiveBoolean.default(false),
   disabled: PermissiveBoolean,
   visibility: z.string().optional().default("public"),
-  pushed_at: z.string().datetime({ offset: true }).nullable(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  pushed_at: z.string().datetime({offset: true}).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   allow_rebase_merge: PermissiveBoolean.optional().default(true),
   temp_clone_token: z.string().optional(),
   allow_squash_merge: PermissiveBoolean.optional().default(true),
@@ -5834,10 +5807,10 @@ export const s_timeline_reviewed_event = z.object({
   html_url: z.string(),
   pull_request_url: z.string(),
   _links: z.object({
-    html: z.object({ href: z.string() }),
-    pull_request: z.object({ href: z.string() }),
+    html: z.object({href: z.string()}),
+    pull_request: z.object({href: z.string()}),
   }),
-  submitted_at: z.string().datetime({ offset: true }).optional(),
+  submitted_at: z.string().datetime({offset: true}).optional(),
   commit_id: z.string(),
   body_html: z.string().optional(),
   body_text: z.string().optional(),
@@ -5851,8 +5824,8 @@ export const s_topic_search_result_item = z.object({
   description: z.string().nullable(),
   created_by: z.string().nullable(),
   released: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   featured: PermissiveBoolean,
   curated: PermissiveBoolean,
   score: z.coerce.number(),
@@ -5893,11 +5866,11 @@ export const s_topic_search_result_item = z.object({
 
 export const s_user_marketplace_purchase = z.object({
   billing_cycle: z.string(),
-  next_billing_date: z.string().datetime({ offset: true }).nullable(),
+  next_billing_date: z.string().datetime({offset: true}).nullable(),
   unit_count: z.coerce.number().nullable(),
   on_free_trial: PermissiveBoolean,
-  free_trial_ends_on: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  free_trial_ends_on: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   account: s_marketplace_account,
   plan: s_marketplace_listing_plan,
 })
@@ -5952,8 +5925,8 @@ export const s_user_search_result_item = z.object({
   public_gists: z.coerce.number().optional(),
   followers: z.coerce.number().optional(),
   following: z.coerce.number().optional(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
   name: z.string().nullable().optional(),
   bio: z.string().nullable().optional(),
   email: z.string().email().nullable().optional(),
@@ -5963,7 +5936,7 @@ export const s_user_search_result_item = z.object({
   text_matches: s_search_result_text_matches.optional(),
   blog: z.string().nullable().optional(),
   company: z.string().nullable().optional(),
-  suspended_at: z.string().datetime({ offset: true }).nullable().optional(),
+  suspended_at: z.string().datetime({offset: true}).nullable().optional(),
   user_view_type: z.string().optional(),
 })
 
@@ -6030,7 +6003,7 @@ export const s_assigned_issue_event = z.object({
 
 export const s_authentication_token = z.object({
   token: z.string(),
-  expires_at: z.string().datetime({ offset: true }),
+  expires_at: z.string().datetime({offset: true}),
   permissions: z.object({}).optional(),
   repositories: z.array(s_repository).optional(),
   single_file: z.string().nullable().optional(),
@@ -6044,28 +6017,28 @@ export const s_authorization = z.object({
   token: z.string(),
   token_last_eight: z.string().nullable(),
   hashed_token: z.string().nullable(),
-  app: z.object({ client_id: z.string(), name: z.string(), url: z.string() }),
+  app: z.object({client_id: z.string(), name: z.string(), url: z.string()}),
   note: z.string().nullable(),
   note_url: z.string().nullable(),
-  updated_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
   fingerprint: z.string().nullable(),
   user: s_nullable_simple_user.optional(),
   installation: s_nullable_scoped_installation.optional(),
-  expires_at: z.string().datetime({ offset: true }).nullable(),
+  expires_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_campaign_summary = z.object({
   number: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   name: z.string().optional(),
   description: z.string(),
   managers: z.array(s_simple_user),
   team_managers: z.array(s_team).optional(),
-  published_at: z.string().datetime({ offset: true }).optional(),
-  ends_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  published_at: z.string().datetime({offset: true}).optional(),
+  ends_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable().optional(),
   state: s_campaign_state,
   contact_link: z.string().nullable(),
   alert_stats: z
@@ -6111,8 +6084,8 @@ export const s_check_suite = z.object({
   pull_requests: z.array(s_pull_request_minimal).nullable(),
   app: s_nullable_integration,
   repository: s_minimal_repository,
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   head_commit: s_simple_commit,
   latest_check_runs_count: z.coerce.number(),
   check_runs_url: z.string(),
@@ -6123,9 +6096,7 @@ export const s_check_suite = z.object({
 export const s_check_suite_preference = z.object({
   preferences: z.object({
     auto_trigger_checks: z
-      .array(
-        z.object({ app_id: z.coerce.number(), setting: PermissiveBoolean }),
-      )
+      .array(z.object({app_id: z.coerce.number(), setting: PermissiveBoolean}))
       .optional(),
   }),
   repository: s_minimal_repository,
@@ -6159,7 +6130,7 @@ export const s_classroom_assignment = z.object({
   submitted: z.coerce.number(),
   passing: z.coerce.number(),
   language: z.string(),
-  deadline: z.string().datetime({ offset: true }).nullable(),
+  deadline: z.string().datetime({offset: true}).nullable(),
   starter_code_repository: s_simple_classroom_repository,
   classroom: s_classroom,
 })
@@ -6246,9 +6217,9 @@ export const s_code_scanning_variant_analysis = z.object({
   actor: s_simple_user,
   query_language: s_code_scanning_variant_analysis_language,
   query_pack_url: z.string(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
-  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
+  completed_at: z.string().datetime({offset: true}).nullable().optional(),
   status: z.enum(["in_progress", "succeeded", "failed", "cancelled"]),
   actions_workflow_run_id: z.coerce.number().optional(),
   failure_reason: z
@@ -6301,7 +6272,7 @@ export const s_code_search_result_item = z.object({
   score: z.coerce.number(),
   file_size: z.coerce.number().optional(),
   language: z.string().nullable().optional(),
-  last_modified_at: z.string().datetime({ offset: true }).optional(),
+  last_modified_at: z.string().datetime({offset: true}).optional(),
   line_numbers: z.array(z.string()).optional(),
   text_matches: s_search_result_text_matches.optional(),
 })
@@ -6333,9 +6304,9 @@ export const s_codespace = z.object({
   machine: s_nullable_codespace_machine,
   devcontainer_path: z.string().nullable().optional(),
   prebuild: PermissiveBoolean.nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  last_used_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  last_used_at: z.string().datetime({offset: true}),
   state: z.enum([
     "Unknown",
     "Created",
@@ -6383,7 +6354,7 @@ export const s_codespace = z.object({
   retention_period_minutes: z.coerce.number().nullable().optional(),
   retention_expires_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   last_known_stop_notice: z.string().nullable().optional(),
@@ -6424,12 +6395,12 @@ export const s_commit_search_result_item = z.object({
     author: z.object({
       name: z.string(),
       email: z.string(),
-      date: z.string().datetime({ offset: true }),
+      date: z.string().datetime({offset: true}),
     }),
     committer: s_nullable_git_user,
     comment_count: z.coerce.number(),
     message: z.string(),
-    tree: z.object({ sha: z.string(), url: z.string() }),
+    tree: z.object({sha: z.string(), url: z.string()}),
     url: z.string(),
     verification: s_verification.optional(),
   }),
@@ -6475,10 +6446,10 @@ export const s_copilot_seat_details = z.object({
   organization: s_nullable_organization_simple.optional(),
   assigning_team: z.union([s_team, s_enterprise_team]).nullable().optional(),
   pending_cancellation_date: z.string().nullable().optional(),
-  last_activity_at: z.string().datetime({ offset: true }).nullable().optional(),
+  last_activity_at: z.string().datetime({offset: true}).nullable().optional(),
   last_activity_editor: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}).optional(),
   plan_type: z.enum(["business", "enterprise", "unknown"]).optional(),
 })
 
@@ -6492,7 +6463,7 @@ export const s_demilestoned_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  milestone: z.object({ title: z.string() }),
+  milestone: z.object({title: z.string()}),
 })
 
 export const s_dependabot_alert_security_advisory = z.object({
@@ -6508,14 +6479,14 @@ export const s_dependabot_alert_security_advisory = z.object({
   }),
   cvss_severities: s_cvss_severities.optional(),
   epss: s_security_advisory_epss.optional(),
-  cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })),
+  cwes: z.array(z.object({cwe_id: z.string(), name: z.string()})),
   identifiers: z.array(
-    z.object({ type: z.enum(["CVE", "GHSA"]), value: z.string() }),
+    z.object({type: z.enum(["CVE", "GHSA"]), value: z.string()}),
   ),
-  references: z.array(z.object({ url: z.string() })),
-  published_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  withdrawn_at: z.string().datetime({ offset: true }).nullable(),
+  references: z.array(z.object({url: z.string()})),
+  published_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  withdrawn_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_dependabot_repository_access_details = z.object({
@@ -6535,8 +6506,8 @@ export const s_deployment = z.object({
   environment: z.string(),
   description: z.string().nullable(),
   creator: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   statuses_url: z.string(),
   repository_url: z.string(),
   transient_environment: PermissiveBoolean.optional(),
@@ -6552,8 +6523,8 @@ export const s_deployment_simple = z.object({
   original_environment: z.string().optional(),
   environment: z.string(),
   description: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   statuses_url: z.string(),
   repository_url: z.string(),
   transient_environment: PermissiveBoolean.optional(),
@@ -6578,8 +6549,8 @@ export const s_deployment_status = z.object({
   description: z.string().max(140).default(""),
   environment: z.string().optional().default(""),
   target_url: z.string().default(""),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   deployment_url: z.string(),
   repository_url: z.string(),
   environment_url: z.string().optional().default(""),
@@ -6593,8 +6564,8 @@ export const s_environment = z.object({
   name: z.string(),
   url: z.string(),
   html_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   protection_rules: z
     .array(
       z.union([
@@ -6700,9 +6671,9 @@ export const s_full_repository = z.object({
   archived: PermissiveBoolean,
   disabled: PermissiveBoolean,
   visibility: z.string().optional(),
-  pushed_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  pushed_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   permissions: z
     .object({
       admin: PermissiveBoolean,
@@ -6754,8 +6725,8 @@ export const s_gist_simple = z.object({
         id: z.string().optional(),
         url: z.string().optional(),
         user: s_public_user.optional(),
-        created_at: z.string().datetime({ offset: true }).optional(),
-        updated_at: z.string().datetime({ offset: true }).optional(),
+        created_at: z.string().datetime({offset: true}).optional(),
+        updated_at: z.string().datetime({offset: true}).optional(),
       }),
     )
     .nullable()
@@ -6781,8 +6752,8 @@ export const s_gist_simple = z.object({
         }),
       ),
       public: PermissiveBoolean,
-      created_at: z.string().datetime({ offset: true }),
-      updated_at: z.string().datetime({ offset: true }),
+      created_at: z.string().datetime({offset: true}),
+      updated_at: z.string().datetime({offset: true}),
       description: z.string().nullable(),
       comments: z.coerce.number(),
       comments_enabled: PermissiveBoolean.optional(),
@@ -6843,14 +6814,14 @@ export const s_global_advisory = z.object({
   severity: z.enum(["critical", "high", "medium", "low", "unknown"]),
   source_code_location: z.string().nullable(),
   identifiers: z
-    .array(z.object({ type: z.enum(["CVE", "GHSA"]), value: z.string() }))
+    .array(z.object({type: z.enum(["CVE", "GHSA"]), value: z.string()}))
     .nullable(),
   references: z.array(z.string()).nullable(),
-  published_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  github_reviewed_at: z.string().datetime({ offset: true }).nullable(),
-  nvd_published_at: z.string().datetime({ offset: true }).nullable(),
-  withdrawn_at: z.string().datetime({ offset: true }).nullable(),
+  published_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  github_reviewed_at: z.string().datetime({offset: true}).nullable(),
+  nvd_published_at: z.string().datetime({offset: true}).nullable(),
+  withdrawn_at: z.string().datetime({offset: true}).nullable(),
   vulnerabilities: z.array(s_vulnerability).nullable(),
   cvss: z
     .object({
@@ -6860,10 +6831,10 @@ export const s_global_advisory = z.object({
     .nullable(),
   cvss_severities: s_cvss_severities.optional(),
   epss: s_security_advisory_epss.optional(),
-  cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })).nullable(),
+  cwes: z.array(z.object({cwe_id: z.string(), name: z.string()})).nullable(),
   credits: z
     .array(
-      z.object({ user: s_simple_user, type: s_security_advisory_credit_types }),
+      z.object({user: s_simple_user, type: s_security_advisory_credit_types}),
     )
     .nullable(),
 })
@@ -6875,8 +6846,8 @@ export const s_hook = z.object({
   active: PermissiveBoolean,
   events: z.array(z.string()),
   config: s_webhook_config,
-  updated_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
   url: z.string(),
   test_url: z.string(),
   ping_url: z.string(),
@@ -6935,16 +6906,16 @@ export const s_issue = z.object({
   comments: z.coerce.number(),
   pull_request: z
     .object({
-      merged_at: z.string().datetime({ offset: true }).nullable().optional(),
+      merged_at: z.string().datetime({offset: true}).nullable().optional(),
       diff_url: z.string().nullable(),
       html_url: z.string().nullable(),
       patch_url: z.string().nullable(),
       url: z.string().nullable(),
     })
     .optional(),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   draft: PermissiveBoolean.optional(),
   closed_by: s_nullable_simple_user.optional(),
   body_html: z.string().optional(),
@@ -6967,8 +6938,8 @@ export const s_issue_comment = z.object({
   body_html: z.string().optional(),
   html_url: z.string(),
   user: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   issue_url: z.string(),
   author_association: s_author_association,
   performed_via_github_app: s_nullable_integration.optional(),
@@ -7013,13 +6984,13 @@ export const s_issue_search_result_item = z.object({
   assignee: s_nullable_simple_user,
   milestone: s_nullable_milestone,
   comments: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
   text_matches: s_search_result_text_matches.optional(),
   pull_request: z
     .object({
-      merged_at: z.string().datetime({ offset: true }).nullable().optional(),
+      merged_at: z.string().datetime({offset: true}).nullable().optional(),
       diff_url: z.string().nullable(),
       html_url: z.string().nullable(),
       patch_url: z.string().nullable(),
@@ -7049,7 +7020,7 @@ export const s_labeled_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  label: z.object({ name: z.string(), color: z.string() }),
+  label: z.object({name: z.string(), color: z.string()}),
 })
 
 export const s_locked_issue_event = z.object({
@@ -7067,7 +7038,7 @@ export const s_locked_issue_event = z.object({
 
 export const s_manifest = z.object({
   name: z.string(),
-  file: z.object({ source_location: z.string().optional() }).optional(),
+  file: z.object({source_location: z.string().optional()}).optional(),
   metadata: s_metadata.optional(),
   resolved: z.record(s_dependency).optional(),
 })
@@ -7086,8 +7057,8 @@ export const s_migration = z.object({
   org_metadata_only: PermissiveBoolean,
   repositories: z.array(s_repository),
   url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   node_id: z.string(),
   archive_url: z.string().optional(),
   exclude: z.array(z.string()).optional(),
@@ -7103,7 +7074,7 @@ export const s_milestoned_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  milestone: z.object({ title: z.string() }),
+  milestone: z.object({title: z.string()}),
 })
 
 export const s_moved_column_in_project_issue_event = z.object({
@@ -7169,16 +7140,16 @@ export const s_nullable_issue = z
     comments: z.coerce.number(),
     pull_request: z
       .object({
-        merged_at: z.string().datetime({ offset: true }).nullable().optional(),
+        merged_at: z.string().datetime({offset: true}).nullable().optional(),
         diff_url: z.string().nullable(),
         html_url: z.string().nullable(),
         patch_url: z.string().nullable(),
         url: z.string().nullable(),
       })
       .optional(),
-    closed_at: z.string().datetime({ offset: true }).nullable(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    closed_at: z.string().datetime({offset: true}).nullable(),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
     draft: PermissiveBoolean.optional(),
     closed_by: s_nullable_simple_user.optional(),
     body_html: z.string().optional(),
@@ -7214,7 +7185,7 @@ export const s_organization_secret_scanning_alert = z.object({
   locations_url: z.string().optional(),
   state: s_secret_scanning_alert_state.optional(),
   resolution: s_secret_scanning_alert_resolution.optional(),
-  resolved_at: z.string().datetime({ offset: true }).nullable().optional(),
+  resolved_at: z.string().datetime({offset: true}).nullable().optional(),
   resolved_by: s_nullable_simple_user.optional(),
   secret_type: z.string().optional(),
   secret_type_display_name: z.string().optional(),
@@ -7224,7 +7195,7 @@ export const s_organization_secret_scanning_alert = z.object({
   push_protection_bypassed_by: s_nullable_simple_user.optional(),
   push_protection_bypassed_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   push_protection_bypass_request_reviewer: s_nullable_simple_user.optional(),
@@ -7261,8 +7232,8 @@ export const s_package = z.object({
   visibility: z.enum(["private", "public"]),
   owner: s_nullable_simple_user.optional(),
   repository: s_nullable_minimal_repository.optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_pending_deployment = z.object({
@@ -7274,7 +7245,7 @@ export const s_pending_deployment = z.object({
     html_url: z.string().optional(),
   }),
   wait_timer: z.coerce.number(),
-  wait_timer_started_at: z.string().datetime({ offset: true }).nullable(),
+  wait_timer_started_at: z.string().datetime({offset: true}).nullable(),
   current_user_can_approve: PermissiveBoolean,
   reviewers: z.array(
     z.object({
@@ -7314,24 +7285,24 @@ export const s_protected_branch = z.object({
     })
     .optional(),
   required_signatures: z
-    .object({ url: z.string(), enabled: PermissiveBoolean })
+    .object({url: z.string(), enabled: PermissiveBoolean})
     .optional(),
   enforce_admins: z
-    .object({ url: z.string(), enabled: PermissiveBoolean })
+    .object({url: z.string(), enabled: PermissiveBoolean})
     .optional(),
-  required_linear_history: z.object({ enabled: PermissiveBoolean }).optional(),
-  allow_force_pushes: z.object({ enabled: PermissiveBoolean }).optional(),
-  allow_deletions: z.object({ enabled: PermissiveBoolean }).optional(),
+  required_linear_history: z.object({enabled: PermissiveBoolean}).optional(),
+  allow_force_pushes: z.object({enabled: PermissiveBoolean}).optional(),
+  allow_deletions: z.object({enabled: PermissiveBoolean}).optional(),
   restrictions: s_branch_restriction_policy.optional(),
   required_conversation_resolution: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
-  block_creations: z.object({ enabled: PermissiveBoolean }).optional(),
+  block_creations: z.object({enabled: PermissiveBoolean}).optional(),
   lock_branch: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
   allow_fork_syncing: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
 })
 
@@ -7392,10 +7363,10 @@ export const s_pull_request = z.object({
   ),
   milestone: s_nullable_milestone,
   active_lock_reason: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  merged_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  merged_at: z.string().datetime({offset: true}).nullable(),
   merge_commit_sha: z.string().nullable(),
   assignee: s_nullable_simple_user,
   assignees: z.array(s_simple_user).nullable().optional(),
@@ -7479,10 +7450,10 @@ export const s_pull_request_simple = z.object({
   ),
   milestone: s_nullable_milestone,
   active_lock_reason: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  merged_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  merged_at: z.string().datetime({offset: true}).nullable(),
   merge_commit_sha: z.string().nullable(),
   assignee: s_nullable_simple_user,
   assignees: z.array(s_simple_user).nullable().optional(),
@@ -7532,8 +7503,8 @@ export const s_release = z.object({
   body: z.string().nullable().optional(),
   draft: PermissiveBoolean,
   prerelease: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }),
-  published_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  published_at: z.string().datetime({offset: true}).nullable(),
   author: s_simple_user,
   assets: z.array(s_release_asset),
   body_html: z.string().optional(),
@@ -7575,7 +7546,7 @@ export const s_renamed_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  rename: z.object({ from: z.string(), to: z.string() }),
+  rename: z.object({from: z.string(), to: z.string()}),
 })
 
 export const s_repository_advisory = z.object({
@@ -7589,15 +7560,15 @@ export const s_repository_advisory = z.object({
   author: s_simple_user.nullable(),
   publisher: s_simple_user.nullable(),
   identifiers: z.array(
-    z.object({ type: z.enum(["CVE", "GHSA"]), value: z.string() }),
+    z.object({type: z.enum(["CVE", "GHSA"]), value: z.string()}),
   ),
   state: z.enum(["published", "closed", "withdrawn", "draft", "triage"]),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
-  published_at: z.string().datetime({ offset: true }).nullable(),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  withdrawn_at: z.string().datetime({ offset: true }).nullable(),
-  submission: z.object({ accepted: PermissiveBoolean }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
+  published_at: z.string().datetime({offset: true}).nullable(),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  withdrawn_at: z.string().datetime({offset: true}).nullable(),
+  submission: z.object({accepted: PermissiveBoolean}).nullable(),
   vulnerabilities: z.array(s_repository_advisory_vulnerability).nullable(),
   cvss: z
     .object({
@@ -7606,7 +7577,7 @@ export const s_repository_advisory = z.object({
     })
     .nullable(),
   cvss_severities: s_cvss_severities.optional(),
-  cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })).nullable(),
+  cwes: z.array(z.object({cwe_id: z.string(), name: z.string()})).nullable(),
   cwe_ids: z.array(z.string()).nullable(),
   credits: z
     .array(
@@ -7628,7 +7599,7 @@ export const s_repository_invitation = z.object({
   invitee: s_nullable_simple_user,
   inviter: s_nullable_simple_user,
   permissions: z.enum(["read", "write", "admin", "triage", "maintain"]),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   expired: PermissiveBoolean.optional(),
   url: z.string(),
   html_url: z.string(),
@@ -7752,7 +7723,7 @@ export const s_secret_scanning_alert = z.object({
   locations_url: z.string().optional(),
   state: s_secret_scanning_alert_state.optional(),
   resolution: s_secret_scanning_alert_resolution.optional(),
-  resolved_at: z.string().datetime({ offset: true }).nullable().optional(),
+  resolved_at: z.string().datetime({offset: true}).nullable().optional(),
   resolved_by: s_nullable_simple_user.optional(),
   resolution_comment: z.string().nullable().optional(),
   secret_type: z.string().optional(),
@@ -7762,7 +7733,7 @@ export const s_secret_scanning_alert = z.object({
   push_protection_bypassed_by: s_nullable_simple_user.optional(),
   push_protection_bypassed_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   push_protection_bypass_request_reviewer: s_nullable_simple_user.optional(),
@@ -7782,7 +7753,7 @@ export const s_secret_scanning_alert = z.object({
 })
 
 export const s_starred_repository = z.object({
-  starred_at: z.string().datetime({ offset: true }),
+  starred_at: z.string().datetime({offset: true}),
   repo: s_repository,
 })
 
@@ -7840,8 +7811,8 @@ export const s_timeline_comment_event = z.object({
   body_html: z.string().optional(),
   html_url: z.string(),
   user: s_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   issue_url: z.string(),
   author_association: s_author_association,
   performed_via_github_app: s_nullable_integration.optional(),
@@ -7898,7 +7869,7 @@ export const s_unlabeled_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  label: z.object({ name: z.string(), color: z.string() }),
+  label: z.object({name: z.string(), color: z.string()}),
 })
 
 export const s_workflow_run = z.object({
@@ -7920,11 +7891,11 @@ export const s_workflow_run = z.object({
   url: z.string(),
   html_url: z.string(),
   pull_requests: z.array(s_pull_request_minimal).nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   actor: s_simple_user.optional(),
   triggering_actor: s_simple_user.optional(),
-  run_started_at: z.string().datetime({ offset: true }).optional(),
+  run_started_at: z.string().datetime({offset: true}).optional(),
   jobs_url: z.string(),
   logs_url: z.string(),
   check_suite_url: z.string(),
@@ -7949,30 +7920,26 @@ export const s_branch_protection = z.object({
     s_protected_branch_pull_request_review.optional(),
   restrictions: s_branch_restriction_policy.optional(),
   required_linear_history: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
   allow_force_pushes: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
-  allow_deletions: z
-    .object({ enabled: PermissiveBoolean.optional() })
-    .optional(),
-  block_creations: z
-    .object({ enabled: PermissiveBoolean.optional() })
-    .optional(),
+  allow_deletions: z.object({enabled: PermissiveBoolean.optional()}).optional(),
+  block_creations: z.object({enabled: PermissiveBoolean.optional()}).optional(),
   required_conversation_resolution: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
   name: z.string().optional(),
   protection_url: z.string().optional(),
   required_signatures: z
-    .object({ url: z.string(), enabled: PermissiveBoolean })
+    .object({url: z.string(), enabled: PermissiveBoolean})
     .optional(),
   lock_branch: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
   allow_fork_syncing: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
 })
 
@@ -8003,8 +7970,8 @@ export const s_check_run = z.object({
       "action_required",
     ])
     .nullable(),
-  started_at: z.string().datetime({ offset: true }).nullable(),
-  completed_at: z.string().datetime({ offset: true }).nullable(),
+  started_at: z.string().datetime({offset: true}).nullable(),
+  completed_at: z.string().datetime({offset: true}).nullable(),
   output: z.object({
     title: z.string().nullable(),
     summary: z.string().nullable(),
@@ -8013,7 +7980,7 @@ export const s_check_run = z.object({
     annotations_url: z.string(),
   }),
   name: z.string(),
-  check_suite: z.object({ id: z.coerce.number() }).nullable(),
+  check_suite: z.object({id: z.coerce.number()}).nullable(),
   app: s_nullable_integration,
   pull_requests: z.array(s_pull_request_minimal),
   deployment: s_deployment_simple.optional(),
@@ -8030,9 +7997,9 @@ export const s_codespace_with_full_repository = z.object({
   machine: s_nullable_codespace_machine,
   devcontainer_path: z.string().nullable().optional(),
   prebuild: PermissiveBoolean.nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  last_used_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  last_used_at: z.string().datetime({offset: true}),
   state: z.enum([
     "Unknown",
     "Created",
@@ -8080,7 +8047,7 @@ export const s_codespace_with_full_repository = z.object({
   retention_period_minutes: z.coerce.number().nullable().optional(),
   retention_expires_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
 })
@@ -8158,7 +8125,7 @@ export const s_event = z.object({
   id: z.string(),
   type: z.string().nullable(),
   actor: s_actor,
-  repo: z.object({ id: z.coerce.number(), name: z.string(), url: z.string() }),
+  repo: z.object({id: z.coerce.number(), name: z.string(), url: z.string()}),
   org: s_actor.optional(),
   payload: z.object({
     action: z.string().optional(),
@@ -8178,7 +8145,7 @@ export const s_event = z.object({
       .optional(),
   }),
   public: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_issue_event = z.object({
@@ -8189,7 +8156,7 @@ export const s_issue_event = z.object({
   event: z.string(),
   commit_id: z.string().nullable(),
   commit_url: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   issue: s_nullable_issue.optional(),
   label: s_issue_event_label.optional(),
   assignee: s_nullable_simple_user.optional(),
@@ -8238,8 +8205,8 @@ export const s_repository_ruleset = z.object({
   node_id: z.string().optional(),
   _links: z
     .object({
-      self: z.object({ href: z.string().optional() }).optional(),
-      html: z.object({ href: z.string().optional() }).nullable().optional(),
+      self: z.object({href: z.string().optional()}).optional(),
+      html: z.object({href: z.string().optional()}).nullable().optional(),
     })
     .optional(),
   conditions: z
@@ -8247,8 +8214,8 @@ export const s_repository_ruleset = z.object({
     .nullable()
     .optional(),
   rules: z.array(s_repository_rule).optional(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_snapshot = z.object({
@@ -8260,28 +8227,24 @@ export const s_snapshot = z.object({
   }),
   sha: z.string().min(40).max(40),
   ref: z.string().regex(new RegExp("^refs/")),
-  detector: z.object({
-    name: z.string(),
-    version: z.string(),
-    url: z.string(),
-  }),
+  detector: z.object({name: z.string(), version: z.string(), url: z.string()}),
   metadata: s_metadata.optional(),
   manifests: z.record(s_manifest).optional(),
-  scanned: z.string().datetime({ offset: true }),
+  scanned: z.string().datetime({offset: true}),
 })
 
 export const s_timeline_cross_referenced_event = z.object({
   event: z.string(),
   actor: s_simple_user.optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  source: z.object({ type: z.string().optional(), issue: s_issue.optional() }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  source: z.object({type: z.string().optional(), issue: s_issue.optional()}),
 })
 
 export const s_branch_with_protection = z.object({
   name: z.string(),
   commit: s_commit,
-  _links: z.object({ html: z.string(), self: z.string() }),
+  _links: z.object({html: z.string(), self: z.string()}),
   protected: PermissiveBoolean,
   protection: s_branch_protection,
   protection_url: z.string(),
@@ -8291,7 +8254,7 @@ export const s_branch_with_protection = z.object({
 
 export const s_short_branch = z.object({
   name: z.string(),
-  commit: z.object({ sha: z.string(), url: z.string() }),
+  commit: z.object({sha: z.string(), url: z.string()}),
   protected: PermissiveBoolean,
   protection: s_branch_protection.optional(),
   protection_url: z.string().optional(),

--- a/integration-tests/typescript-express/src/generated/azure-core-data-plane-service.tsp/generated.ts
+++ b/integration-tests/typescript-express/src/generated/azure-core-data-plane-service.tsp/generated.ts
@@ -113,8 +113,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetServiceStatusResponder = {
   with200(): ExpressRuntimeResponse<{
@@ -631,7 +631,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const getServiceStatusResponseBodyValidator = responseValidationFactory(
-    [["200", z.object({ statusString: z.string() })]],
+    [["200", z.object({statusString: z.string()})]],
     s_Azure_Core_Foundations_ErrorResponse,
   )
 
@@ -682,7 +682,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -701,10 +701,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusParamSchema =
-    z.object({ widgetName: z.string(), operationId: z.string() })
+    z.object({widgetName: z.string(), operationId: z.string()})
 
   const widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusQuerySchema =
-    z.object({ "api-version": z.string().min(1) })
+    z.object({"api-version": z.string().min(1)})
 
   const widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusResponseBodyValidator =
     responseValidationFactory(
@@ -792,7 +792,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -900,7 +900,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -920,7 +920,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const widgetsGetWidgetParamSchema = z.object({ widgetName: z.string() })
+  const widgetsGetWidgetParamSchema = z.object({widgetName: z.string()})
 
   const widgetsGetWidgetQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -988,7 +988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1006,7 +1006,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const widgetsDeleteWidgetParamSchema = z.object({ widgetName: z.string() })
+  const widgetsDeleteWidgetParamSchema = z.object({widgetName: z.string()})
 
   const widgetsDeleteWidgetQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1089,7 +1089,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1174,7 +1174,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1192,7 +1192,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const widgetsGetAnalyticsParamSchema = z.object({ widgetName: z.string() })
+  const widgetsGetAnalyticsParamSchema = z.object({widgetName: z.string()})
 
   const widgetsGetAnalyticsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1260,7 +1260,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1278,7 +1278,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const widgetsUpdateAnalyticsParamSchema = z.object({ widgetName: z.string() })
+  const widgetsUpdateAnalyticsParamSchema = z.object({widgetName: z.string()})
 
   const widgetsUpdateAnalyticsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1361,7 +1361,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1453,7 +1453,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1471,7 +1471,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const widgetsScheduleRepairsParamSchema = z.object({ widgetName: z.string() })
+  const widgetsScheduleRepairsParamSchema = z.object({widgetName: z.string()})
 
   const widgetsScheduleRepairsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1496,10 +1496,10 @@ export function createRouter(implementation: Implementation): Router {
           result: z
             .object({
               requestState: s_WidgetRepairState,
-              scheduledDateTime: z.string().datetime({ offset: true }),
-              createdDateTime: z.string().datetime({ offset: true }),
-              updatedDateTime: z.string().datetime({ offset: true }),
-              completedDateTime: z.string().datetime({ offset: true }),
+              scheduledDateTime: z.string().datetime({offset: true}),
+              createdDateTime: z.string().datetime({offset: true}),
+              updatedDateTime: z.string().datetime({offset: true}),
+              completedDateTime: z.string().datetime({offset: true}),
             })
             .optional(),
         }),
@@ -1574,7 +1574,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1674,7 +1674,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1776,7 +1776,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1863,7 +1863,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1955,7 +1955,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2047,7 +2047,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2067,9 +2067,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const widgetPartsReorderPartsParamSchema = z.object({
-    widgetName: z.string(),
-  })
+  const widgetPartsReorderPartsParamSchema = z.object({widgetName: z.string()})
 
   const widgetPartsReorderPartsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -2155,7 +2153,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2254,7 +2252,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2369,7 +2367,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2463,7 +2461,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2569,7 +2567,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2648,7 +2646,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/azure-core-data-plane-service.tsp/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/azure-core-data-plane-service.tsp/schemas.ts
@@ -7,7 +7,7 @@ import {
   t_Azure_Core_Foundations_ErrorResponse,
   t_Azure_Core_Foundations_InnerError,
 } from "./models"
-import { z } from "zod"
+import {z} from "zod"
 
 export const s_Azure_Core_Foundations_OperationState = z.union([
   z.enum(["NotStarted", "Running", "Succeeded", "Failed", "Canceled"]),
@@ -34,7 +34,7 @@ export const s_WidgetColor = z.union([
   z.enum(["Black", "White", "Red", "Green", "Blue"]),
 ])
 
-export const s_WidgetPartReorderRequest = z.object({ signedOffBy: z.string() })
+export const s_WidgetPartReorderRequest = z.object({signedOffBy: z.string()})
 
 export const s_WidgetRepairState = z.union([
   z.string(),
@@ -69,10 +69,10 @@ export const s_WidgetPart = z.object({
 
 export const s_WidgetRepairRequest = z.object({
   requestState: s_WidgetRepairState,
-  scheduledDateTime: z.string().datetime({ offset: true }),
-  createdDateTime: z.string().datetime({ offset: true }),
-  updatedDateTime: z.string().datetime({ offset: true }),
-  completedDateTime: z.string().datetime({ offset: true }),
+  scheduledDateTime: z.string().datetime({offset: true}),
+  createdDateTime: z.string().datetime({offset: true}),
+  updatedDateTime: z.string().datetime({offset: true}),
+  completedDateTime: z.string().datetime({offset: true}),
 })
 
 export const s_PagedManufacturer = z.object({
@@ -94,7 +94,7 @@ export const s_Azure_Core_Foundations_ErrorResponse: z.ZodType<
   t_Azure_Core_Foundations_ErrorResponse,
   z.ZodTypeDef,
   unknown
-> = z.object({ error: z.lazy(() => s_Azure_Core_Foundations_Error) })
+> = z.object({error: z.lazy(() => s_Azure_Core_Foundations_Error)})
 
 export const s_Azure_Core_Foundations_Error: z.ZodType<
   t_Azure_Core_Foundations_Error,

--- a/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/generated.ts
+++ b/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/generated.ts
@@ -56,8 +56,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type OperationsListResponder = {
   with200(): ExpressRuntimeResponse<t_OperationListResult>
@@ -252,9 +252,7 @@ export type Implementation = {
 export function createRouter(implementation: Implementation): Router {
   const router = Router()
 
-  const operationsListQuerySchema = z.object({
-    "api-version": z.string().min(1),
-  })
+  const operationsListQuerySchema = z.object({"api-version": z.string().min(1)})
 
   const operationsListResponseBodyValidator = responseValidationFactory(
     [["200", s_OperationListResult]],
@@ -302,7 +300,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -330,7 +328,7 @@ export function createRouter(implementation: Implementation): Router {
     employeeName: z.string().regex(new RegExp("^[a-zA-Z0-9-]{3,24}$")),
   })
 
-  const employeesGetQuerySchema = z.object({ "api-version": z.string().min(1) })
+  const employeesGetQuerySchema = z.object({"api-version": z.string().min(1)})
 
   const employeesGetResponseBodyValidator = responseValidationFactory(
     [["200", s_Employee]],
@@ -382,7 +380,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -477,7 +475,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -565,7 +563,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -653,7 +651,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -742,7 +740,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -824,7 +822,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -903,7 +901,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -933,9 +931,7 @@ export function createRouter(implementation: Implementation): Router {
     employeeName: z.string().regex(new RegExp("^[a-zA-Z0-9-]{3,24}$")),
   })
 
-  const employeesMoveQuerySchema = z.object({
-    "api-version": z.string().min(1),
-  })
+  const employeesMoveQuerySchema = z.object({"api-version": z.string().min(1)})
 
   const employeesMoveRequestBodySchema = s_MoveRequest
 
@@ -993,7 +989,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_Azure_Core_armResourceType = string
 

--- a/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/azure-resource-manager.tsp/schemas.ts
@@ -6,7 +6,7 @@ import {
   t_Azure_ResourceManager_CommonTypes_ErrorDetail,
   t_Azure_ResourceManager_CommonTypes_ErrorResponse,
 } from "./models"
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -27,7 +27,7 @@ export const s_Azure_ResourceManager_CommonTypes_ActionType = z.union([
 ])
 
 export const s_Azure_ResourceManager_CommonTypes_ErrorAdditionalInfo = z.object(
-  { type: z.string().optional(), info: z.object({}).optional() },
+  {type: z.string().optional(), info: z.object({}).optional()},
 )
 
 export const s_Azure_ResourceManager_CommonTypes_OperationDisplay = z.object({
@@ -53,9 +53,9 @@ export const s_EmployeeUpdateProperties = z.object({
   profile: z.string().optional(),
 })
 
-export const s_MoveRequest = z.object({ from: z.string(), to: z.string() })
+export const s_MoveRequest = z.object({from: z.string(), to: z.string()})
 
-export const s_MoveResponse = z.object({ movingStatus: z.string() })
+export const s_MoveResponse = z.object({movingStatus: z.string()})
 
 export const s_Azure_ResourceManager_CommonTypes_Operation = z.object({
   name: z.string().optional(),
@@ -68,11 +68,11 @@ export const s_Azure_ResourceManager_CommonTypes_Operation = z.object({
 export const s_Azure_ResourceManager_CommonTypes_SystemData = z.object({
   createdBy: z.string().optional(),
   createdByType: s_Azure_ResourceManager_CommonTypes_createdByType.optional(),
-  createdAt: z.string().datetime({ offset: true }).optional(),
+  createdAt: z.string().datetime({offset: true}).optional(),
   lastModifiedBy: z.string().optional(),
   lastModifiedByType:
     s_Azure_ResourceManager_CommonTypes_createdByType.optional(),
-  lastModifiedAt: z.string().datetime({ offset: true }).optional(),
+  lastModifiedAt: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_EmployeeUpdate = z.object({

--- a/integration-tests/typescript-express/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/okta.idp.yaml/generated.ts
@@ -84,8 +84,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type CreateAppAuthenticatorEnrollmentResponder = {
   with200(): ExpressRuntimeResponse<t_AppAuthenticatorEnrollment>
@@ -777,7 +777,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -866,7 +866,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -956,7 +956,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1036,7 +1036,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1057,7 +1057,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const listAppAuthenticatorPendingPushNotificationChallengesParamSchema =
-    z.object({ enrollmentId: z.string() })
+    z.object({enrollmentId: z.string()})
 
   const listAppAuthenticatorPendingPushNotificationChallengesResponseBodyValidator =
     responseValidationFactory(
@@ -1115,7 +1115,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1193,7 +1193,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1211,11 +1211,9 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getAuthenticatorParamSchema = z.object({ authenticatorId: z.string() })
+  const getAuthenticatorParamSchema = z.object({authenticatorId: z.string()})
 
-  const getAuthenticatorQuerySchema = z.object({
-    expand: z.string().optional(),
-  })
+  const getAuthenticatorQuerySchema = z.object({expand: z.string().optional()})
 
   const getAuthenticatorResponseBodyValidator = responseValidationFactory(
     [
@@ -1276,7 +1274,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1294,7 +1292,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const listEnrollmentsParamSchema = z.object({ authenticatorId: z.string() })
+  const listEnrollmentsParamSchema = z.object({authenticatorId: z.string()})
 
   const listEnrollmentsResponseBodyValidator = responseValidationFactory(
     [
@@ -1351,7 +1349,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1429,7 +1427,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1514,7 +1512,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1575,7 +1573,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1594,7 +1592,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const createEmailRequestBodySchema = z.object({
-    profile: z.object({ email: z.string().email() }),
+    profile: z.object({email: z.string().email()}),
     sendEmail: PermissiveBoolean.optional().default(true),
     state: z.string().optional(),
     role: z.enum(["PRIMARY", "SECONDARY"]).optional(),
@@ -1659,7 +1657,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1677,7 +1675,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getEmailParamSchema = z.object({ id: z.string() })
+  const getEmailParamSchema = z.object({id: z.string()})
 
   const getEmailResponseBodyValidator = responseValidationFactory(
     [
@@ -1726,7 +1724,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1744,7 +1742,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deleteEmailParamSchema = z.object({ id: z.string() })
+  const deleteEmailParamSchema = z.object({id: z.string()})
 
   const deleteEmailResponseBodyValidator = responseValidationFactory(
     [
@@ -1801,7 +1799,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1819,9 +1817,9 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const sendEmailChallengeParamSchema = z.object({ id: z.string() })
+  const sendEmailChallengeParamSchema = z.object({id: z.string()})
 
-  const sendEmailChallengeRequestBodySchema = z.object({ state: z.string() })
+  const sendEmailChallengeRequestBodySchema = z.object({state: z.string()})
 
   const sendEmailChallengeResponseBodyValidator = responseValidationFactory(
     [
@@ -1831,15 +1829,15 @@ export function createRouter(implementation: Implementation): Router {
           id: z.string().min(1),
           status: z.enum(["VERIFIED", "UNVERIFIED"]),
           expiresAt: z.string().min(1),
-          profile: z.object({ email: z.string().min(1) }),
+          profile: z.object({email: z.string().min(1)}),
           _links: z.object({
             verify: z.object({
               href: z.string().min(1),
-              hints: z.object({ allow: z.array(z.enum(["POST"])) }),
+              hints: z.object({allow: z.array(z.enum(["POST"]))}),
             }),
             poll: z.object({
               href: z.string().min(1),
-              hints: z.object({ allow: z.array(z.enum(["GET"])) }),
+              hints: z.object({allow: z.array(z.enum(["GET"]))}),
             }),
           }),
         }),
@@ -1921,7 +1919,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1953,7 +1951,7 @@ export function createRouter(implementation: Implementation): Router {
             id: z.string().min(1),
             status: z.enum(["VERIFIED", "UNVERIFIED"]),
             expiresAt: z.string().min(1),
-            profile: z.object({ email: z.string().min(1) }),
+            profile: z.object({email: z.string().min(1)}),
             _links: z.object({
               verify: z.object({
                 href: z.string().min(1),
@@ -2039,7 +2037,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2127,7 +2125,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2188,7 +2186,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2249,7 +2247,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2310,7 +2308,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2329,7 +2327,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const createPasswordRequestBodySchema = z.object({
-    profile: z.object({ password: z.string() }),
+    profile: z.object({password: z.string()}),
   })
 
   const createPasswordResponseBodyValidator = responseValidationFactory(
@@ -2387,7 +2385,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2406,7 +2404,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const replacePasswordRequestBodySchema = z.object({
-    profile: z.object({ password: z.string() }),
+    profile: z.object({password: z.string()}),
   })
 
   const replacePasswordResponseBodyValidator = responseValidationFactory(
@@ -2464,7 +2462,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2529,7 +2527,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2590,7 +2588,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2609,7 +2607,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const createPhoneRequestBodySchema = z.object({
-    profile: z.object({ phoneNumber: z.string().optional() }),
+    profile: z.object({phoneNumber: z.string().optional()}),
     sendCode: PermissiveBoolean.optional().default(true),
     method: z.enum(["SMS", "CALL"]).optional(),
   })
@@ -2677,7 +2675,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2695,7 +2693,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getPhoneParamSchema = z.object({ id: z.string() })
+  const getPhoneParamSchema = z.object({id: z.string()})
 
   const getPhoneResponseBodyValidator = responseValidationFactory(
     [
@@ -2748,7 +2746,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2766,7 +2764,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deletePhoneParamSchema = z.object({ id: z.string() })
+  const deletePhoneParamSchema = z.object({id: z.string()})
 
   const deletePhoneResponseBodyValidator = responseValidationFactory(
     [
@@ -2823,7 +2821,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2841,7 +2839,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const sendPhoneChallengeParamSchema = z.object({ id: z.string() })
+  const sendPhoneChallengeParamSchema = z.object({id: z.string()})
 
   const sendPhoneChallengeRequestBodySchema = z.object({
     method: z.enum(["SMS", "CALL"]),
@@ -2858,7 +2856,7 @@ export function createRouter(implementation: Implementation): Router {
               verify: z
                 .object({
                   href: z.string().min(1),
-                  hints: z.object({ allow: z.array(z.enum(["GET"])) }),
+                  hints: z.object({allow: z.array(z.enum(["GET"]))}),
                 })
                 .optional(),
             })
@@ -2942,7 +2940,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2960,7 +2958,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const verifyPhoneChallengeParamSchema = z.object({ id: z.string() })
+  const verifyPhoneChallengeParamSchema = z.object({id: z.string()})
 
   const verifyPhoneChallengeRequestBodySchema = z.object({
     verificationCode: z.string(),
@@ -3033,7 +3031,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3094,7 +3092,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3167,7 +3165,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3228,7 +3226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3293,7 +3291,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-express/src/generated/okta.idp.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_AppAuthenticatorEnrollment = {
   readonly authenticatorId?: string | undefined

--- a/integration-tests/typescript-express/src/generated/okta.idp.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/okta.idp.yaml/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -15,25 +15,25 @@ export const PermissiveBoolean = z.preprocess((value) => {
 
 export const s_AppAuthenticatorEnrollment = z.object({
   authenticatorId: z.string().optional(),
-  createdDate: z.string().datetime({ offset: true }).optional(),
+  createdDate: z.string().datetime({offset: true}).optional(),
   device: z
     .object({
       id: z.string().optional(),
       status: z.enum(["ACTIVE"]).optional(),
-      createdDate: z.string().datetime({ offset: true }).optional(),
-      lastUpdated: z.string().datetime({ offset: true }).optional(),
+      createdDate: z.string().datetime({offset: true}).optional(),
+      lastUpdated: z.string().datetime({offset: true}).optional(),
       clientInstanceId: z.string().optional(),
     })
     .optional(),
   id: z.string().optional(),
-  lastUpdated: z.string().datetime({ offset: true }).optional(),
+  lastUpdated: z.string().datetime({offset: true}).optional(),
   links: z
     .object({
       self: z
         .object({
           href: z.string().min(1).optional(),
           hints: z
-            .object({ allow: z.array(z.enum(["PATCH", "DELETE"])).optional() })
+            .object({allow: z.array(z.enum(["PATCH", "DELETE"])).optional()})
             .optional(),
         })
         .optional(),
@@ -44,15 +44,15 @@ export const s_AppAuthenticatorEnrollment = z.object({
       push: z
         .object({
           id: z.string().optional(),
-          createdDate: z.string().datetime({ offset: true }).optional(),
-          lastUpdated: z.string().datetime({ offset: true }).optional(),
+          createdDate: z.string().datetime({offset: true}).optional(),
+          lastUpdated: z.string().datetime({offset: true}).optional(),
           links: z
             .object({
               pending: z
                 .object({
                   href: z.string().min(1).optional(),
                   hints: z
-                    .object({ allow: z.array(z.enum(["GET"])).optional() })
+                    .object({allow: z.array(z.enum(["GET"])).optional()})
                     .optional(),
                 })
                 .optional(),
@@ -63,7 +63,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
     })
     .optional(),
   user: z
-    .object({ id: z.string().optional(), username: z.string().optional() })
+    .object({id: z.string().optional(), username: z.string().optional()})
     .optional(),
 })
 
@@ -91,7 +91,7 @@ export const s_AuthenticatorKey = z.enum([
 
 export const s_Email = z.object({
   id: z.string().min(1),
-  profile: z.object({ email: z.string().min(1) }),
+  profile: z.object({email: z.string().min(1)}),
   roles: z.array(z.enum(["PRIMARY", "SECONDARY"])),
   status: z.enum(["VERIFIED", "UNVERIFIED"]),
   _links: z
@@ -148,7 +148,7 @@ export const s_Email = z.object({
 
 export const s_Error = z.object({
   errorCauses: z
-    .array(z.object({ errorSummary: z.string().optional() }))
+    .array(z.object({errorSummary: z.string().optional()}))
     .optional(),
   errorCode: z.string().optional(),
   errorId: z.string().optional(),
@@ -192,7 +192,7 @@ export const s_Organization = z.object({
         .object({
           href: z.string().min(1).optional(),
           hints: z
-            .object({ allow: z.array(z.enum(["GET"])).optional() })
+            .object({allow: z.array(z.enum(["GET"])).optional()})
             .optional(),
         })
         .optional(),
@@ -223,7 +223,7 @@ export const s_PasswordResponse = z.object({
 
 export const s_Phone = z.object({
   id: z.string().min(1),
-  profile: z.object({ phoneNumber: z.string().min(1) }),
+  profile: z.object({phoneNumber: z.string().min(1)}),
   status: z.enum(["VERIFIED", "UNVERIFIED"]),
   _links: z
     .object({
@@ -266,13 +266,13 @@ export const s_Phone = z.object({
 })
 
 export const s_Profile = z.object({
-  createdAt: z.string().datetime({ offset: true }).optional(),
-  modifiedAt: z.string().datetime({ offset: true }).optional(),
+  createdAt: z.string().datetime({offset: true}).optional(),
+  modifiedAt: z.string().datetime({offset: true}).optional(),
   profile: z.object({}).optional(),
   _links: z
     .object({
-      self: z.object({ href: z.string().optional() }).optional(),
-      describedBy: z.object({ href: z.string().optional() }).optional(),
+      self: z.object({href: z.string().optional()}).optional(),
+      describedBy: z.object({href: z.string().optional()}).optional(),
     })
     .optional(),
 })
@@ -291,8 +291,8 @@ export const s_Schema = z.object({
   properties: z.object({}).optional(),
   _links: z
     .object({
-      self: z.object({ href: z.string().optional() }).optional(),
-      user: z.object({ href: z.string().optional() }).optional(),
+      self: z.object({href: z.string().optional()}).optional(),
+      user: z.object({href: z.string().optional()}).optional(),
     })
     .optional(),
 })
@@ -302,7 +302,7 @@ export const s_UpdateAuthenticatorEnrollmentRequest = z.object({
 })
 
 export const s_HrefObject = z.object({
-  hints: z.object({ allow: z.array(s_HttpMethod).optional() }).optional(),
+  hints: z.object({allow: z.array(s_HttpMethod).optional()}).optional(),
   href: z.string(),
   name: z.string().optional(),
   type: z.string().optional(),
@@ -364,9 +364,7 @@ export const s_UpdateAppAuthenticatorEnrollmentRequest = z.object({
       push: z
         .object({
           pushToken: z.string().optional(),
-          keys: z
-            .object({ userVerification: s_KeyObject.optional() })
-            .optional(),
+          keys: z.object({userVerification: s_KeyObject.optional()}).optional(),
           capabilities: s_AppAuthenticatorMethodCapabilities.optional(),
         })
         .optional(),
@@ -380,7 +378,7 @@ export const s_Authenticator = z.object({
   key: s_AuthenticatorKey.optional(),
   name: z.string().optional(),
   _embedded: z
-    .object({ enrollments: z.array(s_AuthenticatorEnrollment).optional() })
+    .object({enrollments: z.array(s_AuthenticatorEnrollment).optional()})
     .optional(),
   _links: z
     .object({

--- a/integration-tests/typescript-express/src/generated/okta.oauth.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/okta.oauth.yaml/generated.ts
@@ -126,8 +126,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetWellKnownOpenIdConfigurationResponder = {
   with200(): ExpressRuntimeResponse<t_OidcMetadata>
@@ -919,7 +919,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1003,7 +1003,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1064,7 +1064,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1141,7 +1141,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1220,7 +1220,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1295,7 +1295,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1370,7 +1370,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1388,7 +1388,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getClientParamSchema = z.object({ clientId: z.string() })
+  const getClientParamSchema = z.object({clientId: z.string()})
 
   const getClientResponseBodyValidator = responseValidationFactory(
     [
@@ -1445,7 +1445,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1463,7 +1463,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const replaceClientParamSchema = z.object({ clientId: z.string() })
+  const replaceClientParamSchema = z.object({clientId: z.string()})
 
   const replaceClientRequestBodySchema = s_Client
 
@@ -1530,7 +1530,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1548,7 +1548,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deleteClientParamSchema = z.object({ clientId: z.string() })
+  const deleteClientParamSchema = z.object({clientId: z.string()})
 
   const deleteClientResponseBodyValidator = responseValidationFactory(
     [
@@ -1605,7 +1605,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1623,7 +1623,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const generateNewClientSecretParamSchema = z.object({ clientId: z.string() })
+  const generateNewClientSecretParamSchema = z.object({clientId: z.string()})
 
   const generateNewClientSecretResponseBodyValidator =
     responseValidationFactory(
@@ -1681,7 +1681,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1756,7 +1756,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1831,7 +1831,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1906,7 +1906,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -1924,7 +1924,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const oauthKeysQuerySchema = z.object({ client_id: z.string().optional() })
+  const oauthKeysQuerySchema = z.object({client_id: z.string().optional()})
 
   const oauthKeysResponseBodyValidator = responseValidationFactory(
     [
@@ -1973,7 +1973,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2044,7 +2044,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2111,7 +2111,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2190,7 +2190,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2259,7 +2259,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2338,7 +2338,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2413,7 +2413,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2482,7 +2482,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2557,7 +2557,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2626,7 +2626,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2714,7 +2714,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2807,7 +2807,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2902,7 +2902,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -2969,7 +2969,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3054,7 +3054,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3141,7 +3141,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3225,7 +3225,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3308,7 +3308,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3377,7 +3377,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3456,7 +3456,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3531,7 +3531,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3619,7 +3619,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3696,7 +3696,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3714,7 +3714,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const parCustomAsParamSchema = z.object({ authorizationServerId: z.string() })
+  const parCustomAsParamSchema = z.object({authorizationServerId: z.string()})
 
   const parCustomAsRequestBodySchema = s_ParRequest
 
@@ -3781,7 +3781,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3864,7 +3864,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3941,7 +3941,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -3959,9 +3959,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const tokenCustomAsParamSchema = z.object({
-    authorizationServerId: z.string(),
-  })
+  const tokenCustomAsParamSchema = z.object({authorizationServerId: z.string()})
 
   const tokenCustomAsRequestBodySchema = s_TokenRequest
 
@@ -4024,7 +4022,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -4101,7 +4099,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/okta.oauth.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/okta.oauth.yaml/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -97,7 +97,7 @@ export const s_EndpointAuthMethod = z.enum([
 
 export const s_Error = z.object({
   errorCauses: z
-    .array(z.object({ errorSummary: z.string().optional() }))
+    .array(z.object({errorSummary: z.string().optional()}))
     .optional(),
   errorCode: z.string().optional(),
   errorId: z.string().optional(),
@@ -257,7 +257,7 @@ export const s_TokenTypeHintRevoke = z.enum([
 ])
 
 export const s_UserInfo = z.intersection(
-  z.object({ sub: z.string().optional() }),
+  z.object({sub: z.string().optional()}),
   z.record(z.unknown()),
 )
 
@@ -385,7 +385,7 @@ export const s_RevokeRequest = z.object({
   token_type_hint: s_TokenTypeHintRevoke.optional(),
 })
 
-export const s_TokenRequest = z.object({ grant_type: s_GrantType.optional() })
+export const s_TokenRequest = z.object({grant_type: s_GrantType.optional()})
 
 export const s_TokenResponse = z.object({
   access_token: z.string().optional(),
@@ -409,7 +409,7 @@ export const s_Client = z.object({
   frontchannel_logout_uri: z.string().nullable().optional(),
   grant_types: z.array(s_GrantType).optional(),
   initiate_login_uri: z.string().optional(),
-  jwks: z.object({ keys: z.array(s_JsonWebKey).optional() }).optional(),
+  jwks: z.object({keys: z.array(s_JsonWebKey).optional()}).optional(),
   jwks_uri: z.string().optional(),
   logo_uri: z.string().nullable().optional(),
   policy_uri: z.string().nullable().optional(),
@@ -421,7 +421,7 @@ export const s_Client = z.object({
   tos_uri: z.string().nullable().optional(),
 })
 
-export const s_OAuthKeys = z.object({ keys: z.array(s_JsonWebKey).optional() })
+export const s_OAuthKeys = z.object({keys: z.array(s_JsonWebKey).optional()})
 
 export const s_OidcMetadata = s_OAuthMetadata.merge(
   z.object({

--- a/integration-tests/typescript-express/src/generated/petstore-expanded.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/petstore-expanded.yaml/generated.ts
@@ -10,7 +10,7 @@ import {
   t_FindPetsQuerySchema,
   t_Pet,
 } from "./models"
-import { s_Error, s_NewPet, s_Pet } from "./schemas"
+import {s_Error, s_NewPet, s_Pet} from "./schemas"
 import {
   ExpressRuntimeError,
   RequestInputType,
@@ -28,8 +28,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type FindPetsResponder = {
   with200(): ExpressRuntimeResponse<t_Pet[]>
@@ -147,7 +147,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -211,7 +211,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -229,7 +229,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const findPetByIdParamSchema = z.object({ id: z.coerce.number() })
+  const findPetByIdParamSchema = z.object({id: z.coerce.number()})
 
   const findPetByIdResponseBodyValidator = responseValidationFactory(
     [["200", s_Pet]],
@@ -275,7 +275,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -293,7 +293,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deletePetParamSchema = z.object({ id: z.coerce.number() })
+  const deletePetParamSchema = z.object({id: z.coerce.number()})
 
   const deletePetResponseBodyValidator = responseValidationFactory(
     [["204", z.undefined()]],
@@ -339,7 +339,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/petstore-expanded.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/petstore-expanded.yaml/schemas.ts
@@ -2,16 +2,10 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
-export const s_Error = z.object({
-  code: z.coerce.number(),
-  message: z.string(),
-})
+export const s_Error = z.object({code: z.coerce.number(), message: z.string()})
 
-export const s_NewPet = z.object({
-  name: z.string(),
-  tag: z.string().optional(),
-})
+export const s_NewPet = z.object({name: z.string(), tag: z.string().optional()})
 
-export const s_Pet = s_NewPet.merge(z.object({ id: z.coerce.number() }))
+export const s_Pet = s_NewPet.merge(z.object({id: z.coerce.number()}))

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/generated.ts
@@ -1544,8 +1544,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetAccountResponder = {
   with200(): ExpressRuntimeResponse<t_account>
@@ -12921,7 +12921,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -12998,7 +12998,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -13070,10 +13070,7 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
       documents: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
       financial_account: z
         .object({
@@ -13192,22 +13189,13 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
       payouts_list: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
       tax_registrations: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
       tax_settings: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
     }),
     expand: z.array(z.string().max(5000)).optional(),
@@ -13257,7 +13245,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -13363,7 +13351,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -13398,7 +13386,7 @@ export function createRouter(implementation: Implementation): Router {
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string().max(500)).optional() })
+                  .object({files: z.array(z.string().max(500)).optional()})
                   .optional(),
               })
               .optional(),
@@ -13431,7 +13419,7 @@ export function createRouter(implementation: Implementation): Router {
             )
             .optional(),
           monthly_estimated_revenue: z
-            .object({ amount: z.coerce.number(), currency: z.string() })
+            .object({amount: z.coerce.number(), currency: z.string()})
             .optional(),
           name: z.string().max(5000).optional(),
           product_description: z.string().max(40000).optional(),
@@ -13457,181 +13445,181 @@ export function createRouter(implementation: Implementation): Router {
       capabilities: z
         .object({
           acss_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           affirm_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           afterpay_clearpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           alma_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           amazon_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           au_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bacs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bancontact_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           billie_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           blik_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           boleto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_issuing: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cartes_bancaires_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cashapp_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           crypto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           eps_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           fpx_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           gb_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           giropay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           grabpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           ideal_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           india_international_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jcb_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jp_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kakao_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           klarna_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           konbini_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kr_card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           legacy_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           link_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mobilepay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           multibanco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mx_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           naver_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           nz_bank_account_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           oxxo_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           p24_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pay_by_bank_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           payco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           paynow_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pix_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           promptpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           revolut_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           samsung_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           satispay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sofort_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           swish_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_k: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_misc: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           transfers: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           treasury: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           twint_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_account_ach_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           zip_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
         })
         .optional(),
@@ -13756,14 +13744,14 @@ export function createRouter(implementation: Implementation): Router {
       controller: z
         .object({
           fees: z
-            .object({ payer: z.enum(["account", "application"]).optional() })
+            .object({payer: z.enum(["account", "application"]).optional()})
             .optional(),
           losses: z
-            .object({ payments: z.enum(["application", "stripe"]).optional() })
+            .object({payments: z.enum(["application", "stripe"]).optional()})
             .optional(),
           requirement_collection: z.enum(["application", "stripe"]).optional(),
           stripe_dashboard: z
-            .object({ type: z.enum(["express", "full", "none"]).optional() })
+            .object({type: z.enum(["express", "full", "none"]).optional()})
             .optional(),
         })
         .optional(),
@@ -13772,31 +13760,31 @@ export function createRouter(implementation: Implementation): Router {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_license: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_memorandum_of_association: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_ministerial_decree: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_registration_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_tax_id_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_address: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_registration: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_ultimate_beneficial_ownership: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -13915,7 +13903,7 @@ export function createRouter(implementation: Implementation): Router {
       settings: z
         .object({
           bacs_debit_payments: z
-            .object({ display_name: z.string().optional() })
+            .object({display_name: z.string().optional()})
             .optional(),
           branding: z
             .object({
@@ -14082,7 +14070,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -14154,7 +14142,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -14239,7 +14227,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -14287,7 +14275,7 @@ export function createRouter(implementation: Implementation): Router {
             )
             .optional(),
           monthly_estimated_revenue: z
-            .object({ amount: z.coerce.number(), currency: z.string() })
+            .object({amount: z.coerce.number(), currency: z.string()})
             .optional(),
           name: z.string().max(5000).optional(),
           product_description: z.string().max(40000).optional(),
@@ -14313,181 +14301,181 @@ export function createRouter(implementation: Implementation): Router {
       capabilities: z
         .object({
           acss_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           affirm_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           afterpay_clearpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           alma_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           amazon_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           au_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bacs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bancontact_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           billie_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           blik_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           boleto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_issuing: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cartes_bancaires_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cashapp_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           crypto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           eps_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           fpx_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           gb_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           giropay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           grabpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           ideal_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           india_international_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jcb_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jp_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kakao_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           klarna_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           konbini_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kr_card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           legacy_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           link_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mobilepay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           multibanco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mx_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           naver_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           nz_bank_account_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           oxxo_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           p24_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pay_by_bank_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           payco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           paynow_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pix_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           promptpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           revolut_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           samsung_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           satispay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sofort_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           swish_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_k: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_misc: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           transfers: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           treasury: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           twint_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_account_ach_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           zip_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
         })
         .optional(),
@@ -14613,31 +14601,31 @@ export function createRouter(implementation: Implementation): Router {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_license: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_memorandum_of_association: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_ministerial_decree: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_registration_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_tax_id_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_address: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_registration: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_ultimate_beneficial_ownership: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -14756,7 +14744,7 @@ export function createRouter(implementation: Implementation): Router {
       settings: z
         .object({
           bacs_debit_payments: z
-            .object({ display_name: z.string().optional() })
+            .object({display_name: z.string().optional()})
             .optional(),
           branding: z
             .object({
@@ -14929,7 +14917,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -14967,7 +14955,7 @@ export function createRouter(implementation: Implementation): Router {
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string().max(500)).optional() })
+                  .object({files: z.array(z.string().max(500)).optional()})
                   .optional(),
               })
               .optional(),
@@ -15030,7 +15018,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15105,7 +15093,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15196,7 +15184,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15236,7 +15224,7 @@ export function createRouter(implementation: Implementation): Router {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -15294,7 +15282,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15402,7 +15390,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15496,7 +15484,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15583,7 +15571,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15697,7 +15685,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15740,7 +15728,7 @@ export function createRouter(implementation: Implementation): Router {
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string().max(500)).optional() })
+                  .object({files: z.array(z.string().max(500)).optional()})
                   .optional(),
               })
               .optional(),
@@ -15803,7 +15791,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15887,7 +15875,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -15984,7 +15972,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16027,7 +16015,7 @@ export function createRouter(implementation: Implementation): Router {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -16091,7 +16079,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16119,7 +16107,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postAccountsAccountLoginLinksRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postAccountsAccountLoginLinksResponseBodyValidator =
@@ -16168,7 +16156,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16284,7 +16272,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16556,7 +16544,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16629,7 +16617,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16720,7 +16708,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -16995,7 +16983,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17111,7 +17099,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17383,7 +17371,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17458,7 +17446,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17549,7 +17537,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17824,7 +17812,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17899,7 +17887,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -17995,7 +17983,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18062,7 +18050,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18132,7 +18120,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18217,7 +18205,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18324,7 +18312,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18410,7 +18398,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18488,7 +18476,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18508,7 +18496,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getApplicationFeesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getApplicationFeesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getApplicationFeesIdQuerySchema = z.object({
     expand: z
@@ -18573,7 +18561,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18649,7 +18637,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18755,7 +18743,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18833,7 +18821,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -18934,7 +18922,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19007,7 +18995,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19078,7 +19066,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19160,7 +19148,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19237,7 +19225,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19350,7 +19338,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19368,7 +19356,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getBalanceHistoryIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getBalanceHistoryIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getBalanceHistoryIdQuerySchema = z.object({
     expand: z
@@ -19433,7 +19421,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19546,7 +19534,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19629,7 +19617,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19726,7 +19714,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19809,7 +19797,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19827,7 +19815,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getBillingAlertsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getBillingAlertsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getBillingAlertsIdQuerySchema = z.object({
     expand: z
@@ -19892,7 +19880,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19915,7 +19903,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingAlertsIdActivateRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingAlertsIdActivateResponseBodyValidator =
@@ -19964,7 +19952,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -19989,7 +19977,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingAlertsIdArchiveRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingAlertsIdArchiveResponseBodyValidator =
@@ -20038,7 +20026,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20063,7 +20051,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingAlertsIdDeactivateRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingAlertsIdDeactivateResponseBodyValidator =
@@ -20112,7 +20100,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20144,7 +20132,7 @@ export function createRouter(implementation: Implementation): Router {
       applicability_scope: z
         .object({
           price_type: z.enum(["metered"]).optional(),
-          prices: z.array(z.object({ id: z.string().max(5000) })).optional(),
+          prices: z.array(z.object({id: z.string().max(5000)})).optional(),
         })
         .optional(),
       credit_grant: z.string().max(5000).optional(),
@@ -20207,7 +20195,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20312,7 +20300,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20413,7 +20401,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20517,7 +20505,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20538,14 +20526,14 @@ export function createRouter(implementation: Implementation): Router {
   const postBillingCreditGrantsRequestBodySchema = z.object({
     amount: z.object({
       monetary: z
-        .object({ currency: z.string(), value: z.coerce.number() })
+        .object({currency: z.string(), value: z.coerce.number()})
         .optional(),
       type: z.enum(["monetary"]),
     }),
     applicability_config: z.object({
       scope: z.object({
         price_type: z.enum(["metered"]).optional(),
-        prices: z.array(z.object({ id: z.string().max(5000) })).optional(),
+        prices: z.array(z.object({id: z.string().max(5000)})).optional(),
       }),
     }),
     category: z.enum(["paid", "promotional"]),
@@ -20600,7 +20588,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20683,7 +20671,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20759,7 +20747,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20782,7 +20770,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingCreditGrantsIdExpireRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingCreditGrantsIdExpireResponseBodyValidator =
@@ -20831,7 +20819,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20856,7 +20844,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingCreditGrantsIdVoidRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingCreditGrantsIdVoidResponseBodyValidator =
@@ -20905,7 +20893,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -20926,7 +20914,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postBillingMeterEventAdjustmentsRequestBodySchema = z.object({
-    cancel: z.object({ identifier: z.string().max(100).optional() }).optional(),
+    cancel: z.object({identifier: z.string().max(100).optional()}).optional(),
     event_name: z.string().max(100),
     expand: z.array(z.string().max(5000)).optional(),
     type: z.enum(["cancel"]),
@@ -20979,7 +20967,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21051,7 +21039,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21147,7 +21135,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21167,20 +21155,15 @@ export function createRouter(implementation: Implementation): Router {
 
   const postBillingMetersRequestBodySchema = z.object({
     customer_mapping: z
-      .object({
-        event_payload_key: z.string().max(100),
-        type: z.enum(["by_id"]),
-      })
+      .object({event_payload_key: z.string().max(100), type: z.enum(["by_id"])})
       .optional(),
-    default_aggregation: z.object({
-      formula: z.enum(["count", "last", "sum"]),
-    }),
+    default_aggregation: z.object({formula: z.enum(["count", "last", "sum"])}),
     display_name: z.string().max(250),
     event_name: z.string().max(100),
     event_time_window: z.enum(["day", "hour"]).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     value_settings: z
-      .object({ event_payload_key: z.string().max(100) })
+      .object({event_payload_key: z.string().max(100)})
       .optional(),
   })
 
@@ -21228,7 +21211,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21246,7 +21229,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getBillingMetersIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getBillingMetersIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getBillingMetersIdQuerySchema = z.object({
     expand: z
@@ -21311,7 +21294,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21329,7 +21312,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postBillingMetersIdParamSchema = z.object({ id: z.string().max(5000) })
+  const postBillingMetersIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postBillingMetersIdRequestBodySchema = z
     .object({
@@ -21386,7 +21369,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21409,7 +21392,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingMetersIdDeactivateRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingMetersIdDeactivateResponseBodyValidator =
@@ -21458,7 +21441,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21573,7 +21556,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21598,7 +21581,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postBillingMetersIdReactivateRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingMetersIdReactivateResponseBodyValidator =
@@ -21647,7 +21630,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21752,7 +21735,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -21803,10 +21786,8 @@ export function createRouter(implementation: Implementation): Router {
           enabled: PermissiveBoolean,
         })
         .optional(),
-      invoice_history: z.object({ enabled: PermissiveBoolean }).optional(),
-      payment_method_update: z
-        .object({ enabled: PermissiveBoolean })
-        .optional(),
+      invoice_history: z.object({enabled: PermissiveBoolean}).optional(),
+      payment_method_update: z.object({enabled: PermissiveBoolean}).optional(),
       subscription_cancel: z
         .object({
           cancellation_reason: z
@@ -21876,7 +21857,7 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
     }),
-    login_page: z.object({ enabled: PermissiveBoolean }).optional(),
+    login_page: z.object({enabled: PermissiveBoolean}).optional(),
     metadata: z.record(z.string()).optional(),
   })
 
@@ -21927,7 +21908,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22025,7 +22006,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22086,9 +22067,9 @@ export function createRouter(implementation: Implementation): Router {
               enabled: PermissiveBoolean.optional(),
             })
             .optional(),
-          invoice_history: z.object({ enabled: PermissiveBoolean }).optional(),
+          invoice_history: z.object({enabled: PermissiveBoolean}).optional(),
           payment_method_update: z
-            .object({ enabled: PermissiveBoolean })
+            .object({enabled: PermissiveBoolean})
             .optional(),
           subscription_cancel: z
             .object({
@@ -22165,7 +22146,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
         })
         .optional(),
-      login_page: z.object({ enabled: PermissiveBoolean }).optional(),
+      login_page: z.object({enabled: PermissiveBoolean}).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -22227,7 +22208,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22259,9 +22240,9 @@ export function createRouter(implementation: Implementation): Router {
         after_completion: z
           .object({
             hosted_confirmation: z
-              .object({ custom_message: z.string().max(500).optional() })
+              .object({custom_message: z.string().max(500).optional()})
               .optional(),
-            redirect: z.object({ return_url: z.string() }).optional(),
+            redirect: z.object({return_url: z.string()}).optional(),
             type: z.enum([
               "hosted_confirmation",
               "portal_homepage",
@@ -22273,7 +22254,7 @@ export function createRouter(implementation: Implementation): Router {
           .object({
             retention: z
               .object({
-                coupon_offer: z.object({ coupon: z.string().max(5000) }),
+                coupon_offer: z.object({coupon: z.string().max(5000)}),
                 type: z.enum(["coupon_offer"]),
               })
               .optional(),
@@ -22281,7 +22262,7 @@ export function createRouter(implementation: Implementation): Router {
           })
           .optional(),
         subscription_update: z
-          .object({ subscription: z.string().max(5000) })
+          .object({subscription: z.string().max(5000)})
           .optional(),
         subscription_update_confirm: z
           .object({
@@ -22408,7 +22389,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22517,7 +22498,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22577,7 +22558,7 @@ export function createRouter(implementation: Implementation): Router {
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       on_behalf_of: z.string().max(5000).optional(),
       radar_options: z
-        .object({ session: z.string().max(5000).optional() })
+        .object({session: z.string().max(5000).optional()})
         .optional(),
       receipt_email: z.string().optional(),
       shipping: z
@@ -22653,7 +22634,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22752,7 +22733,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22770,7 +22751,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getChargesChargeParamSchema = z.object({ charge: z.string().max(5000) })
+  const getChargesChargeParamSchema = z.object({charge: z.string().max(5000)})
 
   const getChargesChargeQuerySchema = z.object({
     expand: z
@@ -22835,7 +22816,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22853,9 +22834,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postChargesChargeParamSchema = z.object({
-    charge: z.string().max(5000),
-  })
+  const postChargesChargeParamSchema = z.object({charge: z.string().max(5000)})
 
   const postChargesChargeRequestBodySchema = z
     .object({
@@ -22863,7 +22842,7 @@ export function createRouter(implementation: Implementation): Router {
       description: z.string().max(40000).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       fraud_details: z
-        .object({ user_report: z.enum(["", "fraudulent", "safe"]) })
+        .object({user_report: z.enum(["", "fraudulent", "safe"])})
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       receipt_email: z.string().max(5000).optional(),
@@ -22935,7 +22914,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -22967,7 +22946,7 @@ export function createRouter(implementation: Implementation): Router {
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
       transfer_group: z.string().optional(),
     })
@@ -23019,7 +22998,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23102,7 +23081,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23243,7 +23222,7 @@ export function createRouter(implementation: Implementation): Router {
                   })
                   .optional(),
                 visa_compliance: z
-                  .object({ fee_acknowledged: PermissiveBoolean.optional() })
+                  .object({fee_acknowledged: PermissiveBoolean.optional()})
                   .optional(),
               }),
               z.enum([""]),
@@ -23317,7 +23296,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23340,7 +23319,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postChargesChargeDisputeCloseRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postChargesChargeDisputeCloseResponseBodyValidator =
@@ -23389,7 +23368,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23474,7 +23453,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23492,7 +23471,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getChargesChargeRefundsParamSchema = z.object({ charge: z.string() })
+  const getChargesChargeRefundsParamSchema = z.object({charge: z.string()})
 
   const getChargesChargeRefundsQuerySchema = z.object({
     ending_before: z.string().optional(),
@@ -23576,7 +23555,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23662,7 +23641,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23746,7 +23725,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23824,7 +23803,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23857,7 +23836,7 @@ export function createRouter(implementation: Implementation): Router {
       ])
       .optional(),
     customer: z.string().max(5000).optional(),
-    customer_details: z.object({ email: z.string() }).optional(),
+    customer_details: z.object({email: z.string()}).optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z
       .preprocess(
@@ -23938,7 +23917,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -23959,7 +23938,7 @@ export function createRouter(implementation: Implementation): Router {
   const postCheckoutSessionsRequestBodySchema = z
     .object({
       adaptive_pricing: z
-        .object({ enabled: PermissiveBoolean.optional() })
+        .object({enabled: PermissiveBoolean.optional()})
         .optional(),
       after_expiration: z
         .object({
@@ -23989,7 +23968,7 @@ export function createRouter(implementation: Implementation): Router {
       consent_collection: z
         .object({
           payment_method_reuse_agreement: z
-            .object({ position: z.enum(["auto", "hidden"]) })
+            .object({position: z.enum(["auto", "hidden"])})
             .optional(),
           promotions: z.enum(["auto", "none"]).optional(),
           terms_of_service: z.enum(["none", "required"]).optional(),
@@ -24037,16 +24016,16 @@ export function createRouter(implementation: Implementation): Router {
       custom_text: z
         .object({
           after_submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           shipping_address: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           terms_of_service_acceptance: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
         })
         .optional(),
@@ -24294,13 +24273,13 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           affirm: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           afterpay_clearpay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           alipay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           amazon_pay: z
             .object({
@@ -24329,7 +24308,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           bancontact: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           boleto: z
             .object({
@@ -24342,7 +24321,7 @@ export function createRouter(implementation: Implementation): Router {
           card: z
             .object({
               installments: z
-                .object({ enabled: PermissiveBoolean.optional() })
+                .object({enabled: PermissiveBoolean.optional()})
                 .optional(),
               request_extended_authorization: z
                 .enum(["if_available", "never"])
@@ -24390,7 +24369,7 @@ export function createRouter(implementation: Implementation): Router {
               bank_transfer: z
                 .object({
                   eu_bank_transfer: z
-                    .object({ country: z.string().max(5000) })
+                    .object({country: z.string().max(5000)})
                     .optional(),
                   requested_address_types: z
                     .array(
@@ -24419,19 +24398,19 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           eps: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           fpx: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           giropay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           grabpay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           ideal: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           kakao_pay: z
             .object({
@@ -24479,10 +24458,10 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           mobilepay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           multibanco: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           naver_pay: z
             .object({
@@ -24504,10 +24483,10 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           pay_by_bank: z.object({}).optional(),
           payco: z
-            .object({ capture_method: z.enum(["manual"]).optional() })
+            .object({capture_method: z.enum(["manual"]).optional()})
             .optional(),
           paynow: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           paypal: z
             .object({
@@ -24545,7 +24524,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           pix: z
-            .object({ expires_after_seconds: z.coerce.number().optional() })
+            .object({expires_after_seconds: z.coerce.number().optional()})
             .optional(),
           revolut_pay: z
             .object({
@@ -24553,7 +24532,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           samsung_pay: z
-            .object({ capture_method: z.enum(["manual"]).optional() })
+            .object({capture_method: z.enum(["manual"]).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -24571,10 +24550,10 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           sofort: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           swish: z
-            .object({ reference: z.string().max(5000).optional() })
+            .object({reference: z.string().max(5000).optional()})
             .optional(),
           us_bank_account: z
             .object({
@@ -24672,7 +24651,7 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
       phone_number_collection: z
-        .object({ enabled: PermissiveBoolean })
+        .object({enabled: PermissiveBoolean})
         .optional(),
       redirect_on_completion: z
         .enum(["always", "if_required", "never"])
@@ -25010,7 +24989,7 @@ export function createRouter(implementation: Implementation): Router {
           application_fee_percent: z.coerce.number().optional(),
           billing_cycle_anchor: z.coerce.number().optional(),
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           default_tax_rates: z.array(z.string().max(5000)).optional(),
           description: z.string().max(500).optional(),
@@ -25059,7 +25038,7 @@ export function createRouter(implementation: Implementation): Router {
       wallet_options: z
         .object({
           link: z
-            .object({ display: z.enum(["auto", "never"]).optional() })
+            .object({display: z.enum(["auto", "never"]).optional()})
             .optional(),
         })
         .optional(),
@@ -25110,7 +25089,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25193,7 +25172,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25352,7 +25331,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25377,7 +25356,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postCheckoutSessionsSessionExpireRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postCheckoutSessionsSessionExpireResponseBodyValidator =
@@ -25426,7 +25405,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25537,7 +25516,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25637,7 +25616,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25657,7 +25636,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const postClimateOrdersRequestBodySchema = z.object({
     amount: z.coerce.number().optional(),
-    beneficiary: z.object({ public_name: z.string().max(5000) }).optional(),
+    beneficiary: z.object({public_name: z.string().max(5000)}).optional(),
     currency: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
@@ -25709,7 +25688,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25794,7 +25773,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25879,7 +25858,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -25902,7 +25881,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postClimateOrdersOrderCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postClimateOrdersOrderCancelResponseBodyValidator =
@@ -25951,7 +25930,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26048,7 +26027,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26131,7 +26110,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26226,7 +26205,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26309,7 +26288,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26402,7 +26381,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26502,7 +26481,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26587,7 +26566,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26693,7 +26672,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26715,11 +26694,11 @@ export function createRouter(implementation: Implementation): Router {
     .object({
       amount_off: z.coerce.number().optional(),
       applies_to: z
-        .object({ products: z.array(z.string().max(5000)).optional() })
+        .object({products: z.array(z.string().max(5000)).optional()})
         .optional(),
       currency: z.string().optional(),
       currency_options: z
-        .record(z.object({ amount_off: z.coerce.number() }))
+        .record(z.object({amount_off: z.coerce.number()}))
         .optional(),
       duration: z.enum(["forever", "once", "repeating"]).optional(),
       duration_in_months: z.coerce.number().optional(),
@@ -26777,7 +26756,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26849,7 +26828,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26867,7 +26846,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getCouponsCouponParamSchema = z.object({ coupon: z.string().max(5000) })
+  const getCouponsCouponParamSchema = z.object({coupon: z.string().max(5000)})
 
   const getCouponsCouponQuerySchema = z.object({
     expand: z
@@ -26932,7 +26911,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -26950,14 +26929,12 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postCouponsCouponParamSchema = z.object({
-    coupon: z.string().max(5000),
-  })
+  const postCouponsCouponParamSchema = z.object({coupon: z.string().max(5000)})
 
   const postCouponsCouponRequestBodySchema = z
     .object({
       currency_options: z
-        .record(z.object({ amount_off: z.coerce.number() }))
+        .record(z.object({amount_off: z.coerce.number()}))
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
@@ -27013,7 +26990,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27121,7 +27098,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27195,7 +27172,7 @@ export function createRouter(implementation: Implementation): Router {
       )
       .optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().max(5000).optional() })
+      .object({shipping_rate: z.string().max(5000).optional()})
       .optional(),
   })
 
@@ -27243,7 +27220,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27328,7 +27305,7 @@ export function createRouter(implementation: Implementation): Router {
       )
       .optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().max(5000).optional() })
+      .object({shipping_rate: z.string().max(5000).optional()})
       .optional(),
   })
 
@@ -27382,7 +27359,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27469,7 +27446,7 @@ export function createRouter(implementation: Implementation): Router {
       )
       .optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().max(5000).optional() })
+      .object({shipping_rate: z.string().max(5000).optional()})
       .optional(),
     starting_after: z.string().max(5000).optional(),
   })
@@ -27540,7 +27517,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27646,7 +27623,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27666,7 +27643,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getCreditNotesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getCreditNotesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getCreditNotesIdQuerySchema = z.object({
     expand: z
@@ -27731,7 +27708,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27749,7 +27726,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postCreditNotesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const postCreditNotesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postCreditNotesIdRequestBodySchema = z
     .object({
@@ -27807,7 +27784,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27825,12 +27802,10 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postCreditNotesIdVoidParamSchema = z.object({
-    id: z.string().max(5000),
-  })
+  const postCreditNotesIdVoidParamSchema = z.object({id: z.string().max(5000)})
 
   const postCreditNotesIdVoidRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postCreditNotesIdVoidResponseBodyValidator = responseValidationFactory(
@@ -27881,7 +27856,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -27901,7 +27876,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const postCustomerSessionsRequestBodySchema = z.object({
     components: z.object({
-      buy_button: z.object({ enabled: PermissiveBoolean }).optional(),
+      buy_button: z.object({enabled: PermissiveBoolean}).optional(),
       payment_element: z
         .object({
           enabled: PermissiveBoolean,
@@ -27923,7 +27898,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
         })
         .optional(),
-      pricing_table: z.object({ enabled: PermissiveBoolean }).optional(),
+      pricing_table: z.object({enabled: PermissiveBoolean}).optional(),
     }),
     customer: z.string().max(5000),
     expand: z.array(z.string().max(5000)).optional(),
@@ -27973,7 +27948,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28081,7 +28056,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28356,7 +28331,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28455,7 +28430,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28525,7 +28500,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28612,7 +28587,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28814,7 +28789,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -28926,7 +28901,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29018,7 +28993,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29042,7 +29017,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const getCustomersCustomerBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string().max(5000), transaction: z.string() })
+    z.object({customer: z.string().max(5000), transaction: z.string()})
 
   const getCustomersCustomerBalanceTransactionsTransactionQuerySchema =
     z.object({
@@ -29119,7 +29094,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29213,7 +29188,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29324,7 +29299,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29437,7 +29412,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29466,7 +29441,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const deleteCustomersCustomerBankAccountsIdRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteCustomersCustomerBankAccountsIdResponseBodyValidator =
@@ -29531,7 +29506,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29622,7 +29597,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29745,7 +29720,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29832,7 +29807,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -29941,7 +29916,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30052,7 +30027,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30078,7 +30053,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const deleteCustomersCustomerCardsIdRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteCustomersCustomerCardsIdResponseBodyValidator =
@@ -30137,7 +30112,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30223,7 +30198,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30343,7 +30318,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30430,7 +30405,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30513,7 +30488,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30627,7 +30602,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30651,7 +30626,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const getCustomersCustomerCashBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string().max(5000), transaction: z.string() })
+    z.object({customer: z.string().max(5000), transaction: z.string()})
 
   const getCustomersCustomerCashBalanceTransactionsTransactionQuerySchema =
     z.object({
@@ -30727,7 +30702,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30804,7 +30779,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30889,7 +30864,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -30915,7 +30890,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const postCustomersCustomerFundingInstructionsRequestBodySchema = z.object({
     bank_transfer: z.object({
-      eu_bank_transfer: z.object({ country: z.string().max(5000) }).optional(),
+      eu_bank_transfer: z.object({country: z.string().max(5000)}).optional(),
       requested_address_types: z
         .array(z.enum(["iban", "sort_code", "spei", "zengin"]))
         .optional(),
@@ -30984,7 +30959,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31148,7 +31123,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31245,7 +31220,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31361,7 +31336,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31474,7 +31449,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31500,7 +31475,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const deleteCustomersCustomerSourcesIdRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteCustomersCustomerSourcesIdResponseBodyValidator =
@@ -31559,7 +31534,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31645,7 +31620,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31765,7 +31740,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31849,7 +31824,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -31960,7 +31935,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32087,7 +32062,7 @@ export function createRouter(implementation: Implementation): Router {
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
               .optional(),
             discounts: z
               .union([
@@ -32206,7 +32181,7 @@ export function createRouter(implementation: Implementation): Router {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -32390,7 +32365,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32480,7 +32455,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32578,7 +32553,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -32726,10 +32701,7 @@ export function createRouter(implementation: Implementation): Router {
           .array(
             z.object({
               billing_thresholds: z
-                .union([
-                  z.object({ usage_gte: z.coerce.number() }),
-                  z.enum([""]),
-                ])
+                .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
                 .optional(),
               clear_usage: PermissiveBoolean.optional(),
               deleted: PermissiveBoolean.optional(),
@@ -32862,7 +32834,7 @@ export function createRouter(implementation: Implementation): Router {
                       bank_transfer: z
                         .object({
                           eu_bank_transfer: z
-                            .object({ country: z.string().max(5000) })
+                            .object({country: z.string().max(5000)})
                             .optional(),
                           type: z.string().optional(),
                         })
@@ -33055,7 +33027,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33139,7 +33111,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33237,7 +33209,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33346,7 +33318,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33533,7 +33505,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33608,7 +33580,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33694,7 +33666,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33804,7 +33776,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -33889,7 +33861,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34030,7 +34002,7 @@ export function createRouter(implementation: Implementation): Router {
                   })
                   .optional(),
                 visa_compliance: z
-                  .object({ fee_acknowledged: PermissiveBoolean.optional() })
+                  .object({fee_acknowledged: PermissiveBoolean.optional()})
                   .optional(),
               }),
               z.enum([""]),
@@ -34106,7 +34078,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34129,7 +34101,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postDisputesDisputeCloseRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postDisputesDisputeCloseResponseBodyValidator =
@@ -34178,7 +34150,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34277,7 +34249,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34372,7 +34344,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34478,7 +34450,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34545,7 +34517,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34628,7 +34600,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34705,7 +34677,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34779,7 +34751,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34802,7 +34774,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const deleteEphemeralKeysKeyRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteEphemeralKeysKeyResponseBodyValidator = responseValidationFactory(
@@ -34853,7 +34825,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34967,7 +34939,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -34985,7 +34957,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getEventsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getEventsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getEventsIdQuerySchema = z.object({
     expand: z
@@ -35050,7 +35022,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35145,7 +35117,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35230,7 +35202,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35248,7 +35220,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postExternalAccountsIdParamSchema = z.object({ id: z.string() })
+  const postExternalAccountsIdParamSchema = z.object({id: z.string()})
 
   const postExternalAccountsIdRequestBodySchema = z
     .object({
@@ -35265,7 +35237,7 @@ export function createRouter(implementation: Implementation): Router {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -35325,7 +35297,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35433,7 +35405,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35502,7 +35474,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35520,7 +35492,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getFileLinksLinkParamSchema = z.object({ link: z.string() })
+  const getFileLinksLinkParamSchema = z.object({link: z.string()})
 
   const getFileLinksLinkQuerySchema = z.object({
     expand: z
@@ -35585,7 +35557,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35603,7 +35575,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postFileLinksLinkParamSchema = z.object({ link: z.string() })
+  const postFileLinksLinkParamSchema = z.object({link: z.string()})
 
   const postFileLinksLinkRequestBodySchema = z
     .object({
@@ -35663,7 +35635,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35790,7 +35762,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35877,7 +35849,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -35895,7 +35867,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getFilesFileParamSchema = z.object({ file: z.string().max(5000) })
+  const getFilesFileParamSchema = z.object({file: z.string().max(5000)})
 
   const getFilesFileQuerySchema = z.object({
     expand: z
@@ -35960,7 +35932,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36068,7 +36040,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36166,7 +36138,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36190,11 +36162,11 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postFinancialConnectionsAccountsAccountDisconnectParamSchema = z.object(
-    { account: z.string().max(5000) },
+    {account: z.string().max(5000)},
   )
 
   const postFinancialConnectionsAccountsAccountDisconnectRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postFinancialConnectionsAccountsAccountDisconnectResponseBodyValidator =
@@ -36254,7 +36226,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36372,7 +36344,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36462,7 +36434,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36552,7 +36524,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36576,7 +36548,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postFinancialConnectionsAccountsAccountUnsubscribeParamSchema =
-    z.object({ account: z.string().max(5000) })
+    z.object({account: z.string().max(5000)})
 
   const postFinancialConnectionsAccountsAccountUnsubscribeRequestBodySchema =
     z.object({
@@ -36641,7 +36613,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36743,7 +36715,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36841,7 +36813,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -36886,7 +36858,7 @@ export function createRouter(implementation: Implementation): Router {
         z.coerce.number(),
       ])
       .optional(),
-    transaction_refresh: z.object({ after: z.string().max(5000) }).optional(),
+    transaction_refresh: z.object({after: z.string().max(5000)}).optional(),
   })
 
   const getFinancialConnectionsTransactionsRequestBodySchema = z
@@ -36960,7 +36932,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37061,7 +37033,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37169,7 +37141,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37205,10 +37177,7 @@ export function createRouter(implementation: Implementation): Router {
         body: z.string().max(5000).optional(),
         headers: z
           .array(
-            z.object({
-              name: z.string().max(5000),
-              value: z.string().max(5000),
-            }),
+            z.object({name: z.string().max(5000), value: z.string().max(5000)}),
           )
           .optional(),
       })
@@ -37260,7 +37229,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37343,7 +37312,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37458,7 +37427,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37556,7 +37525,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37678,7 +37647,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37721,11 +37690,11 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
       provided_details: z
-        .object({ email: z.string().optional(), phone: z.string().optional() })
+        .object({email: z.string().optional(), phone: z.string().optional()})
         .optional(),
       related_customer: z.string().max(5000).optional(),
       related_person: z
-        .object({ account: z.string().max(5000), person: z.string().max(5000) })
+        .object({account: z.string().max(5000), person: z.string().max(5000)})
         .optional(),
       return_url: z.string().optional(),
       type: z.enum(["document", "id_number"]).optional(),
@@ -37780,7 +37749,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37878,7 +37847,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -37927,7 +37896,7 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
       provided_details: z
-        .object({ email: z.string().optional(), phone: z.string().optional() })
+        .object({email: z.string().optional(), phone: z.string().optional()})
         .optional(),
       type: z.enum(["document", "id_number"]).optional(),
     })
@@ -37990,7 +37959,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38018,7 +37987,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postIdentityVerificationSessionsSessionCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postIdentityVerificationSessionsSessionCancelResponseBodyValidator =
@@ -38078,7 +38047,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38106,7 +38075,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postIdentityVerificationSessionsSessionRedactRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postIdentityVerificationSessionsSessionRedactResponseBodyValidator =
@@ -38166,7 +38135,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38274,7 +38243,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38359,7 +38328,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38458,7 +38427,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38552,7 +38521,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38580,7 +38549,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postInvoiceRenderingTemplatesTemplateArchiveRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoiceRenderingTemplatesTemplateArchiveResponseBodyValidator =
@@ -38635,7 +38604,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38663,7 +38632,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postInvoiceRenderingTemplatesTemplateUnarchiveRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoiceRenderingTemplatesTemplateUnarchiveResponseBodyValidator =
@@ -38718,7 +38687,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38832,7 +38801,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -38872,7 +38841,7 @@ export function createRouter(implementation: Implementation): Router {
     invoice: z.string().max(5000).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     period: z
-      .object({ end: z.coerce.number(), start: z.coerce.number() })
+      .object({end: z.coerce.number(), start: z.coerce.number()})
       .optional(),
     price_data: z
       .object({
@@ -38885,7 +38854,7 @@ export function createRouter(implementation: Implementation): Router {
         unit_amount_decimal: z.string().optional(),
       })
       .optional(),
-    pricing: z.object({ price: z.string().max(5000).optional() }).optional(),
+    pricing: z.object({price: z.string().max(5000).optional()}).optional(),
     quantity: z.coerce.number().optional(),
     subscription: z.string().max(5000).optional(),
     tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
@@ -38938,7 +38907,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39008,7 +38977,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39093,7 +39062,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39137,7 +39106,7 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       period: z
-        .object({ end: z.coerce.number(), start: z.coerce.number() })
+        .object({end: z.coerce.number(), start: z.coerce.number()})
         .optional(),
       price_data: z
         .object({
@@ -39150,7 +39119,7 @@ export function createRouter(implementation: Implementation): Router {
           unit_amount_decimal: z.string().optional(),
         })
         .optional(),
-      pricing: z.object({ price: z.string().max(5000).optional() }).optional(),
+      pricing: z.object({price: z.string().max(5000).optional()}).optional(),
       quantity: z.coerce.number().optional(),
       tax_behavior: z
         .enum(["exclusive", "inclusive", "unspecified"])
@@ -39209,7 +39178,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39336,7 +39305,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39380,7 +39349,7 @@ export function createRouter(implementation: Implementation): Router {
       custom_fields: z
         .union([
           z.array(
-            z.object({ name: z.string().max(40), value: z.string().max(140) }),
+            z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
           z.enum([""]),
         ])
@@ -39408,7 +39377,7 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       footer: z.string().max(5000).optional(),
       from_invoice: z
-        .object({ action: z.enum(["revision"]), invoice: z.string().max(5000) })
+        .object({action: z.enum(["revision"]), invoice: z.string().max(5000)})
         .optional(),
       issuer: z
         .object({
@@ -39488,7 +39457,7 @@ export function createRouter(implementation: Implementation): Router {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -39595,7 +39564,7 @@ export function createRouter(implementation: Implementation): Router {
             .enum(["", "exclude_tax", "include_inclusive_tax"])
             .optional(),
           pdf: z
-            .object({ page_size: z.enum(["a4", "auto", "letter"]).optional() })
+            .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
             .optional(),
           template: z.string().max(5000).optional(),
           template_version: z
@@ -39680,10 +39649,7 @@ export function createRouter(implementation: Implementation): Router {
       statement_descriptor: z.string().max(22).optional(),
       subscription: z.string().max(5000).optional(),
       transfer_data: z
-        .object({
-          amount: z.coerce.number().optional(),
-          destination: z.string(),
-        })
+        .object({amount: z.coerce.number().optional(), destination: z.string()})
         .optional(),
     })
     .optional()
@@ -39732,7 +39698,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -39959,7 +39925,7 @@ export function createRouter(implementation: Implementation): Router {
             invoiceitem: z.string().max(5000).optional(),
             metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
             period: z
-              .object({ end: z.coerce.number(), start: z.coerce.number() })
+              .object({end: z.coerce.number(), start: z.coerce.number()})
               .optional(),
             price: z.string().max(5000).optional(),
             price_data: z
@@ -39998,7 +39964,7 @@ export function createRouter(implementation: Implementation): Router {
       schedule_details: z
         .object({
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           end_behavior: z.enum(["cancel", "release"]).optional(),
           phases: z
@@ -40102,7 +40068,7 @@ export function createRouter(implementation: Implementation): Router {
                   z.object({
                     billing_thresholds: z
                       .union([
-                        z.object({ usage_gte: z.coerce.number() }),
+                        z.object({usage_gte: z.coerce.number()}),
                         z.enum([""]),
                       ])
                       .optional(),
@@ -40175,7 +40141,7 @@ export function createRouter(implementation: Implementation): Router {
             .union([z.enum(["now", "unchanged"]), z.coerce.number()])
             .optional(),
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           cancel_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
           cancel_at_period_end: PermissiveBoolean.optional(),
@@ -40188,7 +40154,7 @@ export function createRouter(implementation: Implementation): Router {
               z.object({
                 billing_thresholds: z
                   .union([
-                    z.object({ usage_gte: z.coerce.number() }),
+                    z.object({usage_gte: z.coerce.number()}),
                     z.enum([""]),
                   ])
                   .optional(),
@@ -40287,7 +40253,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40386,7 +40352,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40458,7 +40424,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40543,7 +40509,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40590,7 +40556,7 @@ export function createRouter(implementation: Implementation): Router {
       custom_fields: z
         .union([
           z.array(
-            z.object({ name: z.string().max(40), value: z.string().max(140) }),
+            z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
           z.enum([""]),
         ])
@@ -40696,7 +40662,7 @@ export function createRouter(implementation: Implementation): Router {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -40802,7 +40768,7 @@ export function createRouter(implementation: Implementation): Router {
             .enum(["", "exclude_tax", "include_inclusive_tax"])
             .optional(),
           pdf: z
-            .object({ page_size: z.enum(["a4", "auto", "letter"]).optional() })
+            .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
             .optional(),
           template: z.string().max(5000).optional(),
           template_version: z
@@ -40951,7 +40917,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -40996,7 +40962,7 @@ export function createRouter(implementation: Implementation): Router {
         invoice_item: z.string().max(5000).optional(),
         metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
         period: z
-          .object({ end: z.coerce.number(), start: z.coerce.number() })
+          .object({end: z.coerce.number(), start: z.coerce.number()})
           .optional(),
         price_data: z
           .object({
@@ -41018,9 +40984,7 @@ export function createRouter(implementation: Implementation): Router {
             unit_amount_decimal: z.string().optional(),
           })
           .optional(),
-        pricing: z
-          .object({ price: z.string().max(5000).optional() })
-          .optional(),
+        pricing: z.object({price: z.string().max(5000).optional()}).optional(),
         quantity: z.coerce.number().optional(),
         tax_amounts: z
           .union([
@@ -41142,7 +41106,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41219,7 +41183,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41296,7 +41260,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41402,7 +41366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41445,7 +41409,7 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       period: z
-        .object({ end: z.coerce.number(), start: z.coerce.number() })
+        .object({end: z.coerce.number(), start: z.coerce.number()})
         .optional(),
       price_data: z
         .object({
@@ -41467,7 +41431,7 @@ export function createRouter(implementation: Implementation): Router {
           unit_amount_decimal: z.string().optional(),
         })
         .optional(),
-      pricing: z.object({ price: z.string().max(5000).optional() }).optional(),
+      pricing: z.object({price: z.string().max(5000).optional()}).optional(),
       quantity: z.coerce.number().optional(),
       tax_amounts: z
         .union([
@@ -41588,7 +41552,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41616,7 +41580,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postInvoicesInvoiceMarkUncollectibleRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoicesInvoiceMarkUncollectibleResponseBodyValidator =
@@ -41671,7 +41635,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41758,7 +41722,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41837,7 +41801,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41862,7 +41826,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postInvoicesInvoiceSendRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoicesInvoiceSendResponseBodyValidator =
@@ -41911,7 +41875,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -41956,7 +41920,7 @@ export function createRouter(implementation: Implementation): Router {
         id: z.string().max(5000),
         metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
         period: z
-          .object({ end: z.coerce.number(), start: z.coerce.number() })
+          .object({end: z.coerce.number(), start: z.coerce.number()})
           .optional(),
         price_data: z
           .object({
@@ -41978,9 +41942,7 @@ export function createRouter(implementation: Implementation): Router {
             unit_amount_decimal: z.string().optional(),
           })
           .optional(),
-        pricing: z
-          .object({ price: z.string().max(5000).optional() })
-          .optional(),
+        pricing: z.object({price: z.string().max(5000).optional()}).optional(),
         quantity: z.coerce.number().optional(),
         tax_amounts: z
           .union([
@@ -42102,7 +42064,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42127,7 +42089,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postInvoicesInvoiceVoidRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoicesInvoiceVoidResponseBodyValidator =
@@ -42176,7 +42138,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42289,7 +42251,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42380,7 +42342,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42466,7 +42428,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42553,7 +42515,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42639,7 +42601,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42757,7 +42719,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -42786,7 +42748,7 @@ export function createRouter(implementation: Implementation): Router {
         state: z.string().max(5000).optional(),
       }),
     }),
-    company: z.object({ tax_id: z.string().max(5000).optional() }).optional(),
+    company: z.object({tax_id: z.string().max(5000).optional()}).optional(),
     email: z.string().optional(),
     expand: z.array(z.string().max(5000)).optional(),
     individual: z
@@ -43804,7 +43766,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43889,7 +43851,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -43927,7 +43889,7 @@ export function createRouter(implementation: Implementation): Router {
           }),
         })
         .optional(),
-      company: z.object({ tax_id: z.string().max(5000).optional() }).optional(),
+      company: z.object({tax_id: z.string().max(5000).optional()}).optional(),
       email: z.string().optional(),
       expand: z.array(z.string().max(5000)).optional(),
       individual: z
@@ -44946,7 +44908,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45061,7 +45023,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -45087,7 +45049,7 @@ export function createRouter(implementation: Implementation): Router {
     metadata: z.record(z.string()).optional(),
     personalization_design: z.string().max(5000).optional(),
     pin: z
-      .object({ encrypted_number: z.string().max(5000).optional() })
+      .object({encrypted_number: z.string().max(5000).optional()})
       .optional(),
     replacement_for: z.string().max(5000).optional(),
     replacement_reason: z
@@ -45114,7 +45076,7 @@ export function createRouter(implementation: Implementation): Router {
           })
           .optional(),
         customs: z
-          .object({ eori_number: z.string().max(5000).optional() })
+          .object({eori_number: z.string().max(5000).optional()})
           .optional(),
         name: z.string().max(5000),
         phone_number: z.string().optional(),
@@ -46095,7 +46057,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46113,9 +46075,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getIssuingCardsCardParamSchema = z.object({
-    card: z.string().max(5000),
-  })
+  const getIssuingCardsCardParamSchema = z.object({card: z.string().max(5000)})
 
   const getIssuingCardsCardQuerySchema = z.object({
     expand: z
@@ -46180,7 +46140,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -46198,9 +46158,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postIssuingCardsCardParamSchema = z.object({
-    card: z.string().max(5000),
-  })
+  const postIssuingCardsCardParamSchema = z.object({card: z.string().max(5000)})
 
   const postIssuingCardsCardRequestBodySchema = z
     .object({
@@ -46209,7 +46167,7 @@ export function createRouter(implementation: Implementation): Router {
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       personalization_design: z.string().max(5000).optional(),
       pin: z
-        .object({ encrypted_number: z.string().max(5000).optional() })
+        .object({encrypted_number: z.string().max(5000).optional()})
         .optional(),
       shipping: z
         .object({
@@ -46231,7 +46189,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           customs: z
-            .object({ eori_number: z.string().max(5000).optional() })
+            .object({eori_number: z.string().max(5000).optional()})
             .optional(),
           name: z.string().max(5000),
           phone_number: z.string().optional(),
@@ -47216,7 +47174,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47326,7 +47284,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47528,7 +47486,7 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
       transaction: z.string().max(5000).optional(),
-      treasury: z.object({ received_debit: z.string().max(5000) }).optional(),
+      treasury: z.object({received_debit: z.string().max(5000)}).optional(),
     })
     .optional()
 
@@ -47576,7 +47534,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47659,7 +47617,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47913,7 +47871,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -47990,7 +47948,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48106,7 +48064,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48141,7 +48099,7 @@ export function createRouter(implementation: Implementation): Router {
     metadata: z.record(z.string()).optional(),
     name: z.string().max(200).optional(),
     physical_bundle: z.string().max(5000),
-    preferences: z.object({ is_default: PermissiveBoolean }).optional(),
+    preferences: z.object({is_default: PermissiveBoolean}).optional(),
     transfer_lookup_key: PermissiveBoolean.optional(),
   })
 
@@ -48192,7 +48150,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48216,7 +48174,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const getIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const getIssuingPersonalizationDesignsPersonalizationDesignQuerySchema =
     z.object({
@@ -48292,7 +48250,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48316,7 +48274,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postIssuingPersonalizationDesignsPersonalizationDesignRequestBodySchema =
     z
@@ -48346,7 +48304,7 @@ export function createRouter(implementation: Implementation): Router {
         metadata: z.record(z.string()).optional(),
         name: z.union([z.string().max(200), z.enum([""])]).optional(),
         physical_bundle: z.string().max(5000).optional(),
-        preferences: z.object({ is_default: PermissiveBoolean }).optional(),
+        preferences: z.object({is_default: PermissiveBoolean}).optional(),
         transfer_lookup_key: PermissiveBoolean.optional(),
       })
       .optional()
@@ -48408,7 +48366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48514,7 +48472,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48605,7 +48563,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48695,7 +48653,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48772,7 +48730,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48882,7 +48840,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -48967,7 +48925,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49042,7 +49000,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49154,7 +49112,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49239,7 +49197,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49319,7 +49277,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49421,7 +49379,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49509,7 +49467,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49616,7 +49574,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49704,7 +49662,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49727,7 +49685,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postLinkedAccountsAccountDisconnectRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postLinkedAccountsAccountDisconnectResponseBodyValidator =
@@ -49781,7 +49739,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49893,7 +49851,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49973,7 +49931,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -49993,7 +49951,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getMandatesMandateParamSchema = z.object({ mandate: z.string() })
+  const getMandatesMandateParamSchema = z.object({mandate: z.string()})
 
   const getMandatesMandateQuerySchema = z.object({
     expand: z
@@ -50058,7 +50016,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50165,7 +50123,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -50282,7 +50240,7 @@ export function createRouter(implementation: Implementation): Router {
           })
           .optional(),
         blik: z.object({}).optional(),
-        boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+        boleto: z.object({tax_id: z.string().max(5000)}).optional(),
         cashapp: z.object({}).optional(),
         crypto: z.object({}).optional(),
         customer_balance: z.object({}).optional(),
@@ -50397,7 +50355,7 @@ export function createRouter(implementation: Implementation): Router {
         mobilepay: z.object({}).optional(),
         multibanco: z.object({}).optional(),
         naver_pay: z
-          .object({ funding: z.enum(["card", "points"]).optional() })
+          .object({funding: z.enum(["card", "points"]).optional()})
           .optional(),
         nz_bank_account: z
           .object({
@@ -50451,14 +50409,14 @@ export function createRouter(implementation: Implementation): Router {
         pix: z.object({}).optional(),
         promptpay: z.object({}).optional(),
         radar_options: z
-          .object({ session: z.string().max(5000).optional() })
+          .object({session: z.string().max(5000).optional()})
           .optional(),
         revolut_pay: z.object({}).optional(),
         samsung_pay: z.object({}).optional(),
         satispay: z.object({}).optional(),
-        sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+        sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
         sofort: z
-          .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+          .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
           .optional(),
         swish: z.object({}).optional(),
         twint: z.object({}).optional(),
@@ -50584,7 +50542,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         alma: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50641,7 +50599,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         billie: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50804,7 +50762,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         crypto: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50814,7 +50772,7 @@ export function createRouter(implementation: Implementation): Router {
               bank_transfer: z
                 .object({
                   eu_bank_transfer: z
-                    .object({ country: z.string().max(5000) })
+                    .object({country: z.string().max(5000)})
                     .optional(),
                   requested_address_types: z
                     .array(
@@ -50846,25 +50804,25 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         eps: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         fpx: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         giropay: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         grabpay: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51032,7 +50990,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         multibanco: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51079,13 +51037,13 @@ export function createRouter(implementation: Implementation): Router {
         pay_by_bank: z.union([z.object({}), z.enum([""])]).optional(),
         payco: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         paynow: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51139,7 +51097,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         promptpay: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51156,13 +51114,13 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         samsung_pay: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         satispay: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51210,7 +51168,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         twint: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51243,7 +51201,7 @@ export function createRouter(implementation: Implementation): Router {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -51278,7 +51236,7 @@ export function createRouter(implementation: Implementation): Router {
           .optional(),
         zip: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -51286,7 +51244,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
     payment_method_types: z.array(z.string().max(5000)).optional(),
     radar_options: z
-      .object({ session: z.string().max(5000).optional() })
+      .object({session: z.string().max(5000).optional()})
       .optional(),
     receipt_email: z.string().optional(),
     return_url: z.string().optional(),
@@ -51310,7 +51268,7 @@ export function createRouter(implementation: Implementation): Router {
     statement_descriptor: z.string().max(22).optional(),
     statement_descriptor_suffix: z.string().max(22).optional(),
     transfer_data: z
-      .object({ amount: z.coerce.number().optional(), destination: z.string() })
+      .object({amount: z.coerce.number().optional(), destination: z.string()})
       .optional(),
     transfer_group: z.string().optional(),
     use_stripe_sdk: PermissiveBoolean.optional(),
@@ -51360,7 +51318,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51460,7 +51418,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51544,7 +51502,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -51635,7 +51593,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -51750,7 +51708,7 @@ export function createRouter(implementation: Implementation): Router {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -51804,14 +51762,14 @@ export function createRouter(implementation: Implementation): Router {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -51939,7 +51897,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           alma: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -51996,7 +51954,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           billie: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52163,7 +52121,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           crypto: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52173,7 +52131,7 @@ export function createRouter(implementation: Implementation): Router {
                 bank_transfer: z
                   .object({
                     eu_bank_transfer: z
-                      .object({ country: z.string().max(5000) })
+                      .object({country: z.string().max(5000)})
                       .optional(),
                     requested_address_types: z
                       .array(
@@ -52205,25 +52163,25 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           eps: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           fpx: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           giropay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           grabpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52393,7 +52351,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           multibanco: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52440,13 +52398,13 @@ export function createRouter(implementation: Implementation): Router {
           pay_by_bank: z.union([z.object({}), z.enum([""])]).optional(),
           payco: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           paynow: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52500,7 +52458,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           promptpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52517,13 +52475,13 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           samsung_pay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           satispay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52571,7 +52529,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           twint: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52604,9 +52562,7 @@ export function createRouter(implementation: Implementation): Router {
                   })
                   .optional(),
                 mandate_options: z
-                  .object({
-                    collection_method: z.enum(["", "paper"]).optional(),
-                  })
+                  .object({collection_method: z.enum(["", "paper"]).optional()})
                   .optional(),
                 networks: z
                   .object({
@@ -52641,7 +52597,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           zip: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52672,7 +52628,7 @@ export function createRouter(implementation: Implementation): Router {
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
       transfer_group: z.string().optional(),
     })
@@ -52724,7 +52680,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52806,7 +52762,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52888,7 +52844,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -52922,7 +52878,7 @@ export function createRouter(implementation: Implementation): Router {
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
     })
     .optional()
@@ -52973,7 +52929,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -53091,7 +53047,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -53206,7 +53162,7 @@ export function createRouter(implementation: Implementation): Router {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -53260,14 +53216,14 @@ export function createRouter(implementation: Implementation): Router {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -53395,7 +53351,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           alma: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53452,7 +53408,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           billie: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53619,7 +53575,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           crypto: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53629,7 +53585,7 @@ export function createRouter(implementation: Implementation): Router {
                 bank_transfer: z
                   .object({
                     eu_bank_transfer: z
-                      .object({ country: z.string().max(5000) })
+                      .object({country: z.string().max(5000)})
                       .optional(),
                     requested_address_types: z
                       .array(
@@ -53661,25 +53617,25 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           eps: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           fpx: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           giropay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           grabpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53849,7 +53805,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           multibanco: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53896,13 +53852,13 @@ export function createRouter(implementation: Implementation): Router {
           pay_by_bank: z.union([z.object({}), z.enum([""])]).optional(),
           payco: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           paynow: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53956,7 +53912,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           promptpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53973,13 +53929,13 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           samsung_pay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           satispay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -54027,7 +53983,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           twint: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -54060,9 +54016,7 @@ export function createRouter(implementation: Implementation): Router {
                   })
                   .optional(),
                 mandate_options: z
-                  .object({
-                    collection_method: z.enum(["", "paper"]).optional(),
-                  })
+                  .object({collection_method: z.enum(["", "paper"]).optional()})
                   .optional(),
                 networks: z
                   .object({
@@ -54097,7 +54051,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           zip: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -54105,7 +54059,7 @@ export function createRouter(implementation: Implementation): Router {
         .optional(),
       payment_method_types: z.array(z.string().max(5000)).optional(),
       radar_options: z
-        .object({ session: z.string().max(5000).optional() })
+        .object({session: z.string().max(5000).optional()})
         .optional(),
       receipt_email: z.union([z.string(), z.enum([""])]).optional(),
       return_url: z.string().optional(),
@@ -54179,7 +54133,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54212,7 +54166,7 @@ export function createRouter(implementation: Implementation): Router {
       metadata: z.record(z.string()).optional(),
       statement_descriptor: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
     })
 
@@ -54268,7 +54222,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54356,7 +54310,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54457,7 +54411,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -54479,9 +54433,9 @@ export function createRouter(implementation: Implementation): Router {
     after_completion: z
       .object({
         hosted_confirmation: z
-          .object({ custom_message: z.string().max(500).optional() })
+          .object({custom_message: z.string().max(500).optional()})
           .optional(),
-        redirect: z.object({ url: z.string() }).optional(),
+        redirect: z.object({url: z.string()}).optional(),
         type: z.enum(["hosted_confirmation", "redirect"]),
       })
       .optional(),
@@ -54503,7 +54457,7 @@ export function createRouter(implementation: Implementation): Router {
     consent_collection: z
       .object({
         payment_method_reuse_agreement: z
-          .object({ position: z.enum(["auto", "hidden"]) })
+          .object({position: z.enum(["auto", "hidden"])})
           .optional(),
         promotions: z.enum(["auto", "none"]).optional(),
         terms_of_service: z.enum(["none", "required"]).optional(),
@@ -54551,16 +54505,16 @@ export function createRouter(implementation: Implementation): Router {
     custom_text: z
       .object({
         after_submit: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
         shipping_address: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
         submit: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
         terms_of_service_acceptance: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
       })
       .optional(),
@@ -54696,11 +54650,9 @@ export function createRouter(implementation: Implementation): Router {
         ]),
       )
       .optional(),
-    phone_number_collection: z
-      .object({ enabled: PermissiveBoolean })
-      .optional(),
+    phone_number_collection: z.object({enabled: PermissiveBoolean}).optional(),
     restrictions: z
-      .object({ completed_sessions: z.object({ limit: z.coerce.number() }) })
+      .object({completed_sessions: z.object({limit: z.coerce.number()})})
       .optional(),
     shipping_address_collection: z
       .object({
@@ -54949,7 +54901,7 @@ export function createRouter(implementation: Implementation): Router {
       })
       .optional(),
     shipping_options: z
-      .array(z.object({ shipping_rate: z.string().max(5000).optional() }))
+      .array(z.object({shipping_rate: z.string().max(5000).optional()}))
       .optional(),
     submit_type: z
       .enum(["auto", "book", "donate", "pay", "subscribe"])
@@ -54989,7 +54941,7 @@ export function createRouter(implementation: Implementation): Router {
       })
       .optional(),
     transfer_data: z
-      .object({ amount: z.coerce.number().optional(), destination: z.string() })
+      .object({amount: z.coerce.number().optional(), destination: z.string()})
       .optional(),
   })
 
@@ -55037,7 +54989,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55120,7 +55072,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55150,9 +55102,9 @@ export function createRouter(implementation: Implementation): Router {
       after_completion: z
         .object({
           hosted_confirmation: z
-            .object({ custom_message: z.string().max(500).optional() })
+            .object({custom_message: z.string().max(500).optional()})
             .optional(),
-          redirect: z.object({ url: z.string() }).optional(),
+          redirect: z.object({url: z.string()}).optional(),
           type: z.enum(["hosted_confirmation", "redirect"]),
         })
         .optional(),
@@ -55213,16 +55165,16 @@ export function createRouter(implementation: Implementation): Router {
       custom_text: z
         .object({
           after_submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           shipping_address: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           terms_of_service_acceptance: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
         })
         .optional(),
@@ -55352,13 +55304,11 @@ export function createRouter(implementation: Implementation): Router {
         ])
         .optional(),
       phone_number_collection: z
-        .object({ enabled: PermissiveBoolean })
+        .object({enabled: PermissiveBoolean})
         .optional(),
       restrictions: z
         .union([
-          z.object({
-            completed_sessions: z.object({ limit: z.coerce.number() }),
-          }),
+          z.object({completed_sessions: z.object({limit: z.coerce.number()})}),
           z.enum([""]),
         ])
         .optional(),
@@ -55701,7 +55651,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55809,7 +55759,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55916,7 +55866,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -55941,133 +55891,133 @@ export function createRouter(implementation: Implementation): Router {
       acss_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       affirm: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       afterpay_clearpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alipay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alma: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       amazon_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay_later: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       au_becs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bacs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bancontact: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       billie: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       blik: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       boleto: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cartes_bancaires: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cashapp: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       customer_balance: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       eps: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56075,91 +56025,91 @@ export function createRouter(implementation: Implementation): Router {
       fpx: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       giropay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       google_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       grabpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       ideal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       jcb: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kakao_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       klarna: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       konbini: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kr_card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       link: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       mobilepay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       multibanco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56167,28 +56117,28 @@ export function createRouter(implementation: Implementation): Router {
       naver_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       nz_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       oxxo: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       p24: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56196,112 +56146,112 @@ export function createRouter(implementation: Implementation): Router {
       pay_by_bank: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       payco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paynow: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paypal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       pix: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       promptpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       revolut_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       samsung_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       satispay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sepa_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sofort: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       swish: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       twint: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       us_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       wechat_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       zip: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56355,7 +56305,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56453,7 +56403,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -56485,7 +56435,7 @@ export function createRouter(implementation: Implementation): Router {
       acss_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56493,126 +56443,126 @@ export function createRouter(implementation: Implementation): Router {
       affirm: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       afterpay_clearpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alipay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alma: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       amazon_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay_later: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       au_becs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bacs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bancontact: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       billie: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       blik: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       boleto: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cartes_bancaires: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cashapp: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       customer_balance: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       eps: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56620,91 +56570,91 @@ export function createRouter(implementation: Implementation): Router {
       fpx: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       giropay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       google_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       grabpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       ideal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       jcb: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kakao_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       klarna: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       konbini: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kr_card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       link: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       mobilepay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       multibanco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56712,140 +56662,140 @@ export function createRouter(implementation: Implementation): Router {
       naver_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       nz_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       oxxo: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       p24: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       pay_by_bank: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       payco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paynow: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paypal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       pix: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       promptpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       revolut_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       samsung_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       satispay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sepa_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sofort: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       swish: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       twint: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       us_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       wechat_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       zip: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56909,7 +56859,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57015,7 +56965,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57081,7 +57031,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57172,7 +57122,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57258,7 +57208,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57282,10 +57232,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateParamSchema =
-    z.object({ payment_method_domain: z.string().max(5000) })
+    z.object({payment_method_domain: z.string().max(5000)})
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateResponseBodyValidator =
@@ -57340,7 +57290,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57493,7 +57443,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57562,7 +57512,7 @@ export function createRouter(implementation: Implementation): Router {
         })
         .optional(),
       blik: z.object({}).optional(),
-      boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+      boleto: z.object({tax_id: z.string().max(5000)}).optional(),
       card: z
         .union([
           z.object({
@@ -57578,7 +57528,7 @@ export function createRouter(implementation: Implementation): Router {
               .optional(),
             number: z.string().max(5000),
           }),
-          z.object({ token: z.string().max(5000) }),
+          z.object({token: z.string().max(5000)}),
         ])
         .optional(),
       cashapp: z.object({}).optional(),
@@ -57697,7 +57647,7 @@ export function createRouter(implementation: Implementation): Router {
       mobilepay: z.object({}).optional(),
       multibanco: z.object({}).optional(),
       naver_pay: z
-        .object({ funding: z.enum(["card", "points"]).optional() })
+        .object({funding: z.enum(["card", "points"]).optional()})
         .optional(),
       nz_bank_account: z
         .object({
@@ -57752,14 +57702,14 @@ export function createRouter(implementation: Implementation): Router {
       pix: z.object({}).optional(),
       promptpay: z.object({}).optional(),
       radar_options: z
-        .object({ session: z.string().max(5000).optional() })
+        .object({session: z.string().max(5000).optional()})
         .optional(),
       revolut_pay: z.object({}).optional(),
       samsung_pay: z.object({}).optional(),
       satispay: z.object({}).optional(),
-      sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+      sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
       sofort: z
-        .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+        .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
         .optional(),
       swish: z.object({}).optional(),
       twint: z.object({}).optional(),
@@ -57873,7 +57823,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -57958,7 +57908,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58078,7 +58028,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58159,7 +58109,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58187,7 +58137,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postPaymentMethodsPaymentMethodDetachRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postPaymentMethodsPaymentMethodDetachResponseBodyValidator =
@@ -58242,7 +58192,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58366,7 +58316,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58440,7 +58390,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58458,7 +58408,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getPayoutsPayoutParamSchema = z.object({ payout: z.string().max(5000) })
+  const getPayoutsPayoutParamSchema = z.object({payout: z.string().max(5000)})
 
   const getPayoutsPayoutQuerySchema = z.object({
     expand: z
@@ -58523,7 +58473,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58541,9 +58491,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postPayoutsPayoutParamSchema = z.object({
-    payout: z.string().max(5000),
-  })
+  const postPayoutsPayoutParamSchema = z.object({payout: z.string().max(5000)})
 
   const postPayoutsPayoutRequestBodySchema = z
     .object({
@@ -58600,7 +58548,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58623,7 +58571,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postPayoutsPayoutCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postPayoutsPayoutCancelResponseBodyValidator =
@@ -58672,7 +58620,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58747,7 +58695,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58855,7 +58803,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58913,7 +58861,7 @@ export function createRouter(implementation: Implementation): Router {
       .optional(),
     tiers_mode: z.enum(["graduated", "volume"]).optional(),
     transform_usage: z
-      .object({ divide_by: z.coerce.number(), round: z.enum(["down", "up"]) })
+      .object({divide_by: z.coerce.number(), round: z.enum(["down", "up"])})
       .optional(),
     trial_period_days: z.coerce.number().optional(),
     usage_type: z.enum(["licensed", "metered"]).optional(),
@@ -58963,7 +58911,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -58981,7 +58929,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deletePlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
+  const deletePlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
   const deletePlansPlanRequestBodySchema = z.object({}).optional()
 
@@ -59033,7 +58981,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59051,7 +58999,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getPlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
+  const getPlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
   const getPlansPlanQuerySchema = z.object({
     expand: z
@@ -59116,7 +59064,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59134,7 +59082,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postPlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
+  const postPlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
   const postPlansPlanRequestBodySchema = z
     .object({
@@ -59195,7 +59143,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59318,7 +59266,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59417,7 +59365,7 @@ export function createRouter(implementation: Implementation): Router {
     tiers_mode: z.enum(["graduated", "volume"]).optional(),
     transfer_lookup_key: PermissiveBoolean.optional(),
     transform_quantity: z
-      .object({ divide_by: z.coerce.number(), round: z.enum(["down", "up"]) })
+      .object({divide_by: z.coerce.number(), round: z.enum(["down", "up"])})
       .optional(),
     unit_amount: z.coerce.number().optional(),
     unit_amount_decimal: z.string().optional(),
@@ -59467,7 +59415,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59566,7 +59514,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59584,7 +59532,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getPricesPriceParamSchema = z.object({ price: z.string().max(5000) })
+  const getPricesPriceParamSchema = z.object({price: z.string().max(5000)})
 
   const getPricesPriceQuerySchema = z.object({
     expand: z
@@ -59649,7 +59597,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59667,7 +59615,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postPricesPriceParamSchema = z.object({ price: z.string().max(5000) })
+  const postPricesPriceParamSchema = z.object({price: z.string().max(5000)})
 
   const postPricesPriceRequestBodySchema = z
     .object({
@@ -59764,7 +59712,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59879,7 +59827,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -59959,7 +59907,7 @@ export function createRouter(implementation: Implementation): Router {
     id: z.string().max(5000).optional(),
     images: z.array(z.string()).optional(),
     marketing_features: z
-      .array(z.object({ name: z.string().max(5000) }))
+      .array(z.object({name: z.string().max(5000)}))
       .optional(),
     metadata: z.record(z.string()).optional(),
     name: z.string().max(5000),
@@ -60022,7 +59970,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60121,7 +60069,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60139,7 +60087,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deleteProductsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const deleteProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const deleteProductsIdRequestBodySchema = z.object({}).optional()
 
@@ -60191,7 +60139,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60209,7 +60157,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getProductsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getProductsIdQuerySchema = z.object({
     expand: z
@@ -60274,7 +60222,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60292,7 +60240,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postProductsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const postProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postProductsIdRequestBodySchema = z
     .object({
@@ -60302,10 +60250,7 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       images: z.union([z.array(z.string()), z.enum([""])]).optional(),
       marketing_features: z
-        .union([
-          z.array(z.object({ name: z.string().max(5000) })),
-          z.enum([""]),
-        ])
+        .union([z.array(z.object({name: z.string().max(5000)})), z.enum([""])])
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       name: z.string().max(5000).optional(),
@@ -60376,7 +60321,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60480,7 +60425,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60555,7 +60500,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60630,7 +60575,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60716,7 +60661,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60828,7 +60773,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60858,7 +60803,7 @@ export function createRouter(implementation: Implementation): Router {
     restrictions: z
       .object({
         currency_options: z
-          .record(z.object({ minimum_amount: z.coerce.number().optional() }))
+          .record(z.object({minimum_amount: z.coerce.number().optional()}))
           .optional(),
         first_time_transaction: PermissiveBoolean.optional(),
         minimum_amount: z.coerce.number().optional(),
@@ -60911,7 +60856,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -60996,7 +60941,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61028,7 +60973,7 @@ export function createRouter(implementation: Implementation): Router {
       restrictions: z
         .object({
           currency_options: z
-            .record(z.object({ minimum_amount: z.coerce.number().optional() }))
+            .record(z.object({minimum_amount: z.coerce.number().optional()}))
             .optional(),
         })
         .optional(),
@@ -61081,7 +61026,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61181,7 +61126,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61304,7 +61249,7 @@ export function createRouter(implementation: Implementation): Router {
       subscription_data: z
         .object({
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           description: z.string().max(500).optional(),
           effective_date: z
@@ -61378,7 +61323,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61396,7 +61341,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getQuotesQuoteParamSchema = z.object({ quote: z.string().max(5000) })
+  const getQuotesQuoteParamSchema = z.object({quote: z.string().max(5000)})
 
   const getQuotesQuoteQuerySchema = z.object({
     expand: z
@@ -61461,7 +61406,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61479,7 +61424,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postQuotesQuoteParamSchema = z.object({ quote: z.string().max(5000) })
+  const postQuotesQuoteParamSchema = z.object({quote: z.string().max(5000)})
 
   const postQuotesQuoteRequestBodySchema = z
     .object({
@@ -61655,7 +61600,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61678,7 +61623,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postQuotesQuoteAcceptRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postQuotesQuoteAcceptResponseBodyValidator = responseValidationFactory(
@@ -61729,7 +61674,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61752,7 +61697,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postQuotesQuoteCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postQuotesQuoteCancelResponseBodyValidator = responseValidationFactory(
@@ -61803,7 +61748,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61915,7 +61860,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -61995,7 +61940,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62099,7 +62044,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62117,7 +62062,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getQuotesQuotePdfParamSchema = z.object({ quote: z.string().max(5000) })
+  const getQuotesQuotePdfParamSchema = z.object({quote: z.string().max(5000)})
 
   const getQuotesQuotePdfQuerySchema = z.object({
     expand: z
@@ -62182,7 +62127,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62294,7 +62239,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62387,7 +62332,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62503,7 +62448,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62569,7 +62514,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62644,7 +62589,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62729,7 +62674,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62839,7 +62784,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62922,7 +62867,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -62994,7 +62939,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63079,7 +63024,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63158,7 +63103,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63268,7 +63213,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63349,7 +63294,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63367,7 +63312,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getRefundsRefundParamSchema = z.object({ refund: z.string() })
+  const getRefundsRefundParamSchema = z.object({refund: z.string()})
 
   const getRefundsRefundQuerySchema = z.object({
     expand: z
@@ -63432,7 +63377,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63450,7 +63395,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postRefundsRefundParamSchema = z.object({ refund: z.string() })
+  const postRefundsRefundParamSchema = z.object({refund: z.string()})
 
   const postRefundsRefundRequestBodySchema = z
     .object({
@@ -63507,7 +63452,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63525,10 +63470,10 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postRefundsRefundCancelParamSchema = z.object({ refund: z.string() })
+  const postRefundsRefundCancelParamSchema = z.object({refund: z.string()})
 
   const postRefundsRefundCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postRefundsRefundCancelResponseBodyValidator =
@@ -63577,7 +63522,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -63686,7 +63631,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64404,7 +64349,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64489,7 +64434,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64584,7 +64529,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64669,7 +64614,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64780,7 +64725,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64798,7 +64743,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getReviewsReviewParamSchema = z.object({ review: z.string().max(5000) })
+  const getReviewsReviewParamSchema = z.object({review: z.string().max(5000)})
 
   const getReviewsReviewQuerySchema = z.object({
     expand: z
@@ -64863,7 +64808,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -64886,7 +64831,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postReviewsReviewApproveRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postReviewsReviewApproveResponseBodyValidator =
@@ -64935,7 +64880,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65042,7 +64987,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65151,7 +65096,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65259,7 +65204,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -65374,7 +65319,7 @@ export function createRouter(implementation: Implementation): Router {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -65428,14 +65373,14 @@ export function createRouter(implementation: Implementation): Router {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -65693,7 +65638,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().max(5000).optional() })
+            .object({billing_agreement_id: z.string().max(5000).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -65734,7 +65679,7 @@ export function createRouter(implementation: Implementation): Router {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -65753,7 +65698,7 @@ export function createRouter(implementation: Implementation): Router {
       payment_method_types: z.array(z.string().max(5000)).optional(),
       return_url: z.string().optional(),
       single_use: z
-        .object({ amount: z.coerce.number(), currency: z.string() })
+        .object({amount: z.coerce.number(), currency: z.string()})
         .optional(),
       usage: z.enum(["off_session", "on_session"]).optional(),
       use_stripe_sdk: PermissiveBoolean.optional(),
@@ -65804,7 +65749,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65890,7 +65835,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -65975,7 +65920,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -66090,7 +66035,7 @@ export function createRouter(implementation: Implementation): Router {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -66144,14 +66089,14 @@ export function createRouter(implementation: Implementation): Router {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -66409,7 +66354,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().max(5000).optional() })
+            .object({billing_agreement_id: z.string().max(5000).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -66450,7 +66395,7 @@ export function createRouter(implementation: Implementation): Router {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -66518,7 +66463,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66595,7 +66540,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -66705,7 +66650,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -66820,7 +66765,7 @@ export function createRouter(implementation: Implementation): Router {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -66874,14 +66819,14 @@ export function createRouter(implementation: Implementation): Router {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -67139,7 +67084,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().max(5000).optional() })
+            .object({billing_agreement_id: z.string().max(5000).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -67180,7 +67125,7 @@ export function createRouter(implementation: Implementation): Router {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -67247,7 +67192,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67332,7 +67277,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67445,7 +67390,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67548,7 +67493,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67633,7 +67578,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67731,7 +67676,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67812,7 +67757,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -67911,7 +67856,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68004,7 +67949,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68042,7 +67987,7 @@ export function createRouter(implementation: Implementation): Router {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              offline: z.object({ contact_email: z.string() }).optional(),
+              offline: z.object({contact_email: z.string()}).optional(),
               online: z
                 .object({
                   date: z.coerce.number().optional(),
@@ -68095,7 +68040,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
         })
         .optional(),
-      redirect: z.object({ return_url: z.string() }).optional(),
+      redirect: z.object({return_url: z.string()}).optional(),
       source_order: z
         .object({
           items: z
@@ -68179,7 +68124,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68197,7 +68142,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getSourcesSourceParamSchema = z.object({ source: z.string().max(5000) })
+  const getSourcesSourceParamSchema = z.object({source: z.string().max(5000)})
 
   const getSourcesSourceQuerySchema = z.object({
     client_secret: z.string().max(5000).optional(),
@@ -68263,7 +68208,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68281,9 +68226,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postSourcesSourceParamSchema = z.object({
-    source: z.string().max(5000),
-  })
+  const postSourcesSourceParamSchema = z.object({source: z.string().max(5000)})
 
   const postSourcesSourceRequestBodySchema = z
     .object({
@@ -68295,7 +68238,7 @@ export function createRouter(implementation: Implementation): Router {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              offline: z.object({ contact_email: z.string() }).optional(),
+              offline: z.object({contact_email: z.string()}).optional(),
               online: z
                 .object({
                   date: z.coerce.number().optional(),
@@ -68423,7 +68366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68518,7 +68461,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68629,7 +68572,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68728,7 +68671,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68806,7 +68749,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68905,7 +68848,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -68925,7 +68868,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const postSubscriptionItemsRequestBodySchema = z.object({
     billing_thresholds: z
-      .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+      .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
       .optional(),
     discounts: z
       .union([
@@ -69020,7 +68963,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69098,7 +69041,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69183,7 +69126,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69208,7 +69151,7 @@ export function createRouter(implementation: Implementation): Router {
   const postSubscriptionItemsItemRequestBodySchema = z
     .object({
       billing_thresholds: z
-        .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+        .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
         .optional(),
       discounts: z
         .union([
@@ -69306,7 +69249,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69451,7 +69394,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69472,7 +69415,7 @@ export function createRouter(implementation: Implementation): Router {
   const postSubscriptionSchedulesRequestBodySchema = z
     .object({
       billing_mode: z
-        .object({ type: z.enum(["classic", "flexible"]) })
+        .object({type: z.enum(["classic", "flexible"])})
         .optional(),
       customer: z.string().max(5000).optional(),
       default_settings: z
@@ -69634,7 +69577,7 @@ export function createRouter(implementation: Implementation): Router {
               z.object({
                 billing_thresholds: z
                   .union([
-                    z.object({ usage_gte: z.coerce.number() }),
+                    z.object({usage_gte: z.coerce.number()}),
                     z.enum([""]),
                   ])
                   .optional(),
@@ -69736,7 +69679,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -69821,7 +69764,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70004,7 +69947,7 @@ export function createRouter(implementation: Implementation): Router {
               z.object({
                 billing_thresholds: z
                   .union([
-                    z.object({ usage_gte: z.coerce.number() }),
+                    z.object({usage_gte: z.coerce.number()}),
                     z.enum([""]),
                   ])
                   .optional(),
@@ -70115,7 +70058,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70202,7 +70145,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70288,7 +70231,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70312,7 +70255,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const getSubscriptionsQuerySchema = z.object({
-    automatic_tax: z.object({ enabled: PermissiveBoolean }).optional(),
+    automatic_tax: z.object({enabled: PermissiveBoolean}).optional(),
     collection_method: z
       .enum(["charge_automatically", "send_invoice"])
       .optional(),
@@ -70442,7 +70385,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70517,9 +70460,7 @@ export function createRouter(implementation: Implementation): Router {
         second: z.coerce.number().optional(),
       })
       .optional(),
-    billing_mode: z
-      .object({ type: z.enum(["classic", "flexible"]) })
-      .optional(),
+    billing_mode: z.object({type: z.enum(["classic", "flexible"])}).optional(),
     billing_thresholds: z
       .union([
         z.object({
@@ -70573,7 +70514,7 @@ export function createRouter(implementation: Implementation): Router {
       .array(
         z.object({
           billing_thresholds: z
-            .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+            .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
             .optional(),
           discounts: z
             .union([
@@ -70693,7 +70634,7 @@ export function createRouter(implementation: Implementation): Router {
                   bank_transfer: z
                     .object({
                       eu_bank_transfer: z
-                        .object({ country: z.string().max(5000) })
+                        .object({country: z.string().max(5000)})
                         .optional(),
                       type: z.string().optional(),
                     })
@@ -70870,7 +70811,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -70969,7 +70910,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71069,7 +71010,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71165,7 +71106,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71309,7 +71250,7 @@ export function createRouter(implementation: Implementation): Router {
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
               .optional(),
             clear_usage: PermissiveBoolean.optional(),
             deleted: PermissiveBoolean.optional(),
@@ -71441,7 +71382,7 @@ export function createRouter(implementation: Implementation): Router {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -71634,7 +71575,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71717,7 +71658,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71745,7 +71686,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postSubscriptionsSubscriptionMigrateRequestBodySchema = z.object({
-    billing_mode: z.object({ type: z.enum(["flexible"]) }),
+    billing_mode: z.object({type: z.enum(["flexible"])}),
     expand: z.array(z.string().max(5000)).optional(),
   })
 
@@ -71801,7 +71742,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -71885,7 +71826,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72130,7 +72071,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72213,7 +72154,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72330,7 +72271,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72431,7 +72372,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72453,10 +72394,10 @@ export function createRouter(implementation: Implementation): Router {
     active_from: z.union([z.enum(["now"]), z.coerce.number()]),
     country: z.string().max(5000),
     country_options: z.object({
-      ae: z.object({ type: z.enum(["standard"]) }).optional(),
-      al: z.object({ type: z.enum(["standard"]) }).optional(),
-      am: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ao: z.object({ type: z.enum(["standard"]) }).optional(),
+      ae: z.object({type: z.enum(["standard"])}).optional(),
+      al: z.object({type: z.enum(["standard"])}).optional(),
+      am: z.object({type: z.enum(["simplified"])}).optional(),
+      ao: z.object({type: z.enum(["standard"])}).optional(),
       at: z
         .object({
           standard: z
@@ -72467,12 +72408,12 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      au: z.object({ type: z.enum(["standard"]) }).optional(),
-      aw: z.object({ type: z.enum(["standard"]) }).optional(),
-      az: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ba: z.object({ type: z.enum(["standard"]) }).optional(),
-      bb: z.object({ type: z.enum(["standard"]) }).optional(),
-      bd: z.object({ type: z.enum(["standard"]) }).optional(),
+      au: z.object({type: z.enum(["standard"])}).optional(),
+      aw: z.object({type: z.enum(["standard"])}).optional(),
+      az: z.object({type: z.enum(["simplified"])}).optional(),
+      ba: z.object({type: z.enum(["standard"])}).optional(),
+      bb: z.object({type: z.enum(["standard"])}).optional(),
+      bd: z.object({type: z.enum(["standard"])}).optional(),
       be: z
         .object({
           standard: z
@@ -72483,7 +72424,7 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      bf: z.object({ type: z.enum(["standard"]) }).optional(),
+      bf: z.object({type: z.enum(["standard"])}).optional(),
       bg: z
         .object({
           standard: z
@@ -72494,25 +72435,25 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      bh: z.object({ type: z.enum(["standard"]) }).optional(),
-      bj: z.object({ type: z.enum(["simplified"]) }).optional(),
-      bs: z.object({ type: z.enum(["standard"]) }).optional(),
-      by: z.object({ type: z.enum(["simplified"]) }).optional(),
+      bh: z.object({type: z.enum(["standard"])}).optional(),
+      bj: z.object({type: z.enum(["simplified"])}).optional(),
+      bs: z.object({type: z.enum(["standard"])}).optional(),
+      by: z.object({type: z.enum(["simplified"])}).optional(),
       ca: z
         .object({
           province_standard: z
-            .object({ province: z.string().max(5000) })
+            .object({province: z.string().max(5000)})
             .optional(),
           type: z.enum(["province_standard", "simplified", "standard"]),
         })
         .optional(),
-      cd: z.object({ type: z.enum(["standard"]) }).optional(),
-      ch: z.object({ type: z.enum(["standard"]) }).optional(),
-      cl: z.object({ type: z.enum(["simplified"]) }).optional(),
-      cm: z.object({ type: z.enum(["simplified"]) }).optional(),
-      co: z.object({ type: z.enum(["simplified"]) }).optional(),
-      cr: z.object({ type: z.enum(["simplified"]) }).optional(),
-      cv: z.object({ type: z.enum(["simplified"]) }).optional(),
+      cd: z.object({type: z.enum(["standard"])}).optional(),
+      ch: z.object({type: z.enum(["standard"])}).optional(),
+      cl: z.object({type: z.enum(["simplified"])}).optional(),
+      cm: z.object({type: z.enum(["simplified"])}).optional(),
+      co: z.object({type: z.enum(["simplified"])}).optional(),
+      cr: z.object({type: z.enum(["simplified"])}).optional(),
+      cv: z.object({type: z.enum(["simplified"])}).optional(),
       cy: z
         .object({
           standard: z
@@ -72553,7 +72494,7 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      ec: z.object({ type: z.enum(["simplified"]) }).optional(),
+      ec: z.object({type: z.enum(["simplified"])}).optional(),
       ee: z
         .object({
           standard: z
@@ -72564,7 +72505,7 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      eg: z.object({ type: z.enum(["simplified"]) }).optional(),
+      eg: z.object({type: z.enum(["simplified"])}).optional(),
       es: z
         .object({
           standard: z
@@ -72575,7 +72516,7 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      et: z.object({ type: z.enum(["standard"]) }).optional(),
+      et: z.object({type: z.enum(["standard"])}).optional(),
       fi: z
         .object({
           standard: z
@@ -72596,9 +72537,9 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      gb: z.object({ type: z.enum(["standard"]) }).optional(),
-      ge: z.object({ type: z.enum(["simplified"]) }).optional(),
-      gn: z.object({ type: z.enum(["standard"]) }).optional(),
+      gb: z.object({type: z.enum(["standard"])}).optional(),
+      ge: z.object({type: z.enum(["simplified"])}).optional(),
+      gn: z.object({type: z.enum(["standard"])}).optional(),
       gr: z
         .object({
           standard: z
@@ -72629,7 +72570,7 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      id: z.object({ type: z.enum(["simplified"]) }).optional(),
+      id: z.object({type: z.enum(["simplified"])}).optional(),
       ie: z
         .object({
           standard: z
@@ -72640,8 +72581,8 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      in: z.object({ type: z.enum(["simplified"]) }).optional(),
-      is: z.object({ type: z.enum(["standard"]) }).optional(),
+      in: z.object({type: z.enum(["simplified"])}).optional(),
+      is: z.object({type: z.enum(["standard"])}).optional(),
       it: z
         .object({
           standard: z
@@ -72652,13 +72593,13 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      jp: z.object({ type: z.enum(["standard"]) }).optional(),
-      ke: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kg: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kh: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kr: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kz: z.object({ type: z.enum(["simplified"]) }).optional(),
-      la: z.object({ type: z.enum(["simplified"]) }).optional(),
+      jp: z.object({type: z.enum(["standard"])}).optional(),
+      ke: z.object({type: z.enum(["simplified"])}).optional(),
+      kg: z.object({type: z.enum(["simplified"])}).optional(),
+      kh: z.object({type: z.enum(["simplified"])}).optional(),
+      kr: z.object({type: z.enum(["simplified"])}).optional(),
+      kz: z.object({type: z.enum(["simplified"])}).optional(),
+      la: z.object({type: z.enum(["simplified"])}).optional(),
       lt: z
         .object({
           standard: z
@@ -72689,11 +72630,11 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      ma: z.object({ type: z.enum(["simplified"]) }).optional(),
-      md: z.object({ type: z.enum(["simplified"]) }).optional(),
-      me: z.object({ type: z.enum(["standard"]) }).optional(),
-      mk: z.object({ type: z.enum(["standard"]) }).optional(),
-      mr: z.object({ type: z.enum(["standard"]) }).optional(),
+      ma: z.object({type: z.enum(["simplified"])}).optional(),
+      md: z.object({type: z.enum(["simplified"])}).optional(),
+      me: z.object({type: z.enum(["standard"])}).optional(),
+      mk: z.object({type: z.enum(["standard"])}).optional(),
+      mr: z.object({type: z.enum(["standard"])}).optional(),
       mt: z
         .object({
           standard: z
@@ -72704,9 +72645,9 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      mx: z.object({ type: z.enum(["simplified"]) }).optional(),
-      my: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ng: z.object({ type: z.enum(["simplified"]) }).optional(),
+      mx: z.object({type: z.enum(["simplified"])}).optional(),
+      my: z.object({type: z.enum(["simplified"])}).optional(),
+      ng: z.object({type: z.enum(["simplified"])}).optional(),
       nl: z
         .object({
           standard: z
@@ -72717,12 +72658,12 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      no: z.object({ type: z.enum(["standard"]) }).optional(),
-      np: z.object({ type: z.enum(["simplified"]) }).optional(),
-      nz: z.object({ type: z.enum(["standard"]) }).optional(),
-      om: z.object({ type: z.enum(["standard"]) }).optional(),
-      pe: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ph: z.object({ type: z.enum(["simplified"]) }).optional(),
+      no: z.object({type: z.enum(["standard"])}).optional(),
+      np: z.object({type: z.enum(["simplified"])}).optional(),
+      nz: z.object({type: z.enum(["standard"])}).optional(),
+      om: z.object({type: z.enum(["standard"])}).optional(),
+      pe: z.object({type: z.enum(["simplified"])}).optional(),
+      ph: z.object({type: z.enum(["simplified"])}).optional(),
       pl: z
         .object({
           standard: z
@@ -72753,9 +72694,9 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      rs: z.object({ type: z.enum(["standard"]) }).optional(),
-      ru: z.object({ type: z.enum(["simplified"]) }).optional(),
-      sa: z.object({ type: z.enum(["simplified"]) }).optional(),
+      rs: z.object({type: z.enum(["standard"])}).optional(),
+      ru: z.object({type: z.enum(["simplified"])}).optional(),
+      sa: z.object({type: z.enum(["simplified"])}).optional(),
       se: z
         .object({
           standard: z
@@ -72766,7 +72707,7 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      sg: z.object({ type: z.enum(["standard"]) }).optional(),
+      sg: z.object({type: z.enum(["standard"])}).optional(),
       si: z
         .object({
           standard: z
@@ -72787,21 +72728,21 @@ export function createRouter(implementation: Implementation): Router {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      sn: z.object({ type: z.enum(["simplified"]) }).optional(),
-      sr: z.object({ type: z.enum(["standard"]) }).optional(),
-      th: z.object({ type: z.enum(["simplified"]) }).optional(),
-      tj: z.object({ type: z.enum(["simplified"]) }).optional(),
-      tr: z.object({ type: z.enum(["simplified"]) }).optional(),
-      tz: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ua: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ug: z.object({ type: z.enum(["simplified"]) }).optional(),
+      sn: z.object({type: z.enum(["simplified"])}).optional(),
+      sr: z.object({type: z.enum(["standard"])}).optional(),
+      th: z.object({type: z.enum(["simplified"])}).optional(),
+      tj: z.object({type: z.enum(["simplified"])}).optional(),
+      tr: z.object({type: z.enum(["simplified"])}).optional(),
+      tz: z.object({type: z.enum(["simplified"])}).optional(),
+      ua: z.object({type: z.enum(["simplified"])}).optional(),
+      ug: z.object({type: z.enum(["simplified"])}).optional(),
       us: z
         .object({
           local_amusement_tax: z
-            .object({ jurisdiction: z.string().max(5000) })
+            .object({jurisdiction: z.string().max(5000)})
             .optional(),
           local_lease_tax: z
-            .object({ jurisdiction: z.string().max(5000) })
+            .object({jurisdiction: z.string().max(5000)})
             .optional(),
           state: z.string().max(5000),
           state_sales_tax: z
@@ -72827,12 +72768,12 @@ export function createRouter(implementation: Implementation): Router {
           ]),
         })
         .optional(),
-      uy: z.object({ type: z.enum(["standard"]) }).optional(),
-      uz: z.object({ type: z.enum(["simplified"]) }).optional(),
-      vn: z.object({ type: z.enum(["simplified"]) }).optional(),
-      za: z.object({ type: z.enum(["standard"]) }).optional(),
-      zm: z.object({ type: z.enum(["simplified"]) }).optional(),
-      zw: z.object({ type: z.enum(["standard"]) }).optional(),
+      uy: z.object({type: z.enum(["standard"])}).optional(),
+      uz: z.object({type: z.enum(["simplified"])}).optional(),
+      vn: z.object({type: z.enum(["simplified"])}).optional(),
+      za: z.object({type: z.enum(["standard"])}).optional(),
+      zm: z.object({type: z.enum(["simplified"])}).optional(),
+      zw: z.object({type: z.enum(["standard"])}).optional(),
     }),
     expand: z.array(z.string().max(5000)).optional(),
     expires_at: z.coerce.number().optional(),
@@ -72882,7 +72823,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72900,9 +72841,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTaxRegistrationsIdParamSchema = z.object({
-    id: z.string().max(5000),
-  })
+  const getTaxRegistrationsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getTaxRegistrationsIdQuerySchema = z.object({
     expand: z
@@ -72967,7 +72906,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -72985,9 +72924,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postTaxRegistrationsIdParamSchema = z.object({
-    id: z.string().max(5000),
-  })
+  const postTaxRegistrationsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postTaxRegistrationsIdRequestBodySchema = z
     .object({
@@ -73047,7 +72984,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73124,7 +73061,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73212,7 +73149,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73286,7 +73223,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73329,7 +73266,7 @@ export function createRouter(implementation: Implementation): Router {
     original_transaction: z.string().max(5000),
     reference: z.string().max(500),
     shipping_cost: z
-      .object({ amount: z.coerce.number(), amount_tax: z.coerce.number() })
+      .object({amount: z.coerce.number(), amount_tax: z.coerce.number()})
       .optional(),
   })
 
@@ -73375,7 +73312,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73463,7 +73400,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73580,7 +73517,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73680,7 +73617,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73698,7 +73635,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTaxCodesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getTaxCodesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getTaxCodesIdQuerySchema = z.object({
     expand: z
@@ -73763,7 +73700,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -73865,7 +73802,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74051,7 +73988,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74069,7 +74006,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deleteTaxIdsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const deleteTaxIdsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const deleteTaxIdsIdRequestBodySchema = z.object({}).optional()
 
@@ -74121,7 +74058,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74139,7 +74076,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTaxIdsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getTaxIdsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getTaxIdsIdQuerySchema = z.object({
     expand: z
@@ -74204,7 +74141,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74312,7 +74249,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74405,7 +74342,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74490,7 +74427,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74591,7 +74528,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74691,7 +74628,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -74712,22 +74649,18 @@ export function createRouter(implementation: Implementation): Router {
   const postTerminalConfigurationsRequestBodySchema = z
     .object({
       bbpos_wisepos_e: z
-        .object({
-          splashscreen: z.union([z.string(), z.enum([""])]).optional(),
-        })
+        .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       name: z.string().max(100).optional(),
       offline: z
-        .union([z.object({ enabled: PermissiveBoolean }), z.enum([""])])
+        .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
         .optional(),
       reboot_window: z
-        .object({ end_hour: z.coerce.number(), start_hour: z.coerce.number() })
+        .object({end_hour: z.coerce.number(), start_hour: z.coerce.number()})
         .optional(),
       stripe_s700: z
-        .object({
-          splashscreen: z.union([z.string(), z.enum([""])]).optional(),
-        })
+        .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
         .optional(),
       tipping: z
         .union([
@@ -74849,9 +74782,7 @@ export function createRouter(implementation: Implementation): Router {
         ])
         .optional(),
       verifone_p400: z
-        .object({
-          splashscreen: z.union([z.string(), z.enum([""])]).optional(),
-        })
+        .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
         .optional(),
       wifi: z
         .union([
@@ -74933,7 +74864,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75018,7 +74949,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75127,7 +75058,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75167,7 +75098,7 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       name: z.string().max(100).optional(),
       offline: z
-        .union([z.object({ enabled: PermissiveBoolean }), z.enum([""])])
+        .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
         .optional(),
       reboot_window: z
         .union([
@@ -75416,7 +75347,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75488,7 +75419,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75588,7 +75519,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75665,7 +75596,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75737,7 +75668,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75827,7 +75758,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -75923,7 +75854,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76036,7 +75967,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76106,7 +76037,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76176,7 +76107,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76271,7 +76202,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76357,7 +76288,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76380,7 +76311,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTerminalReadersReaderCancelActionRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTerminalReadersReaderCancelActionResponseBodyValidator =
@@ -76435,7 +76366,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76558,7 +76489,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76595,7 +76526,7 @@ export function createRouter(implementation: Implementation): Router {
           enable_customer_cancellation: PermissiveBoolean.optional(),
           skip_tipping: PermissiveBoolean.optional(),
           tipping: z
-            .object({ amount_eligible: z.coerce.number().optional() })
+            .object({amount_eligible: z.coerce.number().optional()})
             .optional(),
         })
         .optional(),
@@ -76655,7 +76586,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76684,9 +76615,7 @@ export function createRouter(implementation: Implementation): Router {
 
   const postTerminalReadersReaderConfirmPaymentIntentRequestBodySchema =
     z.object({
-      confirm_config: z
-        .object({ return_url: z.string().optional() })
-        .optional(),
+      confirm_config: z.object({return_url: z.string().optional()}).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       payment_intent: z.string().max(5000),
     })
@@ -76743,7 +76672,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76783,7 +76712,7 @@ export function createRouter(implementation: Implementation): Router {
           return_url: z.string().optional(),
           skip_tipping: PermissiveBoolean.optional(),
           tipping: z
-            .object({ amount_eligible: z.coerce.number().optional() })
+            .object({amount_eligible: z.coerce.number().optional()})
             .optional(),
         })
         .optional(),
@@ -76841,7 +76770,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76873,7 +76802,7 @@ export function createRouter(implementation: Implementation): Router {
       allow_redisplay: z.enum(["always", "limited", "unspecified"]),
       expand: z.array(z.string().max(5000)).optional(),
       process_config: z
-        .object({ enable_customer_cancellation: PermissiveBoolean.optional() })
+        .object({enable_customer_cancellation: PermissiveBoolean.optional()})
         .optional(),
       setup_intent: z.string().max(5000),
     },
@@ -76931,7 +76860,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -76967,7 +76896,7 @@ export function createRouter(implementation: Implementation): Router {
       payment_intent: z.string().max(5000).optional(),
       refund_application_fee: PermissiveBoolean.optional(),
       refund_payment_config: z
-        .object({ enable_customer_cancellation: PermissiveBoolean.optional() })
+        .object({enable_customer_cancellation: PermissiveBoolean.optional()})
         .optional(),
       reverse_transfer: PermissiveBoolean.optional(),
     })
@@ -77025,7 +76954,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77123,7 +77052,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77203,7 +77132,7 @@ export function createRouter(implementation: Implementation): Router {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -77318,7 +77247,7 @@ export function createRouter(implementation: Implementation): Router {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -77372,14 +77301,14 @@ export function createRouter(implementation: Implementation): Router {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -77523,7 +77452,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77615,7 +77544,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -77673,10 +77602,10 @@ export function createRouter(implementation: Implementation): Router {
         reported_breakdown: z
           .object({
             fuel: z
-              .object({ gross_amount_decimal: z.string().optional() })
+              .object({gross_amount_decimal: z.string().optional()})
               .optional(),
             non_fuel: z
-              .object({ gross_amount_decimal: z.string().optional() })
+              .object({gross_amount_decimal: z.string().optional()})
               .optional(),
             tax: z
               .object({
@@ -78033,7 +77962,7 @@ export function createRouter(implementation: Implementation): Router {
       })
       .optional(),
     network_data: z
-      .object({ acquiring_institution_id: z.string().max(5000).optional() })
+      .object({acquiring_institution_id: z.string().max(5000).optional()})
       .optional(),
     verification_data: z
       .object({
@@ -78118,7 +78047,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78142,7 +78071,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureRequestBodySchema =
     z
@@ -78173,10 +78102,10 @@ export function createRouter(implementation: Implementation): Router {
                 reported_breakdown: z
                   .object({
                     fuel: z
-                      .object({ gross_amount_decimal: z.string().optional() })
+                      .object({gross_amount_decimal: z.string().optional()})
                       .optional(),
                     non_fuel: z
-                      .object({ gross_amount_decimal: z.string().optional() })
+                      .object({gross_amount_decimal: z.string().optional()})
                       .optional(),
                     tax: z
                       .object({
@@ -78317,7 +78246,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78341,10 +78270,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireRequestBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireResponseBodyValidator =
     responseValidationFactory([["200", s_issuing_authorization]], s_error)
@@ -78398,7 +78327,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78422,7 +78351,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountRequestBodySchema =
     z.object({
@@ -78449,10 +78378,10 @@ export function createRouter(implementation: Implementation): Router {
           reported_breakdown: z
             .object({
               fuel: z
-                .object({ gross_amount_decimal: z.string().optional() })
+                .object({gross_amount_decimal: z.string().optional()})
                 .optional(),
               non_fuel: z
-                .object({ gross_amount_decimal: z.string().optional() })
+                .object({gross_amount_decimal: z.string().optional()})
                 .optional(),
               tax: z
                 .object({
@@ -78549,7 +78478,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78573,7 +78502,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespondParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespondRequestBodySchema =
     z.object({
@@ -78633,7 +78562,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78657,7 +78586,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementRequestBodySchema =
     z.object({
@@ -78718,7 +78647,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78742,7 +78671,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationReverseParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationReverseRequestBodySchema =
     z
@@ -78804,7 +78733,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78832,7 +78761,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersIssuingCardsCardShippingDeliverRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingDeliverResponseBodyValidator =
@@ -78887,7 +78816,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78915,7 +78844,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersIssuingCardsCardShippingFailRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingFailResponseBodyValidator =
@@ -78970,7 +78899,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -78998,7 +78927,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersIssuingCardsCardShippingReturnRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingReturnResponseBodyValidator =
@@ -79053,7 +78982,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79081,7 +79010,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersIssuingCardsCardShippingShipRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingShipResponseBodyValidator =
@@ -79136,7 +79065,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79164,7 +79093,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersIssuingCardsCardShippingSubmitRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingSubmitResponseBodyValidator =
@@ -79219,7 +79148,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79243,10 +79172,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateRequestBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateResponseBodyValidator =
     responseValidationFactory(
@@ -79305,7 +79234,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79329,10 +79258,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateRequestBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateResponseBodyValidator =
     responseValidationFactory(
@@ -79391,7 +79320,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79415,7 +79344,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectRequestBodySchema =
     z.object({
@@ -79508,7 +79437,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79586,7 +79515,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -79610,10 +79539,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingSettlementsSettlementCompleteParamSchema =
-    z.object({ settlement: z.string().max(5000) })
+    z.object({settlement: z.string().max(5000)})
 
   const postTestHelpersIssuingSettlementsSettlementCompleteRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingSettlementsSettlementCompleteResponseBodyValidator =
@@ -79668,7 +79597,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80030,10 +79959,10 @@ export function createRouter(implementation: Implementation): Router {
               reported_breakdown: z
                 .object({
                   fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   non_fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   tax: z
                     .object({
@@ -80165,7 +80094,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80527,10 +80456,10 @@ export function createRouter(implementation: Implementation): Router {
               reported_breakdown: z
                 .object({
                   fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   non_fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   tax: z
                     .object({
@@ -80662,7 +80591,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80686,7 +80615,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersIssuingTransactionsTransactionRefundParamSchema =
-    z.object({ transaction: z.string().max(5000) })
+    z.object({transaction: z.string().max(5000)})
 
   const postTestHelpersIssuingTransactionsTransactionRefundRequestBodySchema = z
     .object({
@@ -80747,7 +80676,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80775,7 +80704,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersRefundsRefundExpireRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersRefundsRefundExpireResponseBodyValidator =
@@ -80824,7 +80753,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80848,18 +80777,18 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTerminalReadersReaderPresentPaymentMethodParamSchema =
-    z.object({ reader: z.string().max(5000) })
+    z.object({reader: z.string().max(5000)})
 
   const postTestHelpersTerminalReadersReaderPresentPaymentMethodRequestBodySchema =
     z
       .object({
         amount_tip: z.coerce.number().optional(),
         card_present: z
-          .object({ number: z.string().max(5000).optional() })
+          .object({number: z.string().max(5000).optional()})
           .optional(),
         expand: z.array(z.string().max(5000)).optional(),
         interac_present: z
-          .object({ number: z.string().max(5000).optional() })
+          .object({number: z.string().max(5000).optional()})
           .optional(),
         type: z.enum(["card_present", "interac_present"]).optional(),
       })
@@ -80917,7 +80846,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -80941,7 +80870,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTerminalReadersReaderSucceedInputCollectionParamSchema =
-    z.object({ reader: z.string().max(5000) })
+    z.object({reader: z.string().max(5000)})
 
   const postTestHelpersTerminalReadersReaderSucceedInputCollectionRequestBodySchema =
     z
@@ -81003,7 +80932,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81027,10 +80956,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTerminalReadersReaderTimeoutInputCollectionParamSchema =
-    z.object({ reader: z.string().max(5000) })
+    z.object({reader: z.string().max(5000)})
 
   const postTestHelpersTerminalReadersReaderTimeoutInputCollectionRequestBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersTerminalReadersReaderTimeoutInputCollectionResponseBodyValidator =
     responseValidationFactory([["200", s_terminal_reader]], s_error)
@@ -81084,7 +81013,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81188,7 +81117,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81254,7 +81183,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81337,7 +81266,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81427,7 +81356,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81511,7 +81440,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81617,7 +81546,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81645,7 +81574,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersTreasuryInboundTransfersIdReturnRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryInboundTransfersIdReturnResponseBodyValidator =
@@ -81700,7 +81629,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81728,7 +81657,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedResponseBodyValidator =
@@ -81783,7 +81712,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81813,7 +81742,7 @@ export function createRouter(implementation: Implementation): Router {
   const postTestHelpersTreasuryOutboundPaymentsIdRequestBodySchema = z.object({
     expand: z.array(z.string().max(5000)).optional(),
     tracking_details: z.object({
-      ach: z.object({ trace_id: z.string().max(5000) }).optional(),
+      ach: z.object({trace_id: z.string().max(5000)}).optional(),
       type: z.enum(["ach", "us_domestic_wire"]),
       us_domestic_wire: z
         .object({
@@ -81877,7 +81806,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81905,7 +81834,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailResponseBodyValidator =
@@ -81960,7 +81889,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -81988,7 +81917,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostResponseBodyValidator =
@@ -82043,7 +81972,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82146,7 +82075,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82170,13 +82099,13 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferRequestBodySchema =
     z.object({
       expand: z.array(z.string().max(5000)).optional(),
       tracking_details: z.object({
-        ach: z.object({ trace_id: z.string().max(5000) }).optional(),
+        ach: z.object({trace_id: z.string().max(5000)}).optional(),
         type: z.enum(["ach", "us_domestic_wire"]),
         us_domestic_wire: z
           .object({
@@ -82240,7 +82169,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82264,10 +82193,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailRequestBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
@@ -82321,7 +82250,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82345,10 +82274,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostRequestBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostResponseBodyValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
@@ -82402,7 +82331,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82426,7 +82355,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnRequestBodySchema =
     z
@@ -82505,7 +82434,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82597,7 +82526,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82689,7 +82618,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -82986,7 +82915,7 @@ export function createRouter(implementation: Implementation): Router {
         ])
         .optional(),
       customer: z.string().max(5000).optional(),
-      cvc_update: z.object({ cvc: z.string().max(5000) }).optional(),
+      cvc_update: z.object({cvc: z.string().max(5000)}).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       person: z
         .object({
@@ -83189,7 +83118,7 @@ export function createRouter(implementation: Implementation): Router {
             .optional(),
         })
         .optional(),
-      pii: z.object({ id_number: z.string().max(5000).optional() }).optional(),
+      pii: z.object({id_number: z.string().max(5000).optional()}).optional(),
     })
     .optional()
 
@@ -83237,7 +83166,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83255,7 +83184,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTokensTokenParamSchema = z.object({ token: z.string().max(5000) })
+  const getTokensTokenParamSchema = z.object({token: z.string().max(5000)})
 
   const getTokensTokenQuerySchema = z.object({
     expand: z
@@ -83320,7 +83249,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83438,7 +83367,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83511,7 +83440,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83529,7 +83458,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTopupsTopupParamSchema = z.object({ topup: z.string().max(5000) })
+  const getTopupsTopupParamSchema = z.object({topup: z.string().max(5000)})
 
   const getTopupsTopupQuerySchema = z.object({
     expand: z
@@ -83594,7 +83523,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83612,7 +83541,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const postTopupsTopupParamSchema = z.object({ topup: z.string().max(5000) })
+  const postTopupsTopupParamSchema = z.object({topup: z.string().max(5000)})
 
   const postTopupsTopupRequestBodySchema = z
     .object({
@@ -83670,7 +83599,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83693,7 +83622,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTopupsTopupCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTopupsTopupCancelResponseBodyValidator = responseValidationFactory(
@@ -83744,7 +83673,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83852,7 +83781,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -83926,7 +83855,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84030,7 +83959,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84108,7 +84037,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84193,7 +84122,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84271,7 +84200,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84357,7 +84286,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84435,7 +84364,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84536,7 +84465,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84604,7 +84533,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84697,7 +84626,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84802,7 +84731,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84868,7 +84797,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -84961,7 +84890,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85077,7 +85006,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85101,36 +85030,28 @@ export function createRouter(implementation: Implementation): Router {
     expand: z.array(z.string().max(5000)).optional(),
     features: z
       .object({
-        card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
-        deposit_insurance: z
-          .object({ requested: PermissiveBoolean })
-          .optional(),
+        card_issuing: z.object({requested: PermissiveBoolean}).optional(),
+        deposit_insurance: z.object({requested: PermissiveBoolean}).optional(),
         financial_addresses: z
-          .object({
-            aba: z.object({ requested: PermissiveBoolean }).optional(),
-          })
+          .object({aba: z.object({requested: PermissiveBoolean}).optional()})
           .optional(),
         inbound_transfers: z
-          .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
-          })
+          .object({ach: z.object({requested: PermissiveBoolean}).optional()})
           .optional(),
-        intra_stripe_flows: z
-          .object({ requested: PermissiveBoolean })
-          .optional(),
+        intra_stripe_flows: z.object({requested: PermissiveBoolean}).optional(),
         outbound_payments: z
           .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
+            ach: z.object({requested: PermissiveBoolean}).optional(),
             us_domestic_wire: z
-              .object({ requested: PermissiveBoolean })
+              .object({requested: PermissiveBoolean})
               .optional(),
           })
           .optional(),
         outbound_transfers: z
           .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
+            ach: z.object({requested: PermissiveBoolean}).optional(),
             us_domestic_wire: z
-              .object({ requested: PermissiveBoolean })
+              .object({requested: PermissiveBoolean})
               .optional(),
           })
           .optional(),
@@ -85189,7 +85110,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85282,7 +85203,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85314,36 +85235,32 @@ export function createRouter(implementation: Implementation): Router {
       expand: z.array(z.string().max(5000)).optional(),
       features: z
         .object({
-          card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
+          card_issuing: z.object({requested: PermissiveBoolean}).optional(),
           deposit_insurance: z
-            .object({ requested: PermissiveBoolean })
+            .object({requested: PermissiveBoolean})
             .optional(),
           financial_addresses: z
-            .object({
-              aba: z.object({ requested: PermissiveBoolean }).optional(),
-            })
+            .object({aba: z.object({requested: PermissiveBoolean}).optional()})
             .optional(),
           inbound_transfers: z
-            .object({
-              ach: z.object({ requested: PermissiveBoolean }).optional(),
-            })
+            .object({ach: z.object({requested: PermissiveBoolean}).optional()})
             .optional(),
           intra_stripe_flows: z
-            .object({ requested: PermissiveBoolean })
+            .object({requested: PermissiveBoolean})
             .optional(),
           outbound_payments: z
             .object({
-              ach: z.object({ requested: PermissiveBoolean }).optional(),
+              ach: z.object({requested: PermissiveBoolean}).optional(),
               us_domestic_wire: z
-                .object({ requested: PermissiveBoolean })
+                .object({requested: PermissiveBoolean})
                 .optional(),
             })
             .optional(),
           outbound_transfers: z
             .object({
-              ach: z.object({ requested: PermissiveBoolean }).optional(),
+              ach: z.object({requested: PermissiveBoolean}).optional(),
               us_domestic_wire: z
-                .object({ requested: PermissiveBoolean })
+                .object({requested: PermissiveBoolean})
                 .optional(),
             })
             .optional(),
@@ -85419,7 +85336,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85443,7 +85360,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTreasuryFinancialAccountsFinancialAccountCloseParamSchema =
-    z.object({ financial_account: z.string().max(5000) })
+    z.object({financial_account: z.string().max(5000)})
 
   const postTreasuryFinancialAccountsFinancialAccountCloseRequestBodySchema = z
     .object({
@@ -85510,7 +85427,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85534,7 +85451,7 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
-    z.object({ financial_account: z.string().max(5000) })
+    z.object({financial_account: z.string().max(5000)})
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema =
     z.object({
@@ -85610,7 +85527,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85634,42 +85551,34 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
-    z.object({ financial_account: z.string().max(5000) })
+    z.object({financial_account: z.string().max(5000)})
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesRequestBodySchema =
     z
       .object({
-        card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
-        deposit_insurance: z
-          .object({ requested: PermissiveBoolean })
-          .optional(),
+        card_issuing: z.object({requested: PermissiveBoolean}).optional(),
+        deposit_insurance: z.object({requested: PermissiveBoolean}).optional(),
         expand: z.array(z.string().max(5000)).optional(),
         financial_addresses: z
-          .object({
-            aba: z.object({ requested: PermissiveBoolean }).optional(),
-          })
+          .object({aba: z.object({requested: PermissiveBoolean}).optional()})
           .optional(),
         inbound_transfers: z
-          .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
-          })
+          .object({ach: z.object({requested: PermissiveBoolean}).optional()})
           .optional(),
-        intra_stripe_flows: z
-          .object({ requested: PermissiveBoolean })
-          .optional(),
+        intra_stripe_flows: z.object({requested: PermissiveBoolean}).optional(),
         outbound_payments: z
           .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
+            ach: z.object({requested: PermissiveBoolean}).optional(),
             us_domestic_wire: z
-              .object({ requested: PermissiveBoolean })
+              .object({requested: PermissiveBoolean})
               .optional(),
           })
           .optional(),
         outbound_transfers: z
           .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
+            ach: z.object({requested: PermissiveBoolean}).optional(),
             us_domestic_wire: z
-              .object({ requested: PermissiveBoolean })
+              .object({requested: PermissiveBoolean})
               .optional(),
           })
           .optional(),
@@ -85733,7 +85642,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85838,7 +85747,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85911,7 +85820,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -85996,7 +85905,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86017,11 +85926,11 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTreasuryInboundTransfersInboundTransferCancelParamSchema = z.object(
-    { inbound_transfer: z.string().max(5000) },
+    {inbound_transfer: z.string().max(5000)},
   )
 
   const postTreasuryInboundTransfersInboundTransferCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTreasuryInboundTransfersInboundTransferCancelResponseBodyValidator =
@@ -86076,7 +85985,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86196,7 +86105,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86262,16 +86171,14 @@ export function createRouter(implementation: Implementation): Router {
       .object({
         us_bank_account: z
           .union([
-            z.object({
-              network: z.enum(["ach", "us_domestic_wire"]).optional(),
-            }),
+            z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
       })
       .optional(),
     end_user_details: z
-      .object({ ip_address: z.string().optional(), present: PermissiveBoolean })
+      .object({ip_address: z.string().optional(), present: PermissiveBoolean})
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
@@ -86321,7 +86228,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86406,7 +86313,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86431,7 +86338,7 @@ export function createRouter(implementation: Implementation): Router {
   })
 
   const postTreasuryOutboundPaymentsIdCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTreasuryOutboundPaymentsIdCancelResponseBodyValidator =
@@ -86486,7 +86393,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86591,7 +86498,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86626,9 +86533,7 @@ export function createRouter(implementation: Implementation): Router {
       .object({
         us_bank_account: z
           .union([
-            z.object({
-              network: z.enum(["ach", "us_domestic_wire"]).optional(),
-            }),
+            z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -86682,7 +86587,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86775,7 +86680,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86799,10 +86704,10 @@ export function createRouter(implementation: Implementation): Router {
   )
 
   const postTreasuryOutboundTransfersOutboundTransferCancelParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTreasuryOutboundTransfersOutboundTransferCancelRequestBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTreasuryOutboundTransfersOutboundTransferCancelResponseBodyValidator =
@@ -86857,7 +86762,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -86971,7 +86876,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87056,7 +86961,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87156,7 +87061,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87239,7 +87144,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87365,7 +87270,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87452,7 +87357,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87579,7 +87484,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87662,7 +87567,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -87757,7 +87662,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88191,7 +88096,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88269,7 +88174,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88359,7 +88264,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -88691,7 +88596,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_account = {
   business_profile?: (t_account_business_profile | null) | undefined

--- a/integration-tests/typescript-express/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/stripe.yaml/schemas.ts
@@ -200,7 +200,7 @@ import {
   t_treasury_transaction_entry,
   t_treasury_transactions_resource_flow_details,
 } from "./models"
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -475,7 +475,7 @@ export const s_account_unification_account_controller_losses = z.object({
 })
 
 export const s_account_unification_account_controller_stripe_dashboard =
-  z.object({ type: z.enum(["express", "full", "none"]) })
+  z.object({type: z.enum(["express", "full", "none"])})
 
 export const s_address = z.object({
   city: z.string().max(5000).nullable().optional(),
@@ -507,10 +507,10 @@ export const s_balance_amount_by_source_type = z.object({
 })
 
 export const s_bank_connections_resource_balance_api_resource_cash_balance =
-  z.object({ available: z.record(z.coerce.number()).nullable().optional() })
+  z.object({available: z.record(z.coerce.number()).nullable().optional()})
 
 export const s_bank_connections_resource_balance_api_resource_credit_balance =
-  z.object({ used: z.record(z.coerce.number()).nullable().optional() })
+  z.object({used: z.record(z.coerce.number()).nullable().optional()})
 
 export const s_bank_connections_resource_balance_refresh = z.object({
   last_attempted_at: z.coerce.number(),
@@ -567,16 +567,16 @@ export const s_billing_bill_resource_invoicing_lines_common_credited_items =
   })
 
 export const s_billing_bill_resource_invoicing_parents_invoice_quote_parent =
-  z.object({ quote: z.string().max(5000) })
+  z.object({quote: z.string().max(5000)})
 
 export const s_billing_bill_resource_invoicing_pricing_pricing_price_details =
-  z.object({ price: z.string().max(5000), product: z.string().max(5000) })
+  z.object({price: z.string().max(5000), product: z.string().max(5000)})
 
 export const s_billing_bill_resource_invoicing_taxes_tax_rate_details =
-  z.object({ tax_rate: z.string().max(5000) })
+  z.object({tax_rate: z.string().max(5000)})
 
 export const s_billing_clocks_resource_status_details_advancing_status_details =
-  z.object({ target_frozen_time: z.coerce.number() })
+  z.object({target_frozen_time: z.coerce.number()})
 
 export const s_billing_credit_grants_resource_applicable_price = z.object({
   id: z.string().max(5000).nullable().optional(),
@@ -612,10 +612,10 @@ export const s_billing_meter_resource_aggregation_settings = z.object({
 })
 
 export const s_billing_meter_resource_billing_meter_event_adjustment_cancel =
-  z.object({ identifier: z.string().max(100).nullable().optional() })
+  z.object({identifier: z.string().max(100).nullable().optional()})
 
 export const s_billing_meter_resource_billing_meter_status_transitions =
-  z.object({ deactivated_at: z.coerce.number().nullable().optional() })
+  z.object({deactivated_at: z.coerce.number().nullable().optional()})
 
 export const s_billing_meter_resource_billing_meter_value = z.object({
   event_payload_key: z.string().max(5000),
@@ -783,10 +783,10 @@ export const s_checkout_payco_payment_method_options = z.object({
 })
 
 export const s_checkout_payment_method_options_mandate_options_bacs_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_checkout_payment_method_options_mandate_options_sepa_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_checkout_paynow_payment_method_options = z.object({
   setup_future_usage: z.enum(["none"]).optional(),
@@ -865,7 +865,7 @@ export const s_connect_embedded_financial_account_features = z.object({
 })
 
 export const s_connect_embedded_financial_account_transactions_features =
-  z.object({ card_spend_dispute_management: PermissiveBoolean })
+  z.object({card_spend_dispute_management: PermissiveBoolean})
 
 export const s_connect_embedded_issuing_card_features = z.object({
   card_management: PermissiveBoolean,
@@ -955,7 +955,7 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_funde
   })
 
 export const s_customer_session_resource_components_resource_buy_button =
-  z.object({ enabled: PermissiveBoolean })
+  z.object({enabled: PermissiveBoolean})
 
 export const s_customer_session_resource_components_resource_payment_element_resource_features =
   z.object({
@@ -973,7 +973,7 @@ export const s_customer_session_resource_components_resource_payment_element_res
   })
 
 export const s_customer_session_resource_components_resource_pricing_table =
-  z.object({ enabled: PermissiveBoolean })
+  z.object({enabled: PermissiveBoolean})
 
 export const s_customer_tax_location = z.object({
   country: z.string().max(5000),
@@ -1445,7 +1445,7 @@ export const s_invoice_payment_method_options_bancontact = z.object({
 })
 
 export const s_invoice_payment_method_options_customer_balance_bank_transfer_eu_bank_transfer =
-  z.object({ country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"]) })
+  z.object({country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"])})
 
 export const s_invoice_payment_method_options_konbini = z.object({})
 
@@ -2656,7 +2656,7 @@ export const s_mandate_acss_debit = z.object({
 
 export const s_mandate_amazon_pay = z.object({})
 
-export const s_mandate_au_becs_debit = z.object({ url: z.string().max(5000) })
+export const s_mandate_au_becs_debit = z.object({url: z.string().max(5000)})
 
 export const s_mandate_bacs_debit = z.object({
   network_status: z.enum(["accepted", "pending", "refused", "revoked"]),
@@ -2734,10 +2734,10 @@ export const s_online_acceptance = z.object({
 })
 
 export const s_outbound_payments_payment_method_details_financial_account =
-  z.object({ id: z.string().max(5000), network: z.enum(["stripe"]) })
+  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
 
 export const s_outbound_transfers_payment_method_details_financial_account =
-  z.object({ id: z.string().max(5000), network: z.enum(["stripe"]) })
+  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
 
 export const s_package_dimensions = z.object({
   height: z.coerce.number(),
@@ -2775,10 +2775,10 @@ export const s_payment_flows_private_payment_methods_alipay_details = z.object({
 })
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_extended_authorization_extended_authorization =
-  z.object({ status: z.enum(["disabled", "enabled"]) })
+  z.object({status: z.enum(["disabled", "enabled"])})
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_incremental_authorization_incremental_authorization =
-  z.object({ status: z.enum(["available", "unavailable"]) })
+  z.object({status: z.enum(["available", "unavailable"])})
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_overcapture_overcapture =
   z.object({
@@ -2787,7 +2787,7 @@ export const s_payment_flows_private_payment_methods_card_details_api_resource_e
   })
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_multicapture =
-  z.object({ status: z.enum(["available", "unavailable"]) })
+  z.object({status: z.enum(["available", "unavailable"])})
 
 export const s_payment_flows_private_payment_methods_card_present_common_wallet =
   z.object({
@@ -2818,10 +2818,10 @@ export const s_payment_flows_private_payment_methods_naver_pay_payment_method_op
   })
 
 export const s_payment_flows_private_payment_methods_payco_payment_method_options =
-  z.object({ capture_method: z.enum(["manual"]).optional() })
+  z.object({capture_method: z.enum(["manual"]).optional()})
 
 export const s_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
-  z.object({ capture_method: z.enum(["manual"]).optional() })
+  z.object({capture_method: z.enum(["manual"]).optional()})
 
 export const s_payment_intent_next_action_alipay_handle_redirect = z.object({
   native_data: z.string().max(5000).nullable().optional(),
@@ -2947,7 +2947,7 @@ export const s_payment_intent_next_action_wechat_pay_redirect_to_android_app =
   })
 
 export const s_payment_intent_next_action_wechat_pay_redirect_to_ios_app =
-  z.object({ native_url: z.string().max(5000) })
+  z.object({native_url: z.string().max(5000)})
 
 export const s_payment_intent_payment_method_options_au_becs_debit = z.object({
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
@@ -2979,10 +2979,10 @@ export const s_payment_intent_payment_method_options_mandate_options_acss_debit 
   })
 
 export const s_payment_intent_payment_method_options_mandate_options_bacs_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_payment_intent_payment_method_options_mandate_options_sepa_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_payment_intent_payment_method_options_mobilepay = z.object({
   capture_method: z.enum(["manual"]).optional(),
@@ -3014,7 +3014,7 @@ export const s_payment_links_resource_completed_sessions = z.object({
 })
 
 export const s_payment_links_resource_completion_behavior_confirmation_page =
-  z.object({ custom_message: z.string().max(5000).nullable().optional() })
+  z.object({custom_message: z.string().max(5000).nullable().optional()})
 
 export const s_payment_links_resource_completion_behavior_redirect = z.object({
   url: z.string().max(5000),
@@ -3070,7 +3070,7 @@ export const s_payment_links_resource_payment_intent_data = z.object({
 })
 
 export const s_payment_links_resource_payment_method_reuse_agreement = z.object(
-  { position: z.enum(["auto", "hidden"]) },
+  {position: z.enum(["auto", "hidden"])},
 )
 
 export const s_payment_links_resource_phone_number_collection = z.object({
@@ -3361,9 +3361,7 @@ export const s_payment_method_billie = z.object({})
 
 export const s_payment_method_blik = z.object({})
 
-export const s_payment_method_boleto = z.object({
-  tax_id: z.string().max(5000),
-})
+export const s_payment_method_boleto = z.object({tax_id: z.string().max(5000)})
 
 export const s_payment_method_card_checks = z.object({
   address_line1_check: z.string().max(5000).nullable().optional(),
@@ -3784,7 +3782,7 @@ export const s_payment_method_details_wechat_pay = z.object({
 export const s_payment_method_details_zip = z.object({})
 
 export const s_payment_method_domain_resource_payment_method_status_details =
-  z.object({ error_message: z.string().max(5000) })
+  z.object({error_message: z.string().max(5000)})
 
 export const s_payment_method_eps = z.object({
   bank: z
@@ -4029,7 +4027,7 @@ export const s_payment_method_options_crypto = z.object({
 })
 
 export const s_payment_method_options_customer_balance_eu_bank_account =
-  z.object({ country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"]) })
+  z.object({country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"])})
 
 export const s_payment_method_options_fpx = z.object({
   setup_future_usage: z.enum(["none"]).optional(),
@@ -4126,7 +4124,7 @@ export const s_payment_method_options_twint = z.object({
 })
 
 export const s_payment_method_options_us_bank_account_mandate_options =
-  z.object({ collection_method: z.enum(["paper"]).optional() })
+  z.object({collection_method: z.enum(["paper"]).optional()})
 
 export const s_payment_method_options_wechat_pay = z.object({
   app_id: z.string().max(5000).nullable().optional(),
@@ -4299,7 +4297,7 @@ export const s_payment_pages_checkout_session_optional_item_adjustable_quantity 
   })
 
 export const s_payment_pages_checkout_session_payment_method_reuse_agreement =
-  z.object({ position: z.enum(["auto", "hidden"]) })
+  z.object({position: z.enum(["auto", "hidden"])})
 
 export const s_payment_pages_checkout_session_permissions = z.object({
   update_shipping_details: z
@@ -4309,7 +4307,7 @@ export const s_payment_pages_checkout_session_permissions = z.object({
 })
 
 export const s_payment_pages_checkout_session_phone_number_collection =
-  z.object({ enabled: PermissiveBoolean })
+  z.object({enabled: PermissiveBoolean})
 
 export const s_payment_pages_checkout_session_saved_payment_method_options =
   z.object({
@@ -4843,7 +4841,7 @@ export const s_portal_flows_subscription_update_confirm_item = z.object({
   quantity: z.coerce.number().optional(),
 })
 
-export const s_portal_invoice_list = z.object({ enabled: PermissiveBoolean })
+export const s_portal_invoice_list = z.object({enabled: PermissiveBoolean})
 
 export const s_portal_login_page = z.object({
   enabled: PermissiveBoolean,
@@ -4855,7 +4853,7 @@ export const s_portal_payment_method_update = z.object({
 })
 
 export const s_portal_resource_schedule_update_at_period_end_condition =
-  z.object({ type: z.enum(["decreasing_item_amount", "shortening_interval"]) })
+  z.object({type: z.enum(["decreasing_item_amount", "shortening_interval"])})
 
 export const s_portal_subscription_cancellation_reason = z.object({
   enabled: PermissiveBoolean,
@@ -5143,10 +5141,10 @@ export const s_setup_intent_payment_method_options_mandate_options_acss_debit =
   })
 
 export const s_setup_intent_payment_method_options_mandate_options_bacs_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_setup_intent_payment_method_options_mandate_options_sepa_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_setup_intent_payment_method_options_paypal = z.object({
   billing_agreement_id: z.string().max(5000).nullable().optional(),
@@ -5533,25 +5531,25 @@ export const s_tax_id_verification = z.object({
 })
 
 export const s_tax_product_registrations_resource_country_options_ca_province_standard =
-  z.object({ province: z.string().max(5000) })
+  z.object({province: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_default =
-  z.object({ type: z.enum(["standard"]) })
+  z.object({type: z.enum(["standard"])})
 
 export const s_tax_product_registrations_resource_country_options_default_inbound_goods =
-  z.object({ type: z.enum(["standard"]) })
+  z.object({type: z.enum(["standard"])})
 
 export const s_tax_product_registrations_resource_country_options_eu_standard =
-  z.object({ place_of_supply_scheme: z.enum(["small_seller", "standard"]) })
+  z.object({place_of_supply_scheme: z.enum(["small_seller", "standard"])})
 
 export const s_tax_product_registrations_resource_country_options_simplified =
-  z.object({ type: z.enum(["simplified"]) })
+  z.object({type: z.enum(["simplified"])})
 
 export const s_tax_product_registrations_resource_country_options_us_local_amusement_tax =
-  z.object({ jurisdiction: z.string().max(5000) })
+  z.object({jurisdiction: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_us_local_lease_tax =
-  z.object({ jurisdiction: z.string().max(5000) })
+  z.object({jurisdiction: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_us_state_sales_tax_election =
   z.object({
@@ -5736,10 +5734,10 @@ export const s_tax_product_resource_tax_settings_status_details_resource_pending
   })
 
 export const s_tax_product_resource_tax_transaction_line_item_resource_reversal =
-  z.object({ original_line_item: z.string().max(5000) })
+  z.object({original_line_item: z.string().max(5000)})
 
 export const s_tax_product_resource_tax_transaction_resource_reversal =
-  z.object({ original_transaction: z.string().max(5000).nullable().optional() })
+  z.object({original_transaction: z.string().max(5000).nullable().optional()})
 
 export const s_tax_product_resource_tax_transaction_shipping_cost = z.object({
   amount: z.coerce.number(),
@@ -5779,13 +5777,13 @@ export const s_terminal_configuration_configuration_resource_enterprise_tls_wifi
   })
 
 export const s_terminal_configuration_configuration_resource_offline_config =
-  z.object({ enabled: PermissiveBoolean.nullable().optional() })
+  z.object({enabled: PermissiveBoolean.nullable().optional()})
 
 export const s_terminal_configuration_configuration_resource_personal_psk_wifi =
-  z.object({ password: z.string().max(5000), ssid: z.string().max(5000) })
+  z.object({password: z.string().max(5000), ssid: z.string().max(5000)})
 
 export const s_terminal_configuration_configuration_resource_reboot_window =
-  z.object({ end_hour: z.coerce.number(), start_hour: z.coerce.number() })
+  z.object({end_hour: z.coerce.number(), start_hour: z.coerce.number()})
 
 export const s_terminal_connection_token = z.object({
   location: z.string().max(5000).optional(),
@@ -5833,7 +5831,7 @@ export const s_terminal_reader_reader_resource_process_setup_config = z.object({
 })
 
 export const s_terminal_reader_reader_resource_refund_payment_config = z.object(
-  { enable_customer_cancellation: PermissiveBoolean.optional() },
+  {enable_customer_cancellation: PermissiveBoolean.optional()},
 )
 
 export const s_terminal_reader_reader_resource_signature = z.object({
@@ -5929,7 +5927,7 @@ export const s_three_d_secure_details_charge = z.object({
   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).nullable().optional(),
 })
 
-export const s_three_d_secure_usage = z.object({ supported: PermissiveBoolean })
+export const s_three_d_secure_usage = z.object({supported: PermissiveBoolean})
 
 export const s_token_card_networks = z.object({
   preferred: z.string().max(5000).nullable().optional(),
@@ -6035,7 +6033,7 @@ export const s_treasury_inbound_transfers_resource_failure_details = z.object({
 })
 
 export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows =
-  z.object({ received_debit: z.string().max(5000).nullable().optional() })
+  z.object({received_debit: z.string().max(5000).nullable().optional()})
 
 export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions =
   z.object({
@@ -6045,7 +6043,7 @@ export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_sta
   })
 
 export const s_treasury_outbound_payments_resource_ach_tracking_details =
-  z.object({ trace_id: z.string().max(5000) })
+  z.object({trace_id: z.string().max(5000)})
 
 export const s_treasury_outbound_payments_resource_outbound_payment_resource_end_user_details =
   z.object({
@@ -6069,7 +6067,7 @@ export const s_treasury_outbound_payments_resource_us_domestic_wire_tracking_det
   })
 
 export const s_treasury_outbound_transfers_resource_ach_tracking_details =
-  z.object({ trace_id: z.string().max(5000) })
+  z.object({trace_id: z.string().max(5000)})
 
 export const s_treasury_outbound_transfers_resource_status_transitions =
   z.object({
@@ -6101,11 +6099,11 @@ export const s_treasury_received_credits_resource_reversal_details = z.object({
 })
 
 export const s_treasury_received_credits_resource_status_transitions = z.object(
-  { posted_at: z.coerce.number().nullable().optional() },
+  {posted_at: z.coerce.number().nullable().optional()},
 )
 
 export const s_treasury_received_debits_resource_debit_reversal_linked_flows =
-  z.object({ issuing_dispute: z.string().max(5000).nullable().optional() })
+  z.object({issuing_dispute: z.string().max(5000).nullable().optional()})
 
 export const s_treasury_received_debits_resource_linked_flows = z.object({
   debit_reversal: z.string().max(5000).nullable().optional(),
@@ -6612,7 +6610,7 @@ export const s_confirmation_tokens_resource_mandate_data_resource_customer_accep
   })
 
 export const s_confirmation_tokens_resource_payment_method_options_resource_card_resource_installment =
-  z.object({ plan: s_payment_method_details_card_installments_plan.optional() })
+  z.object({plan: s_payment_method_details_card_installments_plan.optional()})
 
 export const s_confirmation_tokens_resource_shipping = z.object({
   address: s_address,
@@ -7773,7 +7771,7 @@ export const s_issuing_card_wallets = z.object({
   primary_account_identifier: z.string().max(5000).nullable().optional(),
 })
 
-export const s_issuing_cardholder_address = z.object({ address: s_address })
+export const s_issuing_cardholder_address = z.object({address: s_address})
 
 export const s_issuing_cardholder_authorization_controls = z.object({
   allowed_categories: z
@@ -8862,7 +8860,7 @@ export const s_payment_pages_checkout_session_after_expiration = z.object({
 })
 
 export const s_payment_pages_checkout_session_checkout_address_details =
-  z.object({ address: s_address, name: z.string().max(5000) })
+  z.object({address: s_address, name: z.string().max(5000)})
 
 export const s_payment_pages_checkout_session_consent_collection = z.object({
   payment_method_reuse_agreement:
@@ -9537,9 +9535,7 @@ export const s_balance_amount_net = z.object({
   source_types: s_balance_amount_by_source_type.optional(),
 })
 
-export const s_balance_detail = z.object({
-  available: z.array(s_balance_amount),
-})
+export const s_balance_detail = z.object({available: z.array(s_balance_amount)})
 
 export const s_balance_detail_ungated = z.object({
   available: z.array(s_balance_amount),
@@ -15448,7 +15444,7 @@ export const s_line_items_discount_amount: z.ZodType<
   t_line_items_discount_amount,
   z.ZodTypeDef,
   unknown
-> = z.object({ amount: z.coerce.number(), discount: z.lazy(() => s_discount) })
+> = z.object({amount: z.coerce.number(), discount: z.lazy(() => s_discount)})
 
 export const s_confirmation_tokens_resource_payment_method_preview: z.ZodType<
   t_confirmation_tokens_resource_payment_method_preview,
@@ -15655,9 +15651,7 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_refun
   t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction,
   z.ZodTypeDef,
   unknown
-> = z.object({
-  refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]),
-})
+> = z.object({refund: z.union([z.string().max(5000), z.lazy(() => s_refund)])})
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance: z.ZodType<
   t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance,
@@ -16789,7 +16783,7 @@ export const s_payment_links_resource_subscription_data_invoice_settings: z.ZodT
   t_payment_links_resource_subscription_data_invoice_settings,
   z.ZodTypeDef,
   unknown
-> = z.object({ issuer: z.lazy(() => s_connect_account_reference) })
+> = z.object({issuer: z.lazy(() => s_connect_account_reference)})
 
 export const s_quotes_resource_recurring: z.ZodType<
   t_quotes_resource_recurring,

--- a/integration-tests/typescript-express/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-express/src/generated/todo-lists.yaml/generated.ts
@@ -42,8 +42,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-express-runtime/zod"
-import { NextFunction, Request, Response, Router } from "express"
-import { z } from "zod"
+import {NextFunction, Request, Response, Router} from "express"
+import {z} from "zod"
 
 export type GetTodoListsResponder = {
   with200(): ExpressRuntimeResponse<t_TodoList[]>
@@ -181,7 +181,7 @@ export function createRouter(implementation: Implementation): Router {
   const router = Router()
 
   const getTodoListsQuerySchema = z.object({
-    created: z.string().datetime({ offset: true }).optional(),
+    created: z.string().datetime({offset: true}).optional(),
     statuses: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
@@ -237,7 +237,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -255,7 +255,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTodoListByIdParamSchema = z.object({ listId: z.string() })
+  const getTodoListByIdParamSchema = z.object({listId: z.string()})
 
   const getTodoListByIdResponseBodyValidator = responseValidationFactory(
     [
@@ -307,7 +307,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -325,7 +325,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const updateTodoListByIdParamSchema = z.object({ listId: z.string() })
+  const updateTodoListByIdParamSchema = z.object({listId: z.string()})
 
   const updateTodoListByIdRequestBodySchema = s_CreateUpdateTodoList
 
@@ -383,7 +383,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -401,7 +401,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const deleteTodoListByIdParamSchema = z.object({ listId: z.string() })
+  const deleteTodoListByIdParamSchema = z.object({listId: z.string()})
 
   const deleteTodoListByIdResponseBodyValidator = responseValidationFactory(
     [
@@ -453,7 +453,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -471,7 +471,7 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const getTodoListItemsParamSchema = z.object({ listId: z.string() })
+  const getTodoListItemsParamSchema = z.object({listId: z.string()})
 
   const getTodoListItemsResponseBodyValidator = responseValidationFactory(
     [
@@ -480,11 +480,11 @@ export function createRouter(implementation: Implementation): Router {
         z.object({
           id: z.string(),
           content: z.string(),
-          createdAt: z.string().datetime({ offset: true }),
-          completedAt: z.string().datetime({ offset: true }).optional(),
+          createdAt: z.string().datetime({offset: true}),
+          completedAt: z.string().datetime({offset: true}).optional(),
         }),
       ],
-      ["5XX", z.object({ message: z.string(), code: z.string() })],
+      ["5XX", z.object({message: z.string(), code: z.string()})],
     ],
     undefined,
   )
@@ -536,7 +536,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -554,12 +554,12 @@ export function createRouter(implementation: Implementation): Router {
     },
   )
 
-  const createTodoListItemParamSchema = z.object({ listId: z.string() })
+  const createTodoListItemParamSchema = z.object({listId: z.string()})
 
   const createTodoListItemRequestBodySchema = z.object({
     id: z.string(),
     content: z.string(),
-    completedAt: z.string().datetime({ offset: true }).optional(),
+    completedAt: z.string().datetime({offset: true}).optional(),
   })
 
   const createTodoListItemResponseBodyValidator = responseValidationFactory(
@@ -607,7 +607,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -662,7 +662,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response
@@ -725,7 +725,7 @@ export function createRouter(implementation: Implementation): Router {
           return
         }
 
-        const { status, body } =
+        const {status, body} =
           response instanceof ExpressRuntimeResponse
             ? response.unpack()
             : response

--- a/integration-tests/typescript-express/src/generated/todo-lists.yaml/schemas.ts
+++ b/integration-tests/typescript-express/src/generated/todo-lists.yaml/schemas.ts
@@ -2,9 +2,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
-export const s_CreateUpdateTodoList = z.object({ name: z.string() })
+export const s_CreateUpdateTodoList = z.object({name: z.string()})
 
 export const s_Error = z.object({
   message: z.string().optional(),
@@ -18,8 +18,8 @@ export const s_TodoList = z.object({
   name: z.string(),
   totalItemCount: z.coerce.number(),
   incompleteItemCount: z.coerce.number(),
-  created: z.string().datetime({ offset: true }),
-  updated: z.string().datetime({ offset: true }),
+  created: z.string().datetime({offset: true}),
+  updated: z.string().datetime({offset: true}),
 })
 
 export const s_UnknownObject = z.record(z.unknown())

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/client.ts
@@ -349,7 +349,7 @@ import {
 export class GitHubV3RestApiServersOperations {
   static reposUploadReleaseAsset(
     url: "https://uploads.github.com" = "https://uploads.github.com",
-  ): { build: () => Server<"reposUploadReleaseAsset_GitHubV3RestApi"> } {
+  ): {build: () => Server<"reposUploadReleaseAsset_GitHubV3RestApi">} {
     switch (url) {
       case "https://uploads.github.com":
         return {
@@ -404,7 +404,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesListGlobalAdvisories(
@@ -469,11 +469,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       sort: p["sort"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesGetGlobalAdvisory(
@@ -486,7 +482,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/advisories/${p["ghsaId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsGetAuthenticated(
@@ -496,7 +492,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/app`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsCreateFromManifest(
@@ -522,7 +518,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/app-manifests/${p["code"]}/conversions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async appsGetWebhookConfigForApp(
@@ -532,7 +528,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/app/hook/config`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsUpdateWebhookConfigForApp(
@@ -549,16 +545,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_webhook_config>> {
     const url = this.basePath + `/app/hook/config`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async appsListWebhookDeliveries(
@@ -575,13 +567,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/app/hook/deliveries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], cursor: p["cursor"] })
+    const query = this._query({per_page: p["perPage"], cursor: p["cursor"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsGetWebhookDelivery(
@@ -598,7 +586,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/app/hook/deliveries/${p["deliveryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsRedeliverWebhookDelivery(
@@ -621,7 +609,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/app/hook/deliveries/${p["deliveryId"]}/attempts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async appsListInstallationRequestsForAuthenticatedApp(
@@ -638,13 +626,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/app/installation-requests`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListInstallations(
@@ -666,11 +650,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       outdated: p["outdated"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsGetInstallation(
@@ -683,7 +663,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/app/installations/${p["installationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsDeleteInstallation(
@@ -696,7 +676,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/app/installations/${p["installationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async appsCreateInstallationAccessToken(
@@ -720,12 +700,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/app/installations/${p["installationId"]}/access_tokens`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async appsSuspendInstallation(
@@ -739,7 +719,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/app/installations/${p["installationId"]}/suspended`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async appsUnsuspendInstallation(
@@ -753,7 +733,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/app/installations/${p["installationId"]}/suspended`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async appsDeleteAuthorization(
@@ -768,16 +748,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<204, void> | Res<422, t_validation_error>> {
     const url = this.basePath + `/applications/${p["clientId"]}/grant`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async appsCheckToken(
@@ -796,12 +772,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/applications/${p["clientId"]}/token`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async appsResetToken(
@@ -816,16 +792,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_authorization> | Res<422, t_validation_error>> {
     const url = this.basePath + `/applications/${p["clientId"]}/token`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async appsDeleteToken(
@@ -840,16 +812,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<204, void> | Res<422, t_validation_error>> {
     const url = this.basePath + `/applications/${p["clientId"]}/token`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async appsScopeToken(
@@ -875,12 +843,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/applications/${p["clientId"]}/token/scoped`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async appsGetBySlug(
@@ -895,7 +863,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/apps/${p["appSlug"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async classroomGetAnAssignment(
@@ -908,7 +876,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/assignments/${p["assignmentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async classroomListAcceptedAssignmentsForAnAssignment(
@@ -923,13 +891,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/assignments/${p["assignmentId"]}/accepted_assignments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async classroomGetAssignmentGrades(
@@ -944,7 +908,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/assignments/${p["assignmentId"]}/grades`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async classroomListClassrooms(
@@ -957,13 +921,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_classroom[]>> {
     const url = this.basePath + `/classrooms`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async classroomGetAClassroom(
@@ -976,7 +936,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/classrooms/${p["classroomId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async classroomListAssignmentsForAClassroom(
@@ -990,13 +950,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_classroom_assignment[]>> {
     const url = this.basePath + `/classrooms/${p["classroomId"]}/assignments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codesOfConductGetAllCodesOfConduct(
@@ -1006,7 +962,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/codes_of_conduct`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codesOfConductGetConductCode(
@@ -1021,7 +977,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/codes_of_conduct/${p["key"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async credentialsRevoke(
@@ -1044,12 +1000,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/credentials/revoke`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async emojisGet(
@@ -1067,7 +1023,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/emojis`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityGetConfigurationsForEnterprise(
@@ -1094,11 +1050,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       after: p["after"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityCreateConfigurationForEnterprise(
@@ -1197,12 +1149,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/enterprises/${p["enterprise"]}/code-security/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityGetDefaultConfigurationsForEnterprise(
@@ -1217,7 +1169,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/enterprises/${p["enterprise"]}/code-security/configurations/defaults`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityGetSingleConfigurationForEnterprise(
@@ -1238,7 +1190,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityUpdateEnterpriseConfiguration(
@@ -1339,16 +1291,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityDeleteConfigurationForEnterprise(
@@ -1370,7 +1318,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codeSecurityAttachEnterpriseConfiguration(
@@ -1398,12 +1346,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}/attach`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeSecuritySetConfigurationAsDefaultForEnterprise(
@@ -1441,12 +1389,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/enterprises/${p["enterprise"]}/code-security/configurations/${p["configurationId"]}/defaults`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityGetRepositoriesForEnterpriseConfiguration(
@@ -1476,11 +1424,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       status: p["status"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotListAlertsForEnterprise(
@@ -1530,11 +1474,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async secretScanningListAlertsForEnterprise(
@@ -1585,11 +1525,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       hide_secret: p["hideSecret"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListPublicEvents(
@@ -1614,13 +1550,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityGetFeeds(
@@ -1630,7 +1562,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/feeds`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsList(
@@ -1652,11 +1584,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsCreate(
@@ -1684,12 +1612,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/gists`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gistsListPublic(
@@ -1714,11 +1642,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsListStarred(
@@ -1743,11 +1667,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsGet(
@@ -1776,7 +1696,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsUpdate(
@@ -1803,16 +1723,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/gists/${p["gistId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async gistsDelete(
@@ -1830,7 +1746,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async gistsListComments(
@@ -1849,13 +1765,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/gists/${p["gistId"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsCreateComment(
@@ -1875,12 +1787,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/gists/${p["gistId"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gistsGetComment(
@@ -1911,7 +1823,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/gists/${p["gistId"]}/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsUpdateComment(
@@ -1928,16 +1840,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/gists/${p["gistId"]}/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async gistsDeleteComment(
@@ -1957,7 +1865,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/gists/${p["gistId"]}/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async gistsListCommits(
@@ -1976,13 +1884,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/gists/${p["gistId"]}/commits`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsListForks(
@@ -2001,13 +1905,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/gists/${p["gistId"]}/forks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsFork(
@@ -2026,7 +1926,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}/forks`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async gistsCheckIsStarred(
@@ -2044,7 +1944,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}/star`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsStar(
@@ -2062,7 +1962,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}/star`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async gistsUnstar(
@@ -2080,7 +1980,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}/star`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async gistsGetRevision(
@@ -2099,7 +1999,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gists/${p["gistId"]}/${p["sha"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitignoreGetAllTemplates(
@@ -2109,7 +2009,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gitignore/templates`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitignoreGetTemplate(
@@ -2122,7 +2022,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/gitignore/templates/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListReposAccessibleToInstallation(
@@ -2147,13 +2047,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/installation/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsRevokeInstallationAccessToken(
@@ -2163,7 +2059,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/installation/token`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesList(
@@ -2213,11 +2109,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async licensesGetAllCommonlyUsed(
@@ -2237,11 +2129,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async licensesGet(
@@ -2259,7 +2147,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/licenses/${p["license"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async markdownRender(
@@ -2275,12 +2163,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, string> | Res<304, void>> {
     const url = this.basePath + `/markdown`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async markdownRenderRaw(
@@ -2291,13 +2179,10 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<Res<200, string> | Res<304, void>> {
     const url = this.basePath + `/markdown/raw`
-    const headers = this._headers(
-      { "Content-Type": "text/plain" },
-      opts.headers,
-    )
+    const headers = this._headers({"Content-Type": "text/plain"}, opts.headers)
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async appsGetSubscriptionPlanForAccount(
@@ -2315,7 +2200,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/marketplace_listing/accounts/${p["accountId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListPlans(
@@ -2332,13 +2217,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/marketplace_listing/plans`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListAccountsForPlan(
@@ -2367,11 +2248,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsGetSubscriptionPlanForAccountStubbed(
@@ -2387,7 +2264,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/marketplace_listing/stubbed/accounts/${p["accountId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListPlansStubbed(
@@ -2400,13 +2277,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_marketplace_listing_plan[]> | Res<401, t_basic_error>> {
     const url = this.basePath + `/marketplace_listing/stubbed/plans`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListAccountsForPlanStubbed(
@@ -2431,11 +2304,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async metaGet(
@@ -2445,7 +2314,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/meta`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListPublicEventsForRepoNetwork(
@@ -2466,13 +2335,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/networks/${p["owner"]}/${p["repo"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListNotificationsForAuthenticatedUser(
@@ -2504,11 +2369,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityMarkNotificationsAsRead(
@@ -2534,12 +2395,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/notifications`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async activityGetThread(
@@ -2557,7 +2418,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/notifications/threads/${p["threadId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityMarkThreadAsRead(
@@ -2570,7 +2431,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/notifications/threads/${p["threadId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PATCH", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PATCH", ...opts, headers}, timeout)
   }
 
   async activityMarkThreadAsDone(
@@ -2583,7 +2444,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/notifications/threads/${p["threadId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async activityGetThreadSubscriptionForAuthenticatedUser(
@@ -2602,7 +2463,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/notifications/threads/${p["threadId"]}/subscription`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activitySetThreadSubscription(
@@ -2623,12 +2484,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/notifications/threads/${p["threadId"]}/subscription`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async activityDeleteThreadSubscription(
@@ -2647,7 +2508,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/notifications/threads/${p["threadId"]}/subscription`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async metaGetOctocat(
@@ -2659,13 +2520,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, string>> {
     const url = this.basePath + `/octocat`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ s: p["s"] })
+    const query = this._query({s: p["s"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsList(
@@ -2678,13 +2535,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_organization_simple[]> | Res<304, void>> {
     const url = this.basePath + `/organizations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"], per_page: p["perPage"] })
+    const query = this._query({since: p["since"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotRepositoryAccessForOrg(
@@ -2703,13 +2556,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/organizations/${p["org"]}/dependabot/repository-access`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotUpdateRepositoryAccessForOrg(
@@ -2728,16 +2577,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/organizations/${p["org"]}/dependabot/repository-access`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async dependabotSetRepositoryAccessDefaultLevel(
@@ -2756,12 +2601,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/organizations/${p["org"]}/dependabot/repository-access/default-level`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async billingGetGithubBillingUsageReportOrg(
@@ -2798,11 +2643,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       hour: p["hour"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsGet(
@@ -2815,7 +2656,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsUpdate(
@@ -2872,16 +2713,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async orgsDelete(
@@ -2903,7 +2740,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsGetActionsCacheUsageForOrg(
@@ -2916,7 +2753,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/actions/cache/usage`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetActionsCacheUsageByRepoForOrg(
@@ -2939,13 +2776,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/cache/usage-by-repository`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListHostedRunnersForOrg(
@@ -2967,13 +2800,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/actions/hosted-runners`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateHostedRunnerForOrg(
@@ -2996,12 +2825,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_actions_hosted_runner>> {
     const url = this.basePath + `/orgs/${p["org"]}/actions/hosted-runners`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetHostedRunnersGithubOwnedImagesForOrg(
@@ -3024,7 +2853,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/hosted-runners/images/github-owned`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetHostedRunnersPartnerImagesForOrg(
@@ -3046,7 +2875,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/hosted-runners/images/partner`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetHostedRunnersLimitsForOrg(
@@ -3060,7 +2889,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/hosted-runners/limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetHostedRunnersMachineSpecsForOrg(
@@ -3082,7 +2911,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/hosted-runners/machine-sizes`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetHostedRunnersPlatformsForOrg(
@@ -3104,7 +2933,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/hosted-runners/platforms`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetHostedRunnerForOrg(
@@ -3120,7 +2949,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/hosted-runners/${p["hostedRunnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsUpdateHostedRunnerForOrg(
@@ -3141,16 +2970,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/hosted-runners/${p["hostedRunnerId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteHostedRunnerForOrg(
@@ -3166,7 +2991,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/hosted-runners/${p["hostedRunnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async oidcGetOidcCustomSubTemplateForOrg(
@@ -3180,7 +3005,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/oidc/customization/sub`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async oidcUpdateOidcCustomSubTemplateForOrg(
@@ -3196,12 +3021,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/oidc/customization/sub`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsGetGithubActionsPermissionsOrganization(
@@ -3214,7 +3039,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/actions/permissions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetGithubActionsPermissionsOrganization(
@@ -3230,12 +3055,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<204, void>> {
     const url = this.basePath + `/orgs/${p["org"]}/actions/permissions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsListSelectedRepositoriesEnabledGithubActionsOrganization(
@@ -3258,13 +3083,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/permissions/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetSelectedRepositoriesEnabledGithubActionsOrganization(
@@ -3280,12 +3101,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/permissions/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsEnableSelectedRepositoryGithubActionsOrganization(
@@ -3301,7 +3122,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/permissions/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsDisableSelectedRepositoryGithubActionsOrganization(
@@ -3317,7 +3138,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/permissions/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsGetAllowedActionsOrganization(
@@ -3331,7 +3152,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/permissions/selected-actions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetAllowedActionsOrganization(
@@ -3345,12 +3166,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/permissions/selected-actions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsGetGithubActionsDefaultWorkflowPermissionsOrganization(
@@ -3363,7 +3184,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/actions/permissions/workflow`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetGithubActionsDefaultWorkflowPermissionsOrganization(
@@ -3376,12 +3197,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<204, void>> {
     const url = this.basePath + `/orgs/${p["org"]}/actions/permissions/workflow`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsListSelfHostedRunnerGroupsForOrg(
@@ -3410,11 +3231,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       visible_to_repository: p["visibleToRepository"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateSelfHostedRunnerGroupForOrg(
@@ -3436,12 +3253,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_runner_groups_org>> {
     const url = this.basePath + `/orgs/${p["org"]}/actions/runner-groups`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetSelfHostedRunnerGroupForOrg(
@@ -3457,7 +3274,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsUpdateSelfHostedRunnerGroupForOrg(
@@ -3480,16 +3297,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteSelfHostedRunnerGroupFromOrg(
@@ -3505,7 +3318,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListGithubHostedRunnersInGroupForOrg(
@@ -3530,13 +3343,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/hosted-runners`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListRepoAccessToSelfHostedRunnerGroupInOrg(
@@ -3561,13 +3370,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetRepoAccessToSelfHostedRunnerGroupInOrg(
@@ -3585,12 +3390,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsAddRepoAccessToSelfHostedRunnerGroupInOrg(
@@ -3607,7 +3412,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsRemoveRepoAccessToSelfHostedRunnerGroupInOrg(
@@ -3624,7 +3429,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListSelfHostedRunnersInGroupForOrg(
@@ -3649,13 +3454,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/runners`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetSelfHostedRunnersInGroupForOrg(
@@ -3673,12 +3474,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/runners`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsAddSelfHostedRunnerToGroupForOrg(
@@ -3695,7 +3496,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/runners/${p["runnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsRemoveSelfHostedRunnerFromGroupForOrg(
@@ -3712,7 +3513,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runner-groups/${p["runnerGroupId"]}/runners/${p["runnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListSelfHostedRunnersForOrg(
@@ -3741,11 +3542,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListRunnerApplicationsForOrg(
@@ -3758,7 +3555,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/actions/runners/downloads`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGenerateRunnerJitconfigForOrg(
@@ -3788,12 +3585,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/runners/generate-jitconfig`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsCreateRegistrationTokenForOrg(
@@ -3807,7 +3604,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/runners/registration-token`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsCreateRemoveTokenForOrg(
@@ -3820,7 +3617,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/actions/runners/remove-token`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsGetSelfHostedRunnerForOrg(
@@ -3835,7 +3632,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDeleteSelfHostedRunnerFromOrg(
@@ -3850,7 +3647,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListLabelsForSelfHostedRunnerForOrg(
@@ -3875,7 +3672,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsAddCustomLabelsToSelfHostedRunnerForOrg(
@@ -3903,12 +3700,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsSetCustomLabelsForSelfHostedRunnerForOrg(
@@ -3936,12 +3733,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrg(
@@ -3966,7 +3763,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsRemoveCustomLabelFromSelfHostedRunnerForOrg(
@@ -3993,7 +3790,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/runners/${p["runnerId"]}/labels/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListOrgSecrets(
@@ -4015,13 +3812,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/actions/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetOrgPublicKey(
@@ -4034,7 +3827,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/actions/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetOrgSecret(
@@ -4049,7 +3842,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateOrUpdateOrgSecret(
@@ -4069,12 +3862,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteOrgSecret(
@@ -4089,7 +3882,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListSelectedReposForOrgSecret(
@@ -4114,13 +3907,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetSelectedReposForOrgSecret(
@@ -4138,12 +3927,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsAddSelectedRepoToOrgSecret(
@@ -4160,7 +3949,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsRemoveSelectedRepoFromOrgSecret(
@@ -4177,7 +3966,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListOrgVariables(
@@ -4199,13 +3988,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/actions/variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateOrgVariable(
@@ -4223,12 +4008,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_empty_object>> {
     const url = this.basePath + `/orgs/${p["org"]}/actions/variables`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetOrgVariable(
@@ -4243,7 +4028,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/variables/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsUpdateOrgVariable(
@@ -4263,16 +4048,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/actions/variables/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteOrgVariable(
@@ -4287,7 +4068,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/actions/variables/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListSelectedReposForOrgVariable(
@@ -4313,13 +4094,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/variables/${p["name"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetSelectedReposForOrgVariable(
@@ -4337,12 +4114,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/actions/variables/${p["name"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsAddSelectedRepoToOrgVariable(
@@ -4359,7 +4136,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/variables/${p["name"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsRemoveSelectedRepoFromOrgVariable(
@@ -4376,7 +4153,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/actions/variables/${p["name"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsListAttestationsBulk(
@@ -4427,7 +4204,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/attestations/bulk-list`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const query = this._query({
@@ -4439,7 +4216,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
@@ -4460,12 +4237,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, void> | Res<404, t_basic_error>> {
     const url = this.basePath + `/orgs/${p["org"]}/attestations/delete-request`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsDeleteAttestationsBySubjectDigest(
@@ -4481,7 +4258,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/attestations/digest/${p["subjectDigest"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsDeleteAttestationsById(
@@ -4501,7 +4278,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/attestations/${p["attestationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsListAttestations(
@@ -4545,11 +4322,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       predicate_type: p["predicateType"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListBlockedUsers(
@@ -4563,13 +4336,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]>> {
     const url = this.basePath + `/orgs/${p["org"]}/blocks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCheckBlockedUser(
@@ -4583,7 +4352,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsBlockUser(
@@ -4597,7 +4366,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async orgsUnblockUser(
@@ -4611,7 +4380,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/blocks/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async campaignsListOrgCampaigns(
@@ -4652,11 +4421,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       sort: p["sort"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async campaignsCreateCampaign(
@@ -4695,12 +4460,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/campaigns`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async campaignsGetCampaignSummary(
@@ -4727,7 +4492,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/campaigns/${p["campaignNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async campaignsUpdateCampaign(
@@ -4763,16 +4528,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/campaigns/${p["campaignNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async campaignsDeleteCampaign(
@@ -4798,7 +4559,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/campaigns/${p["campaignNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codeScanningListAlertsForOrg(
@@ -4844,11 +4605,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       severity: p["severity"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityGetConfigurationsForOrg(
@@ -4875,11 +4632,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       after: p["after"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityCreateConfiguration(
@@ -4982,12 +4735,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_code_security_configuration>> {
     const url = this.basePath + `/orgs/${p["org"]}/code-security/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityGetDefaultConfigurations(
@@ -5006,7 +4759,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/code-security/configurations/defaults`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityDetachConfiguration(
@@ -5028,16 +4781,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/code-security/configurations/detach`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityGetConfiguration(
@@ -5058,7 +4807,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityUpdateConfiguration(
@@ -5164,16 +4913,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityDeleteConfiguration(
@@ -5195,7 +4940,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codeSecurityAttachConfiguration(
@@ -5227,12 +4972,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}/attach`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeSecuritySetConfigurationAsDefault(
@@ -5270,12 +5015,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/code-security/configurations/${p["configurationId"]}/defaults`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codeSecurityGetRepositoriesForConfiguration(
@@ -5305,11 +5050,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       status: p["status"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesListInOrganization(
@@ -5336,13 +5077,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/codespaces`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesSetCodespacesAccess(
@@ -5370,12 +5107,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/codespaces/access`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codespacesSetCodespacesAccessUsers(
@@ -5398,12 +5135,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/codespaces/access/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codespacesDeleteCodespacesAccessUsers(
@@ -5426,16 +5163,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/codespaces/access/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async codespacesListOrgSecrets(
@@ -5457,13 +5190,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/codespaces/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesGetOrgPublicKey(
@@ -5477,7 +5206,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/codespaces/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesGetOrgSecret(
@@ -5492,7 +5221,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCreateOrUpdateOrgSecret(
@@ -5517,12 +5246,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codespacesDeleteOrgSecret(
@@ -5537,7 +5266,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesListSelectedReposForOrgSecret(
@@ -5563,13 +5292,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesSetSelectedReposForOrgSecret(
@@ -5587,12 +5312,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codespacesAddSelectedRepoToOrgSecret(
@@ -5614,7 +5339,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async codespacesRemoveSelectedRepoFromOrgSecret(
@@ -5636,7 +5361,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/codespaces/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async copilotGetCopilotOrganizationDetails(
@@ -5656,7 +5381,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/copilot/billing`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async copilotListCopilotSeats(
@@ -5682,13 +5407,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/copilot/billing/seats`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async copilotAddCopilotSeatsForTeams(
@@ -5716,12 +5437,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/copilot/billing/selected_teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async copilotCancelCopilotSeatAssignmentForTeams(
@@ -5749,16 +5470,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/copilot/billing/selected_teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async copilotAddCopilotSeatsForUsers(
@@ -5786,12 +5503,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/copilot/billing/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async copilotCancelCopilotSeatAssignmentForUsers(
@@ -5819,16 +5536,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/copilot/billing/selected_users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async copilotCopilotMetricsForOrganization(
@@ -5857,11 +5570,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotListAlertsForOrg(
@@ -5911,11 +5620,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotListOrgSecrets(
@@ -5937,13 +5642,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/dependabot/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotGetOrgPublicKey(
@@ -5957,7 +5658,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/dependabot/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotGetOrgSecret(
@@ -5972,7 +5673,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotCreateOrUpdateOrgSecret(
@@ -5992,12 +5693,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async dependabotDeleteOrgSecret(
@@ -6012,7 +5713,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async dependabotListSelectedReposForOrgSecret(
@@ -6037,13 +5738,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotSetSelectedReposForOrgSecret(
@@ -6061,12 +5758,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async dependabotAddSelectedRepoToOrgSecret(
@@ -6083,7 +5780,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async dependabotRemoveSelectedRepoFromOrgSecret(
@@ -6100,7 +5797,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/dependabot/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesListDockerMigrationConflictingPackagesForOrganization(
@@ -6115,7 +5812,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/docker/conflicts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListPublicOrgEvents(
@@ -6129,13 +5826,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event[]>> {
     const url = this.basePath + `/orgs/${p["org"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListFailedInvitations(
@@ -6149,13 +5842,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_organization_invitation[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/orgs/${p["org"]}/failed_invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListWebhooks(
@@ -6169,13 +5858,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_org_hook[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/orgs/${p["org"]}/hooks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCreateWebhook(
@@ -6204,12 +5889,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/hooks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsGetWebhook(
@@ -6223,7 +5908,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsUpdateWebhook(
@@ -6251,16 +5936,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async orgsDeleteWebhook(
@@ -6274,7 +5955,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsGetWebhookConfigForOrg(
@@ -6288,7 +5969,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}/config`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsUpdateWebhookConfigForOrg(
@@ -6307,16 +5988,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_webhook_config>> {
     const url = this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}/config`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async orgsListWebhookDeliveries(
@@ -6336,13 +6013,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}/deliveries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], cursor: p["cursor"] })
+    const query = this._query({per_page: p["perPage"], cursor: p["cursor"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsGetWebhookDelivery(
@@ -6363,7 +6036,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/hooks/${p["hookId"]}/deliveries/${p["deliveryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsRedeliverWebhookDelivery(
@@ -6389,7 +6062,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/hooks/${p["hookId"]}/deliveries/${p["deliveryId"]}/attempts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async orgsPingWebhook(
@@ -6403,7 +6076,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/hooks/${p["hookId"]}/pings`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetRouteStatsByActor(
@@ -6450,11 +6123,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       api_route_substring: p["apiRouteSubstring"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetSubjectStats(
@@ -6490,11 +6159,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       subject_name_substring: p["subjectNameSubstring"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetSummaryStats(
@@ -6513,11 +6178,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       max_timestamp: p["maxTimestamp"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetSummaryStatsByUser(
@@ -6539,11 +6200,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       max_timestamp: p["maxTimestamp"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetSummaryStatsByActor(
@@ -6572,11 +6229,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       max_timestamp: p["maxTimestamp"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetTimeStats(
@@ -6597,11 +6250,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       timestamp_increment: p["timestampIncrement"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetTimeStatsByUser(
@@ -6625,11 +6274,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       timestamp_increment: p["timestampIncrement"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetTimeStatsByActor(
@@ -6660,11 +6305,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       timestamp_increment: p["timestampIncrement"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async apiInsightsGetUserStats(
@@ -6702,11 +6343,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       actor_name_substring: p["actorNameSubstring"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsGetOrgInstallation(
@@ -6719,7 +6356,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/installation`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListAppInstallations(
@@ -6741,13 +6378,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/installations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async interactionsGetRestrictionsForOrg(
@@ -6760,7 +6393,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/interaction-limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async interactionsSetRestrictionsForOrg(
@@ -6775,12 +6408,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/interaction-limits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async interactionsRemoveRestrictionsForOrg(
@@ -6793,7 +6426,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/interaction-limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsListPendingInvitations(
@@ -6822,11 +6455,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       invitation_source: p["invitationSource"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCreateInvitation(
@@ -6853,12 +6482,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/invitations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsCancelInvitation(
@@ -6875,7 +6504,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/invitations/${p["invitationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsListInvitationTeams(
@@ -6891,13 +6520,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/invitations/${p["invitationId"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListIssueTypes(
@@ -6910,7 +6535,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/issue-types`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCreateIssueType(
@@ -6927,12 +6552,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/issue-types`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsUpdateIssueType(
@@ -6951,12 +6576,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/issue-types/${p["issueTypeId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async orgsDeleteIssueType(
@@ -6975,7 +6600,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/issue-types/${p["issueTypeId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesListForOrg(
@@ -7015,11 +6640,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListMembers(
@@ -7042,11 +6663,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCheckMembershipForUser(
@@ -7060,7 +6677,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsRemoveMember(
@@ -7074,7 +6691,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesGetCodespacesForUserInOrg(
@@ -7103,13 +6720,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/members/${p["username"]}/codespaces`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesDeleteFromOrganization(
@@ -7138,7 +6751,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/members/${p["username"]}/codespaces/${p["codespaceName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesStopInOrganization(
@@ -7162,7 +6775,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/members/${p["username"]}/codespaces/${p["codespaceName"]}/stop`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async copilotGetCopilotSeatDetailsForUser(
@@ -7184,7 +6797,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/members/${p["username"]}/copilot`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsGetMembershipForUser(
@@ -7202,7 +6815,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/memberships/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsSetMembershipForUser(
@@ -7222,12 +6835,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/memberships/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async orgsRemoveMembershipForUser(
@@ -7243,7 +6856,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/memberships/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async migrationsListForOrg(
@@ -7264,11 +6877,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       exclude: p["exclude"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsStartForOrg(
@@ -7295,12 +6904,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/migrations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async migrationsGetStatusForOrg(
@@ -7315,13 +6924,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/migrations/${p["migrationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ exclude: p["exclude"] })
+    const query = this._query({exclude: p["exclude"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsDownloadArchiveForOrg(
@@ -7336,7 +6941,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/migrations/${p["migrationId"]}/archive`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsDeleteArchiveForOrg(
@@ -7351,7 +6956,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/migrations/${p["migrationId"]}/archive`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async migrationsUnlockRepoForOrg(
@@ -7368,7 +6973,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/migrations/${p["migrationId"]}/repos/${p["repoName"]}/lock`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async migrationsListReposForOrg(
@@ -7385,13 +6990,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/migrations/${p["migrationId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListOrgRoles(
@@ -7414,7 +7015,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/organization-roles`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsRevokeAllOrgRolesTeam(
@@ -7430,7 +7031,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/organization-roles/teams/${p["teamSlug"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsAssignTeamToOrgRole(
@@ -7447,7 +7048,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/organization-roles/teams/${p["teamSlug"]}/${p["roleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async orgsRevokeOrgRoleTeam(
@@ -7464,7 +7065,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/organization-roles/teams/${p["teamSlug"]}/${p["roleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsRevokeAllOrgRolesUser(
@@ -7480,7 +7081,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/organization-roles/users/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsAssignUserToOrgRole(
@@ -7497,7 +7098,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/organization-roles/users/${p["username"]}/${p["roleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async orgsRevokeOrgRoleUser(
@@ -7514,7 +7115,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/organization-roles/users/${p["username"]}/${p["roleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsGetOrgRole(
@@ -7533,7 +7134,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/organization-roles/${p["roleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListOrgRoleTeams(
@@ -7552,13 +7153,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/organization-roles/${p["roleId"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListOrgRoleUsers(
@@ -7577,13 +7174,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/organization-roles/${p["roleId"]}/users`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListOutsideCollaborators(
@@ -7604,11 +7197,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsConvertMemberToOutsideCollaborator(
@@ -7630,12 +7219,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/outside_collaborators/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async orgsRemoveOutsideCollaborator(
@@ -7659,7 +7248,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/outside_collaborators/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesListPackagesForOrganization(
@@ -7694,11 +7283,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesGetPackageForOrganization(
@@ -7722,7 +7307,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesDeletePackageForOrg(
@@ -7751,7 +7336,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesRestorePackageForOrg(
@@ -7780,13 +7365,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}/restore`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ token: p["token"] })
+    const query = this._query({token: p["token"]})
 
-    return this._fetch(
-      url + query,
-      { method: "POST", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "POST", ...opts, headers}, timeout)
   }
 
   async packagesGetAllPackageVersionsForPackageOwnedByOrg(
@@ -7823,11 +7404,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesGetPackageVersionForOrganization(
@@ -7852,7 +7429,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesDeletePackageVersionForOrg(
@@ -7882,7 +7459,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesRestorePackageVersionForOrg(
@@ -7912,7 +7489,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}/restore`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async orgsListPatGrantRequests(
@@ -7954,11 +7531,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       token_id: p["tokenId"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsReviewPatGrantRequestsInBulk(
@@ -7987,12 +7560,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/personal-access-token-requests`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsReviewPatGrantRequest(
@@ -8017,12 +7590,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/personal-access-token-requests/${p["patRequestId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsListPatGrantRequestRepositories(
@@ -8044,13 +7617,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/personal-access-token-requests/${p["patRequestId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListPatGrants(
@@ -8091,11 +7660,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       token_id: p["tokenId"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsUpdatePatAccesses(
@@ -8122,12 +7687,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/personal-access-tokens`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsUpdatePatAccess(
@@ -8150,12 +7715,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/personal-access-tokens/${p["patId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsListPatGrantRepositories(
@@ -8177,13 +7742,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/personal-access-tokens/${p["patId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async privateRegistriesListOrgPrivateRegistries(
@@ -8207,13 +7768,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/private-registries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async privateRegistriesCreateOrgPrivateRegistry(
@@ -8242,12 +7799,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/private-registries`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async privateRegistriesGetOrgPublicKey(
@@ -8270,7 +7827,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/private-registries/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async privateRegistriesGetOrgPrivateRegistry(
@@ -8287,7 +7844,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/private-registries/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async privateRegistriesUpdateOrgPrivateRegistry(
@@ -8316,16 +7873,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/private-registries/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async privateRegistriesDeleteOrgPrivateRegistry(
@@ -8342,7 +7895,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/private-registries/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async projectsListForOrg(
@@ -8363,11 +7916,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsCreateForOrg(
@@ -8390,12 +7939,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/projects`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async orgsGetAllCustomProperties(
@@ -8412,7 +7961,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/properties/schema`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCreateOrUpdateCustomProperties(
@@ -8431,16 +7980,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/properties/schema`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async orgsGetCustomProperty(
@@ -8460,7 +8005,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/properties/schema/${p["customPropertyName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCreateOrUpdateCustomProperty(
@@ -8480,12 +8025,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/properties/schema/${p["customPropertyName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async orgsRemoveCustomProperty(
@@ -8503,7 +8048,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/properties/schema/${p["customPropertyName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsListCustomPropertiesValuesForRepos(
@@ -8528,11 +8073,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       repository_query: p["repositoryQuery"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCreateOrUpdateCustomPropertiesValuesForRepos(
@@ -8553,16 +8094,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/properties/values`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async orgsListPublicMembers(
@@ -8576,13 +8113,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]>> {
     const url = this.basePath + `/orgs/${p["org"]}/public_members`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsCheckPublicMembershipForUser(
@@ -8597,7 +8130,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/public_members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsSetPublicMembershipForAuthenticatedUser(
@@ -8612,7 +8145,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/public_members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async orgsRemovePublicMembershipForAuthenticatedUser(
@@ -8627,7 +8160,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/public_members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListForOrg(
@@ -8664,11 +8197,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateInOrg(
@@ -8727,12 +8256,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/repos`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetOrgRulesets(
@@ -8757,11 +8286,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       targets: p["targets"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateOrgRuleset(
@@ -8790,12 +8315,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/rulesets`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetOrgRuleSuites(
@@ -8831,11 +8356,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetOrgRuleSuite(
@@ -8853,7 +8374,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/rulesets/rule-suites/${p["ruleSuiteId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetOrgRuleset(
@@ -8871,7 +8392,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateOrgRuleset(
@@ -8901,12 +8422,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteOrgRuleset(
@@ -8922,7 +8443,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async orgsGetOrgRulesetHistory(
@@ -8942,13 +8463,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}/history`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsGetOrgRulesetVersion(
@@ -8969,7 +8486,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/rulesets/${p["rulesetId"]}/history/${p["versionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async secretScanningListAlertsForOrg(
@@ -9021,11 +8538,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       hide_secret: p["hideSecret"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesListOrgRepositoryAdvisories(
@@ -9061,11 +8574,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListSecurityManagerTeams(
@@ -9078,7 +8587,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/security-managers`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsAddSecurityManagerTeam(
@@ -9094,7 +8603,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/security-managers/teams/${p["teamSlug"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async orgsRemoveSecurityManagerTeam(
@@ -9110,7 +8619,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/security-managers/teams/${p["teamSlug"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async billingGetGithubActionsBillingOrg(
@@ -9123,7 +8632,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/settings/billing/actions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async billingGetGithubPackagesBillingOrg(
@@ -9136,7 +8645,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/settings/billing/packages`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async billingGetSharedStorageBillingOrg(
@@ -9150,7 +8659,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/orgs/${p["org"]}/settings/billing/shared-storage`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async hostedComputeListNetworkConfigurationsForOrg(
@@ -9173,13 +8682,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/settings/network-configurations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async hostedComputeCreateNetworkConfigurationForOrg(
@@ -9197,12 +8702,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/settings/network-configurations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async hostedComputeGetNetworkConfigurationForOrg(
@@ -9218,7 +8723,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/settings/network-configurations/${p["networkConfigurationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async hostedComputeUpdateNetworkConfigurationForOrg(
@@ -9238,16 +8743,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/settings/network-configurations/${p["networkConfigurationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async hostedComputeDeleteNetworkConfigurationFromOrg(
@@ -9263,7 +8764,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/settings/network-configurations/${p["networkConfigurationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async hostedComputeGetNetworkSettingsForOrg(
@@ -9279,7 +8780,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/settings/network-settings/${p["networkSettingsId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async copilotCopilotMetricsForTeam(
@@ -9310,11 +8811,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsList(
@@ -9328,13 +8825,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_team[]> | Res<403, t_basic_error>> {
     const url = this.basePath + `/orgs/${p["org"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCreate(
@@ -9363,12 +8856,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async teamsGetByName(
@@ -9382,7 +8875,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsUpdateInOrg(
@@ -9412,16 +8905,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async teamsDeleteInOrg(
@@ -9435,7 +8924,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListDiscussionsInOrg(
@@ -9460,11 +8949,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       pinned: p["pinned"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCreateDiscussionInOrg(
@@ -9483,12 +8968,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async teamsGetDiscussionInOrg(
@@ -9505,7 +8990,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsUpdateDiscussionInOrg(
@@ -9525,16 +9010,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async teamsDeleteDiscussionInOrg(
@@ -9551,7 +9032,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListDiscussionCommentsInOrg(
@@ -9576,11 +9057,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCreateDiscussionCommentInOrg(
@@ -9599,12 +9076,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async teamsGetDiscussionCommentInOrg(
@@ -9622,7 +9099,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsUpdateDiscussionCommentInOrg(
@@ -9642,16 +9119,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async teamsDeleteDiscussionCommentInOrg(
@@ -9669,7 +9142,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForTeamDiscussionCommentInOrg(
@@ -9704,11 +9177,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForTeamDiscussionCommentInOrg(
@@ -9737,12 +9206,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForTeamDiscussionComment(
@@ -9761,7 +9230,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForTeamDiscussionInOrg(
@@ -9795,11 +9264,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForTeamDiscussionInOrg(
@@ -9827,12 +9292,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForTeamDiscussion(
@@ -9850,7 +9315,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/discussions/${p["discussionNumber"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListPendingInvitationsInOrg(
@@ -9866,13 +9331,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}/invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsListMembersInOrg(
@@ -9895,11 +9356,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsGetMembershipForUserInOrg(
@@ -9916,7 +9373,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddOrUpdateMembershipForUserInOrg(
@@ -9935,12 +9392,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async teamsRemoveMembershipForUserInOrg(
@@ -9957,7 +9414,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/memberships/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListProjectsInOrg(
@@ -9973,13 +9430,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCheckPermissionsForProjectInOrg(
@@ -9996,7 +9449,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddOrUpdateProjectPermissionsInOrg(
@@ -10024,12 +9477,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async teamsRemoveProjectInOrg(
@@ -10046,7 +9499,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/projects/${p["projectId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListReposInOrg(
@@ -10061,13 +9514,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_minimal_repository[]>> {
     const url = this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCheckPermissionsForRepoInOrg(
@@ -10085,7 +9534,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddOrUpdateRepoPermissionsInOrg(
@@ -10105,12 +9554,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async teamsRemoveRepoInOrg(
@@ -10128,7 +9577,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/orgs/${p["org"]}/teams/${p["teamSlug"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListChildInOrg(
@@ -10143,13 +9592,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_team[]>> {
     const url = this.basePath + `/orgs/${p["org"]}/teams/${p["teamSlug"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsEnableOrDisableSecurityProductOnAllOrgRepos(
@@ -10176,12 +9621,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/orgs/${p["org"]}/${p["securityProduct"]}/${p["enablement"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async projectsGetCard(
@@ -10200,7 +9645,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/projects/columns/cards/${p["cardId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsUpdateCard(
@@ -10223,16 +9668,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/columns/cards/${p["cardId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async projectsDeleteCard(
@@ -10258,7 +9699,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/projects/columns/cards/${p["cardId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async projectsMoveCard(
@@ -10304,12 +9745,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/columns/cards/${p["cardId"]}/moves`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async projectsGetColumn(
@@ -10328,7 +9769,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/projects/columns/${p["columnId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsUpdateColumn(
@@ -10348,16 +9789,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/columns/${p["columnId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async projectsDeleteColumn(
@@ -10375,7 +9812,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/projects/columns/${p["columnId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async projectsListCards(
@@ -10405,11 +9842,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsCreateCard(
@@ -10447,12 +9880,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/columns/${p["columnId"]}/cards`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async projectsMoveColumn(
@@ -10473,12 +9906,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/columns/${p["columnId"]}/moves`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async projectsGet(
@@ -10496,7 +9929,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/projects/${p["projectId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsUpdate(
@@ -10535,16 +9968,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/${p["projectId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async projectsDelete(
@@ -10571,7 +10000,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/projects/${p["projectId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async projectsListCollaborators(
@@ -10599,11 +10028,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsAddCollaborator(
@@ -10628,12 +10053,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/projects/${p["projectId"]}/collaborators/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async projectsRemoveCollaborator(
@@ -10656,7 +10081,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/projects/${p["projectId"]}/collaborators/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async projectsGetPermissionForUser(
@@ -10679,7 +10104,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/projects/${p["projectId"]}/collaborators/${p["username"]}/permission`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsListColumns(
@@ -10698,13 +10123,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/${p["projectId"]}/columns`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsCreateColumn(
@@ -10725,12 +10146,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/projects/${p["projectId"]}/columns`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async rateLimitGet(
@@ -10742,7 +10163,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/rate_limit`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGet(
@@ -10761,7 +10182,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdate(
@@ -10840,16 +10261,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDelete(
@@ -10875,7 +10292,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListArtifactsForRepo(
@@ -10906,11 +10323,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       name: p["name"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetArtifact(
@@ -10927,7 +10340,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts/${p["artifactId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDeleteArtifact(
@@ -10944,7 +10357,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts/${p["artifactId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsDownloadArtifact(
@@ -10962,7 +10375,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/artifacts/${p["artifactId"]}/${p["archiveFormat"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetActionsCacheUsage(
@@ -10977,7 +10390,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/cache/usage`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetActionsCacheList(
@@ -11010,11 +10423,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       direction: p["direction"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDeleteActionsCacheByKey(
@@ -11030,11 +10439,11 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/caches`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ key: p["key"], ref: p["ref"] })
+    const query = this._query({key: p["key"], ref: p["ref"]})
 
     return this._fetch(
       url + query,
-      { method: "DELETE", ...opts, headers },
+      {method: "DELETE", ...opts, headers},
       timeout,
     )
   }
@@ -11053,7 +10462,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/caches/${p["cacheId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsGetJobForWorkflowRun(
@@ -11070,7 +10479,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/jobs/${p["jobId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDownloadJobLogsForWorkflowRun(
@@ -11087,7 +10496,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/jobs/${p["jobId"]}/logs`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsReRunJobForWorkflowRun(
@@ -11106,12 +10515,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/jobs/${p["jobId"]}/rerun`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetCustomOidcSubClaimForRepo(
@@ -11131,7 +10540,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/oidc/customization/sub`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetCustomOidcSubClaimForRepo(
@@ -11155,12 +10564,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/oidc/customization/sub`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsListRepoOrganizationSecrets(
@@ -11185,13 +10594,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/organization-secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListRepoOrganizationVariables(
@@ -11216,13 +10621,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/organization-variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetGithubActionsPermissionsRepository(
@@ -11237,7 +10638,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/permissions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetGithubActionsPermissionsRepository(
@@ -11255,12 +10656,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/permissions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsGetWorkflowAccessToRepository(
@@ -11276,7 +10677,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/access`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetWorkflowAccessToRepository(
@@ -11292,12 +10693,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/access`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsGetAllowedActionsRepository(
@@ -11313,7 +10714,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/selected-actions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetAllowedActionsRepository(
@@ -11329,12 +10730,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/selected-actions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsGetGithubActionsDefaultWorkflowPermissionsRepository(
@@ -11350,7 +10751,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/workflow`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsSetGithubActionsDefaultWorkflowPermissionsRepository(
@@ -11366,12 +10767,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/permissions/workflow`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsListSelfHostedRunnersForRepo(
@@ -11402,11 +10803,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListRunnerApplicationsForRepo(
@@ -11422,7 +10819,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/downloads`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGenerateRunnerJitconfigForRepo(
@@ -11454,12 +10851,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/generate-jitconfig`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsCreateRegistrationTokenForRepo(
@@ -11475,7 +10872,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/registration-token`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsCreateRemoveTokenForRepo(
@@ -11491,7 +10888,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/remove-token`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsGetSelfHostedRunnerForRepo(
@@ -11508,7 +10905,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDeleteSelfHostedRunnerFromRepo(
@@ -11525,7 +10922,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListLabelsForSelfHostedRunnerForRepo(
@@ -11551,7 +10948,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsAddCustomLabelsToSelfHostedRunnerForRepo(
@@ -11580,12 +10977,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsSetCustomLabelsForSelfHostedRunnerForRepo(
@@ -11614,12 +11011,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsRemoveAllCustomLabelsFromSelfHostedRunnerForRepo(
@@ -11645,7 +11042,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsRemoveCustomLabelFromSelfHostedRunnerForRepo(
@@ -11673,7 +11070,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runners/${p["runnerId"]}/labels/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListWorkflowRunsForRepo(
@@ -11732,11 +11129,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       head_sha: p["headSha"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetWorkflowRun(
@@ -11753,15 +11146,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({
-      exclude_pull_requests: p["excludePullRequests"],
-    })
+    const query = this._query({exclude_pull_requests: p["excludePullRequests"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDeleteWorkflowRun(
@@ -11778,7 +11165,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsGetReviewsForRun(
@@ -11795,7 +11182,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/approvals`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsApproveWorkflowRun(
@@ -11814,7 +11201,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/approve`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsListWorkflowRunArtifacts(
@@ -11847,11 +11234,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       name: p["name"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetWorkflowRunAttempt(
@@ -11869,15 +11252,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/attempts/${p["attemptNumber"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({
-      exclude_pull_requests: p["excludePullRequests"],
-    })
+    const query = this._query({exclude_pull_requests: p["excludePullRequests"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListJobsForWorkflowRunAttempt(
@@ -11905,13 +11282,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/attempts/${p["attemptNumber"]}/jobs`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDownloadWorkflowRunAttemptLogs(
@@ -11929,7 +11302,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/attempts/${p["attemptNumber"]}/logs`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCancelWorkflowRun(
@@ -11946,7 +11319,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/cancel`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsReviewCustomGatesForRun(
@@ -11965,12 +11338,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/deployment_protection_rule`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsForceCancelWorkflowRun(
@@ -11987,7 +11360,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/force-cancel`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async actionsListJobsForWorkflowRun(
@@ -12020,11 +11393,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDownloadWorkflowRunLogs(
@@ -12041,7 +11410,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/logs`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDeleteWorkflowRunLogs(
@@ -12060,7 +11429,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/logs`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsGetPendingDeploymentsForRun(
@@ -12077,7 +11446,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/pending_deployments`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsReviewPendingDeploymentsForRun(
@@ -12098,12 +11467,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/pending_deployments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsReRunWorkflow(
@@ -12122,12 +11491,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/rerun`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsReRunWorkflowFailedJobs(
@@ -12146,12 +11515,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/rerun-failed-jobs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetWorkflowRunUsage(
@@ -12168,7 +11537,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/runs/${p["runId"]}/timing`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsListRepoSecrets(
@@ -12192,13 +11561,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetRepoPublicKey(
@@ -12214,7 +11579,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetRepoSecret(
@@ -12231,7 +11596,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateOrUpdateRepoSecret(
@@ -12251,12 +11616,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteRepoSecret(
@@ -12273,7 +11638,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListRepoVariables(
@@ -12297,13 +11662,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateRepoVariable(
@@ -12321,12 +11682,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/variables`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetRepoVariable(
@@ -12343,7 +11704,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/variables/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsUpdateRepoVariable(
@@ -12363,16 +11724,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/variables/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteRepoVariable(
@@ -12389,7 +11746,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/variables/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListRepoWorkflows(
@@ -12413,13 +11770,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/actions/workflows`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetWorkflow(
@@ -12436,7 +11789,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsDisableWorkflow(
@@ -12453,7 +11806,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}/disable`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsCreateWorkflowDispatch(
@@ -12475,12 +11828,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}/dispatches`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsEnableWorkflow(
@@ -12497,7 +11850,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}/enable`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async actionsListWorkflowRuns(
@@ -12559,11 +11912,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       head_sha: p["headSha"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetWorkflowUsage(
@@ -12580,7 +11929,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/actions/workflows/${p["workflowId"]}/timing`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListActivities(
@@ -12625,11 +11974,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       activity_type: p["activityType"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesListAssignees(
@@ -12644,13 +11989,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/assignees`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesCheckUserCanBeAssigned(
@@ -12667,7 +12008,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/assignees/${p["assignee"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateAttestation(
@@ -12700,12 +12041,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/attestations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposListAttestations(
@@ -12751,11 +12092,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       predicate_type: p["predicateType"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListAutolinks(
@@ -12769,7 +12106,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/autolinks`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateAutolink(
@@ -12787,12 +12124,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_autolink> | Res<422, t_validation_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/autolinks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetAutolink(
@@ -12809,7 +12146,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/autolinks/${p["autolinkId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposDeleteAutolink(
@@ -12826,7 +12163,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/autolinks/${p["autolinkId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposCheckAutomatedSecurityFixes(
@@ -12842,7 +12179,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/automated-security-fixes`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposEnableAutomatedSecurityFixes(
@@ -12858,7 +12195,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/automated-security-fixes`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async reposDisableAutomatedSecurityFixes(
@@ -12874,7 +12211,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/automated-security-fixes`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListBranches(
@@ -12896,11 +12233,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetBranch(
@@ -12921,7 +12254,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetBranchProtection(
@@ -12938,7 +12271,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateBranchProtection(
@@ -12998,12 +12331,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteBranchProtection(
@@ -13020,7 +12353,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetAdminBranchProtection(
@@ -13037,7 +12370,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/enforce_admins`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposSetAdminBranchProtection(
@@ -13054,7 +12387,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/enforce_admins`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async reposDeleteAdminBranchProtection(
@@ -13071,7 +12404,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/enforce_admins`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetPullRequestReviewProtection(
@@ -13088,7 +12421,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdatePullRequestReviewProtection(
@@ -13123,16 +12456,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDeletePullRequestReviewProtection(
@@ -13149,7 +12478,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_pull_request_reviews`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetCommitSignatureProtection(
@@ -13168,7 +12497,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_signatures`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateCommitSignatureProtection(
@@ -13187,7 +12516,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_signatures`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async reposDeleteCommitSignatureProtection(
@@ -13204,7 +12533,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_signatures`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetStatusChecksProtection(
@@ -13221,7 +12550,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateStatusCheckProtection(
@@ -13249,16 +12578,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposRemoveStatusCheckProtection(
@@ -13275,7 +12600,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetAllStatusCheckContexts(
@@ -13292,7 +12617,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposAddStatusCheckContexts(
@@ -13318,12 +12643,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposSetStatusCheckContexts(
@@ -13346,12 +12671,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposRemoveStatusCheckContexts(
@@ -13374,16 +12699,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/required_status_checks/contexts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async reposGetAccessRestrictions(
@@ -13400,7 +12721,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposDeleteAccessRestrictions(
@@ -13417,7 +12738,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetAppsWithAccessToProtectedBranch(
@@ -13434,7 +12755,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposAddAppAccessRestrictions(
@@ -13453,12 +12774,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposSetAppAccessRestrictions(
@@ -13477,12 +12798,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposRemoveAppAccessRestrictions(
@@ -13501,16 +12822,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/apps`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async reposGetTeamsWithAccessToProtectedBranch(
@@ -13527,7 +12844,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposAddTeamAccessRestrictions(
@@ -13548,12 +12865,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposSetTeamAccessRestrictions(
@@ -13574,12 +12891,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposRemoveTeamAccessRestrictions(
@@ -13600,16 +12917,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/teams`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async reposGetUsersWithAccessToProtectedBranch(
@@ -13626,7 +12939,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposAddUserAccessRestrictions(
@@ -13645,12 +12958,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposSetUserAccessRestrictions(
@@ -13669,12 +12982,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposRemoveUserAccessRestrictions(
@@ -13693,16 +13006,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/protection/restrictions/users`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async reposRenameBranch(
@@ -13726,12 +13035,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/branches/${p["branch"]}/rename`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async checksCreate(
@@ -13753,12 +13062,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_check_run>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/check-runs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async checksGet(
@@ -13775,7 +13084,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async checksUpdate(
@@ -13846,16 +13155,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async checksListAnnotations(
@@ -13873,13 +13178,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}/annotations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async checksRerequestRun(
@@ -13901,7 +13202,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/check-runs/${p["checkRunId"]}/rerequest`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async checksCreateSuite(
@@ -13917,12 +13218,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_check_suite> | Res<201, t_check_suite>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/check-suites`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async checksSetSuitesPreferences(
@@ -13943,16 +13244,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/check-suites/preferences`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async checksGetSuite(
@@ -13969,7 +13266,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/check-suites/${p["checkSuiteId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async checksListForSuite(
@@ -14006,11 +13303,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async checksRerequestSuite(
@@ -14027,7 +13320,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/check-suites/${p["checkSuiteId"]}/rerequest`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async codeScanningListAlertsForRepo(
@@ -14081,11 +13374,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       severity: p["severity"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningGetAlert(
@@ -14115,7 +13404,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningUpdateAlert(
@@ -14150,16 +13439,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async codeScanningGetAutofix(
@@ -14189,7 +13474,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}/autofix`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningCreateAutofix(
@@ -14221,7 +13506,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}/autofix`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async codeScanningCommitAutofix(
@@ -14252,12 +13537,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/alerts/${p["alertNumber"]}/autofix/commits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeScanningListAlertInstances(
@@ -14296,11 +13581,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       pr: p["pr"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningListRecentAnalyses(
@@ -14347,11 +13628,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       sort: p["sort"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningGetAnalysis(
@@ -14386,7 +13663,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/analyses/${p["analysisId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningDeleteAnalysis(
@@ -14416,11 +13693,11 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/analyses/${p["analysisId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ confirm_delete: p["confirmDelete"] })
+    const query = this._query({confirm_delete: p["confirmDelete"]})
 
     return this._fetch(
       url + query,
-      { method: "DELETE", ...opts, headers },
+      {method: "DELETE", ...opts, headers},
       timeout,
     )
   }
@@ -14450,7 +13727,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/databases`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningGetCodeqlDatabase(
@@ -14480,7 +13757,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/databases/${p["language"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningDeleteCodeqlDatabase(
@@ -14509,7 +13786,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/databases/${p["language"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codeScanningCreateVariantAnalysis(
@@ -14537,12 +13814,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/variant-analyses`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeScanningGetVariantAnalysis(
@@ -14570,7 +13847,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/variant-analyses/${p["codeqlVariantAnalysisId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningGetVariantAnalysisRepoTask(
@@ -14600,7 +13877,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/codeql/variant-analyses/${p["codeqlVariantAnalysisId"]}/repos/${p["repoOwner"]}/${p["repoName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningGetDefaultSetup(
@@ -14628,7 +13905,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/default-setup`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeScanningUpdateDefaultSetup(
@@ -14659,16 +13936,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/default-setup`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async codeScanningUploadSarif(
@@ -14705,12 +13978,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/code-scanning/sarifs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codeScanningGetSarif(
@@ -14739,7 +14012,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-scanning/sarifs/${p["sarifId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codeSecurityGetConfigurationForRepository(
@@ -14761,7 +14034,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/code-security-configuration`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCodeownersErrors(
@@ -14776,13 +14049,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/codeowners/errors`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesListInRepositoryForAuthenticatedUser(
@@ -14809,13 +14078,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/codespaces`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCreateWithRepoForAuthenticatedUser(
@@ -14861,12 +14126,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/codespaces`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codespacesListDevcontainersInRepositoryForAuthenticatedUser(
@@ -14900,13 +14165,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/codespaces/devcontainers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesRepoMachinesForAuthenticatedUser(
@@ -14942,11 +14203,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       ref: p["ref"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesPreFlightWithRepoForAuthenticatedUser(
@@ -14976,13 +14233,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/codespaces/new`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"], client_ip: p["clientIp"] })
+    const query = this._query({ref: p["ref"], client_ip: p["clientIp"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCheckPermissionsForDevcontainer(
@@ -15018,11 +14271,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       devcontainer_path: p["devcontainerPath"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesListRepoSecrets(
@@ -15046,13 +14295,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesGetRepoPublicKey(
@@ -15068,7 +14313,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesGetRepoSecret(
@@ -15085,7 +14330,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCreateOrUpdateRepoSecret(
@@ -15105,12 +14350,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codespacesDeleteRepoSecret(
@@ -15127,7 +14372,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListCollaborators(
@@ -15158,11 +14403,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCheckCollaborator(
@@ -15179,7 +14420,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposAddCollaborator(
@@ -15203,12 +14444,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposRemoveCollaborator(
@@ -15227,7 +14468,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetCollaboratorPermissionLevel(
@@ -15246,7 +14487,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/collaborators/${p["username"]}/permission`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListCommitCommentsForRepo(
@@ -15261,13 +14502,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_commit_comment[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCommitComment(
@@ -15284,7 +14521,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateCommitComment(
@@ -15303,16 +14540,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteCommitComment(
@@ -15329,7 +14562,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForCommitComment(
@@ -15363,11 +14596,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForCommitComment(
@@ -15397,12 +14626,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForCommitComment(
@@ -15420,7 +14649,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/comments/${p["commentId"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListCommits(
@@ -15458,11 +14687,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListBranchesForHeadCommit(
@@ -15483,7 +14708,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/branches-where-head`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListCommentsForCommit(
@@ -15501,13 +14726,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateCommitComment(
@@ -15533,12 +14754,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposListPullRequestsAssociatedWithCommit(
@@ -15556,13 +14777,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/commits/${p["commitSha"]}/pulls`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCommit(
@@ -15593,13 +14810,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async checksListForRef(
@@ -15638,11 +14851,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       app_id: p["appId"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async checksListSuitesForRef(
@@ -15677,11 +14886,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCombinedStatusForRef(
@@ -15699,13 +14904,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}/status`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListCommitStatusesForRef(
@@ -15723,13 +14924,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/commits/${p["ref"]}/statuses`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCommunityProfileMetrics(
@@ -15744,7 +14941,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/community/profile`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCompareCommits(
@@ -15774,13 +14971,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/compare/${p["basehead"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetContent(
@@ -15808,13 +15001,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateOrUpdateFileContents(
@@ -15851,12 +15040,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteFile(
@@ -15897,16 +15086,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/contents/${p["path"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async reposListContributors(
@@ -15933,11 +15118,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotListAlertsForRepo(
@@ -15993,11 +15174,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       last: p["last"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotGetAlert(
@@ -16019,7 +15196,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/dependabot/alerts/${p["alertNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotUpdateAlert(
@@ -16053,16 +15230,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/dependabot/alerts/${p["alertNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async dependabotListRepoSecrets(
@@ -16086,13 +15259,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotGetRepoPublicKey(
@@ -16108,7 +15277,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotGetRepoSecret(
@@ -16125,7 +15294,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependabotCreateOrUpdateRepoSecret(
@@ -16145,12 +15314,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async dependabotDeleteRepoSecret(
@@ -16167,7 +15336,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/dependabot/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async dependencyGraphDiffRange(
@@ -16188,13 +15357,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/dependency-graph/compare/${p["basehead"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ name: p["name"] })
+    const query = this._query({name: p["name"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependencyGraphExportSbom(
@@ -16213,7 +15378,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/dependency-graph/sbom`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async dependencyGraphCreateRepositorySnapshot(
@@ -16239,12 +15404,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/dependency-graph/snapshots`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposListDeployments(
@@ -16272,11 +15437,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateDeployment(
@@ -16314,12 +15475,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/deployments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetDeployment(
@@ -16336,7 +15497,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposDeleteDeployment(
@@ -16357,7 +15518,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListDeploymentStatuses(
@@ -16375,13 +15536,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateDeploymentStatus(
@@ -16414,12 +15571,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetDeploymentStatus(
@@ -16437,7 +15594,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/deployments/${p["deploymentId"]}/statuses/${p["statusId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateDispatchEvent(
@@ -16458,12 +15615,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/dispatches`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetAllEnvironments(
@@ -16486,13 +15643,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/environments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetEnvironment(
@@ -16509,7 +15662,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateOrUpdateEnvironment(
@@ -16536,12 +15689,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteAnEnvironment(
@@ -16558,7 +15711,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListDeploymentBranchPolicies(
@@ -16584,13 +15737,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateDeploymentBranchPolicy(
@@ -16609,12 +15758,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetDeploymentBranchPolicy(
@@ -16632,7 +15781,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies/${p["branchPolicyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateDeploymentBranchPolicy(
@@ -16650,12 +15799,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies/${p["branchPolicyId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteDeploymentBranchPolicy(
@@ -16673,7 +15822,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment-branch-policies/${p["branchPolicyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetAllDeploymentProtectionRules(
@@ -16698,7 +15847,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateDeploymentProtectionRule(
@@ -16717,12 +15866,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposListCustomDeploymentRuleIntegrations(
@@ -16748,13 +15897,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules/apps`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCustomDeploymentProtectionRule(
@@ -16772,7 +15917,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules/${p["protectionRuleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposDisableDeploymentProtectionRule(
@@ -16790,7 +15935,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/deployment_protection_rules/${p["protectionRuleId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListEnvironmentSecrets(
@@ -16816,13 +15961,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetEnvironmentPublicKey(
@@ -16839,7 +15980,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsGetEnvironmentSecret(
@@ -16857,7 +15998,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateOrUpdateEnvironmentSecret(
@@ -16878,12 +16019,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteEnvironmentSecret(
@@ -16901,7 +16042,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async actionsListEnvironmentVariables(
@@ -16927,13 +16068,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsCreateEnvironmentVariable(
@@ -16953,12 +16090,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async actionsGetEnvironmentVariable(
@@ -16976,7 +16113,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async actionsUpdateEnvironmentVariable(
@@ -16997,16 +16134,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async actionsDeleteEnvironmentVariable(
@@ -17024,7 +16157,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/environments/${p["environmentName"]}/variables/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async activityListRepoEvents(
@@ -17039,13 +16172,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListForks(
@@ -17072,11 +16201,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateFork(
@@ -17100,12 +16225,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/forks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gitCreateBlob(
@@ -17128,12 +16253,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/blobs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gitGetBlob(
@@ -17156,7 +16281,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/git/blobs/${p["fileSha"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitCreateCommit(
@@ -17190,12 +16315,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/commits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gitGetCommit(
@@ -17214,7 +16339,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/git/commits/${p["commitSha"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitListMatchingRefs(
@@ -17231,7 +16356,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/git/matching-refs/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitGetRef(
@@ -17249,7 +16374,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/ref/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitCreateRef(
@@ -17268,12 +16393,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/refs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gitUpdateRef(
@@ -17294,16 +16419,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/refs/${p["ref"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async gitDeleteRef(
@@ -17319,7 +16440,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/refs/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async gitCreateTag(
@@ -17345,12 +16466,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/tags`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gitGetTag(
@@ -17369,7 +16490,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/git/tags/${p["tagSha"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gitCreateTree(
@@ -17404,12 +16525,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/git/trees`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async gitGetTree(
@@ -17431,13 +16552,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/git/trees/${p["treeSha"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ recursive: p["recursive"] })
+    const query = this._query({recursive: p["recursive"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListWebhooks(
@@ -17452,13 +16569,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_hook[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/hooks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateWebhook(
@@ -17487,12 +16600,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/hooks`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetWebhook(
@@ -17508,7 +16621,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateWebhook(
@@ -17532,16 +16645,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteWebhook(
@@ -17557,7 +16666,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetWebhookConfigForRepo(
@@ -17574,7 +16683,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/config`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateWebhookConfigForRepo(
@@ -17596,16 +16705,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/config`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposListWebhookDeliveries(
@@ -17627,13 +16732,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/deliveries`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], cursor: p["cursor"] })
+    const query = this._query({per_page: p["perPage"], cursor: p["cursor"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetWebhookDelivery(
@@ -17655,7 +16756,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/deliveries/${p["deliveryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposRedeliverWebhookDelivery(
@@ -17682,7 +16783,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/deliveries/${p["deliveryId"]}/attempts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async reposPingWebhook(
@@ -17699,7 +16800,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/pings`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async reposTestPushWebhook(
@@ -17716,7 +16817,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/hooks/${p["hookId"]}/tests`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async migrationsGetImportStatus(
@@ -17732,7 +16833,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsStartImport(
@@ -17762,12 +16863,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async migrationsUpdateImport(
@@ -17791,16 +16892,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_import> | Res<503, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async migrationsCancelImport(
@@ -17814,7 +16911,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async migrationsGetCommitAuthors(
@@ -17833,13 +16930,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import/authors`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"] })
+    const query = this._query({since: p["since"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsMapCommitAuthor(
@@ -17864,16 +16957,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/import/authors/${p["authorId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async migrationsGetLargeFiles(
@@ -17888,7 +16977,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import/large_files`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsSetLfsPreference(
@@ -17906,16 +16995,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/import/lfs`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async appsGetRepoInstallation(
@@ -17931,7 +17016,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/installation`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async interactionsGetRestrictionsForRepo(
@@ -17946,7 +17031,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async interactionsSetRestrictionsForRepo(
@@ -17961,12 +17046,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async interactionsRemoveRestrictionsForRepo(
@@ -17981,7 +17066,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/interaction-limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListInvitations(
@@ -17996,13 +17081,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_repository_invitation[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateInvitation(
@@ -18027,16 +17108,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/invitations/${p["invitationId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteInvitation(
@@ -18053,7 +17130,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/invitations/${p["invitationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesListForRepo(
@@ -18098,11 +17175,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesCreate(
@@ -18147,12 +17220,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/issues`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesListCommentsForRepo(
@@ -18183,11 +17256,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesGetComment(
@@ -18204,7 +17273,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesUpdateComment(
@@ -18223,16 +17292,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async issuesDeleteComment(
@@ -18249,7 +17314,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForIssueComment(
@@ -18283,11 +17348,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForIssueComment(
@@ -18317,12 +17378,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForIssueComment(
@@ -18340,7 +17401,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/comments/${p["commentId"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesListEventsForRepo(
@@ -18356,13 +17417,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/issues/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesGetEvent(
@@ -18384,7 +17441,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/events/${p["eventId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesGet(
@@ -18407,7 +17464,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesUpdate(
@@ -18462,16 +17519,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async issuesAddAssignees(
@@ -18490,12 +17543,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesRemoveAssignees(
@@ -18514,16 +17567,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async issuesCheckUserCanBeAssignedToIssue(
@@ -18541,7 +17590,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/assignees/${p["assignee"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesListComments(
@@ -18570,11 +17619,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesCreateComment(
@@ -18599,12 +17644,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesListEvents(
@@ -18622,13 +17667,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesListLabelsOnIssue(
@@ -18651,13 +17692,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesAddLabels(
@@ -18693,12 +17730,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesSetLabels(
@@ -18734,12 +17771,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async issuesRemoveAllLabels(
@@ -18761,7 +17798,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesRemoveLabel(
@@ -18784,7 +17821,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/labels/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesLock(
@@ -18814,12 +17851,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/lock`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async issuesUnlock(
@@ -18838,7 +17875,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/lock`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForIssue(
@@ -18874,11 +17911,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForIssue(
@@ -18908,12 +17941,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForIssue(
@@ -18931,7 +17964,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesRemoveSubIssue(
@@ -18952,16 +17985,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issue`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async issuesListSubIssues(
@@ -18981,13 +18010,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issues`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesAddSubIssue(
@@ -19013,12 +18038,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issues`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesReprioritizeSubIssue(
@@ -19052,16 +18077,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/sub_issues/priority`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async issuesListEventsForTimeline(
@@ -19083,13 +18104,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/issues/${p["issueNumber"]}/timeline`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListDeployKeys(
@@ -19104,13 +18121,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deploy_key[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateDeployKey(
@@ -19128,12 +18141,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_deploy_key> | Res<422, t_validation_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetDeployKey(
@@ -19149,7 +18162,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/keys/${p["keyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposDeleteDeployKey(
@@ -19165,7 +18178,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/keys/${p["keyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesListLabelsForRepo(
@@ -19180,13 +18193,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_label[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/labels`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesCreateLabel(
@@ -19206,12 +18215,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/labels`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesGetLabel(
@@ -19227,7 +18236,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesUpdateLabel(
@@ -19247,16 +18256,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async issuesDeleteLabel(
@@ -19272,7 +18277,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/labels/${p["name"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListLanguages(
@@ -19286,7 +18291,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/languages`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async licensesGetForRepo(
@@ -19300,13 +18305,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_license_content> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/license`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposMergeUpstream(
@@ -19323,12 +18324,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/merge-upstream`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposMerge(
@@ -19353,12 +18354,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/merges`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesListMilestones(
@@ -19384,11 +18385,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesCreateMilestone(
@@ -19411,12 +18408,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/milestones`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async issuesGetMilestone(
@@ -19433,7 +18430,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async issuesUpdateMilestone(
@@ -19455,16 +18452,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async issuesDeleteMilestone(
@@ -19481,7 +18474,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesListLabelsForMilestone(
@@ -19499,13 +18492,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/milestones/${p["milestoneNumber"]}/labels`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListRepoNotificationsForAuthenticatedUser(
@@ -19534,11 +18523,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityMarkRepoNotificationsAsRead(
@@ -19564,12 +18549,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/notifications`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposGetPages(
@@ -19583,7 +18568,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreatePagesSite(
@@ -19605,12 +18590,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposUpdateInformationAboutPagesSite(
@@ -19642,12 +18627,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeletePagesSite(
@@ -19666,7 +18651,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListPagesBuilds(
@@ -19681,13 +18666,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_page_build[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages/builds`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposRequestPagesBuild(
@@ -19701,7 +18682,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages/builds`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async reposGetLatestPagesBuild(
@@ -19716,7 +18697,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages/builds/latest`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetPagesBuild(
@@ -19733,7 +18714,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pages/builds/${p["buildId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreatePagesDeployment(
@@ -19759,12 +18740,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages/deployments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetPagesDeployment(
@@ -19781,7 +18762,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pages/deployments/${p["pagesDeploymentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCancelPagesDeployment(
@@ -19798,7 +18779,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pages/deployments/${p["pagesDeploymentId"]}/cancel`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async reposGetPagesHealthCheck(
@@ -19818,7 +18799,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pages/health`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCheckPrivateVulnerabilityReporting(
@@ -19842,7 +18823,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/private-vulnerability-reporting`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposEnablePrivateVulnerabilityReporting(
@@ -19858,7 +18839,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/private-vulnerability-reporting`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async reposDisablePrivateVulnerabilityReporting(
@@ -19874,7 +18855,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/private-vulnerability-reporting`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async projectsListForRepo(
@@ -19903,11 +18884,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async projectsCreateForRepo(
@@ -19931,12 +18908,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/projects`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetCustomPropertiesValues(
@@ -19955,7 +18932,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/properties/values`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateOrUpdateCustomPropertiesValues(
@@ -19977,16 +18954,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/properties/values`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async pullsList(
@@ -20025,11 +18998,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsCreate(
@@ -20056,12 +19025,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/pulls`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsListReviewCommentsForRepo(
@@ -20088,11 +19057,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsGetReviewComment(
@@ -20111,7 +19076,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsUpdateReviewComment(
@@ -20130,16 +19095,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async pullsDeleteReviewComment(
@@ -20156,7 +19117,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForPullRequestReviewComment(
@@ -20190,11 +19151,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForPullRequestReviewComment(
@@ -20224,12 +19181,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForPullRequestComment(
@@ -20247,7 +19204,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/comments/${p["commentId"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async pullsGet(
@@ -20278,7 +19235,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsUpdate(
@@ -20305,16 +19262,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async codespacesCreateWithPrForAuthenticatedUser(
@@ -20361,12 +19314,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/codespaces`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsListReviewComments(
@@ -20395,11 +19348,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsCreateReviewComment(
@@ -20431,12 +19380,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsCreateReplyForReviewComment(
@@ -20458,12 +19407,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/comments/${p["commentId"]}/replies`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsListCommits(
@@ -20481,13 +19430,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/commits`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsListFiles(
@@ -20517,13 +19462,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/files`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsCheckIfMerged(
@@ -20540,7 +19481,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/merge`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsMerge(
@@ -20581,12 +19522,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/merge`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async pullsListRequestedReviewers(
@@ -20603,7 +19544,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsRequestReviewers(
@@ -20625,12 +19566,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsRemoveRequestedReviewers(
@@ -20650,16 +19591,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/requested_reviewers`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async pullsListReviews(
@@ -20677,13 +19614,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsCreateReview(
@@ -20721,12 +19654,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsGetReview(
@@ -20744,7 +19677,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsUpdateReview(
@@ -20766,12 +19699,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async pullsDeletePendingReview(
@@ -20793,7 +19726,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async pullsListCommentsForReview(
@@ -20812,13 +19745,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/comments`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async pullsDismissReview(
@@ -20843,12 +19772,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/dismissals`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async pullsSubmitReview(
@@ -20878,12 +19807,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/reviews/${p["reviewId"]}/events`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pullsUpdateBranch(
@@ -20912,12 +19841,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/pulls/${p["pullNumber"]}/update-branch`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposGetReadme(
@@ -20936,13 +19865,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/readme`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetReadmeInDirectory(
@@ -20962,13 +19887,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/readme/${p["dir"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ ref: p["ref"] })
+    const query = this._query({ref: p["ref"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListReleases(
@@ -20983,13 +19904,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_release[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/releases`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateRelease(
@@ -21015,12 +19932,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/releases`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetReleaseAsset(
@@ -21039,7 +19956,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateReleaseAsset(
@@ -21060,16 +19977,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteReleaseAsset(
@@ -21086,7 +19999,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/releases/assets/${p["assetId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGenerateReleaseNotes(
@@ -21107,12 +20020,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/releases/generate-notes`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetLatestRelease(
@@ -21127,7 +20040,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/releases/latest`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetReleaseByTag(
@@ -21144,7 +20057,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/releases/tags/${p["tag"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetRelease(
@@ -21161,7 +20074,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateRelease(
@@ -21187,16 +20100,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteRelease(
@@ -21213,7 +20122,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListReleaseAssets(
@@ -21231,13 +20140,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/assets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUploadReleaseAsset(
@@ -21261,15 +20166,15 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       basePath +
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/assets`
     const headers = this._headers(
-      { "Content-Type": "application/octet-stream" },
+      {"Content-Type": "application/octet-stream"},
       opts.headers,
     )
-    const query = this._query({ name: p["name"], label: p["label"] })
+    const query = this._query({name: p["name"], label: p["label"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
@@ -21303,11 +20208,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForRelease(
@@ -21335,12 +20236,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsDeleteForRelease(
@@ -21358,7 +20259,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/releases/${p["releaseId"]}/reactions/${p["reactionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetBranchRules(
@@ -21376,13 +20277,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/rules/branches/${p["branch"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetRepoRulesets(
@@ -21410,11 +20307,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       targets: p["targets"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateRepoRuleset(
@@ -21439,12 +20332,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/rulesets`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposGetRepoRuleSuites(
@@ -21480,11 +20373,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetRepoRuleSuite(
@@ -21503,7 +20392,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/rulesets/rule-suites/${p["ruleSuiteId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetRepoRuleset(
@@ -21524,13 +20413,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ includes_parents: p["includesParents"] })
+    const query = this._query({includes_parents: p["includesParents"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposUpdateRepoRuleset(
@@ -21558,12 +20443,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteRepoRuleset(
@@ -21582,7 +20467,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposGetRepoRulesetHistory(
@@ -21604,13 +20489,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}/history`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetRepoRulesetVersion(
@@ -21632,7 +20513,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/rulesets/${p["rulesetId"]}/history/${p["versionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async secretScanningListAlertsForRepo(
@@ -21686,11 +20567,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       hide_secret: p["hideSecret"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async secretScanningGetAlert(
@@ -21719,13 +20596,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ hide_secret: p["hideSecret"] })
+    const query = this._query({hide_secret: p["hideSecret"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async secretScanningUpdateAlert(
@@ -21759,16 +20632,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/alerts/${p["alertNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async secretScanningListLocationsForAlert(
@@ -21797,13 +20666,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/alerts/${p["alertNumber"]}/locations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async secretScanningCreatePushProtectionBypass(
@@ -21835,12 +20700,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/push-protection-bypasses`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async secretScanningGetScanHistory(
@@ -21867,7 +20732,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/secret-scanning/scan-history`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesListRepositoryAdvisories(
@@ -21905,11 +20770,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesCreateRepositoryAdvisory(
@@ -21929,12 +20790,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/security-advisories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesCreatePrivateVulnerabilityReport(
@@ -21955,12 +20816,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/security-advisories/reports`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesGetRepositoryAdvisory(
@@ -21981,7 +20842,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/security-advisories/${p["ghsaId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesUpdateRepositoryAdvisory(
@@ -22003,16 +20864,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["owner"]}/${p["repo"]}/security-advisories/${p["ghsaId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesCreateRepositoryAdvisoryCveRequest(
@@ -22040,7 +20897,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/security-advisories/${p["ghsaId"]}/cve`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async securityAdvisoriesCreateFork(
@@ -22063,7 +20920,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/security-advisories/${p["ghsaId"]}/forks`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async activityListStargazersForRepo(
@@ -22080,13 +20937,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/stargazers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCodeFrequencyStats(
@@ -22111,7 +20964,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/stats/code_frequency`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetCommitActivityStats(
@@ -22135,7 +20988,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/stats/commit_activity`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetContributorsStats(
@@ -22159,7 +21012,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/stats/contributors`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetParticipationStats(
@@ -22174,7 +21027,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/stats/participation`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetPunchCardStats(
@@ -22189,7 +21042,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/stats/punch_card`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateCommitStatus(
@@ -22215,12 +21068,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/statuses/${p["sha"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async activityListWatchersForRepo(
@@ -22235,13 +21088,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscribers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityGetRepoSubscription(
@@ -22259,7 +21108,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activitySetRepoSubscription(
@@ -22276,12 +21125,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_repository_subscription>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async activityDeleteRepoSubscription(
@@ -22295,7 +21144,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/subscription`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposListTags(
@@ -22310,13 +21159,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tag[]>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/tags`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListTagProtection(
@@ -22335,7 +21180,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/tags/protection`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateTagProtection(
@@ -22356,12 +21201,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/tags/protection`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposDeleteTagProtection(
@@ -22380,7 +21225,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/tags/protection/${p["tagProtectionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposDownloadTarballArchive(
@@ -22396,7 +21241,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/tarball/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListTeams(
@@ -22411,13 +21256,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_team[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetAllTopics(
@@ -22432,13 +21273,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_topic> | Res<404, t_basic_error>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/topics`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ page: p["page"], per_page: p["perPage"] })
+    const query = this._query({page: p["page"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposReplaceAllTopics(
@@ -22458,12 +21295,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/topics`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async reposGetClones(
@@ -22478,13 +21315,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/traffic/clones`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per: p["per"] })
+    const query = this._query({per: p["per"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetTopPaths(
@@ -22499,7 +21332,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/traffic/popular/paths`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetTopReferrers(
@@ -22515,7 +21348,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/repos/${p["owner"]}/${p["repo"]}/traffic/popular/referrers`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposGetViews(
@@ -22530,13 +21363,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/traffic/views`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per: p["per"] })
+    const query = this._query({per: p["per"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposTransfer(
@@ -22554,12 +21383,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<202, t_minimal_repository>> {
     const url = this.basePath + `/repos/${p["owner"]}/${p["repo"]}/transfer`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposCheckVulnerabilityAlerts(
@@ -22574,7 +21403,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/vulnerability-alerts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposEnableVulnerabilityAlerts(
@@ -22589,7 +21418,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/vulnerability-alerts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async reposDisableVulnerabilityAlerts(
@@ -22604,7 +21433,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/vulnerability-alerts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reposDownloadZipballArchive(
@@ -22620,7 +21449,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/repos/${p["owner"]}/${p["repo"]}/zipball/${p["ref"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateUsingTemplate(
@@ -22642,12 +21471,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/repos/${p["templateOwner"]}/${p["templateRepo"]}/generate`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposListPublic(
@@ -22663,13 +21492,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"] })
+    const query = this._query({since: p["since"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchCode(
@@ -22713,11 +21538,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchCommits(
@@ -22751,11 +21572,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchIssuesAndPullRequests(
@@ -22813,11 +21630,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       advanced_search: p["advancedSearch"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchLabels(
@@ -22856,11 +21669,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchRepos(
@@ -22908,11 +21717,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchTopics(
@@ -22942,11 +21747,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async searchUsers(
@@ -22989,11 +21790,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsGetLegacy(
@@ -23006,7 +21803,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/teams/${p["teamId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsUpdateLegacy(
@@ -23035,16 +21832,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/teams/${p["teamId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async teamsDeleteLegacy(
@@ -23059,7 +21852,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/teams/${p["teamId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListDiscussionsLegacy(
@@ -23080,11 +21873,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCreateDiscussionLegacy(
@@ -23101,12 +21890,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<201, t_team_discussion>> {
     const url = this.basePath + `/teams/${p["teamId"]}/discussions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async teamsGetDiscussionLegacy(
@@ -23122,7 +21911,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsUpdateDiscussionLegacy(
@@ -23141,16 +21930,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async teamsDeleteDiscussionLegacy(
@@ -23166,7 +21951,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListDiscussionCommentsLegacy(
@@ -23190,11 +21975,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCreateDiscussionCommentLegacy(
@@ -23212,12 +21993,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async teamsGetDiscussionCommentLegacy(
@@ -23234,7 +22015,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsUpdateDiscussionCommentLegacy(
@@ -23253,16 +22034,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async teamsDeleteDiscussionCommentLegacy(
@@ -23279,7 +22056,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async reactionsListForTeamDiscussionCommentLegacy(
@@ -23313,11 +22090,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForTeamDiscussionCommentLegacy(
@@ -23345,12 +22118,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/comments/${p["commentNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reactionsListForTeamDiscussionLegacy(
@@ -23383,11 +22156,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reactionsCreateForTeamDiscussionLegacy(
@@ -23414,12 +22183,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/teams/${p["teamId"]}/discussions/${p["discussionNumber"]}/reactions`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async teamsListPendingInvitationsLegacy(
@@ -23433,13 +22202,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_organization_invitation[]>> {
     const url = this.basePath + `/teams/${p["teamId"]}/invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsListMembersLegacy(
@@ -23460,11 +22225,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsGetMemberLegacy(
@@ -23478,7 +22239,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/teams/${p["teamId"]}/members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddMemberLegacy(
@@ -23494,7 +22255,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/teams/${p["teamId"]}/members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async teamsRemoveMemberLegacy(
@@ -23508,7 +22269,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/teams/${p["teamId"]}/members/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsGetMembershipForUserLegacy(
@@ -23523,7 +22284,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/teams/${p["teamId"]}/memberships/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddOrUpdateMembershipForUserLegacy(
@@ -23545,12 +22306,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/teams/${p["teamId"]}/memberships/${p["username"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async teamsRemoveMembershipForUserLegacy(
@@ -23565,7 +22326,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/teams/${p["teamId"]}/memberships/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListProjectsLegacy(
@@ -23579,13 +22340,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_team_project[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/teams/${p["teamId"]}/projects`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCheckPermissionsForProjectLegacy(
@@ -23600,7 +22357,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/teams/${p["teamId"]}/projects/${p["projectId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddOrUpdateProjectPermissionsLegacy(
@@ -23628,12 +22385,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/teams/${p["teamId"]}/projects/${p["projectId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async teamsRemoveProjectLegacy(
@@ -23650,7 +22407,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/teams/${p["teamId"]}/projects/${p["projectId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListReposLegacy(
@@ -23664,13 +22421,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_minimal_repository[]> | Res<404, t_basic_error>> {
     const url = this.basePath + `/teams/${p["teamId"]}/repos`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsCheckPermissionsForRepoLegacy(
@@ -23686,7 +22439,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsAddOrUpdateRepoPermissionsLegacy(
@@ -23706,12 +22459,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async teamsRemoveRepoLegacy(
@@ -23727,7 +22480,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/teams/${p["teamId"]}/repos/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async teamsListChildLegacy(
@@ -23746,13 +22499,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/teams/${p["teamId"]}/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersGetAuthenticated(
@@ -23767,7 +22516,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersUpdateAuthenticated(
@@ -23795,16 +22544,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async usersListBlockedByAuthenticatedUser(
@@ -23823,13 +22568,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/blocks`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersCheckBlocked(
@@ -23848,7 +22589,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/blocks/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersBlock(
@@ -23868,7 +22609,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/blocks/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async usersUnblock(
@@ -23887,7 +22628,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/blocks/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesListForAuthenticatedUser(
@@ -23920,11 +22661,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       repository_id: p["repositoryId"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCreateForAuthenticatedUser(
@@ -23986,12 +22723,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/codespaces`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codespacesListSecretsForAuthenticatedUser(
@@ -24012,13 +22749,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/codespaces/secrets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesGetPublicKeyForAuthenticatedUser(
@@ -24028,7 +22761,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/secrets/public-key`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesGetSecretForAuthenticatedUser(
@@ -24041,7 +22774,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCreateOrUpdateSecretForAuthenticatedUser(
@@ -24063,12 +22796,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codespacesDeleteSecretForAuthenticatedUser(
@@ -24081,7 +22814,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/secrets/${p["secretName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesListRepositoriesForSecretForAuthenticatedUser(
@@ -24107,7 +22840,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/user/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesSetRepositoriesForSecretForAuthenticatedUser(
@@ -24129,12 +22862,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/user/codespaces/secrets/${p["secretName"]}/repositories`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async codespacesAddRepositoryForSecretForAuthenticatedUser(
@@ -24156,7 +22889,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/codespaces/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async codespacesRemoveRepositoryForSecretForAuthenticatedUser(
@@ -24178,7 +22911,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/codespaces/secrets/${p["secretName"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesGetForAuthenticatedUser(
@@ -24198,7 +22931,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesUpdateForAuthenticatedUser(
@@ -24220,16 +22953,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async codespacesDeleteForAuthenticatedUser(
@@ -24254,7 +22983,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async codespacesExportForAuthenticatedUser(
@@ -24274,7 +23003,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}/exports`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async codespacesGetExportDetailsForAuthenticatedUser(
@@ -24290,7 +23019,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/codespaces/${p["codespaceName"]}/exports/${p["exportId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesCodespaceMachinesForAuthenticatedUser(
@@ -24317,7 +23046,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/user/codespaces/${p["codespaceName"]}/machines`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async codespacesPublishForAuthenticatedUser(
@@ -24339,12 +23068,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}/publish`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async codespacesStartForAuthenticatedUser(
@@ -24367,7 +23096,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}/start`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async codespacesStopForAuthenticatedUser(
@@ -24386,7 +23115,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/codespaces/${p["codespaceName"]}/stop`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async packagesListDockerMigrationConflictingPackagesForAuthenticatedUser(
@@ -24396,7 +23125,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/docker/conflicts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersSetPrimaryEmailVisibilityForAuthenticatedUser(
@@ -24417,16 +23146,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/email/visibility`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async usersListEmailsForAuthenticatedUser(
@@ -24445,13 +23170,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/emails`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersAddEmailForAuthenticatedUser(
@@ -24475,12 +23196,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/emails`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersDeleteEmailForAuthenticatedUser(
@@ -24504,16 +23225,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/emails`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async usersListFollowersForAuthenticatedUser(
@@ -24531,13 +23248,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/followers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListFollowedByAuthenticatedUser(
@@ -24555,13 +23268,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/following`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersCheckPersonIsFollowedByAuthenticated(
@@ -24580,7 +23289,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/following/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersFollow(
@@ -24600,7 +23309,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/following/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async usersUnfollow(
@@ -24619,7 +23328,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/following/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async usersListGpgKeysForAuthenticatedUser(
@@ -24638,13 +23347,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/gpg_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersCreateGpgKeyForAuthenticatedUser(
@@ -24666,12 +23371,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/gpg_keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersGetGpgKeyForAuthenticatedUser(
@@ -24690,7 +23395,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/gpg_keys/${p["gpgKeyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersDeleteGpgKeyForAuthenticatedUser(
@@ -24710,7 +23415,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/gpg_keys/${p["gpgKeyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async appsListInstallationsForAuthenticatedUser(
@@ -24734,13 +23439,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/installations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListInstallationReposForAuthenticatedUser(
@@ -24767,13 +23468,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/user/installations/${p["installationId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsAddRepoToInstallationForAuthenticatedUser(
@@ -24794,7 +23491,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/installations/${p["installationId"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async appsRemoveRepoFromInstallationForAuthenticatedUser(
@@ -24816,7 +23513,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/installations/${p["installationId"]}/repositories/${p["repositoryId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async interactionsGetRestrictionsForAuthenticatedUser(
@@ -24828,7 +23525,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/interaction-limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async interactionsSetRestrictionsForAuthenticatedUser(
@@ -24842,12 +23539,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/interaction-limits`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async interactionsRemoveRestrictionsForAuthenticatedUser(
@@ -24857,7 +23554,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/interaction-limits`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async issuesListForAuthenticatedUser(
@@ -24894,11 +23591,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListPublicSshKeysForAuthenticatedUser(
@@ -24917,13 +23610,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersCreatePublicSshKeyForAuthenticatedUser(
@@ -24945,12 +23634,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersGetPublicSshKeyForAuthenticatedUser(
@@ -24969,7 +23658,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/keys/${p["keyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersDeletePublicSshKeyForAuthenticatedUser(
@@ -24988,7 +23677,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/keys/${p["keyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async appsListSubscriptionsForAuthenticatedUser(
@@ -25006,13 +23695,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/marketplace_purchases`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsListSubscriptionsForAuthenticatedUserStubbed(
@@ -25029,13 +23714,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/marketplace_purchases/stubbed`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListMembershipsForAuthenticatedUser(
@@ -25061,11 +23742,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsGetMembershipForAuthenticatedUser(
@@ -25082,7 +23759,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/memberships/orgs/${p["org"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsUpdateMembershipForAuthenticatedUser(
@@ -25102,16 +23779,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/memberships/orgs/${p["org"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async migrationsListForAuthenticatedUser(
@@ -25129,13 +23802,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/migrations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsStartForAuthenticatedUser(
@@ -25163,12 +23832,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/migrations`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async migrationsGetStatusForAuthenticatedUser(
@@ -25187,13 +23856,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/migrations/${p["migrationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ exclude: p["exclude"] })
+    const query = this._query({exclude: p["exclude"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsGetArchiveForAuthenticatedUser(
@@ -25211,7 +23876,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/migrations/${p["migrationId"]}/archive`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async migrationsDeleteArchiveForAuthenticatedUser(
@@ -25230,7 +23895,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/migrations/${p["migrationId"]}/archive`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async migrationsUnlockRepoForAuthenticatedUser(
@@ -25252,7 +23917,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/migrations/${p["migrationId"]}/repos/${p["repoName"]}/lock`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async migrationsListReposForAuthenticatedUser(
@@ -25267,13 +23932,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/user/migrations/${p["migrationId"]}/repositories`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListForAuthenticatedUser(
@@ -25291,13 +23952,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/orgs`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesListPackagesForAuthenticatedUser(
@@ -25326,11 +23983,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesGetPackageForAuthenticatedUser(
@@ -25352,7 +24005,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/user/packages/${p["packageType"]}/${p["packageName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesDeletePackageForAuthenticatedUser(
@@ -25379,7 +24032,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/user/packages/${p["packageType"]}/${p["packageName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesRestorePackageForAuthenticatedUser(
@@ -25407,13 +24060,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/user/packages/${p["packageType"]}/${p["packageName"]}/restore`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ token: p["token"] })
+    const query = this._query({token: p["token"]})
 
-    return this._fetch(
-      url + query,
-      { method: "POST", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "POST", ...opts, headers}, timeout)
   }
 
   async packagesGetAllPackageVersionsForPackageOwnedByAuthenticatedUser(
@@ -25449,11 +24098,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesGetPackageVersionForAuthenticatedUser(
@@ -25477,7 +24122,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesDeletePackageVersionForAuthenticatedUser(
@@ -25506,7 +24151,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesRestorePackageVersionForAuthenticatedUser(
@@ -25535,7 +24180,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/user/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}/restore`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async projectsCreateForAuthenticatedUser(
@@ -25556,12 +24201,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/projects`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersListPublicEmailsForAuthenticatedUser(
@@ -25580,13 +24225,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/public_emails`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListForAuthenticatedUser(
@@ -25635,11 +24276,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       before: p["before"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposCreateForAuthenticatedUser(
@@ -25697,12 +24334,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/repos`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async reposListInvitationsForAuthenticatedUser(
@@ -25721,13 +24358,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/repository_invitations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposAcceptInvitationForAuthenticatedUser(
@@ -25747,7 +24380,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/user/repository_invitations/${p["invitationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PATCH", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PATCH", ...opts, headers}, timeout)
   }
 
   async reposDeclineInvitationForAuthenticatedUser(
@@ -25767,7 +24400,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/user/repository_invitations/${p["invitationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async usersListSocialAccountsForAuthenticatedUser(
@@ -25786,13 +24419,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/social_accounts`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersAddSocialAccountForAuthenticatedUser(
@@ -25813,12 +24442,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/social_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersDeleteSocialAccountForAuthenticatedUser(
@@ -25839,16 +24468,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/social_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async usersListSshSigningKeysForAuthenticatedUser(
@@ -25867,13 +24492,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/ssh_signing_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersCreateSshSigningKeyForAuthenticatedUser(
@@ -25895,12 +24516,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/ssh_signing_keys`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersGetSshSigningKeyForAuthenticatedUser(
@@ -25919,7 +24540,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/ssh_signing_keys/${p["sshSigningKeyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersDeleteSshSigningKeyForAuthenticatedUser(
@@ -25938,7 +24559,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/ssh_signing_keys/${p["sshSigningKeyId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async activityListReposStarredByAuthenticatedUser(
@@ -25965,11 +24586,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityCheckRepoIsStarredByAuthenticatedUser(
@@ -25989,7 +24606,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/starred/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityStarRepoForAuthenticatedUser(
@@ -26009,7 +24626,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/starred/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "PUT", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", ...opts, headers}, timeout)
   }
 
   async activityUnstarRepoForAuthenticatedUser(
@@ -26029,7 +24646,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/starred/${p["owner"]}/${p["repo"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async activityListWatchedReposForAuthenticatedUser(
@@ -26047,13 +24664,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/subscriptions`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async teamsListForAuthenticatedUser(
@@ -26071,13 +24684,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/user/teams`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersGetById(
@@ -26092,7 +24701,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/user/${p["accountId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersList(
@@ -26105,13 +24714,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]> | Res<304, void>> {
     const url = this.basePath + `/users`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ since: p["since"], per_page: p["perPage"] })
+    const query = this._query({since: p["since"], per_page: p["perPage"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersGetByUsername(
@@ -26126,7 +24731,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/users/${p["username"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListAttestationsBulk(
@@ -26177,7 +24782,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/users/${p["username"]}/attestations/bulk-list`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const query = this._query({
@@ -26189,7 +24794,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
@@ -26211,12 +24816,12 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/users/${p["username"]}/attestations/delete-request`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async usersDeleteAttestationsBySubjectDigest(
@@ -26232,7 +24837,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/attestations/digest/${p["subjectDigest"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async usersDeleteAttestationsById(
@@ -26253,7 +24858,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/attestations/${p["attestationId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async usersListAttestations(
@@ -26301,11 +24906,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       predicate_type: p["predicateType"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesListDockerMigrationConflictingPackagesForUser(
@@ -26320,7 +24921,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/users/${p["username"]}/docker/conflicts`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListEventsForAuthenticatedUser(
@@ -26334,13 +24935,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event[]>> {
     const url = this.basePath + `/users/${p["username"]}/events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListOrgEventsForAuthenticatedUser(
@@ -26356,13 +24953,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url =
       this.basePath + `/users/${p["username"]}/events/orgs/${p["org"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListPublicEventsForUser(
@@ -26376,13 +24969,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event[]>> {
     const url = this.basePath + `/users/${p["username"]}/events/public`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListFollowersForUser(
@@ -26396,13 +24985,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]>> {
     const url = this.basePath + `/users/${p["username"]}/followers`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListFollowingForUser(
@@ -26416,13 +25001,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_simple_user[]>> {
     const url = this.basePath + `/users/${p["username"]}/following`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersCheckFollowingForUser(
@@ -26437,7 +25018,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/users/${p["username"]}/following/${p["targetUser"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async gistsListForUser(
@@ -26458,11 +25039,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListGpgKeysForUser(
@@ -26476,13 +25053,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_gpg_key[]>> {
     const url = this.basePath + `/users/${p["username"]}/gpg_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersGetContextForUser(
@@ -26510,11 +25083,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       subject_id: p["subjectId"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async appsGetUserInstallation(
@@ -26527,7 +25096,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/users/${p["username"]}/installation`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListPublicKeysForUser(
@@ -26541,13 +25110,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_key_simple[]>> {
     const url = this.basePath + `/users/${p["username"]}/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async orgsListForUser(
@@ -26561,13 +25126,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_organization_simple[]>> {
     const url = this.basePath + `/users/${p["username"]}/orgs`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesListPackagesForUser(
@@ -26602,11 +25163,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       per_page: p["perPage"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesGetPackageForUser(
@@ -26630,7 +25187,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesDeletePackageForUser(
@@ -26659,7 +25216,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesRestorePackageForUser(
@@ -26688,13 +25245,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath +
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}/restore`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ token: p["token"] })
+    const query = this._query({token: p["token"]})
 
-    return this._fetch(
-      url + query,
-      { method: "POST", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "POST", ...opts, headers}, timeout)
   }
 
   async packagesGetAllPackageVersionsForPackageOwnedByUser(
@@ -26723,7 +25276,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}/versions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesGetPackageVersionForUser(
@@ -26748,7 +25301,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async packagesDeletePackageVersionForUser(
@@ -26778,7 +25331,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async packagesRestorePackageVersionForUser(
@@ -26808,7 +25361,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       `/users/${p["username"]}/packages/${p["packageType"]}/${p["packageName"]}/versions/${p["packageVersionId"]}/restore`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async projectsListForUser(
@@ -26829,11 +25382,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListReceivedEventsForUser(
@@ -26847,13 +25396,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event[]>> {
     const url = this.basePath + `/users/${p["username"]}/received_events`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListReceivedPublicEventsForUser(
@@ -26867,13 +25412,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event[]>> {
     const url = this.basePath + `/users/${p["username"]}/received_events/public`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async reposListForUser(
@@ -26903,11 +25444,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async billingGetGithubActionsBillingUser(
@@ -26921,7 +25458,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/users/${p["username"]}/settings/billing/actions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async billingGetGithubPackagesBillingUser(
@@ -26935,7 +25472,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/users/${p["username"]}/settings/billing/packages`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async billingGetSharedStorageBillingUser(
@@ -26949,7 +25486,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       this.basePath + `/users/${p["username"]}/settings/billing/shared-storage`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async billingGetGithubBillingUsageReportUser(
@@ -26985,11 +25522,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       hour: p["hour"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListSocialAccountsForUser(
@@ -27003,13 +25536,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_social_account[]>> {
     const url = this.basePath + `/users/${p["username"]}/social_accounts`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async usersListSshSigningKeysForUser(
@@ -27023,13 +25552,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_ssh_signing_key[]>> {
     const url = this.basePath + `/users/${p["username"]}/ssh_signing_keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListReposStarredByUser(
@@ -27052,11 +25577,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
       page: p["page"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async activityListReposWatchedByUser(
@@ -27070,13 +25591,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
   ): Promise<Res<200, t_minimal_repository[]>> {
     const url = this.basePath + `/users/${p["username"]}/subscriptions`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ per_page: p["perPage"], page: p["page"] })
+    const query = this._query({per_page: p["perPage"], page: p["page"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async metaGetAllVersions(
@@ -27086,7 +25603,7 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/versions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async metaGetZen(
@@ -27096,9 +25613,9 @@ export class GitHubV3RestApi extends AbstractFetchClient {
     const url = this.basePath + `/zen`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 }
 
-export { GitHubV3RestApi as ApiClient }
-export type { GitHubV3RestApiConfig as ApiClientConfig }
+export {GitHubV3RestApi as ApiClient}
+export type {GitHubV3RestApiConfig as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/api.github.com.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-core-data-plane-service.tsp/client.ts
@@ -76,16 +76,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   > {
     const url = this.basePath + `/service-status`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatus(
@@ -117,13 +113,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       this.basePath +
       `/widgets/${p["widgetName"]}/operations/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetsCreateOrUpdateWidget(
@@ -160,12 +152,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "PATCH", body, ...opts, headers },
+      {method: "PATCH", body, ...opts, headers},
       timeout,
     )
   }
@@ -196,13 +188,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetsDeleteWidget(
@@ -243,11 +231,11 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._fetch(
       url + query,
-      { method: "DELETE", ...opts, headers },
+      {method: "DELETE", ...opts, headers},
       timeout,
     )
   }
@@ -269,7 +257,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   > {
     const url = this.basePath + `/widgets`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
     const query = this._query({
@@ -280,11 +268,7 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       select: p["select"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetsGetAnalytics(
@@ -314,13 +298,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetsUpdateAnalytics(
@@ -357,12 +337,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "PATCH", body, ...opts, headers },
+      {method: "PATCH", body, ...opts, headers},
       timeout,
     )
   }
@@ -390,13 +370,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
     const url =
       this.basePath + `/widgets/${p["widgetId"]}/repairs/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetsScheduleRepairs(
@@ -438,12 +414,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
@@ -473,13 +449,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       this.basePath +
       `/widgets/${p["widgetName"]}/parts/${p["widgetPartName"]}/operations/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetPartsCreateWidgetPart(
@@ -514,12 +486,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
@@ -538,16 +510,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   > {
     const url = this.basePath + `/widgets/${p["widgetName"]}/parts`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetPartsGetWidgetPart(
@@ -579,13 +547,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async widgetPartsDeleteWidgetPart(
@@ -620,11 +584,11 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._fetch(
       url + query,
-      { method: "DELETE", ...opts, headers },
+      {method: "DELETE", ...opts, headers},
       timeout,
     )
   }
@@ -661,12 +625,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
@@ -695,13 +659,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       this.basePath +
       `/manufacturers/${p["manufacturerId"]}/operations/${p["operationId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async manufacturersCreateOrReplaceManufacturer(
@@ -738,12 +698,12 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "PUT", body, ...opts, headers },
+      {method: "PUT", body, ...opts, headers},
       timeout,
     )
   }
@@ -775,13 +735,9 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async manufacturersDeleteManufacturer(
@@ -822,11 +778,11 @@ export class ContosoWidgetManager extends AbstractFetchClient {
       },
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._fetch(
       url + query,
-      { method: "DELETE", ...opts, headers },
+      {method: "DELETE", ...opts, headers},
       timeout,
     )
   }
@@ -844,18 +800,14 @@ export class ContosoWidgetManager extends AbstractFetchClient {
   > {
     const url = this.basePath + `/manufacturers`
     const headers = this._headers(
-      { "x-ms-client-request-id": p["xMsClientRequestId"] },
+      {"x-ms-client-request-id": p["xMsClientRequestId"]},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 }
 
-export { ContosoWidgetManager as ApiClient }
-export type { ContosoWidgetManagerConfig as ApiClientConfig }
+export {ContosoWidgetManager as ApiClient}
+export type {ContosoWidgetManagerConfig as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/client.ts
@@ -27,7 +27,7 @@ export class ContosoProviderHubClientServers {
 
   static server(
     url: "https://management.azure.com" = "https://management.azure.com",
-  ): { build: () => Server<"ContosoProviderHubClient"> } {
+  ): {build: () => Server<"ContosoProviderHubClient">} {
     switch (url) {
       case "https://management.azure.com":
         return {
@@ -65,13 +65,9 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
     const url =
       this.basePath + `/providers/Microsoft.ContosoProviderHub/operations`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async employeesGet(
@@ -91,13 +87,9 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async employeesCreateOrUpdate(
@@ -119,15 +111,15 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "PUT", body, ...opts, headers },
+      {method: "PUT", body, ...opts, headers},
       timeout,
     )
   }
@@ -150,15 +142,15 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "PATCH", body, ...opts, headers },
+      {method: "PATCH", body, ...opts, headers},
       timeout,
     )
   }
@@ -181,11 +173,11 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
     return this._fetch(
       url + query,
-      { method: "DELETE", ...opts, headers },
+      {method: "DELETE", ...opts, headers},
       timeout,
     )
   }
@@ -208,13 +200,9 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "HEAD", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "HEAD", ...opts, headers}, timeout)
   }
 
   async employeesListByResourceGroup(
@@ -233,13 +221,9 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async employeesListBySubscription(
@@ -257,13 +241,9 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/providers/Microsoft.ContosoProviderHub/employees`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async employeesMove(
@@ -284,19 +264,19 @@ export class ContosoProviderHubClient extends AbstractFetchClient {
       this.basePath +
       `/subscriptions/${p["subscriptionId"]}/resourceGroups/${p["resourceGroupName"]}/providers/Microsoft.ContosoProviderHub/employees/${p["employeeName"]}/move`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
-    const query = this._query({ "api-version": p["apiVersion"] })
+    const query = this._query({"api-version": p["apiVersion"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "POST", body, ...opts, headers },
+      {method: "POST", body, ...opts, headers},
       timeout,
     )
   }
 }
 
-export { ContosoProviderHubClient as ApiClient }
-export type { ContosoProviderHubClientConfig as ApiClientConfig }
+export {ContosoProviderHubClient as ApiClient}
+export type {ContosoProviderHubClientConfig as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/azure-resource-manager.tsp/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/client.ts
@@ -80,12 +80,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/app-authenticators`
     const headers = this._headers(
-      { "Content-Type": "application/json, okta-version=1.0.0" },
+      {"Content-Type": "application/json, okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async verifyAppAuthenticatorPushNotificationChallenge(
@@ -100,12 +100,12 @@ export class MyAccountManagement extends AbstractFetchClient {
       this.basePath +
       `/idp/myaccount/app-authenticators/challenge/${p["challengeId"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/json;okta-version=1.0.0" },
+      {"Content-Type": "application/json;okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async updateAppAuthenticatorEnrollment(
@@ -124,16 +124,12 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url =
       this.basePath + `/idp/myaccount/app-authenticators/${p["enrollmentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/merge-patch+json;okta-version=1.0.0" },
+      {"Content-Type": "application/merge-patch+json;okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async deleteAppAuthenticatorEnrollment(
@@ -149,7 +145,7 @@ export class MyAccountManagement extends AbstractFetchClient {
       this.basePath + `/idp/myaccount/app-authenticators/${p["enrollmentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async listAppAuthenticatorPendingPushNotificationChallenges(
@@ -164,7 +160,7 @@ export class MyAccountManagement extends AbstractFetchClient {
       `/idp/myaccount/app-authenticators/${p["enrollmentId"]}/push/notifications`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async listAuthenticators(
@@ -178,13 +174,9 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/authenticators`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getAuthenticator(
@@ -203,13 +195,9 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url =
       this.basePath + `/idp/myaccount/authenticators/${p["authenticatorId"]}`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async listEnrollments(
@@ -229,7 +217,7 @@ export class MyAccountManagement extends AbstractFetchClient {
       `/idp/myaccount/authenticators/${p["authenticatorId"]}/enrollments`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getEnrollment(
@@ -250,7 +238,7 @@ export class MyAccountManagement extends AbstractFetchClient {
       `/idp/myaccount/authenticators/${p["authenticatorId"]}/enrollments/${p["enrollmentId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async updateEnrollment(
@@ -271,16 +259,12 @@ export class MyAccountManagement extends AbstractFetchClient {
       this.basePath +
       `/idp/myaccount/authenticators/${p["authenticatorId"]}/enrollments/${p["enrollmentId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/merge-patch+json;okta-version=1.0.0" },
+      {"Content-Type": "application/merge-patch+json;okta-version=1.0.0"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "PATCH", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "PATCH", body, ...opts, headers}, timeout)
   }
 
   async listEmails(
@@ -290,7 +274,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/emails`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async createEmail(
@@ -315,12 +299,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/emails`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getEmail(
@@ -333,7 +317,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/emails/${p["id"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteEmail(
@@ -348,7 +332,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/emails/${p["id"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async sendEmailChallenge(
@@ -392,12 +376,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/emails/${p["id"]}/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async pollChallengeForEmailMagicLink(
@@ -453,7 +437,7 @@ export class MyAccountManagement extends AbstractFetchClient {
       `/idp/myaccount/emails/${p["id"]}/challenge/${p["challengeId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async verifyEmailOtp(
@@ -473,12 +457,12 @@ export class MyAccountManagement extends AbstractFetchClient {
       this.basePath +
       `/idp/myaccount/emails/${p["id"]}/challenge/${p["challengeId"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async listOktaApplications(
@@ -488,7 +472,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/okta-applications`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getOrganization(
@@ -498,7 +482,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/organization`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getPassword(
@@ -508,7 +492,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/password`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async createPassword(
@@ -529,12 +513,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/password`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async replacePassword(
@@ -555,12 +539,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/password`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async deletePassword(
@@ -570,7 +554,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/password`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async listPhones(
@@ -580,7 +564,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/phones`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async createPhone(
@@ -605,12 +589,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/phones`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPhone(
@@ -623,7 +607,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/phones/${p["id"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deletePhone(
@@ -638,7 +622,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/phones/${p["id"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async sendPhoneChallenge(
@@ -673,12 +657,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/phones/${p["id"]}/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async verifyPhoneChallenge(
@@ -700,12 +684,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   > {
     const url = this.basePath + `/idp/myaccount/phones/${p["id"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getProfile(
@@ -715,7 +699,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/profile`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async replaceProfile(
@@ -729,12 +713,12 @@ export class MyAccountManagement extends AbstractFetchClient {
   ): Promise<Res<200, t_Profile> | Res<400, t_Error> | Res<401, t_Error>> {
     const url = this.basePath + `/idp/myaccount/profile`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async getProfileSchema(
@@ -744,7 +728,7 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/profile/schema`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deleteSessions(
@@ -754,9 +738,9 @@ export class MyAccountManagement extends AbstractFetchClient {
     const url = this.basePath + `/idp/myaccount/sessions`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 }
 
-export { MyAccountManagement as ApiClient }
-export type { MyAccountManagementConfig as ApiClientConfig }
+export {MyAccountManagement as ApiClient}
+export type {MyAccountManagementConfig as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.idp.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/okta.oauth.yaml/client.ts
@@ -88,13 +88,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   ): Promise<Res<200, t_OidcMetadata> | Res<400, t_Error>> {
     const url = this.basePath + `/.well-known/openid-configuration`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async authorize(
@@ -148,11 +144,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async authorizeWithPost(
@@ -164,12 +156,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   ): Promise<Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async bcAuthorize(
@@ -186,12 +178,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/bc/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async challenge(
@@ -209,12 +201,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async listClients(
@@ -228,17 +220,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   ): Promise<Res<200, t_Client[]> | Res<403, t_Error> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/clients`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({
-      after: p["after"],
-      limit: p["limit"],
-      q: p["q"],
-    })
+    const query = this._query({after: p["after"], limit: p["limit"], q: p["q"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async createClient(
@@ -255,12 +239,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/clients`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getClient(
@@ -278,7 +262,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url = this.basePath + `/oauth2/v1/clients/${p["clientId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async replaceClient(
@@ -297,12 +281,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/clients/${p["clientId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async deleteClient(
@@ -317,7 +301,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url = this.basePath + `/oauth2/v1/clients/${p["clientId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async generateNewClientSecret(
@@ -336,7 +320,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       this.basePath + `/oauth2/v1/clients/${p["clientId"]}/lifecycle/newSecret`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "POST", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", ...opts, headers}, timeout)
   }
 
   async deviceAuthorize(
@@ -353,12 +337,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/device/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async globalTokenRevocation(
@@ -372,12 +356,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/global-token-revocation`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async introspect(
@@ -394,12 +378,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/introspect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async oauthKeys(
@@ -411,13 +395,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   ): Promise<Res<200, t_OAuthKeys> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/keys`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async logout(
@@ -437,11 +417,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async logoutWithPost(
@@ -453,12 +429,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   ): Promise<Res<200, void> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/logout`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async oobAuthenticate(
@@ -476,12 +452,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/oob-authenticate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async parOptions(
@@ -492,9 +468,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<Res<204, void> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/par`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
-    return this._fetch(url, { method: "OPTIONS", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "OPTIONS", ...opts, headers}, timeout)
   }
 
   async par(
@@ -512,12 +488,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/par`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async revoke(
@@ -534,12 +510,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/revoke`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async tokenOptions(
@@ -550,9 +526,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<Res<204, void> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/v1/token`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
-    return this._fetch(url, { method: "OPTIONS", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "OPTIONS", ...opts, headers}, timeout)
   }
 
   async token(
@@ -569,12 +545,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/v1/token`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async userinfo(
@@ -586,7 +562,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url = this.basePath + `/oauth2/v1/userinfo`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getWellKnownOAuthConfigurationCustomAs(
@@ -603,13 +579,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       this.basePath +
       `/oauth2/${p["authorizationServerId"]}/.well-known/oauth-authorization-server`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getWellKnownOpenIdConfigurationCustomAs(
@@ -624,13 +596,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       this.basePath +
       `/oauth2/${p["authorizationServerId"]}/.well-known/openid-configuration`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ client_id: p["clientId"] })
+    const query = this._query({client_id: p["clientId"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async authorizeCustomAs(
@@ -686,11 +654,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async authorizeCustomAsWithPost(
@@ -704,12 +668,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async bcAuthorizeCustomAs(
@@ -728,12 +692,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/bc/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async challengeCustomAs(
@@ -753,12 +717,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/challenge`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deviceAuthorizeCustomAs(
@@ -778,12 +742,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       this.basePath +
       `/oauth2/${p["authorizationServerId"]}/v1/device/authorize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async introspectCustomAs(
@@ -802,12 +766,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/introspect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async oauthKeysCustomAs(
@@ -820,7 +784,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url = this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/keys`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async logoutCustomAs(
@@ -842,11 +806,7 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       state: p["state"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async logoutCustomAsWithPost(
@@ -860,12 +820,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/logout`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async oobAuthenticateCustomAs(
@@ -886,12 +846,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       this.basePath +
       `/oauth2/${p["authorizationServerId"]}/v1/oob-authenticate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async parOptionsCustomAs(
@@ -903,9 +863,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<Res<204, void> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/par`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
-    return this._fetch(url, { method: "OPTIONS", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "OPTIONS", ...opts, headers}, timeout)
   }
 
   async parCustomAs(
@@ -924,12 +884,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/par`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async revokeCustomAs(
@@ -948,12 +908,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     const url =
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/revoke`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async tokenOptionsCustomAs(
@@ -965,9 +925,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
     opts: RequestInit = {},
   ): Promise<Res<204, void> | Res<429, t_Error>> {
     const url = this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/token`
-    const headers = this._headers({ Origin: p["origin"] }, opts.headers)
+    const headers = this._headers({Origin: p["origin"]}, opts.headers)
 
-    return this._fetch(url, { method: "OPTIONS", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "OPTIONS", ...opts, headers}, timeout)
   }
 
   async tokenCustomAs(
@@ -985,12 +945,12 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
   > {
     const url = this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/token`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async userinfoCustomAs(
@@ -1006,9 +966,9 @@ export class OktaOpenIdConnectOAuth20 extends AbstractFetchClient {
       this.basePath + `/oauth2/${p["authorizationServerId"]}/v1/userinfo`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 }
 
-export { OktaOpenIdConnectOAuth20 as ApiClient }
-export type { OktaOpenIdConnectOAuth20Config as ApiClientConfig }
+export {OktaOpenIdConnectOAuth20 as ApiClient}
+export type {OktaOpenIdConnectOAuth20Config as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/petstore-expanded.yaml/client.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { t_Error, t_NewPet, t_Pet } from "./models"
+import {t_Error, t_NewPet, t_Pet} from "./models"
 import {
   AbstractFetchClient,
   AbstractFetchClientConfig,
@@ -18,7 +18,7 @@ export class SwaggerPetstoreServers {
 
   static server(
     url: "https://petstore.swagger.io/v2" = "https://petstore.swagger.io/v2",
-  ): { build: () => Server<"SwaggerPetstore"> } {
+  ): {build: () => Server<"SwaggerPetstore">} {
     switch (url) {
       case "https://petstore.swagger.io/v2":
         return {
@@ -52,13 +52,9 @@ export class SwaggerPetstore extends AbstractFetchClient {
   ): Promise<Res<200, t_Pet[]> | Res<StatusCode, t_Error>> {
     const url = this.basePath + `/pets`
     const headers = this._headers({}, opts.headers)
-    const query = this._query({ tags: p["tags"], limit: p["limit"] })
+    const query = this._query({tags: p["tags"], limit: p["limit"]})
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async addPet(
@@ -70,12 +66,12 @@ export class SwaggerPetstore extends AbstractFetchClient {
   ): Promise<Res<200, t_Pet> | Res<StatusCode, t_Error>> {
     const url = this.basePath + `/pets`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async findPetById(
@@ -88,7 +84,7 @@ export class SwaggerPetstore extends AbstractFetchClient {
     const url = this.basePath + `/pets/${p["id"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async deletePet(
@@ -101,9 +97,9 @@ export class SwaggerPetstore extends AbstractFetchClient {
     const url = this.basePath + `/pets/${p["id"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 }
 
-export { SwaggerPetstore as ApiClient }
-export type { SwaggerPetstoreConfig as ApiClientConfig }
+export {SwaggerPetstore as ApiClient}
+export type {SwaggerPetstoreConfig as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/client.ts
@@ -174,7 +174,7 @@ import {
 export class StripeApiServersOperations {
   static postFiles(
     url: "https://files.stripe.com/" = "https://files.stripe.com/",
-  ): { build: () => Server<"postFiles_StripeApi"> } {
+  ): {build: () => Server<"postFiles_StripeApi">} {
     switch (url) {
       case "https://files.stripe.com/":
         return {
@@ -190,7 +190,7 @@ export class StripeApiServersOperations {
 
   static getQuotesQuotePdf(
     url: "https://files.stripe.com/" = "https://files.stripe.com/",
-  ): { build: () => Server<"getQuotesQuotePdf_StripeApi"> } {
+  ): {build: () => Server<"getQuotesQuotePdf_StripeApi">} {
     switch (url) {
       case "https://files.stripe.com/":
         return {
@@ -248,15 +248,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/account`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -281,12 +281,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/account_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postAccountSessions(
@@ -429,12 +429,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/account_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAccounts(
@@ -469,7 +469,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -483,7 +483,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -1073,12 +1073,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteAccountsAccount(
@@ -1091,16 +1091,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccount(
@@ -1114,15 +1110,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -1672,12 +1668,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postAccountsAccountBankAccounts(
@@ -1722,12 +1718,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/bank_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteAccountsAccountBankAccountsId(
@@ -1742,16 +1738,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountBankAccountsId(
@@ -1767,15 +1759,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -1827,12 +1819,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountCapabilities(
@@ -1857,15 +1849,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/capabilities`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -1884,15 +1876,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -1913,12 +1905,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/accounts/${p["account"]}/capabilities/${p["capability"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountExternalAccounts(
@@ -1947,7 +1939,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/external_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -1961,7 +1953,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -2008,12 +2000,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/external_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteAccountsAccountExternalAccountsId(
@@ -2029,16 +2021,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountExternalAccountsId(
@@ -2055,15 +2043,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -2116,12 +2104,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/accounts/${p["account"]}/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postAccountsAccountLoginLinks(
@@ -2136,12 +2124,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_login_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/login_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountPeople(
@@ -2177,7 +2165,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/people`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -2191,7 +2179,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -2357,12 +2345,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/people`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteAccountsAccountPeoplePerson(
@@ -2377,16 +2365,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountPeoplePerson(
@@ -2402,15 +2386,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -2578,12 +2562,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/people/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountPersons(
@@ -2619,7 +2603,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/accounts/${p["account"]}/persons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -2633,7 +2617,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -2799,12 +2783,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_person> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/persons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteAccountsAccountPersonsPerson(
@@ -2819,16 +2803,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getAccountsAccountPersonsPerson(
@@ -2844,15 +2824,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3020,12 +3000,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/accounts/${p["account"]}/persons/${p["person"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postAccountsAccountReject(
@@ -3041,12 +3021,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/accounts/${p["account"]}/reject`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getApplePayDomains(
@@ -3074,7 +3054,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/apple_pay/domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3088,7 +3068,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3105,12 +3085,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_apple_pay_domain> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apple_pay/domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteApplePayDomainsDomain(
@@ -3123,16 +3103,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_apple_pay_domain> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apple_pay/domains/${p["domain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getApplePayDomainsDomain(
@@ -3146,15 +3122,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_apple_pay_domain> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apple_pay/domains/${p["domain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3192,7 +3168,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/application_fees`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3207,7 +3183,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3225,15 +3201,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3258,12 +3234,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/application_fees/${p["fee"]}/refunds/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getApplicationFeesId(
@@ -3277,15 +3253,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_application_fee> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/application_fees/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3304,12 +3280,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_application_fee> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getApplicationFeesIdRefunds(
@@ -3337,7 +3313,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3350,7 +3326,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3371,12 +3347,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_fee_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/application_fees/${p["id"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAppsSecrets(
@@ -3407,7 +3383,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/apps/secrets`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3421,7 +3397,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3444,12 +3420,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apps/secrets`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postAppsSecretsDelete(
@@ -3468,12 +3444,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apps/secrets/delete`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getAppsSecretsFind(
@@ -3491,7 +3467,7 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_apps_secret> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/apps/secrets/find`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3503,7 +3479,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3518,15 +3494,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_balance> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3567,7 +3543,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/balance/history`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3585,7 +3561,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3601,15 +3577,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_balance_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/balance/history/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3650,7 +3626,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3668,7 +3644,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3684,15 +3660,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_balance_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/balance_transactions/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3723,7 +3699,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/alerts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3738,7 +3714,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3765,12 +3741,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/alerts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingAlertsId(
@@ -3784,15 +3760,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3809,12 +3785,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}/activate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingAlertsIdArchive(
@@ -3829,12 +3805,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}/archive`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingAlertsIdDeactivate(
@@ -3849,12 +3825,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_alert> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/alerts/${p["id"]}/deactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingCreditBalanceSummary(
@@ -3880,7 +3856,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/credit_balance_summary`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3892,7 +3868,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3923,7 +3899,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/credit_balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -3938,7 +3914,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3957,15 +3933,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/billing/credit_balance_transactions/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -3995,7 +3971,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/credit_grants`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4009,7 +3985,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4049,12 +4025,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/credit_grants`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingCreditGrantsId(
@@ -4068,15 +4044,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4097,12 +4073,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingCreditGrantsIdExpire(
@@ -4117,12 +4093,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingCreditGrantsIdVoid(
@@ -4137,12 +4113,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_credit_grant> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/credit_grants/${p["id"]}/void`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingMeterEventAdjustments(
@@ -4163,12 +4139,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/meter_event_adjustments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingMeterEvents(
@@ -4188,12 +4164,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_meter_event> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meter_events`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingMeters(
@@ -4221,7 +4197,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/meters`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4235,7 +4211,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4264,12 +4240,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meters`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingMetersId(
@@ -4283,15 +4259,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4309,12 +4285,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingMetersIdDeactivate(
@@ -4329,12 +4305,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/deactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingMetersIdEventSummaries(
@@ -4366,7 +4342,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/event_summaries`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4383,7 +4359,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4400,12 +4376,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_meter> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing/meters/${p["id"]}/reactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingPortalConfigurations(
@@ -4434,7 +4410,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing_portal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4449,7 +4425,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4560,12 +4536,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/billing_portal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getBillingPortalConfigurationsConfiguration(
@@ -4582,15 +4558,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/billing_portal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4710,12 +4686,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/billing_portal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postBillingPortalSessions(
@@ -4827,12 +4803,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_billing_portal_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/billing_portal/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCharges(
@@ -4870,7 +4846,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/charges`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -4887,7 +4863,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -4968,12 +4944,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getChargesSearch(
@@ -5002,7 +4978,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/charges/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5015,7 +4991,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -5031,15 +5007,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -5083,12 +5059,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postChargesChargeCapture(
@@ -5113,12 +5089,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getChargesChargeDispute(
@@ -5132,15 +5108,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -5252,12 +5228,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postChargesChargeDisputeClose(
@@ -5272,12 +5248,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/dispute/close`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postChargesChargeRefund(
@@ -5308,12 +5284,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_charge> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getChargesChargeRefunds(
@@ -5341,7 +5317,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5354,7 +5330,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -5390,12 +5366,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/charges/${p["charge"]}/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getChargesChargeRefundsRefund(
@@ -5411,15 +5387,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -5444,12 +5420,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/charges/${p["charge"]}/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCheckoutSessions(
@@ -5492,7 +5468,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/checkout/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -5512,7 +5488,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6554,12 +6530,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/checkout/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCheckoutSessionsSession(
@@ -6573,15 +6549,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6674,12 +6650,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postCheckoutSessionsSessionExpire(
@@ -6694,12 +6670,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_checkout_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/checkout/sessions/${p["session"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCheckoutSessionsSessionLineItems(
@@ -6728,7 +6704,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/checkout/sessions/${p["session"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6741,7 +6717,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6770,7 +6746,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/climate/orders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6783,7 +6759,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6809,12 +6785,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/orders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getClimateOrdersOrder(
@@ -6828,15 +6804,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6862,12 +6838,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postClimateOrdersOrderCancel(
@@ -6882,12 +6858,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_climate_order> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/orders/${p["order"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getClimateProducts(
@@ -6914,7 +6890,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/climate/products`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6927,7 +6903,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6943,15 +6919,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_climate_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/products/${p["product"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -6980,7 +6956,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/climate/suppliers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -6993,7 +6969,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7009,15 +6985,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_climate_supplier> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/climate/suppliers/${p["supplier"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7034,15 +7010,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/confirmation_tokens/${p["confirmationToken"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7071,7 +7047,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/country_specs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7084,7 +7060,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7100,15 +7076,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_country_spec> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/country_specs/${p["country"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7145,7 +7121,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/coupons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7159,7 +7135,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7200,12 +7176,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/coupons`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCouponsCoupon(
@@ -7218,16 +7194,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_coupon> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCouponsCoupon(
@@ -7241,15 +7213,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7280,12 +7252,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_coupon> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/coupons/${p["coupon"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCreditNotes(
@@ -7322,7 +7294,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/credit_notes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7338,7 +7310,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7399,12 +7371,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCreditNotesPreview(
@@ -7459,7 +7431,7 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes/preview`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7482,7 +7454,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7553,7 +7525,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/credit_notes/preview/lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7579,7 +7551,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7609,7 +7581,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/credit_notes/${p["creditNote"]}/lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7622,7 +7594,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7638,15 +7610,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -7667,12 +7639,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postCreditNotesIdVoid(
@@ -7687,12 +7659,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_credit_note> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/credit_notes/${p["id"]}/void`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postCustomerSessions(
@@ -7743,12 +7715,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_customer_session> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customer_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomers(
@@ -7785,7 +7757,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -7801,7 +7773,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8014,12 +7986,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_customer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersSearch(
@@ -8048,7 +8020,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8061,7 +8033,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8076,16 +8048,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_customer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomer(
@@ -8101,15 +8069,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8244,12 +8212,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_customer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerBalanceTransactions(
@@ -8278,7 +8246,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8291,7 +8259,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8320,12 +8288,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerBalanceTransactionsTransaction(
@@ -8344,15 +8312,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8381,12 +8349,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/balance_transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerBankAccounts(
@@ -8414,7 +8382,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/bank_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8427,7 +8395,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8482,12 +8450,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/bank_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerBankAccountsId(
@@ -8507,16 +8475,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerBankAccountsId(
@@ -8532,15 +8496,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8591,12 +8555,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerBankAccountsIdVerify(
@@ -8615,12 +8579,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/bank_accounts/${p["id"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerCards(
@@ -8648,7 +8612,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8661,7 +8625,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8716,12 +8680,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerCardsId(
@@ -8741,16 +8705,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerCardsId(
@@ -8766,15 +8726,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8825,12 +8785,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cards/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerCashBalance(
@@ -8844,15 +8804,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_cash_balance> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cash_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8876,12 +8836,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_cash_balance> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/cash_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerCashBalanceTransactions(
@@ -8910,7 +8870,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/cash_balance_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -8923,7 +8883,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8944,15 +8904,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/cash_balance_transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -8967,16 +8927,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_discount> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerDiscount(
@@ -8990,15 +8946,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_discount> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -9037,12 +8993,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/funding_instructions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerPaymentMethods(
@@ -9125,7 +9081,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/payment_methods`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9140,7 +9096,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -9159,15 +9115,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -9198,7 +9154,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/sources`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9212,7 +9168,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -9267,12 +9223,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/sources`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerSourcesId(
@@ -9292,16 +9248,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerSourcesId(
@@ -9317,15 +9269,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -9376,12 +9328,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postCustomersCustomerSourcesIdVerify(
@@ -9399,12 +9351,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/sources/${p["id"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerSubscriptions(
@@ -9432,7 +9384,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -9445,7 +9397,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -9770,12 +9722,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerSubscriptionsSubscriptionExposedId(
@@ -9795,16 +9747,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerSubscriptionsSubscriptionExposedId(
@@ -9821,15 +9769,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10189,12 +10137,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
@@ -10210,16 +10158,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount(
@@ -10236,15 +10180,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/customers/${p["customer"]}/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10274,7 +10218,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/customers/${p["customer"]}/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10287,7 +10231,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10417,12 +10361,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/customers/${p["customer"]}/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteCustomersCustomerTaxIdsId(
@@ -10437,16 +10381,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getCustomersCustomerTaxIdsId(
@@ -10462,15 +10402,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/customers/${p["customer"]}/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10509,7 +10449,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/disputes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10525,7 +10465,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10541,15 +10481,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10661,12 +10601,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postDisputesDisputeClose(
@@ -10681,12 +10621,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/disputes/${p["dispute"]}/close`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getEntitlementsActiveEntitlements(
@@ -10714,7 +10654,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/entitlements/active_entitlements`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10728,7 +10668,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10747,15 +10687,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/entitlements/active_entitlements/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10786,7 +10726,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/entitlements/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10801,7 +10741,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10822,12 +10762,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/entitlements/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getEntitlementsFeaturesId(
@@ -10841,15 +10781,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/entitlements/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10874,12 +10814,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_entitlements_feature> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/entitlements/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postEphemeralKeys(
@@ -10897,12 +10837,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_ephemeral_key> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/ephemeral_keys`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteEphemeralKeysKey(
@@ -10917,16 +10857,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_ephemeral_key> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/ephemeral_keys/${p["key"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getEvents(
@@ -10964,7 +10900,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/events`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -10981,7 +10917,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -10997,15 +10933,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_event> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/events/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11034,7 +10970,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/exchange_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11047,7 +10983,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11063,15 +10999,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_exchange_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/exchange_rates/${p["rateId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11121,12 +11057,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_external_account> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/external_accounts/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getFileLinks(
@@ -11163,7 +11099,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/file_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11179,7 +11115,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11203,12 +11139,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/file_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getFileLinksLink(
@@ -11222,15 +11158,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/file_links/${p["link"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11254,12 +11190,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_file_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/file_links/${p["link"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getFiles(
@@ -11313,7 +11249,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/files`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11328,7 +11264,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11371,12 +11307,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_file> | Res<StatusCode, t_error>> {
     const url = basePath + `/v1/files`
     const headers = this._headers(
-      { "Content-Type": "multipart/form-data" },
+      {"Content-Type": "multipart/form-data"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getFilesFile(
@@ -11390,15 +11326,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_file> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/files/${p["file"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11432,7 +11368,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/financial_connections/accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11447,7 +11383,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11466,15 +11402,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/financial_connections/accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11495,12 +11431,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/financial_connections/accounts/${p["account"]}/disconnect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getFinancialConnectionsAccountsAccountOwners(
@@ -11531,7 +11467,7 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/financial_connections/accounts/${p["account"]}/owners`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11545,7 +11481,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11572,12 +11508,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/financial_connections/accounts/${p["account"]}/refresh`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postFinancialConnectionsAccountsAccountSubscribe(
@@ -11597,12 +11533,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/financial_connections/accounts/${p["account"]}/subscribe`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postFinancialConnectionsAccountsAccountUnsubscribe(
@@ -11622,12 +11558,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/financial_connections/accounts/${p["account"]}/unsubscribe`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postFinancialConnectionsSessions(
@@ -11673,12 +11609,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/financial_connections/sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getFinancialConnectionsSessionsSession(
@@ -11695,15 +11631,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/financial_connections/sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11744,7 +11680,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/financial_connections/transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11760,7 +11696,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11780,15 +11716,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/financial_connections/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11823,7 +11759,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/forwarding/requests`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11837,7 +11773,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11873,12 +11809,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_forwarding_request> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/forwarding/requests`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getForwardingRequestsId(
@@ -11892,15 +11828,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_forwarding_request> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/forwarding/requests/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11940,7 +11876,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/identity/verification_reports`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -11957,7 +11893,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -11976,15 +11912,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/identity/verification_reports/${p["report"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12029,7 +11965,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/identity/verification_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -12046,7 +11982,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12096,12 +12032,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/identity/verification_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIdentityVerificationSessionsSession(
@@ -12118,15 +12054,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/identity/verification_sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12170,12 +12106,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/identity/verification_sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postIdentityVerificationSessionsSessionCancel(
@@ -12194,12 +12130,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/identity/verification_sessions/${p["session"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postIdentityVerificationSessionsSessionRedact(
@@ -12218,12 +12154,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/identity/verification_sessions/${p["session"]}/redact`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getInvoicePayments(
@@ -12256,7 +12192,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/invoice_payments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -12272,7 +12208,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12288,15 +12224,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice_payment> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoice_payments/${p["invoicePayment"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12326,7 +12262,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/invoice_rendering_templates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -12340,7 +12276,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12360,15 +12296,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/invoice_rendering_templates/${p["template"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"], version: p["version"] })
+    const query = this._query({expand: p["expand"], version: p["version"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12388,12 +12324,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/invoice_rendering_templates/${p["template"]}/archive`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoiceRenderingTemplatesTemplateUnarchive(
@@ -12412,12 +12348,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/invoice_rendering_templates/${p["template"]}/unarchive`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getInvoiceitems(
@@ -12455,7 +12391,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/invoiceitems`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -12472,7 +12408,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12536,12 +12472,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoiceitems`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteInvoiceitemsInvoiceitem(
@@ -12554,16 +12490,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_invoiceitem> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getInvoiceitemsInvoiceitem(
@@ -12577,15 +12509,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -12646,12 +12578,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoiceitem> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoiceitems/${p["invoiceitem"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getInvoices(
@@ -12707,7 +12639,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/invoices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -12726,7 +12658,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -13034,12 +12966,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesCreatePreview(
@@ -13484,12 +13416,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/create_preview`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getInvoicesSearch(
@@ -13518,7 +13450,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/invoices/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -13531,7 +13463,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -13546,16 +13478,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getInvoicesInvoice(
@@ -13569,15 +13497,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -13884,12 +13812,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceAddLines(
@@ -14016,12 +13944,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/add_lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceAttachPayment(
@@ -14037,12 +13965,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/attach_payment`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceFinalize(
@@ -14058,12 +13986,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/finalize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getInvoicesInvoiceLines(
@@ -14091,7 +14019,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14104,7 +14032,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -14226,12 +14154,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/invoices/${p["invoice"]}/lines/${p["lineItemId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceMarkUncollectible(
@@ -14247,12 +14175,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/invoices/${p["invoice"]}/mark_uncollectible`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoicePay(
@@ -14273,12 +14201,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/pay`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceRemoveLines(
@@ -14303,12 +14231,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/remove_lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceSend(
@@ -14323,12 +14251,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/send`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceUpdateLines(
@@ -14455,12 +14383,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/update_lines`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postInvoicesInvoiceVoid(
@@ -14475,12 +14403,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_invoice> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/invoices/${p["invoice"]}/void`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingAuthorizations(
@@ -14523,7 +14451,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/authorizations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14540,7 +14468,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -14557,15 +14485,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -14589,12 +14517,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postIssuingAuthorizationsAuthorizationApprove(
@@ -14617,12 +14545,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}/approve`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postIssuingAuthorizationsAuthorizationDecline(
@@ -14644,12 +14572,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/issuing/authorizations/${p["authorization"]}/decline`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingCardholders(
@@ -14688,7 +14616,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/cardholders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -14706,7 +14634,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -15683,12 +15611,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cardholders`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingCardholdersCardholder(
@@ -15702,15 +15630,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cardholders/${p["cardholder"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -16686,12 +16614,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_cardholder> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cardholders/${p["cardholder"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingCards(
@@ -16733,7 +16661,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -16754,7 +16682,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -17724,12 +17652,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cards`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingCardsCard(
@@ -17743,15 +17671,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cards/${p["card"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -18714,12 +18642,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_card> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/cards/${p["card"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingDisputes(
@@ -18762,7 +18690,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/disputes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -18778,7 +18706,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -18917,12 +18845,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/disputes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingDisputesDispute(
@@ -18936,15 +18864,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19083,12 +19011,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postIssuingDisputesDisputeSubmit(
@@ -19109,12 +19037,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_dispute> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/disputes/${p["dispute"]}/submit`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingPersonalizationDesigns(
@@ -19152,7 +19080,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/personalization_designs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19168,7 +19096,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19203,12 +19131,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/personalization_designs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingPersonalizationDesignsPersonalizationDesign(
@@ -19226,15 +19154,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19275,12 +19203,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/issuing/personalization_designs/${p["personalizationDesign"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingPhysicalBundles(
@@ -19309,7 +19237,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/physical_bundles`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19324,7 +19252,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19341,15 +19269,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/issuing/physical_bundles/${p["physicalBundle"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19365,15 +19293,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/settlements/${p["settlement"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19393,12 +19321,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/settlements/${p["settlement"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingTokens(
@@ -19440,7 +19368,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19456,7 +19384,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19472,15 +19400,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/tokens/${p["token"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19498,12 +19426,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/tokens/${p["token"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getIssuingTransactions(
@@ -19541,7 +19469,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/issuing/transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19558,7 +19486,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19574,15 +19502,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19605,12 +19533,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/issuing/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postLinkAccountSessions(
@@ -19656,12 +19584,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/link_account_sessions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getLinkAccountSessionsSession(
@@ -19677,15 +19605,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/link_account_sessions/${p["session"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19719,7 +19647,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/linked_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19734,7 +19662,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19752,15 +19680,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19779,12 +19707,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/disconnect`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getLinkedAccountsAccountOwners(
@@ -19813,7 +19741,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/owners`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19827,7 +19755,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19852,12 +19780,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/linked_accounts/${p["account"]}/refresh`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getMandatesMandate(
@@ -19871,15 +19799,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_mandate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/mandates/${p["mandate"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -19917,7 +19845,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -19932,7 +19860,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -21052,12 +20980,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentIntentsSearch(
@@ -21086,7 +21014,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_intents/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -21099,7 +21027,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -21116,7 +21044,7 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -21127,7 +21055,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -22224,12 +22152,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntentApplyCustomerBalance(
@@ -22248,12 +22176,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/payment_intents/${p["intent"]}/apply_customer_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntentCancel(
@@ -22274,12 +22202,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntentCapture(
@@ -22308,12 +22236,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}/capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntentConfirm(
@@ -23423,12 +23351,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_intents/${p["intent"]}/confirm`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntentIncrementAuthorization(
@@ -23455,12 +23383,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/payment_intents/${p["intent"]}/increment_authorization`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentIntentsIntentVerifyMicrodeposits(
@@ -23479,12 +23407,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_intents/${p["intent"]}/verify_microdeposits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentLinks(
@@ -23512,7 +23440,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -23526,7 +23454,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -24037,12 +23965,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_links`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentLinksPaymentLink(
@@ -24056,15 +23984,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_links/${p["paymentLink"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -24561,12 +24489,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_link> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_links/${p["paymentLink"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentLinksPaymentLinkLineItems(
@@ -24595,7 +24523,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_links/${p["paymentLink"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -24608,7 +24536,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -24638,7 +24566,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_method_configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -24652,7 +24580,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -24932,12 +24860,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_method_configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentMethodConfigurationsConfiguration(
@@ -24954,15 +24882,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_method_configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -25244,12 +25172,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_method_configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentMethodDomains(
@@ -25278,7 +25206,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_method_domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -25293,7 +25221,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -25311,12 +25239,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_method_domain> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_method_domains`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentMethodDomainsPaymentMethodDomain(
@@ -25331,15 +25259,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -25358,12 +25286,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_method_domains/${p["paymentMethodDomain"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentMethodDomainsPaymentMethodDomainValidate(
@@ -25380,12 +25308,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/payment_method_domains/${p["paymentMethodDomain"]}/validate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentMethods(
@@ -25463,7 +25391,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payment_methods`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -25478,7 +25406,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -25791,12 +25719,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_methods`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPaymentMethodsPaymentMethod(
@@ -25810,15 +25738,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -25884,12 +25812,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payment_method> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payment_methods/${p["paymentMethod"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentMethodsPaymentMethodAttach(
@@ -25906,12 +25834,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_methods/${p["paymentMethod"]}/attach`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPaymentMethodsPaymentMethodDetach(
@@ -25927,12 +25855,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/payment_methods/${p["paymentMethod"]}/detach`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPayouts(
@@ -25977,7 +25905,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/payouts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -25994,7 +25922,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26020,12 +25948,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payouts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPayoutsPayout(
@@ -26039,15 +25967,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26070,12 +25998,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPayoutsPayoutCancel(
@@ -26090,12 +26018,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postPayoutsPayoutReverse(
@@ -26113,12 +26041,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_payout> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/payouts/${p["payout"]}/reverse`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPlans(
@@ -26155,7 +26083,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/plans`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -26171,7 +26099,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26230,12 +26158,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/plans`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deletePlansPlan(
@@ -26248,16 +26176,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_plan> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getPlansPlan(
@@ -26271,15 +26195,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26306,12 +26230,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_plan> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/plans/${p["plan"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPrices(
@@ -26356,7 +26280,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/prices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -26376,7 +26300,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26470,12 +26394,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/prices`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPricesSearch(
@@ -26504,7 +26428,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/prices/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -26517,7 +26441,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26533,15 +26457,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/prices/${p["price"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26602,12 +26526,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_price> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/prices/${p["price"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getProducts(
@@ -26646,7 +26570,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/products`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -26664,7 +26588,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26751,12 +26675,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getProductsSearch(
@@ -26785,7 +26709,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/products/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -26798,7 +26722,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26813,16 +26737,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getProductsId(
@@ -26836,15 +26756,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26892,12 +26812,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_product> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getProductsProductFeatures(
@@ -26925,7 +26845,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/products/${p["product"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -26938,7 +26858,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -26956,12 +26876,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_product_feature> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/products/${p["product"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteProductsProductFeaturesId(
@@ -26976,16 +26896,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getProductsProductFeaturesId(
@@ -27001,15 +26917,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/products/${p["product"]}/features/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27050,7 +26966,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/promotion_codes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27068,7 +26984,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27105,12 +27021,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/promotion_codes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getPromotionCodesPromotionCode(
@@ -27124,15 +27040,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/promotion_codes/${p["promotionCode"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27165,12 +27081,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_promotion_code> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/promotion_codes/${p["promotionCode"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getQuotes(
@@ -27205,7 +27121,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/quotes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27221,7 +27137,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27336,12 +27252,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getQuotesQuote(
@@ -27355,15 +27271,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27472,12 +27388,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postQuotesQuoteAccept(
@@ -27492,12 +27408,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/accept`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postQuotesQuoteCancel(
@@ -27512,12 +27428,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getQuotesQuoteComputedUpfrontLineItems(
@@ -27546,7 +27462,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/quotes/${p["quote"]}/computed_upfront_line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27559,7 +27475,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27577,12 +27493,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_quote> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/finalize`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getQuotesQuoteLineItems(
@@ -27610,7 +27526,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/quotes/${p["quote"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27623,7 +27539,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27642,15 +27558,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, string> | Res<StatusCode, t_error>> {
     const url = basePath + `/v1/quotes/${p["quote"]}/pdf`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27689,7 +27605,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/radar/early_fraud_warnings`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27705,7 +27621,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27722,15 +27638,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/radar/early_fraud_warnings/${p["earlyFraudWarning"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27769,7 +27685,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/radar/value_list_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27785,7 +27701,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27803,12 +27719,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_radar_value_list_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_list_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteRadarValueListItemsItem(
@@ -27823,16 +27739,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/radar/value_list_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getRadarValueListItemsItem(
@@ -27846,15 +27758,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_radar_value_list_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_list_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27893,7 +27805,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/radar/value_lists`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -27909,7 +27821,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -27942,12 +27854,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_lists`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteRadarValueListsValueList(
@@ -27960,16 +27872,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_radar_value_list> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getRadarValueListsValueList(
@@ -27983,15 +27891,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -28013,12 +27921,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_radar_value_list> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/radar/value_lists/${p["valueList"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getRefunds(
@@ -28055,7 +27963,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -28071,7 +27979,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -28107,12 +28015,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/refunds`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getRefundsRefund(
@@ -28126,15 +28034,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -28157,12 +28065,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postRefundsRefundCancel(
@@ -28177,12 +28085,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/refunds/${p["refund"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getReportingReportRuns(
@@ -28217,7 +28125,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/reporting/report_runs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -28231,7 +28139,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -28895,12 +28803,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_reporting_report_run> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reporting/report_runs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getReportingReportRunsReportRun(
@@ -28914,15 +28822,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_reporting_report_run> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reporting/report_runs/${p["reportRun"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -28948,15 +28856,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/reporting/report_types`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -28972,15 +28880,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_reporting_report_type> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reporting/report_types/${p["reportType"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -29017,7 +28925,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/reviews`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -29031,7 +28939,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -29047,15 +28955,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_review> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reviews/${p["review"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -29072,12 +28980,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_review> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/reviews/${p["review"]}/approve`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSetupAttempts(
@@ -29113,7 +29021,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/setup_attempts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -29128,7 +29036,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -29168,7 +29076,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/setup_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -29185,7 +29093,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -29759,12 +29667,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/setup_intents`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSetupIntentsIntent(
@@ -29779,7 +29687,7 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -29790,7 +29698,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -30340,12 +30248,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSetupIntentsIntentCancel(
@@ -30365,12 +30273,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSetupIntentsIntentConfirm(
@@ -30933,12 +30841,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_setup_intent> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/setup_intents/${p["intent"]}/confirm`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSetupIntentsIntentVerifyMicrodeposits(
@@ -30957,12 +30865,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/setup_intents/${p["intent"]}/verify_microdeposits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getShippingRates(
@@ -30999,7 +30907,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/shipping_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31015,7 +30923,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31080,12 +30988,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/shipping_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getShippingRatesShippingRateToken(
@@ -31099,15 +31007,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/shipping_rates/${p["shippingRateToken"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31150,12 +31058,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_shipping_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/shipping_rates/${p["shippingRateToken"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSigmaSavedQueriesId(
@@ -31172,12 +31080,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_sigma_sigma_api_query> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/sigma/saved_queries/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSigmaScheduledQueryRuns(
@@ -31204,7 +31112,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/sigma/scheduled_query_runs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31217,7 +31125,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31234,15 +31142,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/sigma/scheduled_query_runs/${p["scheduledQueryRun"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31363,12 +31271,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/sources`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSourcesSource(
@@ -31383,7 +31291,7 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31394,7 +31302,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31496,12 +31404,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSourcesSourceMandateNotificationsMandateNotification(
@@ -31520,15 +31428,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/sources/${p["source"]}/mandate_notifications/${p["mandateNotification"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31558,7 +31466,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/sources/${p["source"]}/source_transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31571,7 +31479,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31590,15 +31498,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/sources/${p["source"]}/source_transactions/${p["sourceTransaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31616,12 +31524,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_source> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/sources/${p["source"]}/verify`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptionItems(
@@ -31649,7 +31557,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/subscription_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31663,7 +31571,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31727,12 +31635,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteSubscriptionItemsItem(
@@ -31753,16 +31661,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_subscription_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptionItemsItem(
@@ -31776,15 +31680,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -31852,12 +31756,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription_item> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_items/${p["item"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptionSchedules(
@@ -31918,7 +31822,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/subscription_schedules`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -31937,7 +31841,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -32139,12 +32043,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_schedules`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptionSchedulesSchedule(
@@ -32158,15 +32062,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_schedules/${p["schedule"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -32368,12 +32272,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription_schedule> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscription_schedules/${p["schedule"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSubscriptionSchedulesScheduleCancel(
@@ -32391,12 +32295,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/subscription_schedules/${p["schedule"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSubscriptionSchedulesScheduleRelease(
@@ -32413,12 +32317,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/subscription_schedules/${p["schedule"]}/release`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptions(
@@ -32491,7 +32395,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -32513,7 +32417,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -32850,12 +32754,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscriptions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptionsSearch(
@@ -32884,7 +32788,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/subscriptions/search`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -32897,7 +32801,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -32931,16 +32835,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getSubscriptionsSubscriptionExposedId(
@@ -32955,15 +32855,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -33323,12 +33223,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteSubscriptionsSubscriptionExposedIdDiscount(
@@ -33342,16 +33242,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/subscriptions/${p["subscriptionExposedId"]}/discount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async postSubscriptionsSubscriptionMigrate(
@@ -33369,12 +33265,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscriptions/${p["subscription"]}/migrate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postSubscriptionsSubscriptionResume(
@@ -33396,12 +33292,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_subscription> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/subscriptions/${p["subscription"]}/resume`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTaxCalculations(
@@ -33577,12 +33473,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_calculation> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/calculations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTaxCalculationsCalculation(
@@ -33596,15 +33492,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_calculation> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/calculations/${p["calculation"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -33635,7 +33531,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/tax/calculations/${p["calculation"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33648,7 +33544,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -33683,7 +33579,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/tax/registrations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -33697,7 +33593,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34342,12 +34238,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/registrations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTaxRegistrationsId(
@@ -34361,15 +34257,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/registrations/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34388,12 +34284,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_registration> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/registrations/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTaxSettings(
@@ -34406,15 +34302,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_settings> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/settings`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34448,12 +34344,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_settings> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/settings`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTaxTransactionsCreateFromCalculation(
@@ -34473,12 +34369,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/transactions/create_from_calculation`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTaxTransactionsCreateReversal(
@@ -34513,12 +34409,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/transactions/create_reversal`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTaxTransactionsTransaction(
@@ -34532,15 +34428,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax/transactions/${p["transaction"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34571,7 +34467,7 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/tax/transactions/${p["transaction"]}/line_items`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34584,7 +34480,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34613,7 +34509,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/tax_codes`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34626,7 +34522,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34642,15 +34538,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_code> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_codes/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34689,7 +34585,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34703,7 +34599,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34842,12 +34738,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_ids`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteTaxIdsId(
@@ -34860,16 +34756,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_tax_id> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getTaxIdsId(
@@ -34883,15 +34775,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_id> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_ids/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34930,7 +34822,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/tax_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -34946,7 +34838,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -34989,12 +34881,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_rates`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTaxRatesTaxRate(
@@ -35008,15 +34900,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_rates/${p["taxRate"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35061,12 +34953,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_tax_rate> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tax_rates/${p["taxRate"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTerminalConfigurations(
@@ -35094,7 +34986,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -35108,7 +35000,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35256,12 +35148,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_terminal_configuration> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/configurations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteTerminalConfigurationsConfiguration(
@@ -35277,16 +35169,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getTerminalConfigurationsConfiguration(
@@ -35304,15 +35192,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35477,12 +35365,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/configurations/${p["configuration"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalConnectionTokens(
@@ -35497,12 +35385,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_terminal_connection_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/connection_tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTerminalLocations(
@@ -35529,7 +35417,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/locations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -35542,7 +35430,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35574,12 +35462,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_terminal_location> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/locations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteTerminalLocationsLocation(
@@ -35592,16 +35480,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_terminal_location> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getTerminalLocationsLocation(
@@ -35618,15 +35502,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35662,12 +35546,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/locations/${p["location"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTerminalReaders(
@@ -35708,7 +35592,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/readers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -35725,7 +35609,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35750,12 +35634,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_terminal_reader> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/readers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteTerminalReadersReader(
@@ -35768,16 +35652,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_terminal_reader> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getTerminalReadersReader(
@@ -35794,15 +35674,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -35829,12 +35709,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/terminal/readers/${p["reader"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderCancelAction(
@@ -35850,12 +35730,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/cancel_action`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderCollectInputs(
@@ -35903,12 +35783,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/collect_inputs`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderCollectPaymentMethod(
@@ -35938,12 +35818,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/terminal/readers/${p["reader"]}/collect_payment_method`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderConfirmPaymentIntent(
@@ -35964,12 +35844,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/terminal/readers/${p["reader"]}/confirm_payment_intent`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderProcessPaymentIntent(
@@ -36000,12 +35880,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/terminal/readers/${p["reader"]}/process_payment_intent`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderProcessSetupIntent(
@@ -36030,12 +35910,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/process_setup_intent`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderRefundPayment(
@@ -36062,12 +35942,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/refund_payment`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTerminalReadersReaderSetReaderDisplay(
@@ -36094,12 +35974,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/terminal/readers/${p["reader"]}/set_reader_display`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersConfirmationTokens(
@@ -36425,12 +36305,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_confirmation_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/confirmation_tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersCustomersCustomerFundCashBalance(
@@ -36452,12 +36332,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/customers/${p["customer"]}/fund_cash_balance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizations(
@@ -36893,12 +36773,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_authorization> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/issuing/authorizations`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizationsAuthorizationCapture(
@@ -36997,12 +36877,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizationsAuthorizationExpire(
@@ -37019,12 +36899,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmount(
@@ -37095,12 +36975,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/finalize_amount`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespond(
@@ -37118,12 +36998,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/fraud_challenges/respond`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizationsAuthorizationIncrement(
@@ -37142,12 +37022,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/increment`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingAuthorizationsAuthorizationReverse(
@@ -37165,12 +37045,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/authorizations/${p["authorization"]}/reverse`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingCardsCardShippingDeliver(
@@ -37187,12 +37067,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/deliver`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingCardsCardShippingFail(
@@ -37209,12 +37089,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingCardsCardShippingReturn(
@@ -37231,12 +37111,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingCardsCardShippingShip(
@@ -37253,12 +37133,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/ship`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingCardsCardShippingSubmit(
@@ -37275,12 +37155,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/cards/${p["card"]}/shipping/submit`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivate(
@@ -37299,12 +37179,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/personalization_designs/${p["personalizationDesign"]}/activate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivate(
@@ -37323,12 +37203,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/personalization_designs/${p["personalizationDesign"]}/deactivate`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignReject(
@@ -37370,12 +37250,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/personalization_designs/${p["personalizationDesign"]}/reject`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingSettlements(
@@ -37398,12 +37278,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_issuing_settlement> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/issuing/settlements`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingSettlementsSettlementComplete(
@@ -37420,12 +37300,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/settlements/${p["settlement"]}/complete`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingTransactionsCreateForceCapture(
@@ -37830,12 +37710,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/transactions/create_force_capture`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingTransactionsCreateUnlinkedRefund(
@@ -38240,12 +38120,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/transactions/create_unlinked_refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersIssuingTransactionsTransactionRefund(
@@ -38263,12 +38143,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/issuing/transactions/${p["transaction"]}/refund`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersRefundsRefundExpire(
@@ -38283,12 +38163,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_refund> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/refunds/${p["refund"]}/expire`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTerminalReadersReaderPresentPaymentMethod(
@@ -38313,12 +38193,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/terminal/readers/${p["reader"]}/present_payment_method`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTerminalReadersReaderSucceedInputCollection(
@@ -38336,12 +38216,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/terminal/readers/${p["reader"]}/succeed_input_collection`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTerminalReadersReaderTimeoutInputCollection(
@@ -38358,12 +38238,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/terminal/readers/${p["reader"]}/timeout_input_collection`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTestHelpersTestClocks(
@@ -38390,7 +38270,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/test_helpers/test_clocks`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -38403,7 +38283,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -38421,12 +38301,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_test_helpers_test_clock> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/test_clocks`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteTestHelpersTestClocksTestClock(
@@ -38441,16 +38321,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getTestHelpersTestClocksTestClock(
@@ -38464,15 +38340,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_test_helpers_test_clock> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -38491,12 +38367,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/test_helpers/test_clocks/${p["testClock"]}/advance`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryInboundTransfersIdFail(
@@ -38530,12 +38406,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryInboundTransfersIdReturn(
@@ -38552,12 +38428,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryInboundTransfersIdSucceed(
@@ -38574,12 +38450,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/inbound_transfers/${p["id"]}/succeed`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundPaymentsId(
@@ -38606,12 +38482,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/test_helpers/treasury/outbound_payments/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundPaymentsIdFail(
@@ -38628,12 +38504,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundPaymentsIdPost(
@@ -38650,12 +38526,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/post`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundPaymentsIdReturn(
@@ -38686,12 +38562,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_payments/${p["id"]}/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundTransfersOutboundTransfer(
@@ -38721,12 +38597,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundTransfersOutboundTransferFail(
@@ -38745,12 +38621,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}/fail`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundTransfersOutboundTransferPost(
@@ -38769,12 +38645,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}/post`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryOutboundTransfersOutboundTransferReturn(
@@ -38807,12 +38683,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/test_helpers/treasury/outbound_transfers/${p["outboundTransfer"]}/return`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryReceivedCredits(
@@ -38839,12 +38715,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_received_credit> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/treasury/received_credits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTestHelpersTreasuryReceivedDebits(
@@ -38871,12 +38747,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_received_debit> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/test_helpers/treasury/received_debits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTokens(
@@ -39276,12 +39152,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tokens`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTokensToken(
@@ -39295,15 +39171,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_token> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/tokens/${p["token"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39354,7 +39230,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/topups`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39370,7 +39246,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39398,12 +39274,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/topups`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTopupsTopup(
@@ -39417,15 +39293,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39449,12 +39325,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTopupsTopupCancel(
@@ -39469,12 +39345,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_topup> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/topups/${p["topup"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTransfers(
@@ -39511,7 +39387,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39527,7 +39403,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39553,12 +39429,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTransfersIdReversals(
@@ -39586,7 +39462,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/transfers/${p["id"]}/reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39599,7 +39475,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39625,12 +39501,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_transfer_reversal> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/transfers/${p["id"]}/reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTransfersTransfer(
@@ -39644,15 +39520,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/transfers/${p["transfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39676,12 +39552,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/transfers/${p["transfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTransfersTransferReversalsId(
@@ -39697,15 +39573,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39730,12 +39606,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/transfers/${p["transfer"]}/reversals/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryCreditReversals(
@@ -39765,7 +39641,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/credit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39781,7 +39657,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39801,12 +39677,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_credit_reversal> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/credit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryCreditReversalsCreditReversal(
@@ -39821,15 +39697,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/treasury/credit_reversals/${p["creditReversal"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39862,7 +39738,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/debit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39879,7 +39755,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39899,12 +39775,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_debit_reversal> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/debit_reversals`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryDebitReversalsDebitReversal(
@@ -39919,15 +39795,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/treasury/debit_reversals/${p["debitReversal"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -39965,7 +39841,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/financial_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -39980,7 +39856,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40047,12 +39923,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/financial_accounts`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryFinancialAccountsFinancialAccount(
@@ -40069,15 +39945,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/treasury/financial_accounts/${p["financialAccount"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40150,12 +40026,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/treasury/financial_accounts/${p["financialAccount"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async postTreasuryFinancialAccountsFinancialAccountClose(
@@ -40179,12 +40055,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/treasury/financial_accounts/${p["financialAccount"]}/close`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryFinancialAccountsFinancialAccountFeatures(
@@ -40202,15 +40078,15 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40266,12 +40142,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/treasury/financial_accounts/${p["financialAccount"]}/features`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryInboundTransfers(
@@ -40305,7 +40181,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/inbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40320,7 +40196,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40345,12 +40221,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/inbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryInboundTransfersId(
@@ -40364,15 +40240,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_inbound_transfer> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/inbound_transfers/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40391,12 +40267,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/treasury/inbound_transfers/${p["inboundTransfer"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryOutboundPayments(
@@ -40440,7 +40316,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/outbound_payments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40457,7 +40333,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40528,12 +40404,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/outbound_payments`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryOutboundPaymentsId(
@@ -40547,15 +40423,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_outbound_payment> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/outbound_payments/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40573,12 +40449,12 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/treasury/outbound_payments/${p["id"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryOutboundTransfers(
@@ -40613,7 +40489,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/outbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40628,7 +40504,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40667,12 +40543,12 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/outbound_transfers`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryOutboundTransfersOutboundTransfer(
@@ -40689,15 +40565,15 @@ export class StripeApi extends AbstractFetchClient {
     const url =
       this.basePath + `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40718,12 +40594,12 @@ export class StripeApi extends AbstractFetchClient {
       this.basePath +
       `/v1/treasury/outbound_transfers/${p["outboundTransfer"]}/cancel`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async getTreasuryReceivedCredits(
@@ -40761,7 +40637,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/received_credits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40777,7 +40653,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40793,15 +40669,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_received_credit> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/received_credits/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40832,7 +40708,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/received_debits`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40847,7 +40723,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40863,15 +40739,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_received_debit> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/received_debits/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40919,7 +40795,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/transaction_entries`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -40937,7 +40813,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -40955,15 +40831,15 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/transaction_entries/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -41013,7 +40889,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/treasury/transactions`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -41031,7 +40907,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -41047,15 +40923,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_treasury_transaction> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/treasury/transactions/${p["id"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -41084,7 +40960,7 @@ export class StripeApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/v1/webhook_endpoints`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const query = this._query({
@@ -41097,7 +40973,7 @@ export class StripeApi extends AbstractFetchClient {
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -41483,12 +41359,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/webhook_endpoints`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async deleteWebhookEndpointsWebhookEndpoint(
@@ -41501,16 +41377,12 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_deleted_webhook_endpoint> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(
-      url,
-      { method: "DELETE", body, ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url, {method: "DELETE", body, ...opts, headers}, timeout)
   }
 
   async getWebhookEndpointsWebhookEndpoint(
@@ -41524,15 +41396,15 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
-    const query = this._query({ expand: p["expand"] })
+    const query = this._query({expand: p["expand"]})
     const body = JSON.stringify(p.requestBody)
 
     return this._fetch(
       url + query,
-      { method: "GET", body, ...opts, headers },
+      {method: "GET", body, ...opts, headers},
       timeout,
     )
   }
@@ -41804,14 +41676,14 @@ export class StripeApi extends AbstractFetchClient {
   ): Promise<Res<200, t_webhook_endpoint> | Res<StatusCode, t_error>> {
     const url = this.basePath + `/v1/webhook_endpoints/${p["webhookEndpoint"]}`
     const headers = this._headers(
-      { "Content-Type": "application/x-www-form-urlencoded" },
+      {"Content-Type": "application/x-www-form-urlencoded"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 }
 
-export { StripeApi as ApiClient }
-export type { StripeApiConfig as ApiClientConfig }
+export {StripeApi as ApiClient}
+export type {StripeApiConfig as ApiClientConfig}

--- a/integration-tests/typescript-fetch/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-fetch/src/generated/stripe.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type UnknownEnumStringValue = string & {
   _brand: "unknown enum string value"

--- a/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
+++ b/integration-tests/typescript-fetch/src/generated/todo-lists.yaml/client.ts
@@ -174,11 +174,7 @@ export class TodoListsExampleApi extends AbstractFetchClient {
       tags: p["tags"],
     })
 
-    return this._fetch(
-      url + query,
-      { method: "GET", ...opts, headers },
-      timeout,
-    )
+    return this._fetch(url + query, {method: "GET", ...opts, headers}, timeout)
   }
 
   async getTodoListById(
@@ -193,7 +189,7 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     const url = this.basePath + `/list/${p["listId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async updateTodoListById(
@@ -208,12 +204,12 @@ export class TodoListsExampleApi extends AbstractFetchClient {
   > {
     const url = this.basePath + `/list/${p["listId"]}`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "PUT", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "PUT", body, ...opts, headers}, timeout)
   }
 
   async deleteTodoListById(
@@ -228,7 +224,7 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     const url = this.basePath + `/list/${p["listId"]}`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "DELETE", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "DELETE", ...opts, headers}, timeout)
   }
 
   async getTodoListItems(
@@ -258,7 +254,7 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     const url = this.basePath + `/list/${p["listId"]}/items`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async createTodoListItem(
@@ -275,12 +271,12 @@ export class TodoListsExampleApi extends AbstractFetchClient {
   ): Promise<Res<204, void>> {
     const url = this.basePath + `/list/${p["listId"]}/items`
     const headers = this._headers(
-      { "Content-Type": "application/json" },
+      {"Content-Type": "application/json"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 
   async listAttachments(
@@ -295,7 +291,7 @@ export class TodoListsExampleApi extends AbstractFetchClient {
     const url = basePath + `/attachments`
     const headers = this._headers({}, opts.headers)
 
-    return this._fetch(url, { method: "GET", ...opts, headers }, timeout)
+    return this._fetch(url, {method: "GET", ...opts, headers}, timeout)
   }
 
   async uploadAttachment(
@@ -314,14 +310,14 @@ export class TodoListsExampleApi extends AbstractFetchClient {
   ): Promise<Res<202, void>> {
     const url = basePath + `/attachments`
     const headers = this._headers(
-      { "Content-Type": "multipart/form-data" },
+      {"Content-Type": "multipart/form-data"},
       opts.headers,
     )
     const body = JSON.stringify(p.requestBody)
 
-    return this._fetch(url, { method: "POST", body, ...opts, headers }, timeout)
+    return this._fetch(url, {method: "POST", body, ...opts, headers}, timeout)
   }
 }
 
-export { TodoListsExampleApi as ApiClient }
-export type { TodoListsExampleApiConfig as ApiClientConfig }
+export {TodoListsExampleApi as ApiClient}
+export type {TodoListsExampleApiConfig as ApiClientConfig}

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/generated.ts
@@ -2150,7 +2150,7 @@ import {
   s_workflow_run_usage,
   s_workflow_usage,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -2169,8 +2169,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type MetaRootResponder = {
   with200(): KoaRuntimeResponse<t_root>
@@ -27548,7 +27548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = metaRootResponseValidator(status, body)
@@ -27636,7 +27636,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesListGlobalAdvisoriesResponseValidator(
@@ -27699,7 +27699,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesGetGlobalAdvisoryResponseValidator(
@@ -27744,7 +27744,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = appsGetAuthenticatedResponseValidator(status, body)
@@ -27752,7 +27752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const appsCreateFromManifestParamSchema = z.object({ code: z.string() })
+  const appsCreateFromManifestParamSchema = z.object({code: z.string()})
 
   const appsCreateFromManifestResponseValidator = responseValidationFactory(
     [
@@ -27826,7 +27826,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsCreateFromManifestResponseValidator(status, body)
@@ -27871,7 +27871,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetWebhookConfigForAppResponseValidator(status, body)
@@ -27925,7 +27925,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsUpdateWebhookConfigForAppResponseValidator(status, body)
@@ -27989,7 +27989,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListWebhookDeliveriesResponseValidator(status, body)
@@ -28052,7 +28052,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetWebhookDeliveryResponseValidator(status, body)
@@ -28118,7 +28118,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsRedeliverWebhookDeliveryResponseValidator(status, body)
@@ -28190,7 +28190,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -28206,7 +28206,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const appsListInstallationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     outdated: z.string().optional(),
   })
 
@@ -28250,7 +28250,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListInstallationsResponseValidator(status, body)
@@ -28309,7 +28309,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetInstallationResponseValidator(status, body)
@@ -28368,7 +28368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsDeleteInstallationResponseValidator(status, body)
@@ -28452,7 +28452,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsCreateInstallationAccessTokenResponseValidator(
@@ -28514,7 +28514,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsSuspendInstallationResponseValidator(status, body)
@@ -28573,7 +28573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsUnsuspendInstallationResponseValidator(status, body)
@@ -28582,11 +28582,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsDeleteAuthorizationParamSchema = z.object({ client_id: z.string() })
+  const appsDeleteAuthorizationParamSchema = z.object({client_id: z.string()})
 
-  const appsDeleteAuthorizationBodySchema = z.object({
-    access_token: z.string(),
-  })
+  const appsDeleteAuthorizationBodySchema = z.object({access_token: z.string()})
 
   const appsDeleteAuthorizationResponseValidator = responseValidationFactory(
     [
@@ -28638,7 +28636,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsDeleteAuthorizationResponseValidator(status, body)
@@ -28647,9 +28645,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsCheckTokenParamSchema = z.object({ client_id: z.string() })
+  const appsCheckTokenParamSchema = z.object({client_id: z.string()})
 
-  const appsCheckTokenBodySchema = z.object({ access_token: z.string() })
+  const appsCheckTokenBodySchema = z.object({access_token: z.string()})
 
   const appsCheckTokenResponseValidator = responseValidationFactory(
     [
@@ -28705,7 +28703,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsCheckTokenResponseValidator(status, body)
@@ -28714,9 +28712,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsResetTokenParamSchema = z.object({ client_id: z.string() })
+  const appsResetTokenParamSchema = z.object({client_id: z.string()})
 
-  const appsResetTokenBodySchema = z.object({ access_token: z.string() })
+  const appsResetTokenBodySchema = z.object({access_token: z.string()})
 
   const appsResetTokenResponseValidator = responseValidationFactory(
     [
@@ -28768,7 +28766,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsResetTokenResponseValidator(status, body)
@@ -28777,9 +28775,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsDeleteTokenParamSchema = z.object({ client_id: z.string() })
+  const appsDeleteTokenParamSchema = z.object({client_id: z.string()})
 
-  const appsDeleteTokenBodySchema = z.object({ access_token: z.string() })
+  const appsDeleteTokenBodySchema = z.object({access_token: z.string()})
 
   const appsDeleteTokenResponseValidator = responseValidationFactory(
     [
@@ -28831,7 +28829,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsDeleteTokenResponseValidator(status, body)
@@ -28840,7 +28838,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsScopeTokenParamSchema = z.object({ client_id: z.string() })
+  const appsScopeTokenParamSchema = z.object({client_id: z.string()})
 
   const appsScopeTokenBodySchema = z.object({
     access_token: z.string(),
@@ -28913,7 +28911,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsScopeTokenResponseValidator(status, body)
@@ -28922,7 +28920,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsGetBySlugParamSchema = z.object({ app_slug: z.string() })
+  const appsGetBySlugParamSchema = z.object({app_slug: z.string()})
 
   const appsGetBySlugResponseValidator = responseValidationFactory(
     [
@@ -28971,7 +28969,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = appsGetBySlugResponseValidator(status, body)
@@ -29029,7 +29027,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = classroomGetAnAssignmentResponseValidator(status, body)
@@ -29097,7 +29095,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -29161,7 +29159,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = classroomGetAssignmentGradesResponseValidator(status, body)
@@ -29212,7 +29210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = classroomListClassroomsResponseValidator(status, body)
@@ -29270,7 +29268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = classroomGetAClassroomResponseValidator(status, body)
@@ -29333,7 +29331,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = classroomListAssignmentsForAClassroomResponseValidator(
@@ -29388,7 +29386,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codesOfConductGetAllCodesOfConductResponseValidator(
@@ -29400,7 +29398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codesOfConductGetConductCodeParamSchema = z.object({ key: z.string() })
+  const codesOfConductGetConductCodeParamSchema = z.object({key: z.string()})
 
   const codesOfConductGetConductCodeResponseValidator =
     responseValidationFactory(
@@ -29453,7 +29451,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codesOfConductGetConductCodeResponseValidator(status, body)
@@ -29515,7 +29513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = credentialsRevokeResponseValidator(status, body)
@@ -29564,7 +29562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = emojisGetResponseValidator(status, body)
@@ -29637,7 +29635,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityGetConfigurationsForEnterpriseResponseValidator(
@@ -29669,7 +29667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional()
       .default("disabled"),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional().default(false) })
+      .object({labeled_runners: PermissiveBoolean.optional().default(false)})
       .optional(),
     dependabot_alerts: z
       .enum(["enabled", "disabled", "not_set"])
@@ -29787,7 +29785,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityCreateConfigurationForEnterpriseResponseValidator(
@@ -29800,7 +29798,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codeSecurityGetDefaultConfigurationsForEnterpriseParamSchema = z.object(
-    { enterprise: z.string() },
+    {enterprise: z.string()},
   )
 
   const codeSecurityGetDefaultConfigurationsForEnterpriseResponseValidator =
@@ -29851,7 +29849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -29929,7 +29927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -29958,7 +29956,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .enum(["enabled", "disabled", "not_set"])
       .optional(),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional() })
+      .object({labeled_runners: PermissiveBoolean.optional()})
       .optional(),
     dependabot_alerts: z.enum(["enabled", "disabled", "not_set"]).optional(),
     dependabot_security_updates: z
@@ -30060,7 +30058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityUpdateEnterpriseConfigurationResponseValidator(
@@ -30141,7 +30139,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityDeleteConfigurationForEnterpriseResponseValidator(
@@ -30223,7 +30221,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityAttachEnterpriseConfigurationResponseValidator(
@@ -30236,7 +30234,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codeSecuritySetConfigurationAsDefaultForEnterpriseParamSchema =
-    z.object({ enterprise: z.string(), configuration_id: z.coerce.number() })
+    z.object({enterprise: z.string(), configuration_id: z.coerce.number()})
 
   const codeSecuritySetConfigurationAsDefaultForEnterpriseBodySchema = z.object(
     {
@@ -30321,7 +30319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -30335,7 +30333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codeSecurityGetRepositoriesForEnterpriseConfigurationParamSchema =
-    z.object({ enterprise: z.string(), configuration_id: z.coerce.number() })
+    z.object({enterprise: z.string(), configuration_id: z.coerce.number()})
 
   const codeSecurityGetRepositoriesForEnterpriseConfigurationQuerySchema =
     z.object({
@@ -30407,7 +30405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -30509,7 +30507,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotListAlertsForEnterpriseResponseValidator(
@@ -30608,7 +30606,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningListAlertsForEnterpriseResponseValidator(
@@ -30687,7 +30685,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = activityListPublicEventsResponseValidator(status, body)
@@ -30728,7 +30726,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = activityGetFeedsResponseValidator(status, body)
@@ -30737,7 +30735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const gistsListQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -30789,7 +30787,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsListResponseValidator(status, body)
@@ -30799,7 +30797,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const gistsCreateBodySchema = z.object({
     description: z.string().optional(),
-    files: z.record(z.object({ content: z.string() })),
+    files: z.record(z.object({content: z.string()})),
     public: z
       .union([
         PermissiveBoolean.default(false),
@@ -30863,7 +30861,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsCreateResponseValidator(status, body)
@@ -30872,7 +30870,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const gistsListPublicQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -30928,7 +30926,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsListPublicResponseValidator(status, body)
@@ -30937,7 +30935,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const gistsListStarredQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -30993,7 +30991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsListStarredResponseValidator(status, body)
@@ -31001,7 +30999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsGetParamSchema = z.object({ gist_id: z.string() })
+  const gistsGetParamSchema = z.object({gist_id: z.string()})
 
   const gistsGetResponseValidator = responseValidationFactory(
     [
@@ -31075,7 +31073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsGetResponseValidator(status, body)
@@ -31083,7 +31081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsUpdateParamSchema = z.object({ gist_id: z.string() })
+  const gistsUpdateParamSchema = z.object({gist_id: z.string()})
 
   const gistsUpdateBodySchema = z
     .object({
@@ -31152,7 +31150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsUpdateResponseValidator(status, body)
@@ -31160,7 +31158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsDeleteParamSchema = z.object({ gist_id: z.string() })
+  const gistsDeleteParamSchema = z.object({gist_id: z.string()})
 
   const gistsDeleteResponseValidator = responseValidationFactory(
     [
@@ -31213,7 +31211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsDeleteResponseValidator(status, body)
@@ -31221,7 +31219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsListCommentsParamSchema = z.object({ gist_id: z.string() })
+  const gistsListCommentsParamSchema = z.object({gist_id: z.string()})
 
   const gistsListCommentsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -31286,7 +31284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsListCommentsResponseValidator(status, body)
@@ -31295,9 +31293,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const gistsCreateCommentParamSchema = z.object({ gist_id: z.string() })
+  const gistsCreateCommentParamSchema = z.object({gist_id: z.string()})
 
-  const gistsCreateCommentBodySchema = z.object({ body: z.string().max(65535) })
+  const gistsCreateCommentBodySchema = z.object({body: z.string().max(65535)})
 
   const gistsCreateCommentResponseValidator = responseValidationFactory(
     [
@@ -31357,7 +31355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsCreateCommentResponseValidator(status, body)
@@ -31446,7 +31444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsGetCommentResponseValidator(status, body)
@@ -31460,7 +31458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     comment_id: z.coerce.number(),
   })
 
-  const gistsUpdateCommentBodySchema = z.object({ body: z.string().max(65535) })
+  const gistsUpdateCommentBodySchema = z.object({body: z.string().max(65535)})
 
   const gistsUpdateCommentResponseValidator = responseValidationFactory(
     [
@@ -31512,7 +31510,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsUpdateCommentResponseValidator(status, body)
@@ -31580,7 +31578,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsDeleteCommentResponseValidator(status, body)
@@ -31589,7 +31587,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const gistsListCommitsParamSchema = z.object({ gist_id: z.string() })
+  const gistsListCommitsParamSchema = z.object({gist_id: z.string()})
 
   const gistsListCommitsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -31654,7 +31652,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsListCommitsResponseValidator(status, body)
@@ -31663,7 +31661,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const gistsListForksParamSchema = z.object({ gist_id: z.string() })
+  const gistsListForksParamSchema = z.object({gist_id: z.string()})
 
   const gistsListForksQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -31725,7 +31723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsListForksResponseValidator(status, body)
@@ -31733,7 +31731,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsForkParamSchema = z.object({ gist_id: z.string() })
+  const gistsForkParamSchema = z.object({gist_id: z.string()})
 
   const gistsForkResponseValidator = responseValidationFactory(
     [
@@ -31790,7 +31788,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsForkResponseValidator(status, body)
@@ -31798,7 +31796,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsCheckIsStarredParamSchema = z.object({ gist_id: z.string() })
+  const gistsCheckIsStarredParamSchema = z.object({gist_id: z.string()})
 
   const gistsCheckIsStarredResponseValidator = responseValidationFactory(
     [
@@ -31854,7 +31852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsCheckIsStarredResponseValidator(status, body)
@@ -31863,7 +31861,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const gistsStarParamSchema = z.object({ gist_id: z.string() })
+  const gistsStarParamSchema = z.object({gist_id: z.string()})
 
   const gistsStarResponseValidator = responseValidationFactory(
     [
@@ -31916,7 +31914,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsStarResponseValidator(status, body)
@@ -31924,7 +31922,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const gistsUnstarParamSchema = z.object({ gist_id: z.string() })
+  const gistsUnstarParamSchema = z.object({gist_id: z.string()})
 
   const gistsUnstarResponseValidator = responseValidationFactory(
     [
@@ -31977,7 +31975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsUnstarResponseValidator(status, body)
@@ -32041,7 +32039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = gistsGetRevisionResponseValidator(status, body)
@@ -32091,7 +32089,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitignoreGetAllTemplatesResponseValidator(status, body)
@@ -32100,7 +32098,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const gitignoreGetTemplateParamSchema = z.object({ name: z.string() })
+  const gitignoreGetTemplateParamSchema = z.object({name: z.string()})
 
   const gitignoreGetTemplateResponseValidator = responseValidationFactory(
     [
@@ -32148,7 +32146,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitignoreGetTemplateResponseValidator(status, body)
@@ -32228,7 +32226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListReposAccessibleToInstallationResponseValidator(
@@ -32274,7 +32272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsRevokeInstallationAccessTokenResponseValidator(
@@ -32298,7 +32296,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     collab: PermissiveBoolean.optional(),
     orgs: PermissiveBoolean.optional(),
     owned: PermissiveBoolean.optional(),
@@ -32358,7 +32356,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = issuesListResponseValidator(status, body)
@@ -32415,7 +32413,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = licensesGetAllCommonlyUsedResponseValidator(status, body)
@@ -32423,7 +32421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const licensesGetParamSchema = z.object({ license: z.string() })
+  const licensesGetParamSchema = z.object({license: z.string()})
 
   const licensesGetResponseValidator = responseValidationFactory(
     [
@@ -32476,7 +32474,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = licensesGetResponseValidator(status, body)
@@ -32533,7 +32531,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = markdownRenderResponseValidator(status, body)
@@ -32586,7 +32584,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = markdownRenderRawResponseValidator(status, body)
@@ -32649,7 +32647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetSubscriptionPlanForAccountResponseValidator(
@@ -32716,7 +32714,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListPlansResponseValidator(status, body)
@@ -32794,7 +32792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListAccountsForPlanResponseValidator(status, body)
@@ -32858,7 +32856,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetSubscriptionPlanForAccountStubbedResponseValidator(
@@ -32921,7 +32919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListPlansStubbedResponseValidator(status, body)
@@ -32992,7 +32990,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListAccountsForPlanStubbedResponseValidator(status, body)
@@ -33040,7 +33038,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = metaGetResponseValidator(status, body)
@@ -33121,7 +33119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListPublicEventsForRepoNetworkResponseValidator(
@@ -33136,8 +33134,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const activityListNotificationsForAuthenticatedUserQuerySchema = z.object({
     all: PermissiveBoolean.optional().default(false),
     participating: PermissiveBoolean.optional().default(false),
-    since: z.string().datetime({ offset: true }).optional(),
-    before: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
+    before: z.string().datetime({offset: true}).optional(),
     page: z.coerce.number().optional().default(1),
     per_page: z.coerce.number().optional().default(50),
   })
@@ -33206,7 +33204,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListNotificationsForAuthenticatedUserResponseValidator(
@@ -33220,7 +33218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const activityMarkNotificationsAsReadBodySchema = z
     .object({
-      last_read_at: z.string().datetime({ offset: true }).optional(),
+      last_read_at: z.string().datetime({offset: true}).optional(),
       read: PermissiveBoolean.optional(),
     })
     .optional()
@@ -33228,7 +33226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const activityMarkNotificationsAsReadResponseValidator =
     responseValidationFactory(
       [
-        ["202", z.object({ message: z.string().optional() })],
+        ["202", z.object({message: z.string().optional()})],
         ["205", z.undefined()],
         ["304", z.undefined()],
         ["401", s_basic_error],
@@ -33286,7 +33284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityMarkNotificationsAsReadResponseValidator(status, body)
@@ -33295,9 +33293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const activityGetThreadParamSchema = z.object({
-    thread_id: z.coerce.number(),
-  })
+  const activityGetThreadParamSchema = z.object({thread_id: z.coerce.number()})
 
   const activityGetThreadResponseValidator = responseValidationFactory(
     [
@@ -33353,7 +33349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityGetThreadResponseValidator(status, body)
@@ -33416,7 +33412,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityMarkThreadAsReadResponseValidator(status, body)
@@ -33469,7 +33465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityMarkThreadAsDoneResponseValidator(status, body)
@@ -33479,7 +33475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const activityGetThreadSubscriptionForAuthenticatedUserParamSchema = z.object(
-    { thread_id: z.coerce.number() },
+    {thread_id: z.coerce.number()},
   )
 
   const activityGetThreadSubscriptionForAuthenticatedUserResponseValidator =
@@ -33542,7 +33538,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -33560,7 +33556,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const activitySetThreadSubscriptionBodySchema = z
-    .object({ ignored: PermissiveBoolean.optional().default(false) })
+    .object({ignored: PermissiveBoolean.optional().default(false)})
     .optional()
 
   const activitySetThreadSubscriptionResponseValidator =
@@ -33622,7 +33618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activitySetThreadSubscriptionResponseValidator(status, body)
@@ -33690,7 +33686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityDeleteThreadSubscriptionResponseValidator(status, body)
@@ -33699,7 +33695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const metaGetOctocatQuerySchema = z.object({ s: z.string().optional() })
+  const metaGetOctocatQuerySchema = z.object({s: z.string().optional()})
 
   const metaGetOctocatResponseValidator = responseValidationFactory(
     [["200", z.string()]],
@@ -33738,7 +33734,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = metaGetOctocatResponseValidator(status, body)
@@ -33794,7 +33790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsListResponseValidator(status, body)
@@ -33868,7 +33864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotRepositoryAccessForOrgResponseValidator(status, body)
@@ -33941,7 +33937,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotUpdateRepositoryAccessForOrgResponseValidator(
@@ -34016,7 +34012,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotSetRepositoryAccessDefaultLevelResponseValidator(
@@ -34113,7 +34109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetGithubBillingUsageReportOrgResponseValidator(
@@ -34125,7 +34121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsGetParamSchema = z.object({ org: z.string() })
+  const orgsGetParamSchema = z.object({org: z.string()})
 
   const orgsGetResponseValidator = responseValidationFactory(
     [
@@ -34170,7 +34166,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsGetResponseValidator(status, body)
@@ -34178,7 +34174,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const orgsUpdateParamSchema = z.object({ org: z.string() })
+  const orgsUpdateParamSchema = z.object({org: z.string()})
 
   const orgsUpdateBodySchema = z
     .object({
@@ -34284,7 +34280,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsUpdateResponseValidator(status, body)
@@ -34292,7 +34288,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const orgsDeleteParamSchema = z.object({ org: z.string() })
+  const orgsDeleteParamSchema = z.object({org: z.string()})
 
   const orgsDeleteResponseValidator = responseValidationFactory(
     [
@@ -34343,7 +34339,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsDeleteResponseValidator(status, body)
@@ -34398,7 +34394,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetActionsCacheUsageForOrgResponseValidator(
@@ -34477,7 +34473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetActionsCacheUsageByRepoForOrgResponseValidator(
@@ -34489,9 +34485,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsListHostedRunnersForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const actionsListHostedRunnersForOrgParamSchema = z.object({org: z.string()})
 
   const actionsListHostedRunnersForOrgQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -34554,7 +34548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListHostedRunnersForOrgResponseValidator(status, body)
@@ -34563,9 +34557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsCreateHostedRunnerForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const actionsCreateHostedRunnerForOrgParamSchema = z.object({org: z.string()})
 
   const actionsCreateHostedRunnerForOrgBodySchema = z.object({
     name: z.string(),
@@ -34621,7 +34613,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateHostedRunnerForOrgResponseValidator(status, body)
@@ -34691,7 +34683,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -34760,7 +34752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetHostedRunnersPartnerImagesForOrgResponseValidator(
@@ -34817,7 +34809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetHostedRunnersLimitsForOrgResponseValidator(
@@ -34885,7 +34877,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetHostedRunnersMachineSpecsForOrgResponseValidator(
@@ -34953,7 +34945,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetHostedRunnersPlatformsForOrgResponseValidator(
@@ -35008,7 +35000,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetHostedRunnerForOrgResponseValidator(status, body)
@@ -35071,7 +35063,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsUpdateHostedRunnerForOrgResponseValidator(status, body)
@@ -35123,7 +35115,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteHostedRunnerForOrgResponseValidator(status, body)
@@ -35174,7 +35166,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = oidcGetOidcCustomSubTemplateForOrgResponseValidator(
@@ -35247,7 +35239,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = oidcUpdateOidcCustomSubTemplateForOrgResponseValidator(
@@ -35309,7 +35301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35378,7 +35370,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35392,7 +35384,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsListSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsListSelectedRepositoriesEnabledGithubActionsOrganizationQuerySchema =
     z.object({
@@ -35461,7 +35453,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35475,10 +35467,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationBodySchema =
-    z.object({ selected_repository_ids: z.array(z.coerce.number()) })
+    z.object({selected_repository_ids: z.array(z.coerce.number())})
 
   const actionsSetSelectedRepositoriesEnabledGithubActionsOrganizationResponseValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -35527,7 +35519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35541,7 +35533,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsEnableSelectedRepositoryGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string(), repository_id: z.coerce.number() })
+    z.object({org: z.string(), repository_id: z.coerce.number()})
 
   const actionsEnableSelectedRepositoryGithubActionsOrganizationResponseValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -35586,7 +35578,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35600,7 +35592,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsDisableSelectedRepositoryGithubActionsOrganizationParamSchema =
-    z.object({ org: z.string(), repository_id: z.coerce.number() })
+    z.object({org: z.string(), repository_id: z.coerce.number()})
 
   const actionsDisableSelectedRepositoryGithubActionsOrganizationResponseValidator =
     responseValidationFactory([["204", z.undefined()]], undefined)
@@ -35645,7 +35637,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35700,7 +35692,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetAllowedActionsOrganizationResponseValidator(
@@ -35761,7 +35753,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetAllowedActionsOrganizationResponseValidator(
@@ -35774,7 +35766,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsOrganizationResponseValidator =
     responseValidationFactory(
@@ -35824,7 +35816,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35838,7 +35830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsOrganizationBodySchema =
     s_actions_set_default_workflow_permissions.optional()
@@ -35890,7 +35882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -35969,7 +35961,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListSelfHostedRunnerGroupsForOrgResponseValidator(
@@ -36041,7 +36033,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateSelfHostedRunnerGroupForOrgResponseValidator(
@@ -36096,7 +36088,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetSelfHostedRunnerGroupForOrgResponseValidator(
@@ -36164,7 +36156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsUpdateSelfHostedRunnerGroupForOrgResponseValidator(
@@ -36219,7 +36211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteSelfHostedRunnerGroupFromOrgResponseValidator(
@@ -36302,7 +36294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListGithubHostedRunnersInGroupForOrgResponseValidator(
@@ -36315,7 +36307,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsListRepoAccessToSelfHostedRunnerGroupInOrgParamSchema = z.object(
-    { org: z.string(), runner_group_id: z.coerce.number() },
+    {org: z.string(), runner_group_id: z.coerce.number()},
   )
 
   const actionsListRepoAccessToSelfHostedRunnerGroupInOrgQuerySchema = z.object(
@@ -36386,7 +36378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -36455,7 +36447,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -36517,7 +36509,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -36580,7 +36572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -36659,7 +36651,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListSelfHostedRunnersInGroupForOrgResponseValidator(
@@ -36722,7 +36714,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetSelfHostedRunnersInGroupForOrgResponseValidator(
@@ -36778,7 +36770,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsAddSelfHostedRunnerToGroupForOrgResponseValidator(
@@ -36839,7 +36831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsRemoveSelfHostedRunnerFromGroupForOrgResponseValidator(
@@ -36917,7 +36909,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListSelfHostedRunnersForOrgResponseValidator(
@@ -36974,7 +36966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRunnerApplicationsForOrgResponseValidator(
@@ -37000,7 +36992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const actionsGenerateRunnerJitconfigForOrgResponseValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ runner: s_runner, encoded_jit_config: z.string() })],
+        ["201", z.object({runner: s_runner, encoded_jit_config: z.string()})],
         ["404", s_basic_error],
         ["409", s_basic_error],
         ["422", s_validation_error_simple],
@@ -37059,7 +37051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGenerateRunnerJitconfigForOrgResponseValidator(
@@ -37113,7 +37105,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateRegistrationTokenForOrgResponseValidator(
@@ -37125,9 +37117,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsCreateRemoveTokenForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const actionsCreateRemoveTokenForOrgParamSchema = z.object({org: z.string()})
 
   const actionsCreateRemoveTokenForOrgResponseValidator =
     responseValidationFactory([["201", s_authentication_token]], undefined)
@@ -37167,7 +37157,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateRemoveTokenForOrgResponseValidator(status, body)
@@ -37219,7 +37209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetSelfHostedRunnerForOrgResponseValidator(status, body)
@@ -37280,7 +37270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteSelfHostedRunnerFromOrgResponseValidator(
@@ -37353,7 +37343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListLabelsForSelfHostedRunnerForOrgResponseValidator(
@@ -37443,7 +37433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37534,7 +37524,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37548,7 +37538,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgParamSchema =
-    z.object({ org: z.string(), runner_id: z.coerce.number() })
+    z.object({org: z.string(), runner_id: z.coerce.number()})
 
   const actionsRemoveAllCustomLabelsFromSelfHostedRunnerForOrgResponseValidator =
     responseValidationFactory(
@@ -37611,7 +37601,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37625,11 +37615,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsRemoveCustomLabelFromSelfHostedRunnerForOrgParamSchema =
-    z.object({
-      org: z.string(),
-      runner_id: z.coerce.number(),
-      name: z.string(),
-    })
+    z.object({org: z.string(), runner_id: z.coerce.number(), name: z.string()})
 
   const actionsRemoveCustomLabelFromSelfHostedRunnerForOrgResponseValidator =
     responseValidationFactory(
@@ -37696,7 +37682,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37709,7 +37695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsListOrgSecretsParamSchema = z.object({ org: z.string() })
+  const actionsListOrgSecretsParamSchema = z.object({org: z.string()})
 
   const actionsListOrgSecretsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -37771,7 +37757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListOrgSecretsResponseValidator(status, body)
@@ -37780,7 +37766,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsGetOrgPublicKeyParamSchema = z.object({ org: z.string() })
+  const actionsGetOrgPublicKeyParamSchema = z.object({org: z.string()})
 
   const actionsGetOrgPublicKeyResponseValidator = responseValidationFactory(
     [["200", s_actions_public_key]],
@@ -37822,7 +37808,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetOrgPublicKeyResponseValidator(status, body)
@@ -37876,7 +37862,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetOrgSecretResponseValidator(status, body)
@@ -37954,7 +37940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateOrUpdateOrgSecretResponseValidator(status, body)
@@ -38008,7 +37994,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteOrgSecretResponseValidator(status, body)
@@ -38083,7 +38069,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListSelectedReposForOrgSecretResponseValidator(
@@ -38146,7 +38132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetSelectedReposForOrgSecretResponseValidator(
@@ -38211,7 +38197,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsAddSelectedRepoToOrgSecretResponseValidator(
@@ -38276,7 +38262,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsRemoveSelectedRepoFromOrgSecretResponseValidator(
@@ -38288,7 +38274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsListOrgVariablesParamSchema = z.object({ org: z.string() })
+  const actionsListOrgVariablesParamSchema = z.object({org: z.string()})
 
   const actionsListOrgVariablesQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(10),
@@ -38350,7 +38336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListOrgVariablesResponseValidator(status, body)
@@ -38359,7 +38345,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const actionsCreateOrgVariableParamSchema = z.object({ org: z.string() })
+  const actionsCreateOrgVariableParamSchema = z.object({org: z.string()})
 
   const actionsCreateOrgVariableBodySchema = z.object({
     name: z.string(),
@@ -38412,7 +38398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateOrgVariableResponseValidator(status, body)
@@ -38466,7 +38452,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetOrgVariableResponseValidator(status, body)
@@ -38531,7 +38517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsUpdateOrgVariableResponseValidator(status, body)
@@ -38585,7 +38571,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteOrgVariableResponseValidator(status, body)
@@ -38664,7 +38650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListSelectedReposForOrgVariableResponseValidator(
@@ -38736,7 +38722,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetSelectedReposForOrgVariableResponseValidator(
@@ -38801,7 +38787,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsAddSelectedRepoToOrgVariableResponseValidator(
@@ -38866,7 +38852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsRemoveSelectedRepoFromOrgVariableResponseValidator(
@@ -38878,7 +38864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListAttestationsBulkParamSchema = z.object({ org: z.string() })
+  const orgsListAttestationsBulkParamSchema = z.object({org: z.string()})
 
   const orgsListAttestationsBulkQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -38999,7 +38985,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListAttestationsBulkResponseValidator(status, body)
@@ -39008,11 +38994,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsDeleteAttestationsBulkParamSchema = z.object({ org: z.string() })
+  const orgsDeleteAttestationsBulkParamSchema = z.object({org: z.string()})
 
   const orgsDeleteAttestationsBulkBodySchema = z.union([
-    z.object({ subject_digests: z.array(z.string()).min(1).max(1024) }),
-    z.object({ attestation_ids: z.array(z.coerce.number()).min(1).max(1024) }),
+    z.object({subject_digests: z.array(z.string()).min(1).max(1024)}),
+    z.object({attestation_ids: z.array(z.coerce.number()).min(1).max(1024)}),
   ])
 
   const orgsDeleteAttestationsBulkResponseValidator = responseValidationFactory(
@@ -39065,7 +39051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsDeleteAttestationsBulkResponseValidator(status, body)
@@ -39130,7 +39116,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsDeleteAttestationsBySubjectDigestResponseValidator(
@@ -39201,7 +39187,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsDeleteAttestationsByIdResponseValidator(status, body)
@@ -39301,7 +39287,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListAttestationsResponseValidator(status, body)
@@ -39310,7 +39296,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListBlockedUsersParamSchema = z.object({ org: z.string() })
+  const orgsListBlockedUsersParamSchema = z.object({org: z.string()})
 
   const orgsListBlockedUsersQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -39358,7 +39344,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsListBlockedUsersResponseValidator(status, body)
@@ -39417,7 +39403,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCheckBlockedUserResponseValidator(status, body)
@@ -39477,7 +39463,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsBlockUserResponseValidator(status, body)
@@ -39531,7 +39517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUnblockUserResponseValidator(status, body)
@@ -39540,7 +39526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const campaignsListOrgCampaignsParamSchema = z.object({ org: z.string() })
+  const campaignsListOrgCampaignsParamSchema = z.object({org: z.string()})
 
   const campaignsListOrgCampaignsQuerySchema = z.object({
     page: z.coerce.number().optional().default(1),
@@ -39618,7 +39604,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = campaignsListOrgCampaignsResponseValidator(status, body)
@@ -39627,14 +39613,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const campaignsCreateCampaignParamSchema = z.object({ org: z.string() })
+  const campaignsCreateCampaignParamSchema = z.object({org: z.string()})
 
   const campaignsCreateCampaignBodySchema = z.object({
     name: z.string().min(1).max(50),
     description: z.string().min(1).max(255),
     managers: z.array(z.string()).max(10).optional(),
     team_managers: z.array(z.string()).max(10).optional(),
-    ends_at: z.string().datetime({ offset: true }),
+    ends_at: z.string().datetime({offset: true}),
     contact_link: z.string().nullable().optional(),
     code_scanning_alerts: z
       .array(
@@ -39724,7 +39710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = campaignsCreateCampaignResponseValidator(status, body)
@@ -39804,7 +39790,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = campaignsGetCampaignSummaryResponseValidator(status, body)
@@ -39823,7 +39809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     description: z.string().min(1).max(255).optional(),
     managers: z.array(z.string()).max(10).optional(),
     team_managers: z.array(z.string()).max(10).optional(),
-    ends_at: z.string().datetime({ offset: true }).optional(),
+    ends_at: z.string().datetime({offset: true}).optional(),
     contact_link: z.string().nullable().optional(),
     state: s_campaign_state.optional(),
   })
@@ -39901,7 +39887,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = campaignsUpdateCampaignResponseValidator(status, body)
@@ -39976,7 +39962,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = campaignsDeleteCampaignResponseValidator(status, body)
@@ -39985,7 +39971,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codeScanningListAlertsForOrgParamSchema = z.object({ org: z.string() })
+  const codeScanningListAlertsForOrgParamSchema = z.object({org: z.string()})
 
   const codeScanningListAlertsForOrgQuerySchema = z.object({
     tool_name: s_code_scanning_analysis_tool_name.optional(),
@@ -40068,7 +40054,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningListAlertsForOrgResponseValidator(status, body)
@@ -40143,7 +40129,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityGetConfigurationsForOrgResponseValidator(
@@ -40155,9 +40141,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codeSecurityCreateConfigurationParamSchema = z.object({
-    org: z.string(),
-  })
+  const codeSecurityCreateConfigurationParamSchema = z.object({org: z.string()})
 
   const codeSecurityCreateConfigurationBodySchema = z.object({
     name: z.string(),
@@ -40175,7 +40159,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional()
       .default("disabled"),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional().default(false) })
+      .object({labeled_runners: PermissiveBoolean.optional().default(false)})
       .optional(),
     dependabot_alerts: z
       .enum(["enabled", "disabled", "not_set"])
@@ -40289,7 +40273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityCreateConfigurationResponseValidator(status, body)
@@ -40359,7 +40343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityGetDefaultConfigurationsResponseValidator(
@@ -40371,9 +40355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codeSecurityDetachConfigurationParamSchema = z.object({
-    org: z.string(),
-  })
+  const codeSecurityDetachConfigurationParamSchema = z.object({org: z.string()})
 
   const codeSecurityDetachConfigurationBodySchema = z.object({
     selected_repository_ids: z
@@ -40446,7 +40428,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityDetachConfigurationResponseValidator(status, body)
@@ -40515,7 +40497,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityGetConfigurationResponseValidator(status, body)
@@ -40540,7 +40522,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .enum(["enabled", "disabled", "not_set"])
       .optional(),
     dependency_graph_autosubmit_action_options: z
-      .object({ labeled_runners: PermissiveBoolean.optional() })
+      .object({labeled_runners: PermissiveBoolean.optional()})
       .optional(),
     dependabot_alerts: z.enum(["enabled", "disabled", "not_set"]).optional(),
     dependabot_security_updates: z
@@ -40643,7 +40625,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityUpdateConfigurationResponseValidator(status, body)
@@ -40716,7 +40698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityDeleteConfigurationResponseValidator(status, body)
@@ -40785,7 +40767,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityAttachConfigurationResponseValidator(status, body)
@@ -40875,7 +40857,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecuritySetConfigurationAsDefaultResponseValidator(
@@ -40961,7 +40943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityGetRepositoriesForConfigurationResponseValidator(
@@ -40973,7 +40955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codespacesListInOrganizationParamSchema = z.object({ org: z.string() })
+  const codespacesListInOrganizationParamSchema = z.object({org: z.string()})
 
   const codespacesListInOrganizationQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -41056,7 +41038,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesListInOrganizationResponseValidator(status, body)
@@ -41065,7 +41047,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codespacesSetCodespacesAccessParamSchema = z.object({ org: z.string() })
+  const codespacesSetCodespacesAccessParamSchema = z.object({org: z.string()})
 
   const codespacesSetCodespacesAccessBodySchema = z.object({
     visibility: z.enum([
@@ -41144,7 +41126,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesSetCodespacesAccessResponseValidator(status, body)
@@ -41228,7 +41210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesSetCodespacesAccessUsersResponseValidator(
@@ -41315,7 +41297,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesDeleteCodespacesAccessUsersResponseValidator(
@@ -41327,7 +41309,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codespacesListOrgSecretsParamSchema = z.object({ org: z.string() })
+  const codespacesListOrgSecretsParamSchema = z.object({org: z.string()})
 
   const codespacesListOrgSecretsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -41389,7 +41371,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesListOrgSecretsResponseValidator(status, body)
@@ -41398,7 +41380,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const codespacesGetOrgPublicKeyParamSchema = z.object({ org: z.string() })
+  const codespacesGetOrgPublicKeyParamSchema = z.object({org: z.string()})
 
   const codespacesGetOrgPublicKeyResponseValidator = responseValidationFactory(
     [["200", s_codespaces_public_key]],
@@ -41440,7 +41422,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetOrgPublicKeyResponseValidator(status, body)
@@ -41494,7 +41476,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetOrgSecretResponseValidator(status, body)
@@ -41581,7 +41563,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesCreateOrUpdateOrgSecretResponseValidator(
@@ -41644,7 +41626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesDeleteOrgSecretResponseValidator(status, body)
@@ -41723,7 +41705,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesListSelectedReposForOrgSecretResponseValidator(
@@ -41799,7 +41781,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesSetSelectedReposForOrgSecretResponseValidator(
@@ -41872,7 +41854,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesAddSelectedRepoToOrgSecretResponseValidator(
@@ -41945,7 +41927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesRemoveSelectedRepoFromOrgSecretResponseValidator(
@@ -42024,7 +42006,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotGetCopilotOrganizationDetailsResponseValidator(
@@ -42036,7 +42018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const copilotListCopilotSeatsParamSchema = z.object({ org: z.string() })
+  const copilotListCopilotSeatsParamSchema = z.object({org: z.string()})
 
   const copilotListCopilotSeatsQuerySchema = z.object({
     page: z.coerce.number().optional().default(1),
@@ -42114,7 +42096,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotListCopilotSeatsResponseValidator(status, body)
@@ -42123,9 +42105,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const copilotAddCopilotSeatsForTeamsParamSchema = z.object({
-    org: z.string(),
-  })
+  const copilotAddCopilotSeatsForTeamsParamSchema = z.object({org: z.string()})
 
   const copilotAddCopilotSeatsForTeamsBodySchema = z.object({
     selected_teams: z.array(z.string()).min(1),
@@ -42134,7 +42114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const copilotAddCopilotSeatsForTeamsResponseValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ seats_created: z.coerce.number() })],
+        ["201", z.object({seats_created: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -42200,7 +42180,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotAddCopilotSeatsForTeamsResponseValidator(status, body)
@@ -42220,7 +42200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const copilotCancelCopilotSeatAssignmentForTeamsResponseValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ seats_cancelled: z.coerce.number() })],
+        ["200", z.object({seats_cancelled: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -42286,7 +42266,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotCancelCopilotSeatAssignmentForTeamsResponseValidator(
@@ -42298,9 +42278,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const copilotAddCopilotSeatsForUsersParamSchema = z.object({
-    org: z.string(),
-  })
+  const copilotAddCopilotSeatsForUsersParamSchema = z.object({org: z.string()})
 
   const copilotAddCopilotSeatsForUsersBodySchema = z.object({
     selected_usernames: z.array(z.string()).min(1),
@@ -42309,7 +42287,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const copilotAddCopilotSeatsForUsersResponseValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ seats_created: z.coerce.number() })],
+        ["201", z.object({seats_created: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -42375,7 +42353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotAddCopilotSeatsForUsersResponseValidator(status, body)
@@ -42395,7 +42373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const copilotCancelCopilotSeatAssignmentForUsersResponseValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ seats_cancelled: z.coerce.number() })],
+        ["200", z.object({seats_cancelled: z.coerce.number()})],
         ["401", s_basic_error],
         ["403", s_basic_error],
         ["404", s_basic_error],
@@ -42461,7 +42439,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotCancelCopilotSeatAssignmentForUsersResponseValidator(
@@ -42547,7 +42525,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotCopilotMetricsForOrganizationResponseValidator(
@@ -42559,7 +42537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const dependabotListAlertsForOrgParamSchema = z.object({ org: z.string() })
+  const dependabotListAlertsForOrgParamSchema = z.object({org: z.string()})
 
   const dependabotListAlertsForOrgQuerySchema = z.object({
     state: z.string().optional(),
@@ -42649,7 +42627,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotListAlertsForOrgResponseValidator(status, body)
@@ -42658,7 +42636,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const dependabotListOrgSecretsParamSchema = z.object({ org: z.string() })
+  const dependabotListOrgSecretsParamSchema = z.object({org: z.string()})
 
   const dependabotListOrgSecretsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -42720,7 +42698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotListOrgSecretsResponseValidator(status, body)
@@ -42729,7 +42707,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const dependabotGetOrgPublicKeyParamSchema = z.object({ org: z.string() })
+  const dependabotGetOrgPublicKeyParamSchema = z.object({org: z.string()})
 
   const dependabotGetOrgPublicKeyResponseValidator = responseValidationFactory(
     [["200", s_dependabot_public_key]],
@@ -42771,7 +42749,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotGetOrgPublicKeyResponseValidator(status, body)
@@ -42825,7 +42803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotGetOrgSecretResponseValidator(status, body)
@@ -42904,7 +42882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotCreateOrUpdateOrgSecretResponseValidator(
@@ -42961,7 +42939,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotDeleteOrgSecretResponseValidator(status, body)
@@ -43036,7 +43014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotListSelectedReposForOrgSecretResponseValidator(
@@ -43099,7 +43077,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotSetSelectedReposForOrgSecretResponseValidator(
@@ -43164,7 +43142,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotAddSelectedRepoToOrgSecretResponseValidator(
@@ -43229,7 +43207,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotRemoveSelectedRepoFromOrgSecretResponseValidator(
@@ -43242,7 +43220,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const packagesListDockerMigrationConflictingPackagesForOrganizationParamSchema =
-    z.object({ org: z.string() })
+    z.object({org: z.string()})
 
   const packagesListDockerMigrationConflictingPackagesForOrganizationResponseValidator =
     responseValidationFactory(
@@ -43300,7 +43278,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -43313,7 +43291,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const activityListPublicOrgEventsParamSchema = z.object({ org: z.string() })
+  const activityListPublicOrgEventsParamSchema = z.object({org: z.string()})
 
   const activityListPublicOrgEventsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -43362,7 +43340,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListPublicOrgEventsResponseValidator(status, body)
@@ -43371,7 +43349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListFailedInvitationsParamSchema = z.object({ org: z.string() })
+  const orgsListFailedInvitationsParamSchema = z.object({org: z.string()})
 
   const orgsListFailedInvitationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -43428,7 +43406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListFailedInvitationsResponseValidator(status, body)
@@ -43437,7 +43415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListWebhooksParamSchema = z.object({ org: z.string() })
+  const orgsListWebhooksParamSchema = z.object({org: z.string()})
 
   const orgsListWebhooksQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -43491,7 +43469,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsListWebhooksResponseValidator(status, body)
@@ -43499,7 +43477,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const orgsCreateWebhookParamSchema = z.object({ org: z.string() })
+  const orgsCreateWebhookParamSchema = z.object({org: z.string()})
 
   const orgsCreateWebhookBodySchema = z.object({
     name: z.string(),
@@ -43566,7 +43544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsCreateWebhookResponseValidator(status, body)
@@ -43625,7 +43603,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetWebhookResponseValidator(status, body)
@@ -43709,7 +43687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUpdateWebhookResponseValidator(status, body)
@@ -43769,7 +43747,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsDeleteWebhookResponseValidator(status, body)
@@ -43823,7 +43801,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetWebhookConfigForOrgResponseValidator(status, body)
@@ -43888,7 +43866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUpdateWebhookConfigForOrgResponseValidator(status, body)
@@ -43961,7 +43939,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListWebhookDeliveriesResponseValidator(status, body)
@@ -44026,7 +44004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetWebhookDeliveryResponseValidator(status, body)
@@ -44094,7 +44072,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRedeliverWebhookDeliveryResponseValidator(status, body)
@@ -44154,7 +44132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsPingWebhookResponseValidator(status, body)
@@ -44243,7 +44221,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetRouteStatsByActorResponseValidator(status, body)
@@ -44252,7 +44230,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const apiInsightsGetSubjectStatsParamSchema = z.object({ org: z.string() })
+  const apiInsightsGetSubjectStatsParamSchema = z.object({org: z.string()})
 
   const apiInsightsGetSubjectStatsQuerySchema = z.object({
     min_timestamp: z.string(),
@@ -44323,7 +44301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetSubjectStatsResponseValidator(status, body)
@@ -44332,7 +44310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const apiInsightsGetSummaryStatsParamSchema = z.object({ org: z.string() })
+  const apiInsightsGetSummaryStatsParamSchema = z.object({org: z.string()})
 
   const apiInsightsGetSummaryStatsQuerySchema = z.object({
     min_timestamp: z.string(),
@@ -44383,7 +44361,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetSummaryStatsResponseValidator(status, body)
@@ -44447,7 +44425,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetSummaryStatsByUserResponseValidator(status, body)
@@ -44518,7 +44496,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetSummaryStatsByActorResponseValidator(
@@ -44530,7 +44508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const apiInsightsGetTimeStatsParamSchema = z.object({ org: z.string() })
+  const apiInsightsGetTimeStatsParamSchema = z.object({org: z.string()})
 
   const apiInsightsGetTimeStatsQuerySchema = z.object({
     min_timestamp: z.string(),
@@ -44582,7 +44560,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetTimeStatsResponseValidator(status, body)
@@ -44644,7 +44622,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetTimeStatsByUserResponseValidator(status, body)
@@ -44713,7 +44691,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetTimeStatsByActorResponseValidator(status, body)
@@ -44796,7 +44774,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = apiInsightsGetUserStatsResponseValidator(status, body)
@@ -44805,7 +44783,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsGetOrgInstallationParamSchema = z.object({ org: z.string() })
+  const appsGetOrgInstallationParamSchema = z.object({org: z.string()})
 
   const appsGetOrgInstallationResponseValidator = responseValidationFactory(
     [["200", s_installation]],
@@ -44847,7 +44825,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetOrgInstallationResponseValidator(status, body)
@@ -44856,7 +44834,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListAppInstallationsParamSchema = z.object({ org: z.string() })
+  const orgsListAppInstallationsParamSchema = z.object({org: z.string()})
 
   const orgsListAppInstallationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -44918,7 +44896,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListAppInstallationsResponseValidator(status, body)
@@ -44974,7 +44952,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = interactionsGetRestrictionsForOrgResponseValidator(
@@ -45043,7 +45021,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = interactionsSetRestrictionsForOrgResponseValidator(
@@ -45097,7 +45075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = interactionsRemoveRestrictionsForOrgResponseValidator(
@@ -45109,7 +45087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListPendingInvitationsParamSchema = z.object({ org: z.string() })
+  const orgsListPendingInvitationsParamSchema = z.object({org: z.string()})
 
   const orgsListPendingInvitationsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -45180,7 +45158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListPendingInvitationsResponseValidator(status, body)
@@ -45189,7 +45167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsCreateInvitationParamSchema = z.object({ org: z.string() })
+  const orgsCreateInvitationParamSchema = z.object({org: z.string()})
 
   const orgsCreateInvitationBodySchema = z
     .object({
@@ -45257,7 +45235,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCreateInvitationResponseValidator(status, body)
@@ -45321,7 +45299,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCancelInvitationResponseValidator(status, body)
@@ -45390,7 +45368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListInvitationTeamsResponseValidator(status, body)
@@ -45399,7 +45377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListIssueTypesParamSchema = z.object({ org: z.string() })
+  const orgsListIssueTypesParamSchema = z.object({org: z.string()})
 
   const orgsListIssueTypesResponseValidator = responseValidationFactory(
     [
@@ -45447,7 +45425,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListIssueTypesResponseValidator(status, body)
@@ -45456,7 +45434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsCreateIssueTypeParamSchema = z.object({ org: z.string() })
+  const orgsCreateIssueTypeParamSchema = z.object({org: z.string()})
 
   const orgsCreateIssueTypeBodySchema = s_organization_create_issue_type
 
@@ -45514,7 +45492,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCreateIssueTypeResponseValidator(status, body)
@@ -45584,7 +45562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUpdateIssueTypeResponseValidator(status, body)
@@ -45648,7 +45626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsDeleteIssueTypeResponseValidator(status, body)
@@ -45657,7 +45635,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const issuesListForOrgParamSchema = z.object({ org: z.string() })
+  const issuesListForOrgParamSchema = z.object({org: z.string()})
 
   const issuesListForOrgQuerySchema = z.object({
     filter: z
@@ -45672,7 +45650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -45724,7 +45702,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = issuesListForOrgResponseValidator(status, body)
@@ -45732,7 +45710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const orgsListMembersParamSchema = z.object({ org: z.string() })
+  const orgsListMembersParamSchema = z.object({org: z.string()})
 
   const orgsListMembersQuerySchema = z.object({
     filter: z
@@ -45791,7 +45769,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsListMembersResponseValidator(status, body)
@@ -45854,7 +45832,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCheckMembershipForUserResponseValidator(status, body)
@@ -45914,7 +45892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRemoveMemberResponseValidator(status, body)
@@ -46009,7 +45987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetCodespacesForUserInOrgResponseValidator(
@@ -46092,7 +46070,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesDeleteFromOrganizationResponseValidator(status, body)
@@ -46170,7 +46148,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesStopInOrganizationResponseValidator(status, body)
@@ -46247,7 +46225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotGetCopilotSeatDetailsForUserResponseValidator(
@@ -46314,7 +46292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetMembershipForUserResponseValidator(status, body)
@@ -46329,7 +46307,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const orgsSetMembershipForUserBodySchema = z
-    .object({ role: z.enum(["admin", "member"]).optional().default("member") })
+    .object({role: z.enum(["admin", "member"]).optional().default("member")})
     .optional()
 
   const orgsSetMembershipForUserResponseValidator = responseValidationFactory(
@@ -46386,7 +46364,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsSetMembershipForUserResponseValidator(status, body)
@@ -46451,7 +46429,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRemoveMembershipForUserResponseValidator(status, body)
@@ -46460,7 +46438,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const migrationsListForOrgParamSchema = z.object({ org: z.string() })
+  const migrationsListForOrgParamSchema = z.object({org: z.string()})
 
   const migrationsListForOrgQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -46517,7 +46495,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsListForOrgResponseValidator(status, body)
@@ -46526,7 +46504,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const migrationsStartForOrgParamSchema = z.object({ org: z.string() })
+  const migrationsStartForOrgParamSchema = z.object({org: z.string()})
 
   const migrationsStartForOrgBodySchema = z.object({
     repositories: z.array(z.string()),
@@ -46594,7 +46572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsStartForOrgResponseValidator(status, body)
@@ -46667,7 +46645,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsGetStatusForOrgResponseValidator(status, body)
@@ -46728,7 +46706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsDownloadArchiveForOrgResponseValidator(status, body)
@@ -46789,7 +46767,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsDeleteArchiveForOrgResponseValidator(status, body)
@@ -46850,7 +46828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsUnlockRepoForOrgResponseValidator(status, body)
@@ -46919,7 +46897,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsListReposForOrgResponseValidator(status, body)
@@ -46928,7 +46906,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListOrgRolesParamSchema = z.object({ org: z.string() })
+  const orgsListOrgRolesParamSchema = z.object({org: z.string()})
 
   const orgsListOrgRolesResponseValidator = responseValidationFactory(
     [
@@ -46989,7 +46967,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListOrgRolesResponseValidator(status, body)
@@ -47043,7 +47021,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRevokeAllOrgRolesTeamResponseValidator(status, body)
@@ -47108,7 +47086,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsAssignTeamToOrgRoleResponseValidator(status, body)
@@ -47163,7 +47141,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRevokeOrgRoleTeamResponseValidator(status, body)
@@ -47217,7 +47195,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRevokeAllOrgRolesUserResponseValidator(status, body)
@@ -47282,7 +47260,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsAssignUserToOrgRoleResponseValidator(status, body)
@@ -47337,7 +47315,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRevokeOrgRoleUserResponseValidator(status, body)
@@ -47401,7 +47379,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetOrgRoleResponseValidator(status, body)
@@ -47474,7 +47452,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListOrgRoleTeamsResponseValidator(status, body)
@@ -47547,7 +47525,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListOrgRoleUsersResponseValidator(status, body)
@@ -47556,7 +47534,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListOutsideCollaboratorsParamSchema = z.object({ org: z.string() })
+  const orgsListOutsideCollaboratorsParamSchema = z.object({org: z.string()})
 
   const orgsListOutsideCollaboratorsQuerySchema = z.object({
     filter: z
@@ -47609,7 +47587,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListOutsideCollaboratorsResponseValidator(status, body)
@@ -47624,7 +47602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const orgsConvertMemberToOutsideCollaboratorBodySchema = z
-    .object({ async: PermissiveBoolean.optional().default(false) })
+    .object({async: PermissiveBoolean.optional().default(false)})
     .optional()
 
   const orgsConvertMemberToOutsideCollaboratorResponseValidator =
@@ -47686,7 +47664,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsConvertMemberToOutsideCollaboratorResponseValidator(
@@ -47759,7 +47737,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRemoveOutsideCollaboratorResponseValidator(status, body)
@@ -47845,7 +47823,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesListPackagesForOrganizationResponseValidator(
@@ -47908,7 +47886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesGetPackageForOrganizationResponseValidator(
@@ -47988,7 +47966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesDeletePackageForOrgResponseValidator(status, body)
@@ -48073,7 +48051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesRestorePackageForOrgResponseValidator(status, body)
@@ -48169,7 +48147,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -48234,7 +48212,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesGetPackageVersionForOrganizationResponseValidator(
@@ -48315,7 +48293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesDeletePackageVersionForOrgResponseValidator(
@@ -48396,7 +48374,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesRestorePackageVersionForOrgResponseValidator(
@@ -48408,7 +48386,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListPatGrantRequestsParamSchema = z.object({ org: z.string() })
+  const orgsListPatGrantRequestsParamSchema = z.object({org: z.string()})
 
   const orgsListPatGrantRequestsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -48423,8 +48401,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     repository: z.string().optional(),
     permission: z.string().optional(),
-    last_used_before: z.string().datetime({ offset: true }).optional(),
-    last_used_after: z.string().datetime({ offset: true }).optional(),
+    last_used_before: z.string().datetime({offset: true}).optional(),
+    last_used_after: z.string().datetime({offset: true}).optional(),
     token_id: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
@@ -48497,7 +48475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListPatGrantRequestsResponseValidator(status, body)
@@ -48581,7 +48559,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsReviewPatGrantRequestsInBulkResponseValidator(status, body)
@@ -48662,7 +48640,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsReviewPatGrantRequestResponseValidator(status, body)
@@ -48740,7 +48718,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListPatGrantRequestRepositoriesResponseValidator(
@@ -48752,7 +48730,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListPatGrantsParamSchema = z.object({ org: z.string() })
+  const orgsListPatGrantsParamSchema = z.object({org: z.string()})
 
   const orgsListPatGrantsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -48767,8 +48745,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     repository: z.string().optional(),
     permission: z.string().optional(),
-    last_used_before: z.string().datetime({ offset: true }).optional(),
-    last_used_after: z.string().datetime({ offset: true }).optional(),
+    last_used_before: z.string().datetime({offset: true}).optional(),
+    last_used_after: z.string().datetime({offset: true}).optional(),
     token_id: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
@@ -48841,7 +48819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListPatGrantsResponseValidator(status, body)
@@ -48850,7 +48828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsUpdatePatAccessesParamSchema = z.object({ org: z.string() })
+  const orgsUpdatePatAccessesParamSchema = z.object({org: z.string()})
 
   const orgsUpdatePatAccessesBodySchema = z.object({
     action: z.enum(["revoke"]),
@@ -48921,7 +48899,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUpdatePatAccessesResponseValidator(status, body)
@@ -48935,7 +48913,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     pat_id: z.coerce.number(),
   })
 
-  const orgsUpdatePatAccessBodySchema = z.object({ action: z.enum(["revoke"]) })
+  const orgsUpdatePatAccessBodySchema = z.object({action: z.enum(["revoke"])})
 
   const orgsUpdatePatAccessResponseValidator = responseValidationFactory(
     [
@@ -48999,7 +48977,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUpdatePatAccessResponseValidator(status, body)
@@ -49077,7 +49055,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListPatGrantRepositoriesResponseValidator(status, body)
@@ -49159,7 +49137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = privateRegistriesListOrgPrivateRegistriesResponseValidator(
@@ -49251,7 +49229,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = privateRegistriesCreateOrgPrivateRegistryResponseValidator(
@@ -49270,7 +49248,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const privateRegistriesGetOrgPublicKeyResponseValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ key_id: z.string(), key: z.string() })],
+        ["200", z.object({key_id: z.string(), key: z.string()})],
         ["404", s_basic_error],
       ],
       undefined,
@@ -49317,7 +49295,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = privateRegistriesGetOrgPublicKeyResponseValidator(status, body)
@@ -49380,7 +49358,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = privateRegistriesGetOrgPrivateRegistryResponseValidator(
@@ -49471,7 +49449,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = privateRegistriesUpdateOrgPrivateRegistryResponseValidator(
@@ -49539,7 +49517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = privateRegistriesDeleteOrgPrivateRegistryResponseValidator(
@@ -49551,7 +49529,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsListForOrgParamSchema = z.object({ org: z.string() })
+  const projectsListForOrgParamSchema = z.object({org: z.string()})
 
   const projectsListForOrgQuerySchema = z.object({
     state: z.enum(["open", "closed", "all"]).optional().default("open"),
@@ -49606,7 +49584,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = projectsListForOrgResponseValidator(status, body)
@@ -49614,7 +49592,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const projectsCreateForOrgParamSchema = z.object({ org: z.string() })
+  const projectsCreateForOrgParamSchema = z.object({org: z.string()})
 
   const projectsCreateForOrgBodySchema = z.object({
     name: z.string(),
@@ -49687,7 +49665,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsCreateForOrgResponseValidator(status, body)
@@ -49696,7 +49674,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsGetAllCustomPropertiesParamSchema = z.object({ org: z.string() })
+  const orgsGetAllCustomPropertiesParamSchema = z.object({org: z.string()})
 
   const orgsGetAllCustomPropertiesResponseValidator = responseValidationFactory(
     [
@@ -49748,7 +49726,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetAllCustomPropertiesResponseValidator(status, body)
@@ -49820,7 +49798,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCreateOrUpdateCustomPropertiesResponseValidator(
@@ -49887,7 +49865,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetCustomPropertyResponseValidator(status, body)
@@ -49959,7 +49937,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCreateOrUpdateCustomPropertyResponseValidator(status, body)
@@ -50023,7 +50001,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRemoveCustomPropertyResponseValidator(status, body)
@@ -50099,7 +50077,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListCustomPropertiesValuesForReposResponseValidator(
@@ -50184,7 +50162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -50197,7 +50175,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListPublicMembersParamSchema = z.object({ org: z.string() })
+  const orgsListPublicMembersParamSchema = z.object({org: z.string()})
 
   const orgsListPublicMembersQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -50248,7 +50226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListPublicMembersResponseValidator(status, body)
@@ -50309,7 +50287,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsCheckPublicMembershipForUserResponseValidator(status, body)
@@ -50375,7 +50353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsSetPublicMembershipForAuthenticatedUserResponseValidator(
@@ -50435,7 +50413,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -50448,7 +50426,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const reposListForOrgParamSchema = z.object({ org: z.string() })
+  const reposListForOrgParamSchema = z.object({org: z.string()})
 
   const reposListForOrgQuerySchema = z.object({
     type: z
@@ -50505,7 +50483,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposListForOrgResponseValidator(status, body)
@@ -50513,7 +50491,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const reposCreateInOrgParamSchema = z.object({ org: z.string() })
+  const reposCreateInOrgParamSchema = z.object({org: z.string()})
 
   const reposCreateInOrgBodySchema = z.object({
     name: z.string(),
@@ -50598,7 +50576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposCreateInOrgResponseValidator(status, body)
@@ -50606,7 +50584,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const reposGetOrgRulesetsParamSchema = z.object({ org: z.string() })
+  const reposGetOrgRulesetsParamSchema = z.object({org: z.string()})
 
   const reposGetOrgRulesetsQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -50668,7 +50646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetOrgRulesetsResponseValidator(status, body)
@@ -50677,7 +50655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const reposCreateOrgRulesetParamSchema = z.object({ org: z.string() })
+  const reposCreateOrgRulesetParamSchema = z.object({org: z.string()})
 
   const reposCreateOrgRulesetBodySchema = z.object({
     name: z.string(),
@@ -50745,7 +50723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateOrgRulesetResponseValidator(status, body)
@@ -50754,7 +50732,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const reposGetOrgRuleSuitesParamSchema = z.object({ org: z.string() })
+  const reposGetOrgRuleSuitesParamSchema = z.object({org: z.string()})
 
   const reposGetOrgRuleSuitesQuerySchema = z.object({
     ref: z.string().optional(),
@@ -50826,7 +50804,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetOrgRuleSuitesResponseValidator(status, body)
@@ -50890,7 +50868,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetOrgRuleSuiteResponseValidator(status, body)
@@ -50954,7 +50932,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetOrgRulesetResponseValidator(status, body)
@@ -51033,7 +51011,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateOrgRulesetResponseValidator(status, body)
@@ -51097,7 +51075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteOrgRulesetResponseValidator(status, body)
@@ -51170,7 +51148,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetOrgRulesetHistoryResponseValidator(status, body)
@@ -51235,7 +51213,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetOrgRulesetVersionResponseValidator(status, body)
@@ -51244,9 +51222,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const secretScanningListAlertsForOrgParamSchema = z.object({
-    org: z.string(),
-  })
+  const secretScanningListAlertsForOrgParamSchema = z.object({org: z.string()})
 
   const secretScanningListAlertsForOrgQuerySchema = z.object({
     state: z.enum(["open", "resolved"]).optional(),
@@ -51332,7 +51308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningListAlertsForOrgResponseValidator(status, body)
@@ -51417,7 +51393,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesListOrgRepositoryAdvisoriesResponseValidator(
@@ -51429,7 +51405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListSecurityManagerTeamsParamSchema = z.object({ org: z.string() })
+  const orgsListSecurityManagerTeamsParamSchema = z.object({org: z.string()})
 
   const orgsListSecurityManagerTeamsResponseValidator =
     responseValidationFactory([["200", z.array(s_team_simple)]], undefined)
@@ -51469,7 +51445,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListSecurityManagerTeamsResponseValidator(status, body)
@@ -51523,7 +51499,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsAddSecurityManagerTeamResponseValidator(status, body)
@@ -51575,7 +51551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsRemoveSecurityManagerTeamResponseValidator(status, body)
@@ -51626,7 +51602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetGithubActionsBillingOrgResponseValidator(
@@ -51680,7 +51656,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetGithubPackagesBillingOrgResponseValidator(
@@ -51734,7 +51710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetSharedStorageBillingOrgResponseValidator(
@@ -51816,7 +51792,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = hostedComputeListNetworkConfigurationsForOrgResponseValidator(
@@ -51885,7 +51861,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = hostedComputeCreateNetworkConfigurationForOrgResponseValidator(
@@ -51940,7 +51916,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = hostedComputeGetNetworkConfigurationForOrgResponseValidator(
@@ -52010,7 +51986,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = hostedComputeUpdateNetworkConfigurationForOrgResponseValidator(
@@ -52070,7 +52046,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -52126,7 +52102,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = hostedComputeGetNetworkSettingsForOrgResponseValidator(
@@ -52213,7 +52189,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = copilotCopilotMetricsForTeamResponseValidator(status, body)
@@ -52222,7 +52198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const teamsListParamSchema = z.object({ org: z.string() })
+  const teamsListParamSchema = z.object({org: z.string()})
 
   const teamsListQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -52276,7 +52252,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = teamsListResponseValidator(status, body)
@@ -52284,7 +52260,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const teamsCreateParamSchema = z.object({ org: z.string() })
+  const teamsCreateParamSchema = z.object({org: z.string()})
 
   const teamsCreateBodySchema = z.object({
     name: z.string(),
@@ -52350,7 +52326,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = teamsCreateResponseValidator(status, body)
@@ -52409,7 +52385,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetByNameResponseValidator(status, body)
@@ -52498,7 +52474,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsUpdateInOrgResponseValidator(status, body)
@@ -52552,7 +52528,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsDeleteInOrgResponseValidator(status, body)
@@ -52617,7 +52593,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListDiscussionsInOrgResponseValidator(status, body)
@@ -52681,7 +52657,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCreateDiscussionInOrgResponseValidator(status, body)
@@ -52736,7 +52712,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetDiscussionInOrgResponseValidator(status, body)
@@ -52752,7 +52728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const teamsUpdateDiscussionInOrgBodySchema = z
-    .object({ title: z.string().optional(), body: z.string().optional() })
+    .object({title: z.string().optional(), body: z.string().optional()})
     .optional()
 
   const teamsUpdateDiscussionInOrgResponseValidator = responseValidationFactory(
@@ -52799,7 +52775,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsUpdateDiscussionInOrgResponseValidator(status, body)
@@ -52854,7 +52830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsDeleteDiscussionInOrgResponseValidator(status, body)
@@ -52920,7 +52896,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListDiscussionCommentsInOrgResponseValidator(status, body)
@@ -52981,7 +52957,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCreateDiscussionCommentInOrgResponseValidator(
@@ -53038,7 +53014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetDiscussionCommentInOrgResponseValidator(status, body)
@@ -53100,7 +53076,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsUpdateDiscussionCommentInOrgResponseValidator(
@@ -53157,7 +53133,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsDeleteDiscussionCommentInOrgResponseValidator(
@@ -53235,7 +53211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForTeamDiscussionCommentInOrgResponseValidator(
@@ -53323,7 +53299,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForTeamDiscussionCommentInOrgResponseValidator(
@@ -53381,7 +53357,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForTeamDiscussionCommentResponseValidator(
@@ -53458,7 +53434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForTeamDiscussionInOrgResponseValidator(
@@ -53540,7 +53516,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForTeamDiscussionInOrgResponseValidator(
@@ -53597,7 +53573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForTeamDiscussionResponseValidator(status, body)
@@ -53661,7 +53637,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListPendingInvitationsInOrgResponseValidator(status, body)
@@ -53725,7 +53701,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListMembersInOrgResponseValidator(status, body)
@@ -53787,7 +53763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetMembershipForUserInOrgResponseValidator(status, body)
@@ -53863,7 +53839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddOrUpdateMembershipForUserInOrgResponseValidator(
@@ -53928,7 +53904,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveMembershipForUserInOrgResponseValidator(
@@ -53994,7 +53970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListProjectsInOrgResponseValidator(status, body)
@@ -54056,7 +54032,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCheckPermissionsForProjectInOrgResponseValidator(
@@ -54075,7 +54051,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const teamsAddOrUpdateProjectPermissionsInOrgBodySchema = z
-    .object({ permission: z.enum(["read", "write", "admin"]).optional() })
+    .object({permission: z.enum(["read", "write", "admin"]).optional()})
     .nullable()
     .optional()
 
@@ -54139,7 +54115,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddOrUpdateProjectPermissionsInOrgResponseValidator(
@@ -54197,7 +54173,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveProjectInOrgResponseValidator(status, body)
@@ -54260,7 +54236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListReposInOrgResponseValidator(status, body)
@@ -54327,7 +54303,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCheckPermissionsForRepoInOrgResponseValidator(
@@ -54347,7 +54323,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const teamsAddOrUpdateRepoPermissionsInOrgBodySchema = z
-    .object({ permission: z.string().optional() })
+    .object({permission: z.string().optional()})
     .optional()
 
   const teamsAddOrUpdateRepoPermissionsInOrgResponseValidator =
@@ -54392,7 +54368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddOrUpdateRepoPermissionsInOrgResponseValidator(
@@ -54451,7 +54427,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveRepoInOrgResponseValidator(status, body)
@@ -54514,7 +54490,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListChildInOrgResponseValidator(status, body)
@@ -54538,7 +54514,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const orgsEnableOrDisableSecurityProductOnAllOrgReposBodySchema = z
-    .object({ query_suite: z.enum(["default", "extended"]).optional() })
+    .object({query_suite: z.enum(["default", "extended"]).optional()})
     .optional()
 
   const orgsEnableOrDisableSecurityProductOnAllOrgReposResponseValidator =
@@ -54597,7 +54573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -54610,7 +54586,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsGetCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsGetCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsGetCardResponseValidator = responseValidationFactory(
     [
@@ -54670,7 +54646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsGetCardResponseValidator(status, body)
@@ -54679,7 +54655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsUpdateCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsUpdateCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsUpdateCardBodySchema = z
     .object({
@@ -54754,7 +54730,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsUpdateCardResponseValidator(status, body)
@@ -54763,7 +54739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsDeleteCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsDeleteCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsDeleteCardResponseValidator = responseValidationFactory(
     [
@@ -54834,7 +54810,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsDeleteCardResponseValidator(status, body)
@@ -54843,7 +54819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsMoveCardParamSchema = z.object({ card_id: z.coerce.number() })
+  const projectsMoveCardParamSchema = z.object({card_id: z.coerce.number()})
 
   const projectsMoveCardBodySchema = z.object({
     position: z.string().regex(new RegExp("^(?:top|bottom|after:\\d+)$")),
@@ -54964,7 +54940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsMoveCardResponseValidator(status, body)
@@ -54973,9 +54949,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsGetColumnParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsGetColumnParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsGetColumnResponseValidator = responseValidationFactory(
     [
@@ -55035,7 +55009,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsGetColumnResponseValidator(status, body)
@@ -55048,7 +55022,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     column_id: z.coerce.number(),
   })
 
-  const projectsUpdateColumnBodySchema = z.object({ name: z.string() })
+  const projectsUpdateColumnBodySchema = z.object({name: z.string()})
 
   const projectsUpdateColumnResponseValidator = responseValidationFactory(
     [
@@ -55108,7 +55082,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsUpdateColumnResponseValidator(status, body)
@@ -55175,7 +55149,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsDeleteColumnResponseValidator(status, body)
@@ -55184,9 +55158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsListCardsParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsListCardsParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsListCardsQuerySchema = z.object({
     archived_state: z
@@ -55255,7 +55227,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsListCardsResponseValidator(status, body)
@@ -55264,13 +55236,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsCreateCardParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsCreateCardParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsCreateCardBodySchema = z.union([
-    z.object({ note: z.string().nullable() }),
-    z.object({ content_id: z.coerce.number(), content_type: z.string() }),
+    z.object({note: z.string().nullable()}),
+    z.object({content_id: z.coerce.number(), content_type: z.string()}),
   ])
 
   const projectsCreateCardResponseValidator = responseValidationFactory(
@@ -55364,7 +55334,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsCreateCardResponseValidator(status, body)
@@ -55373,9 +55343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsMoveColumnParamSchema = z.object({
-    column_id: z.coerce.number(),
-  })
+  const projectsMoveColumnParamSchema = z.object({column_id: z.coerce.number()})
 
   const projectsMoveColumnBodySchema = z.object({
     position: z.string().regex(new RegExp("^(?:first|last|after:\\d+)$")),
@@ -55443,7 +55411,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsMoveColumnResponseValidator(status, body)
@@ -55452,7 +55420,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsGetParamSchema = z.object({ project_id: z.coerce.number() })
+  const projectsGetParamSchema = z.object({project_id: z.coerce.number()})
 
   const projectsGetResponseValidator = responseValidationFactory(
     [
@@ -55505,7 +55473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = projectsGetResponseValidator(status, body)
@@ -55513,7 +55481,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const projectsUpdateParamSchema = z.object({ project_id: z.coerce.number() })
+  const projectsUpdateParamSchema = z.object({project_id: z.coerce.number()})
 
   const projectsUpdateBodySchema = z
     .object({
@@ -55605,7 +55573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = projectsUpdateResponseValidator(status, body)
@@ -55613,7 +55581,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const projectsDeleteParamSchema = z.object({ project_id: z.coerce.number() })
+  const projectsDeleteParamSchema = z.object({project_id: z.coerce.number()})
 
   const projectsDeleteResponseValidator = responseValidationFactory(
     [
@@ -55688,7 +55656,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsDeleteResponseValidator(status, body)
@@ -55773,7 +55741,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsListCollaboratorsResponseValidator(status, body)
@@ -55863,7 +55831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsAddCollaboratorResponseValidator(status, body)
@@ -55939,7 +55907,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsRemoveCollaboratorResponseValidator(status, body)
@@ -56016,7 +55984,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsGetPermissionForUserResponseValidator(status, body)
@@ -56092,7 +56060,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsListColumnsResponseValidator(status, body)
@@ -56105,7 +56073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     project_id: z.coerce.number(),
   })
 
-  const projectsCreateColumnBodySchema = z.object({ name: z.string() })
+  const projectsCreateColumnBodySchema = z.object({name: z.string()})
 
   const projectsCreateColumnResponseValidator = responseValidationFactory(
     [
@@ -56169,7 +56137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsCreateColumnResponseValidator(status, body)
@@ -56221,7 +56189,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = rateLimitGetResponseValidator(status, body)
@@ -56229,7 +56197,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const reposGetParamSchema = z.object({ owner: z.string(), repo: z.string() })
+  const reposGetParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposGetResponseValidator = responseValidationFactory(
     [
@@ -56282,7 +56250,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposGetResponseValidator(status, body)
@@ -56290,10 +56258,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const reposUpdateParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const reposUpdateParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposUpdateBodySchema = z
     .object({
@@ -56305,20 +56270,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
       security_and_analysis: z
         .object({
           advanced_security: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
-          code_security: z.object({ status: z.string().optional() }).optional(),
-          secret_scanning: z
-            .object({ status: z.string().optional() })
-            .optional(),
+          code_security: z.object({status: z.string().optional()}).optional(),
+          secret_scanning: z.object({status: z.string().optional()}).optional(),
           secret_scanning_push_protection: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
           secret_scanning_ai_detection: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
           secret_scanning_non_provider_patterns: z
-            .object({ status: z.string().optional() })
+            .object({status: z.string().optional()})
             .optional(),
         })
         .nullable()
@@ -56409,7 +56372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposUpdateResponseValidator(status, body)
@@ -56417,10 +56380,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const reposDeleteParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const reposDeleteParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposDeleteResponseValidator = responseValidationFactory(
     [
@@ -56486,7 +56446,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposDeleteResponseValidator(status, body)
@@ -56561,7 +56521,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListArtifactsForRepoResponseValidator(status, body)
@@ -56616,7 +56576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetArtifactResponseValidator(status, body)
@@ -56671,7 +56631,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteArtifactResponseValidator(status, body)
@@ -56733,7 +56693,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDownloadArtifactResponseValidator(status, body)
@@ -56790,7 +56750,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetActionsCacheUsageResponseValidator(status, body)
@@ -56860,7 +56820,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetActionsCacheListResponseValidator(status, body)
@@ -56921,7 +56881,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteActionsCacheByKeyResponseValidator(status, body)
@@ -56974,7 +56934,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteActionsCacheByIdResponseValidator(status, body)
@@ -57027,7 +56987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetJobForWorkflowRunResponseValidator(status, body)
@@ -57080,7 +57040,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDownloadJobLogsForWorkflowRunResponseValidator(
@@ -57099,9 +57059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsReRunJobForWorkflowRunBodySchema = z
-    .object({
-      enable_debug_logging: PermissiveBoolean.optional().default(false),
-    })
+    .object({enable_debug_logging: PermissiveBoolean.optional().default(false)})
     .nullable()
     .optional()
 
@@ -57156,7 +57114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsReRunJobForWorkflowRunResponseValidator(status, body)
@@ -57221,7 +57179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetCustomOidcSubClaimForRepoResponseValidator(
@@ -57302,7 +57260,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetCustomOidcSubClaimForRepoResponseValidator(
@@ -57380,7 +57338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRepoOrganizationSecretsResponseValidator(
@@ -57458,7 +57416,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRepoOrganizationVariablesResponseValidator(
@@ -57521,7 +57479,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetGithubActionsPermissionsRepositoryResponseValidator(
@@ -57590,7 +57548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetGithubActionsPermissionsRepositoryResponseValidator(
@@ -57650,7 +57608,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetWorkflowAccessToRepositoryResponseValidator(
@@ -57712,7 +57670,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetWorkflowAccessToRepositoryResponseValidator(
@@ -57767,7 +57725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetAllowedActionsRepositoryResponseValidator(
@@ -57829,7 +57787,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsSetAllowedActionsRepositoryResponseValidator(
@@ -57842,7 +57800,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const actionsGetGithubActionsDefaultWorkflowPermissionsRepositoryResponseValidator =
     responseValidationFactory(
@@ -57892,7 +57850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -57906,7 +57864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const actionsSetGithubActionsDefaultWorkflowPermissionsRepositoryBodySchema =
     s_actions_set_default_workflow_permissions
@@ -57967,7 +57925,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -58047,7 +58005,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListSelfHostedRunnersForRepoResponseValidator(
@@ -58105,7 +58063,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRunnerApplicationsForRepoResponseValidator(
@@ -58132,7 +58090,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const actionsGenerateRunnerJitconfigForRepoResponseValidator =
     responseValidationFactory(
       [
-        ["201", z.object({ runner: s_runner, encoded_jit_config: z.string() })],
+        ["201", z.object({runner: s_runner, encoded_jit_config: z.string()})],
         ["404", s_basic_error],
         ["409", s_basic_error],
         ["422", s_validation_error_simple],
@@ -58191,7 +58149,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGenerateRunnerJitconfigForRepoResponseValidator(
@@ -58246,7 +58204,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateRegistrationTokenForRepoResponseValidator(
@@ -58301,7 +58259,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateRemoveTokenForRepoResponseValidator(status, body)
@@ -58354,7 +58312,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetSelfHostedRunnerForRepoResponseValidator(
@@ -58419,7 +58377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteSelfHostedRunnerFromRepoResponseValidator(
@@ -58498,7 +58456,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListLabelsForSelfHostedRunnerForRepoResponseValidator(
@@ -58589,7 +58547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -58681,7 +58639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -58762,7 +58720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -58848,7 +58806,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -58890,7 +58848,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    created: z.string().datetime({ offset: true }).optional(),
+    created: z.string().datetime({offset: true}).optional(),
     exclude_pull_requests: PermissiveBoolean.optional().default(false),
     check_suite_id: z.coerce.number().optional(),
     head_sha: z.string().optional(),
@@ -58952,7 +58910,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListWorkflowRunsForRepoResponseValidator(status, body)
@@ -59015,7 +58973,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetWorkflowRunResponseValidator(status, body)
@@ -59070,7 +59028,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteWorkflowRunResponseValidator(status, body)
@@ -59125,7 +59083,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetReviewsForRunResponseValidator(status, body)
@@ -59190,7 +59148,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsApproveWorkflowRunResponseValidator(status, body)
@@ -59267,7 +59225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListWorkflowRunArtifactsResponseValidator(status, body)
@@ -59329,7 +59287,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetWorkflowRunAttemptResponseValidator(status, body)
@@ -59355,7 +59313,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       [
         [
           "200",
-          z.object({ total_count: z.coerce.number(), jobs: z.array(s_job) }),
+          z.object({total_count: z.coerce.number(), jobs: z.array(s_job)}),
         ],
         ["404", s_basic_error],
       ],
@@ -59407,7 +59365,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListJobsForWorkflowRunAttemptResponseValidator(
@@ -59464,7 +59422,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDownloadWorkflowRunAttemptLogsResponseValidator(
@@ -59528,7 +59486,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCancelWorkflowRunResponseValidator(status, body)
@@ -59590,7 +59548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsReviewCustomGatesForRunResponseValidator(status, body)
@@ -59652,7 +59610,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsForceCancelWorkflowRunResponseValidator(status, body)
@@ -59678,7 +59636,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       [
         [
           "200",
-          z.object({ total_count: z.coerce.number(), jobs: z.array(s_job) }),
+          z.object({total_count: z.coerce.number(), jobs: z.array(s_job)}),
         ],
       ],
       undefined,
@@ -59726,7 +59684,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListJobsForWorkflowRunResponseValidator(status, body)
@@ -59779,7 +59737,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDownloadWorkflowRunLogsResponseValidator(status, body)
@@ -59845,7 +59803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteWorkflowRunLogsResponseValidator(status, body)
@@ -59901,7 +59859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetPendingDeploymentsForRunResponseValidator(
@@ -59967,7 +59925,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsReviewPendingDeploymentsForRunResponseValidator(
@@ -59986,9 +59944,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsReRunWorkflowBodySchema = z
-    .object({
-      enable_debug_logging: PermissiveBoolean.optional().default(false),
-    })
+    .object({enable_debug_logging: PermissiveBoolean.optional().default(false)})
     .nullable()
     .optional()
 
@@ -60036,7 +59992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsReRunWorkflowResponseValidator(status, body)
@@ -60052,9 +60008,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const actionsReRunWorkflowFailedJobsBodySchema = z
-    .object({
-      enable_debug_logging: PermissiveBoolean.optional().default(false),
-    })
+    .object({enable_debug_logging: PermissiveBoolean.optional().default(false)})
     .nullable()
     .optional()
 
@@ -60100,7 +60054,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsReRunWorkflowFailedJobsResponseValidator(status, body)
@@ -60155,7 +60109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetWorkflowRunUsageResponseValidator(status, body)
@@ -60229,7 +60183,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRepoSecretsResponseValidator(status, body)
@@ -60283,7 +60237,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetRepoPublicKeyResponseValidator(status, body)
@@ -60338,7 +60292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetRepoSecretResponseValidator(status, body)
@@ -60415,7 +60369,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateOrUpdateRepoSecretResponseValidator(status, body)
@@ -60470,7 +60424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteRepoSecretResponseValidator(status, body)
@@ -60544,7 +60498,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRepoVariablesResponseValidator(status, body)
@@ -60607,7 +60561,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateRepoVariableResponseValidator(status, body)
@@ -60662,7 +60616,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetRepoVariableResponseValidator(status, body)
@@ -60726,7 +60680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsUpdateRepoVariableResponseValidator(status, body)
@@ -60781,7 +60735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteRepoVariableResponseValidator(status, body)
@@ -60855,7 +60809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListRepoWorkflowsResponseValidator(status, body)
@@ -60910,7 +60864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetWorkflowResponseValidator(status, body)
@@ -60965,7 +60919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDisableWorkflowResponseValidator(status, body)
@@ -61027,7 +60981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateWorkflowDispatchResponseValidator(status, body)
@@ -61082,7 +61036,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsEnableWorkflowResponseValidator(status, body)
@@ -61121,7 +61075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    created: z.string().datetime({ offset: true }).optional(),
+    created: z.string().datetime({offset: true}).optional(),
     exclude_pull_requests: PermissiveBoolean.optional().default(false),
     check_suite_id: z.coerce.number().optional(),
     head_sha: z.string().optional(),
@@ -61182,7 +61136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListWorkflowRunsResponseValidator(status, body)
@@ -61237,7 +61191,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetWorkflowUsageResponseValidator(status, body)
@@ -61321,7 +61275,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListActivitiesResponseValidator(status, body)
@@ -61390,7 +61344,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListAssigneesResponseValidator(status, body)
@@ -61452,7 +61406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesCheckUserCanBeAssignedResponseValidator(status, body)
@@ -61476,7 +61430,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const reposCreateAttestationResponseValidator = responseValidationFactory(
     [
-      ["201", z.object({ id: z.coerce.number().optional() })],
+      ["201", z.object({id: z.coerce.number().optional()})],
       ["403", s_basic_error],
       ["422", s_validation_error],
     ],
@@ -61530,7 +61484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateAttestationResponseValidator(status, body)
@@ -61631,7 +61585,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListAttestationsResponseValidator(status, body)
@@ -61685,7 +61639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListAutolinksResponseValidator(status, body)
@@ -61755,7 +61709,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateAutolinkResponseValidator(status, body)
@@ -61816,7 +61770,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAutolinkResponseValidator(status, body)
@@ -61877,7 +61831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteAutolinkResponseValidator(status, body)
@@ -61938,7 +61892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCheckAutomatedSecurityFixesResponseValidator(status, body)
@@ -61990,7 +61944,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposEnableAutomatedSecurityFixesResponseValidator(
@@ -62045,7 +61999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDisableAutomatedSecurityFixesResponseValidator(
@@ -62118,7 +62072,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListBranchesResponseValidator(status, body)
@@ -62183,7 +62137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetBranchResponseValidator(status, body)
@@ -62244,7 +62198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetBranchProtectionResponseValidator(status, body)
@@ -62372,7 +62326,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateBranchProtectionResponseValidator(status, body)
@@ -62434,7 +62388,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteBranchProtectionResponseValidator(status, body)
@@ -62490,7 +62444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAdminBranchProtectionResponseValidator(status, body)
@@ -62546,7 +62500,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposSetAdminBranchProtectionResponseValidator(status, body)
@@ -62608,7 +62562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteAdminBranchProtectionResponseValidator(status, body)
@@ -62666,7 +62620,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetPullRequestReviewProtectionResponseValidator(
@@ -62760,7 +62714,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdatePullRequestReviewProtectionResponseValidator(
@@ -62825,7 +62779,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeletePullRequestReviewProtectionResponseValidator(
@@ -62890,7 +62844,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCommitSignatureProtectionResponseValidator(
@@ -62955,7 +62909,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateCommitSignatureProtectionResponseValidator(
@@ -63020,7 +62974,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteCommitSignatureProtectionResponseValidator(
@@ -63085,7 +63039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetStatusChecksProtectionResponseValidator(status, body)
@@ -63106,10 +63060,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       contexts: z.array(z.string()).optional(),
       checks: z
         .array(
-          z.object({
-            context: z.string(),
-            app_id: z.coerce.number().optional(),
-          }),
+          z.object({context: z.string(), app_id: z.coerce.number().optional()}),
         )
         .optional(),
     })
@@ -63170,7 +63121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateStatusCheckProtectionResponseValidator(status, body)
@@ -63223,7 +63174,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRemoveStatusCheckProtectionResponseValidator(status, body)
@@ -63285,7 +63236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAllStatusCheckContextsResponseValidator(status, body)
@@ -63301,7 +63252,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposAddStatusCheckContextsBodySchema = z
-    .union([z.object({ contexts: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({contexts: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposAddStatusCheckContextsResponseValidator =
@@ -63363,7 +63314,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposAddStatusCheckContextsResponseValidator(status, body)
@@ -63379,7 +63330,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposSetStatusCheckContextsBodySchema = z
-    .union([z.object({ contexts: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({contexts: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposSetStatusCheckContextsResponseValidator =
@@ -63437,7 +63388,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposSetStatusCheckContextsResponseValidator(status, body)
@@ -63453,7 +63404,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposRemoveStatusCheckContextsBodySchema = z.union([
-    z.object({ contexts: z.array(z.string()) }),
+    z.object({contexts: z.array(z.string())}),
     z.array(z.string()),
   ])
 
@@ -63512,7 +63463,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRemoveStatusCheckContextsResponseValidator(status, body)
@@ -63573,7 +63524,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAccessRestrictionsResponseValidator(status, body)
@@ -63626,7 +63577,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteAccessRestrictionsResponseValidator(status, body)
@@ -63688,7 +63639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAppsWithAccessToProtectedBranchResponseValidator(
@@ -63761,7 +63712,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposAddAppAccessRestrictionsResponseValidator(status, body)
@@ -63831,7 +63782,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposSetAppAccessRestrictionsResponseValidator(status, body)
@@ -63901,7 +63852,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRemoveAppAccessRestrictionsResponseValidator(status, body)
@@ -63963,7 +63914,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetTeamsWithAccessToProtectedBranchResponseValidator(
@@ -63982,7 +63933,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposAddTeamAccessRestrictionsBodySchema = z
-    .union([z.object({ teams: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({teams: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposAddTeamAccessRestrictionsResponseValidator =
@@ -64036,7 +63987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposAddTeamAccessRestrictionsResponseValidator(status, body)
@@ -64052,7 +64003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposSetTeamAccessRestrictionsBodySchema = z
-    .union([z.object({ teams: z.array(z.string()) }), z.array(z.string())])
+    .union([z.object({teams: z.array(z.string())}), z.array(z.string())])
     .optional()
 
   const reposSetTeamAccessRestrictionsResponseValidator =
@@ -64106,7 +64057,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposSetTeamAccessRestrictionsResponseValidator(status, body)
@@ -64122,7 +64073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposRemoveTeamAccessRestrictionsBodySchema = z.union([
-    z.object({ teams: z.array(z.string()) }),
+    z.object({teams: z.array(z.string())}),
     z.array(z.string()),
   ])
 
@@ -64177,7 +64128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRemoveTeamAccessRestrictionsResponseValidator(
@@ -64242,7 +64193,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetUsersWithAccessToProtectedBranchResponseValidator(
@@ -64315,7 +64266,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposAddUserAccessRestrictionsResponseValidator(status, body)
@@ -64385,7 +64336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposSetUserAccessRestrictionsResponseValidator(status, body)
@@ -64455,7 +64406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRemoveUserAccessRestrictionsResponseValidator(
@@ -64473,7 +64424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     branch: z.string(),
   })
 
-  const reposRenameBranchBodySchema = z.object({ new_name: z.string() })
+  const reposRenameBranchBodySchema = z.object({new_name: z.string()})
 
   const reposRenameBranchResponseValidator = responseValidationFactory(
     [
@@ -64533,7 +64484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRenameBranchResponseValidator(status, body)
@@ -64548,9 +64499,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const checksCreateBodySchema = z.union([
-    z.intersection(z.object({ status: z.object({}) }), z.record(z.unknown())),
+    z.intersection(z.object({status: z.object({})}), z.record(z.unknown())),
     z.intersection(
-      z.object({ status: z.object({}).optional() }),
+      z.object({status: z.object({}).optional()}),
       z.record(z.unknown()),
     ),
   ])
@@ -64599,7 +64550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksCreateResponseValidator(status, body)
@@ -64654,7 +64605,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksGetResponseValidator(status, body)
@@ -64673,7 +64624,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     name: z.string().optional(),
     details_url: z.string().optional(),
     external_id: z.string().optional(),
-    started_at: z.string().datetime({ offset: true }).optional(),
+    started_at: z.string().datetime({offset: true}).optional(),
     status: z
       .enum([
         "queued",
@@ -64696,7 +64647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         "timed_out",
       ])
       .optional(),
-    completed_at: z.string().datetime({ offset: true }).optional(),
+    completed_at: z.string().datetime({offset: true}).optional(),
     output: z
       .object({
         title: z.string().optional(),
@@ -64785,7 +64736,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksUpdateResponseValidator(status, body)
@@ -64849,7 +64800,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksListAnnotationsResponseValidator(status, body)
@@ -64918,7 +64869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksRerequestRunResponseValidator(status, body)
@@ -64932,7 +64883,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     repo: z.string(),
   })
 
-  const checksCreateSuiteBodySchema = z.object({ head_sha: z.string() })
+  const checksCreateSuiteBodySchema = z.object({head_sha: z.string()})
 
   const checksCreateSuiteResponseValidator = responseValidationFactory(
     [
@@ -64984,7 +64935,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksCreateSuiteResponseValidator(status, body)
@@ -65053,7 +65004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksSetSuitesPreferencesResponseValidator(status, body)
@@ -65108,7 +65059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksGetSuiteResponseValidator(status, body)
@@ -65186,7 +65137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksListForSuiteResponseValidator(status, body)
@@ -65241,7 +65192,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksRerequestSuiteResponseValidator(status, body)
@@ -65344,7 +65295,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningListAlertsForRepoResponseValidator(status, body)
@@ -65428,7 +65379,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetAlertResponseValidator(status, body)
@@ -65523,7 +65474,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningUpdateAlertResponseValidator(status, body)
@@ -65607,7 +65558,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetAutofixResponseValidator(status, body)
@@ -65699,7 +65650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningCreateAutofixResponseValidator(status, body)
@@ -65796,7 +65747,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningCommitAutofixResponseValidator(status, body)
@@ -65888,7 +65839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningListAlertInstancesResponseValidator(status, body)
@@ -65984,7 +65935,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningListRecentAnalysesResponseValidator(status, body)
@@ -66070,7 +66021,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetAnalysisResponseValidator(status, body)
@@ -66162,7 +66113,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningDeleteAnalysisResponseValidator(status, body)
@@ -66242,7 +66193,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningListCodeqlDatabasesResponseValidator(status, body)
@@ -66327,7 +66278,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetCodeqlDatabaseResponseValidator(status, body)
@@ -66408,7 +66359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningDeleteCodeqlDatabaseResponseValidator(status, body)
@@ -66498,7 +66449,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningCreateVariantAnalysisResponseValidator(
@@ -66578,7 +66529,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetVariantAnalysisResponseValidator(status, body)
@@ -66659,7 +66610,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetVariantAnalysisRepoTaskResponseValidator(
@@ -66742,7 +66693,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetDefaultSetupResponseValidator(status, body)
@@ -66843,7 +66794,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningUpdateDefaultSetupResponseValidator(status, body)
@@ -66862,7 +66813,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     ref: s_code_scanning_ref_full,
     sarif: s_code_scanning_analysis_sarif_file,
     checkout_uri: z.string().optional(),
-    started_at: z.string().datetime({ offset: true }).optional(),
+    started_at: z.string().datetime({offset: true}).optional(),
     tool_name: z.string().optional(),
     validate: PermissiveBoolean.optional(),
   })
@@ -66944,7 +66895,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningUploadSarifResponseValidator(status, body)
@@ -67024,7 +66975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeScanningGetSarifResponseValidator(status, body)
@@ -67099,7 +67050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codeSecurityGetConfigurationForRepositoryResponseValidator(
@@ -67170,7 +67121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCodeownersErrorsResponseValidator(status, body)
@@ -67266,7 +67217,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -67389,7 +67340,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesCreateWithRepoForAuthenticatedUserResponseValidator(
@@ -67402,7 +67353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codespacesListDevcontainersInRepositoryForAuthenticatedUserParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const codespacesListDevcontainersInRepositoryForAuthenticatedUserQuerySchema =
     z.object({
@@ -67501,7 +67452,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -67601,7 +67552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesRepoMachinesForAuthenticatedUserResponseValidator(
@@ -67704,7 +67655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -67807,7 +67758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesCheckPermissionsForDevcontainerResponseValidator(
@@ -67884,7 +67835,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesListRepoSecretsResponseValidator(status, body)
@@ -67938,7 +67889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetRepoPublicKeyResponseValidator(status, body)
@@ -67993,7 +67944,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetRepoSecretResponseValidator(status, body)
@@ -68071,7 +68022,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesCreateOrUpdateRepoSecretResponseValidator(
@@ -68129,7 +68080,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesDeleteRepoSecretResponseValidator(status, body)
@@ -68202,7 +68153,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListCollaboratorsResponseValidator(status, body)
@@ -68263,7 +68214,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCheckCollaboratorResponseValidator(status, body)
@@ -68279,7 +68230,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const reposAddCollaboratorBodySchema = z
-    .object({ permission: z.string().optional().default("push") })
+    .object({permission: z.string().optional().default("push")})
     .optional()
 
   const reposAddCollaboratorResponseValidator = responseValidationFactory(
@@ -68340,7 +68291,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposAddCollaboratorResponseValidator(status, body)
@@ -68405,7 +68356,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRemoveCollaboratorResponseValidator(status, body)
@@ -68469,7 +68420,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCollaboratorPermissionLevelResponseValidator(
@@ -68533,7 +68484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListCommitCommentsForRepoResponseValidator(status, body)
@@ -68594,7 +68545,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCommitCommentResponseValidator(status, body)
@@ -68609,7 +68560,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     comment_id: z.coerce.number(),
   })
 
-  const reposUpdateCommitCommentBodySchema = z.object({ body: z.string() })
+  const reposUpdateCommitCommentBodySchema = z.object({body: z.string()})
 
   const reposUpdateCommitCommentResponseValidator = responseValidationFactory(
     [
@@ -68661,7 +68612,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateCommitCommentResponseValidator(status, body)
@@ -68722,7 +68673,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteCommitCommentResponseValidator(status, body)
@@ -68805,7 +68756,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForCommitCommentResponseValidator(status, body)
@@ -68888,7 +68839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForCommitCommentResponseValidator(status, body)
@@ -68942,7 +68893,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForCommitCommentResponseValidator(status, body)
@@ -68961,8 +68912,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     path: z.string().optional(),
     author: z.string().optional(),
     committer: z.string().optional(),
-    since: z.string().datetime({ offset: true }).optional(),
-    until: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
+    until: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -69029,7 +68980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListCommitsResponseValidator(status, body)
@@ -69095,7 +69046,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListBranchesForHeadCommitResponseValidator(status, body)
@@ -69159,7 +69110,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListCommentsForCommitResponseValidator(status, body)
@@ -69235,7 +69186,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateCommitCommentResponseValidator(status, body)
@@ -69306,7 +69257,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListPullRequestsAssociatedWithCommitResponseValidator(
@@ -69406,7 +69357,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCommitResponseValidator(status, body)
@@ -69485,7 +69436,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksListForRefResponseValidator(status, body)
@@ -69562,7 +69513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = checksListSuitesForRefResponseValidator(status, body)
@@ -69633,7 +69584,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCombinedStatusForRefResponseValidator(status, body)
@@ -69704,7 +69655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListCommitStatusesForRefResponseValidator(status, body)
@@ -69756,7 +69707,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCommunityProfileMetricsResponseValidator(status, body)
@@ -69845,7 +69796,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCompareCommitsResponseValidator(status, body)
@@ -69860,7 +69811,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     path: z.string(),
   })
 
-  const reposGetContentQuerySchema = z.object({ ref: z.string().optional() })
+  const reposGetContentQuerySchema = z.object({ref: z.string().optional()})
 
   const reposGetContentResponseValidator = responseValidationFactory(
     [
@@ -69937,7 +69888,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetContentResponseValidator(status, body)
@@ -70038,7 +69989,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateOrUpdateFileContentsResponseValidator(status, body)
@@ -70058,10 +70009,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     sha: z.string(),
     branch: z.string().optional(),
     committer: z
-      .object({ name: z.string().optional(), email: z.string().optional() })
+      .object({name: z.string().optional(), email: z.string().optional()})
       .optional(),
     author: z
-      .object({ name: z.string().optional(), email: z.string().optional() })
+      .object({name: z.string().optional(), email: z.string().optional()})
       .optional(),
   })
 
@@ -70138,7 +70089,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteFileResponseValidator(status, body)
@@ -70216,7 +70167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListContributorsResponseValidator(status, body)
@@ -70319,7 +70270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotListAlertsForRepoResponseValidator(status, body)
@@ -70388,7 +70339,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotGetAlertResponseValidator(status, body)
@@ -70483,7 +70434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotUpdateAlertResponseValidator(status, body)
@@ -70557,7 +70508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotListRepoSecretsResponseValidator(status, body)
@@ -70611,7 +70562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotGetRepoPublicKeyResponseValidator(status, body)
@@ -70666,7 +70617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotGetRepoSecretResponseValidator(status, body)
@@ -70744,7 +70695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotCreateOrUpdateRepoSecretResponseValidator(
@@ -70802,7 +70753,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependabotDeleteRepoSecretResponseValidator(status, body)
@@ -70875,7 +70826,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependencyGraphDiffRangeResponseValidator(status, body)
@@ -70939,7 +70890,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependencyGraphExportSbomResponseValidator(status, body)
@@ -71015,7 +70966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = dependencyGraphCreateRepositorySnapshotResponseValidator(
@@ -71085,7 +71036,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListDeploymentsResponseValidator(status, body)
@@ -71116,7 +71067,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposCreateDeploymentResponseValidator = responseValidationFactory(
     [
       ["201", s_deployment],
-      ["202", z.object({ message: z.string().optional() })],
+      ["202", z.object({message: z.string().optional()})],
       ["409", z.undefined()],
       ["422", s_validation_error],
     ],
@@ -71173,7 +71124,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateDeploymentResponseValidator(status, body)
@@ -71234,7 +71185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetDeploymentResponseValidator(status, body)
@@ -71299,7 +71250,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteDeploymentResponseValidator(status, body)
@@ -71370,7 +71321,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListDeploymentStatusesResponseValidator(status, body)
@@ -71454,7 +71405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateDeploymentStatusResponseValidator(status, body)
@@ -71516,7 +71467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetDeploymentStatusResponseValidator(status, body)
@@ -71589,7 +71540,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateDispatchEventResponseValidator(status, body)
@@ -71663,7 +71614,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAllEnvironmentsResponseValidator(status, body)
@@ -71718,7 +71669,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetEnvironmentResponseValidator(status, body)
@@ -71802,7 +71753,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateOrUpdateEnvironmentResponseValidator(status, body)
@@ -71857,7 +71808,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteAnEnvironmentResponseValidator(status, body)
@@ -71933,7 +71884,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListDeploymentBranchPoliciesResponseValidator(
@@ -72009,7 +71960,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateDeploymentBranchPolicyResponseValidator(
@@ -72066,7 +72017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetDeploymentBranchPolicyResponseValidator(status, body)
@@ -72127,7 +72078,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateDeploymentBranchPolicyResponseValidator(
@@ -72184,7 +72135,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteDeploymentBranchPolicyResponseValidator(
@@ -72256,7 +72207,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAllDeploymentProtectionRulesResponseValidator(
@@ -72323,7 +72274,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateDeploymentProtectionRuleResponseValidator(
@@ -72404,7 +72355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListCustomDeploymentRuleIntegrationsResponseValidator(
@@ -72464,7 +72415,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCustomDeploymentProtectionRuleResponseValidator(
@@ -72521,7 +72472,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDisableDeploymentProtectionRuleResponseValidator(
@@ -72600,7 +72551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListEnvironmentSecretsResponseValidator(status, body)
@@ -72653,7 +72604,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetEnvironmentPublicKeyResponseValidator(status, body)
@@ -72707,7 +72658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetEnvironmentSecretResponseValidator(status, body)
@@ -72785,7 +72736,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateOrUpdateEnvironmentSecretResponseValidator(
@@ -72842,7 +72793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteEnvironmentSecretResponseValidator(status, body)
@@ -72918,7 +72869,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsListEnvironmentVariablesResponseValidator(status, body)
@@ -72980,7 +72931,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsCreateEnvironmentVariableResponseValidator(status, body)
@@ -73034,7 +72985,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsGetEnvironmentVariableResponseValidator(status, body)
@@ -73097,7 +73048,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsUpdateEnvironmentVariableResponseValidator(status, body)
@@ -73151,7 +73102,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = actionsDeleteEnvironmentVariableResponseValidator(status, body)
@@ -73214,7 +73165,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListRepoEventsResponseValidator(status, body)
@@ -73287,7 +73238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListForksResponseValidator(status, body)
@@ -73372,7 +73323,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateForkResponseValidator(status, body)
@@ -73455,7 +73406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitCreateBlobResponseValidator(status, body)
@@ -73528,7 +73479,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitGetBlobResponseValidator(status, body)
@@ -73550,14 +73501,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .object({
         name: z.string(),
         email: z.string(),
-        date: z.string().datetime({ offset: true }).optional(),
+        date: z.string().datetime({offset: true}).optional(),
       })
       .optional(),
     committer: z
       .object({
         name: z.string().optional(),
         email: z.string().optional(),
-        date: z.string().datetime({ offset: true }).optional(),
+        date: z.string().datetime({offset: true}).optional(),
       })
       .optional(),
     signature: z.string().optional(),
@@ -73621,7 +73572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitCreateCommitResponseValidator(status, body)
@@ -73686,7 +73637,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitGetCommitResponseValidator(status, body)
@@ -73747,7 +73698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitListMatchingRefsResponseValidator(status, body)
@@ -73812,7 +73763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitGetRefResponseValidator(status, body)
@@ -73826,7 +73777,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     repo: z.string(),
   })
 
-  const gitCreateRefBodySchema = z.object({ ref: z.string(), sha: z.string() })
+  const gitCreateRefBodySchema = z.object({ref: z.string(), sha: z.string()})
 
   const gitCreateRefResponseValidator = responseValidationFactory(
     [
@@ -73882,7 +73833,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitCreateRefResponseValidator(status, body)
@@ -73956,7 +73907,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitUpdateRefResponseValidator(status, body)
@@ -74021,7 +73972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitDeleteRefResponseValidator(status, body)
@@ -74044,7 +73995,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .object({
         name: z.string(),
         email: z.string(),
-        date: z.string().datetime({ offset: true }).optional(),
+        date: z.string().datetime({offset: true}).optional(),
       })
       .optional(),
   })
@@ -74103,7 +74054,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitCreateTagResponseValidator(status, body)
@@ -74168,7 +74119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitGetTagResponseValidator(status, body)
@@ -74259,7 +74210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitCreateTreeResponseValidator(status, body)
@@ -74274,7 +74225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     tree_sha: z.string(),
   })
 
-  const gitGetTreeQuerySchema = z.object({ recursive: z.string().optional() })
+  const gitGetTreeQuerySchema = z.object({recursive: z.string().optional()})
 
   const gitGetTreeResponseValidator = responseValidationFactory(
     [
@@ -74334,7 +74285,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gitGetTreeResponseValidator(status, body)
@@ -74403,7 +74354,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListWebhooksResponseValidator(status, body)
@@ -74492,7 +74443,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateWebhookResponseValidator(status, body)
@@ -74553,7 +74504,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetWebhookResponseValidator(status, body)
@@ -74630,7 +74581,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateWebhookResponseValidator(status, body)
@@ -74691,7 +74642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteWebhookResponseValidator(status, body)
@@ -74744,7 +74695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetWebhookConfigForRepoResponseValidator(status, body)
@@ -74810,7 +74761,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateWebhookConfigForRepoResponseValidator(status, body)
@@ -74884,7 +74835,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListWebhookDeliveriesResponseValidator(status, body)
@@ -74950,7 +74901,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetWebhookDeliveryResponseValidator(status, body)
@@ -75019,7 +74970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRedeliverWebhookDeliveryResponseValidator(status, body)
@@ -75080,7 +75031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposPingWebhookResponseValidator(status, body)
@@ -75141,7 +75092,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposTestPushWebhookResponseValidator(status, body)
@@ -75205,7 +75156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsGetImportStatusResponseValidator(status, body)
@@ -75285,7 +75236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsStartImportResponseValidator(status, body)
@@ -75359,7 +75310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsUpdateImportResponseValidator(status, body)
@@ -75419,7 +75370,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsCancelImportResponseValidator(status, body)
@@ -75491,7 +75442,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsGetCommitAuthorsResponseValidator(status, body)
@@ -75507,7 +75458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const migrationsMapCommitAuthorBodySchema = z
-    .object({ email: z.string().optional(), name: z.string().optional() })
+    .object({email: z.string().optional(), name: z.string().optional()})
     .optional()
 
   const migrationsMapCommitAuthorResponseValidator = responseValidationFactory(
@@ -75568,7 +75519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsMapCommitAuthorResponseValidator(status, body)
@@ -75628,7 +75579,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsGetLargeFilesResponseValidator(status, body)
@@ -75700,7 +75651,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsSetLfsPreferenceResponseValidator(status, body)
@@ -75764,7 +75715,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetRepoInstallationResponseValidator(status, body)
@@ -75821,7 +75772,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = interactionsGetRestrictionsForRepoResponseValidator(
@@ -75891,7 +75842,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = interactionsSetRestrictionsForRepoResponseValidator(
@@ -75955,7 +75906,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = interactionsRemoveRestrictionsForRepoResponseValidator(
@@ -76021,7 +75972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListInvitationsResponseValidator(status, body)
@@ -76088,7 +76039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateInvitationResponseValidator(status, body)
@@ -76143,7 +76094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteInvitationResponseValidator(status, body)
@@ -76170,7 +76121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -76233,7 +76184,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListForRepoResponseValidator(status, body)
@@ -76350,7 +76301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesCreateResponseValidator(status, body)
@@ -76367,7 +76318,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const issuesListCommentsForRepoQuerySchema = z.object({
     sort: z.enum(["created", "updated"]).optional().default("created"),
     direction: z.enum(["asc", "desc"]).optional(),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -76426,7 +76377,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListCommentsForRepoResponseValidator(status, body)
@@ -76487,7 +76438,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesGetCommentResponseValidator(status, body)
@@ -76502,7 +76453,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     comment_id: z.coerce.number(),
   })
 
-  const issuesUpdateCommentBodySchema = z.object({ body: z.string() })
+  const issuesUpdateCommentBodySchema = z.object({body: z.string()})
 
   const issuesUpdateCommentResponseValidator = responseValidationFactory(
     [
@@ -76554,7 +76505,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesUpdateCommentResponseValidator(status, body)
@@ -76609,7 +76560,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesDeleteCommentResponseValidator(status, body)
@@ -76692,7 +76643,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForIssueCommentResponseValidator(status, body)
@@ -76775,7 +76726,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForIssueCommentResponseValidator(status, body)
@@ -76829,7 +76780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForIssueCommentResponseValidator(status, body)
@@ -76898,7 +76849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListEventsForRepoResponseValidator(status, body)
@@ -76967,7 +76918,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesGetEventResponseValidator(status, body)
@@ -77040,7 +76991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesGetResponseValidator(status, body)
@@ -77165,7 +77116,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesUpdateResponseValidator(status, body)
@@ -77181,7 +77132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const issuesAddAssigneesBodySchema = z
-    .object({ assignees: z.array(z.string()).optional() })
+    .object({assignees: z.array(z.string()).optional()})
     .optional()
 
   const issuesAddAssigneesResponseValidator = responseValidationFactory(
@@ -77228,7 +77179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesAddAssigneesResponseValidator(status, body)
@@ -77291,7 +77242,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesRemoveAssigneesResponseValidator(status, body)
@@ -77354,7 +77305,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesCheckUserCanBeAssignedToIssueResponseValidator(
@@ -77373,7 +77324,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const issuesListCommentsQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -77432,7 +77383,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListCommentsResponseValidator(status, body)
@@ -77447,7 +77398,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     issue_number: z.coerce.number(),
   })
 
-  const issuesCreateCommentBodySchema = z.object({ body: z.string() })
+  const issuesCreateCommentBodySchema = z.object({body: z.string()})
 
   const issuesCreateCommentResponseValidator = responseValidationFactory(
     [
@@ -77511,7 +77462,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesCreateCommentResponseValidator(status, body)
@@ -77581,7 +77532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListEventsResponseValidator(status, body)
@@ -77659,7 +77610,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListLabelsOnIssueResponseValidator(status, body)
@@ -77676,15 +77627,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const issuesAddLabelsBodySchema = z
     .union([
-      z.object({ labels: z.array(z.string()).min(1).optional() }),
+      z.object({labels: z.array(z.string()).min(1).optional()}),
       z.array(z.string()).min(1),
       z.object({
         labels: z
-          .array(z.object({ name: z.string() }))
+          .array(z.object({name: z.string()}))
           .min(1)
           .optional(),
       }),
-      z.array(z.object({ name: z.string() })).min(1),
+      z.array(z.object({name: z.string()})).min(1),
       z.string(),
     ])
     .optional()
@@ -77751,7 +77702,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesAddLabelsResponseValidator(status, body)
@@ -77768,15 +77719,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const issuesSetLabelsBodySchema = z
     .union([
-      z.object({ labels: z.array(z.string()).min(1).optional() }),
+      z.object({labels: z.array(z.string()).min(1).optional()}),
       z.array(z.string()).min(1),
       z.object({
         labels: z
-          .array(z.object({ name: z.string() }))
+          .array(z.object({name: z.string()}))
           .min(1)
           .optional(),
       }),
-      z.array(z.object({ name: z.string() })).min(1),
+      z.array(z.object({name: z.string()})).min(1),
       z.string(),
     ])
     .optional()
@@ -77843,7 +77794,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesSetLabelsResponseValidator(status, body)
@@ -77912,7 +77863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesRemoveAllLabelsResponseValidator(status, body)
@@ -77982,7 +77933,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesRemoveLabelResponseValidator(status, body)
@@ -78068,7 +78019,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesLockResponseValidator(status, body)
@@ -78133,7 +78084,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesUnlockResponseValidator(status, body)
@@ -78219,7 +78170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForIssueResponseValidator(status, body)
@@ -78301,7 +78252,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForIssueResponseValidator(status, body)
@@ -78357,7 +78308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForIssueResponseValidator(status, body)
@@ -78430,7 +78381,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesRemoveSubIssueResponseValidator(status, body)
@@ -78504,7 +78455,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListSubIssuesResponseValidator(status, body)
@@ -78586,7 +78537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesAddSubIssueResponseValidator(status, body)
@@ -78680,7 +78631,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesReprioritizeSubIssueResponseValidator(status, body)
@@ -78755,7 +78706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListEventsForTimelineResponseValidator(status, body)
@@ -78818,7 +78769,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListDeployKeysResponseValidator(status, body)
@@ -78888,7 +78839,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateDeployKeyResponseValidator(status, body)
@@ -78949,7 +78900,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetDeployKeyResponseValidator(status, body)
@@ -79004,7 +78955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteDeployKeyResponseValidator(status, body)
@@ -79073,7 +79024,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListLabelsForRepoResponseValidator(status, body)
@@ -79147,7 +79098,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesCreateLabelResponseValidator(status, body)
@@ -79208,7 +79159,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesGetLabelResponseValidator(status, body)
@@ -79275,7 +79226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesUpdateLabelResponseValidator(status, body)
@@ -79330,7 +79281,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesDeleteLabelResponseValidator(status, body)
@@ -79384,7 +79335,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListLanguagesResponseValidator(status, body)
@@ -79452,7 +79403,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = licensesGetForRepoResponseValidator(status, body)
@@ -79466,7 +79417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     repo: z.string(),
   })
 
-  const reposMergeUpstreamBodySchema = z.object({ branch: z.string() })
+  const reposMergeUpstreamBodySchema = z.object({branch: z.string()})
 
   const reposMergeUpstreamResponseValidator = responseValidationFactory(
     [
@@ -79522,7 +79473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposMergeUpstreamResponseValidator(status, body)
@@ -79531,10 +79482,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const reposMergeParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const reposMergeParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const reposMergeBodySchema = z.object({
     base: z.string(),
@@ -79605,7 +79553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposMergeResponseValidator(status, body)
@@ -79676,7 +79624,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListMilestonesResponseValidator(status, body)
@@ -79694,7 +79642,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     title: z.string(),
     state: z.enum(["open", "closed"]).optional().default("open"),
     description: z.string().optional(),
-    due_on: z.string().datetime({ offset: true }).optional(),
+    due_on: z.string().datetime({offset: true}).optional(),
   })
 
   const issuesCreateMilestoneResponseValidator = responseValidationFactory(
@@ -79751,7 +79699,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesCreateMilestoneResponseValidator(status, body)
@@ -79812,7 +79760,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesGetMilestoneResponseValidator(status, body)
@@ -79832,7 +79780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       title: z.string().optional(),
       state: z.enum(["open", "closed"]).optional().default("open"),
       description: z.string().optional(),
-      due_on: z.string().datetime({ offset: true }).optional(),
+      due_on: z.string().datetime({offset: true}).optional(),
     })
     .optional()
 
@@ -79880,7 +79828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesUpdateMilestoneResponseValidator(status, body)
@@ -79941,7 +79889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesDeleteMilestoneResponseValidator(status, body)
@@ -80003,7 +79951,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListLabelsForMilestoneResponseValidator(status, body)
@@ -80013,15 +79961,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const activityListRepoNotificationsForAuthenticatedUserParamSchema = z.object(
-    { owner: z.string(), repo: z.string() },
+    {owner: z.string(), repo: z.string()},
   )
 
   const activityListRepoNotificationsForAuthenticatedUserQuerySchema = z.object(
     {
       all: PermissiveBoolean.optional().default(false),
       participating: PermissiveBoolean.optional().default(false),
-      since: z.string().datetime({ offset: true }).optional(),
-      before: z.string().datetime({ offset: true }).optional(),
+      since: z.string().datetime({offset: true}).optional(),
+      before: z.string().datetime({offset: true}).optional(),
       per_page: z.coerce.number().optional().default(30),
       page: z.coerce.number().optional().default(1),
     },
@@ -80074,7 +80022,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -80093,7 +80041,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const activityMarkRepoNotificationsAsReadBodySchema = z
-    .object({ last_read_at: z.string().datetime({ offset: true }).optional() })
+    .object({last_read_at: z.string().datetime({offset: true}).optional()})
     .optional()
 
   const activityMarkRepoNotificationsAsReadResponseValidator =
@@ -80156,7 +80104,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityMarkRepoNotificationsAsReadResponseValidator(
@@ -80219,7 +80167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetPagesResponseValidator(status, body)
@@ -80299,7 +80247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreatePagesSiteResponseValidator(status, body)
@@ -80320,7 +80268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     source: z
       .union([
         z.enum(["gh-pages", "master", "master /docs"]),
-        z.object({ branch: z.string(), path: z.enum(["/", "/docs"]) }),
+        z.object({branch: z.string(), path: z.enum(["/", "/docs"])}),
       ])
       .optional(),
   })
@@ -80384,7 +80332,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateInformationAboutPagesSiteResponseValidator(
@@ -80455,7 +80403,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeletePagesSiteResponseValidator(status, body)
@@ -80518,7 +80466,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListPagesBuildsResponseValidator(status, body)
@@ -80572,7 +80520,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposRequestPagesBuildResponseValidator(status, body)
@@ -80626,7 +80574,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetLatestPagesBuildResponseValidator(status, body)
@@ -80681,7 +80629,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetPagesBuildResponseValidator(status, body)
@@ -80761,7 +80709,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreatePagesDeploymentResponseValidator(status, body)
@@ -80822,7 +80770,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetPagesDeploymentResponseValidator(status, body)
@@ -80883,7 +80831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCancelPagesDeploymentResponseValidator(status, body)
@@ -80955,7 +80903,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetPagesHealthCheckResponseValidator(status, body)
@@ -80972,7 +80920,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const reposCheckPrivateVulnerabilityReportingResponseValidator =
     responseValidationFactory(
       [
-        ["200", z.object({ enabled: PermissiveBoolean })],
+        ["200", z.object({enabled: PermissiveBoolean})],
         ["422", s_scim_error],
       ],
       undefined,
@@ -81018,7 +80966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCheckPrivateVulnerabilityReportingResponseValidator(
@@ -81082,7 +81030,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposEnablePrivateVulnerabilityReportingResponseValidator(
@@ -81146,7 +81094,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDisablePrivateVulnerabilityReportingResponseValidator(
@@ -81235,7 +81183,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsListForRepoResponseValidator(status, body)
@@ -81320,7 +81268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsCreateForRepoResponseValidator(status, body)
@@ -81385,7 +81333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCustomPropertiesValuesResponseValidator(status, body)
@@ -81462,7 +81410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateOrUpdateCustomPropertiesValuesResponseValidator(
@@ -81474,7 +81422,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const pullsListParamSchema = z.object({ owner: z.string(), repo: z.string() })
+  const pullsListParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const pullsListQuerySchema = z.object({
     state: z.enum(["open", "closed", "all"]).optional().default("open"),
@@ -81540,7 +81488,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = pullsListResponseValidator(status, body)
@@ -81548,10 +81496,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const pullsCreateParamSchema = z.object({
-    owner: z.string(),
-    repo: z.string(),
-  })
+  const pullsCreateParamSchema = z.object({owner: z.string(), repo: z.string()})
 
   const pullsCreateBodySchema = z.object({
     title: z.string().optional(),
@@ -81615,7 +81560,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = pullsCreateResponseValidator(status, body)
@@ -81631,7 +81576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const pullsListReviewCommentsForRepoQuerySchema = z.object({
     sort: z.enum(["created", "updated", "created_at"]).optional(),
     direction: z.enum(["asc", "desc"]).optional(),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -81681,7 +81626,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListReviewCommentsForRepoResponseValidator(status, body)
@@ -81742,7 +81687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsGetReviewCommentResponseValidator(status, body)
@@ -81757,7 +81702,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     comment_id: z.coerce.number(),
   })
 
-  const pullsUpdateReviewCommentBodySchema = z.object({ body: z.string() })
+  const pullsUpdateReviewCommentBodySchema = z.object({body: z.string()})
 
   const pullsUpdateReviewCommentResponseValidator = responseValidationFactory(
     [["200", s_pull_request_review_comment]],
@@ -81803,7 +81748,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsUpdateReviewCommentResponseValidator(status, body)
@@ -81864,7 +81809,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsDeleteReviewCommentResponseValidator(status, body)
@@ -81947,7 +81892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForPullRequestReviewCommentResponseValidator(
@@ -82033,7 +81978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForPullRequestReviewCommentResponseValidator(
@@ -82090,7 +82035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForPullRequestCommentResponseValidator(
@@ -82181,7 +82126,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsGetResponseValidator(status, body)
@@ -82260,7 +82205,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsUpdateResponseValidator(status, body)
@@ -82370,7 +82315,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesCreateWithPrForAuthenticatedUserResponseValidator(
@@ -82391,7 +82336,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const pullsListReviewCommentsQuerySchema = z.object({
     sort: z.enum(["created", "updated"]).optional().default("created"),
     direction: z.enum(["asc", "desc"]).optional(),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -82440,7 +82385,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListReviewCommentsResponseValidator(status, body)
@@ -82522,7 +82467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsCreateReviewCommentResponseValidator(status, body)
@@ -82593,7 +82538,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsCreateReplyForReviewCommentResponseValidator(status, body)
@@ -82657,7 +82602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListCommitsResponseValidator(status, body)
@@ -82746,7 +82691,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListFilesResponseValidator(status, body)
@@ -82807,7 +82752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsCheckIfMergedResponseValidator(status, body)
@@ -82916,7 +82861,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsMergeResponseValidator(status, body)
@@ -82972,7 +82917,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListRequestedReviewersResponseValidator(status, body)
@@ -83048,7 +82993,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsRequestReviewersResponseValidator(status, body)
@@ -83119,7 +83064,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsRemoveRequestedReviewersResponseValidator(status, body)
@@ -83183,7 +83128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListReviewsResponseValidator(status, body)
@@ -83273,7 +83218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsCreateReviewResponseValidator(status, body)
@@ -83335,7 +83280,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsGetReviewResponseValidator(status, body)
@@ -83351,7 +83296,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     review_id: z.coerce.number(),
   })
 
-  const pullsUpdateReviewBodySchema = z.object({ body: z.string() })
+  const pullsUpdateReviewBodySchema = z.object({body: z.string()})
 
   const pullsUpdateReviewResponseValidator = responseValidationFactory(
     [
@@ -83403,7 +83348,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsUpdateReviewResponseValidator(status, body)
@@ -83469,7 +83414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsDeletePendingReviewResponseValidator(status, body)
@@ -83540,7 +83485,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsListCommentsForReviewResponseValidator(status, body)
@@ -83615,7 +83560,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsDismissReviewResponseValidator(status, body)
@@ -83694,7 +83639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsSubmitReviewResponseValidator(status, body)
@@ -83710,7 +83655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const pullsUpdateBranchBodySchema = z
-    .object({ expected_head_sha: z.string().optional() })
+    .object({expected_head_sha: z.string().optional()})
     .nullable()
     .optional()
 
@@ -83718,10 +83663,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     [
       [
         "202",
-        z.object({
-          message: z.string().optional(),
-          url: z.string().optional(),
-        }),
+        z.object({message: z.string().optional(), url: z.string().optional()}),
       ],
       ["403", s_basic_error],
       ["422", s_validation_error],
@@ -83777,7 +83719,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pullsUpdateBranchResponseValidator(status, body)
@@ -83791,7 +83733,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     repo: z.string(),
   })
 
-  const reposGetReadmeQuerySchema = z.object({ ref: z.string().optional() })
+  const reposGetReadmeQuerySchema = z.object({ref: z.string().optional()})
 
   const reposGetReadmeResponseValidator = responseValidationFactory(
     [
@@ -83851,7 +83793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetReadmeResponseValidator(status, body)
@@ -83924,7 +83866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetReadmeInDirectoryResponseValidator(status, body)
@@ -83993,7 +83935,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListReleasesResponseValidator(status, body)
@@ -84073,7 +84015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateReleaseResponseValidator(status, body)
@@ -84138,7 +84080,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetReleaseAssetResponseValidator(status, body)
@@ -84205,7 +84147,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateReleaseAssetResponseValidator(status, body)
@@ -84260,7 +84202,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteReleaseAssetResponseValidator(status, body)
@@ -84331,7 +84273,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGenerateReleaseNotesResponseValidator(status, body)
@@ -84385,7 +84327,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetLatestReleaseResponseValidator(status, body)
@@ -84446,7 +84388,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetReleaseByTagResponseValidator(status, body)
@@ -84507,7 +84449,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetReleaseResponseValidator(status, body)
@@ -84588,7 +84530,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateReleaseResponseValidator(status, body)
@@ -84643,7 +84585,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteReleaseResponseValidator(status, body)
@@ -84707,7 +84649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListReleaseAssetsResponseValidator(status, body)
@@ -84783,7 +84725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUploadReleaseAssetResponseValidator(status, body)
@@ -84856,7 +84798,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForReleaseResponseValidator(status, body)
@@ -84929,7 +84871,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForReleaseResponseValidator(status, body)
@@ -84985,7 +84927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsDeleteForReleaseResponseValidator(status, body)
@@ -85049,7 +84991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetBranchRulesResponseValidator(status, body)
@@ -85124,7 +85066,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetRepoRulesetsResponseValidator(status, body)
@@ -85201,7 +85143,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateRepoRulesetResponseValidator(status, body)
@@ -85284,7 +85226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetRepoRuleSuitesResponseValidator(status, body)
@@ -85349,7 +85291,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetRepoRuleSuiteResponseValidator(status, body)
@@ -85422,7 +85364,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetRepoRulesetResponseValidator(status, body)
@@ -85502,7 +85444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposUpdateRepoRulesetResponseValidator(status, body)
@@ -85567,7 +85509,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteRepoRulesetResponseValidator(status, body)
@@ -85641,7 +85583,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetRepoRulesetHistoryResponseValidator(status, body)
@@ -85707,7 +85649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetRepoRulesetVersionResponseValidator(status, body)
@@ -85803,7 +85745,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningListAlertsForRepoResponseValidator(status, body)
@@ -85891,7 +85833,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningGetAlertResponseValidator(status, body)
@@ -85985,7 +85927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningUpdateAlertResponseValidator(status, body)
@@ -86071,7 +86013,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningListLocationsForAlertResponseValidator(
@@ -86169,7 +86111,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningCreatePushProtectionBypassResponseValidator(
@@ -86248,7 +86190,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = secretScanningGetScanHistoryResponseValidator(status, body)
@@ -86329,7 +86271,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesListRepositoryAdvisoriesResponseValidator(
@@ -86408,7 +86350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesCreateRepositoryAdvisoryResponseValidator(
@@ -86421,7 +86363,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const securityAdvisoriesCreatePrivateVulnerabilityReportParamSchema =
-    z.object({ owner: z.string(), repo: z.string() })
+    z.object({owner: z.string(), repo: z.string()})
 
   const securityAdvisoriesCreatePrivateVulnerabilityReportBodySchema =
     s_private_vulnerability_report_create
@@ -86490,7 +86432,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -86560,7 +86502,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesGetRepositoryAdvisoryResponseValidator(
@@ -86640,7 +86582,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesUpdateRepositoryAdvisoryResponseValidator(
@@ -86653,7 +86595,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const securityAdvisoriesCreateRepositoryAdvisoryCveRequestParamSchema =
-    z.object({ owner: z.string(), repo: z.string(), ghsa_id: z.string() })
+    z.object({owner: z.string(), repo: z.string(), ghsa_id: z.string()})
 
   const securityAdvisoriesCreateRepositoryAdvisoryCveRequestResponseValidator =
     responseValidationFactory(
@@ -86721,7 +86663,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -86799,7 +86741,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = securityAdvisoriesCreateForkResponseValidator(status, body)
@@ -86869,7 +86811,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListStargazersForRepoResponseValidator(status, body)
@@ -86939,7 +86881,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCodeFrequencyStatsResponseValidator(status, body)
@@ -87006,7 +86948,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetCommitActivityStatsResponseValidator(status, body)
@@ -87072,7 +87014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetContributorsStatsResponseValidator(status, body)
@@ -87132,7 +87074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetParticipationStatsResponseValidator(status, body)
@@ -87192,7 +87134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetPunchCardStatsResponseValidator(status, body)
@@ -87258,7 +87200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateCommitStatusResponseValidator(status, body)
@@ -87319,7 +87261,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListWatchersForRepoResponseValidator(status, body)
@@ -87384,7 +87326,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityGetRepoSubscriptionResponseValidator(status, body)
@@ -87447,7 +87389,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activitySetRepoSubscriptionResponseValidator(status, body)
@@ -87499,7 +87441,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityDeleteRepoSubscriptionResponseValidator(status, body)
@@ -87559,7 +87501,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposListTagsResponseValidator(status, body)
@@ -87622,7 +87564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListTagProtectionResponseValidator(status, body)
@@ -87636,7 +87578,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     repo: z.string(),
   })
 
-  const reposCreateTagProtectionBodySchema = z.object({ pattern: z.string() })
+  const reposCreateTagProtectionBodySchema = z.object({pattern: z.string()})
 
   const reposCreateTagProtectionResponseValidator = responseValidationFactory(
     [
@@ -87692,7 +87634,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateTagProtectionResponseValidator(status, body)
@@ -87757,7 +87699,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeleteTagProtectionResponseValidator(status, body)
@@ -87810,7 +87752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDownloadTarballArchiveResponseValidator(status, body)
@@ -87879,7 +87821,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListTeamsResponseValidator(status, body)
@@ -87948,7 +87890,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetAllTopicsResponseValidator(status, body)
@@ -87962,9 +87904,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     repo: z.string(),
   })
 
-  const reposReplaceAllTopicsBodySchema = z.object({
-    names: z.array(z.string()),
-  })
+  const reposReplaceAllTopicsBodySchema = z.object({names: z.array(z.string())})
 
   const reposReplaceAllTopicsResponseValidator = responseValidationFactory(
     [
@@ -88020,7 +87960,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposReplaceAllTopicsResponseValidator(status, body)
@@ -88088,7 +88028,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetClonesResponseValidator(status, body)
@@ -88148,7 +88088,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetTopPathsResponseValidator(status, body)
@@ -88208,7 +88148,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetTopReferrersResponseValidator(status, body)
@@ -88276,7 +88216,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposGetViewsResponseValidator(status, body)
@@ -88340,7 +88280,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposTransferResponseValidator(status, body)
@@ -88401,7 +88341,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCheckVulnerabilityAlertsResponseValidator(status, body)
@@ -88453,7 +88393,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposEnableVulnerabilityAlertsResponseValidator(status, body)
@@ -88505,7 +88445,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDisableVulnerabilityAlertsResponseValidator(status, body)
@@ -88558,7 +88498,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDownloadZipballArchiveResponseValidator(status, body)
@@ -88624,7 +88564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateUsingTemplateResponseValidator(status, body)
@@ -88684,7 +88624,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = reposListPublicResponseValidator(status, body)
@@ -88777,7 +88717,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = searchCodeResponseValidator(status, body)
@@ -88847,7 +88787,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = searchCommitsResponseValidator(status, body)
@@ -88959,7 +88899,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = searchIssuesAndPullRequestsResponseValidator(status, body)
@@ -89043,7 +88983,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = searchLabelsResponseValidator(status, body)
@@ -89134,7 +89074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = searchReposResponseValidator(status, body)
@@ -89202,7 +89142,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = searchTopicsResponseValidator(status, body)
@@ -89291,7 +89231,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = searchUsersResponseValidator(status, body)
@@ -89299,7 +89239,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const teamsGetLegacyParamSchema = z.object({ team_id: z.coerce.number() })
+  const teamsGetLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsGetLegacyResponseValidator = responseValidationFactory(
     [
@@ -89344,7 +89284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = teamsGetLegacyResponseValidator(status, body)
@@ -89352,7 +89292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const teamsUpdateLegacyParamSchema = z.object({ team_id: z.coerce.number() })
+  const teamsUpdateLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsUpdateLegacyBodySchema = z.object({
     name: z.string(),
@@ -89424,7 +89364,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = teamsUpdateLegacyResponseValidator(status, body)
@@ -89432,7 +89372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const teamsDeleteLegacyParamSchema = z.object({ team_id: z.coerce.number() })
+  const teamsDeleteLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsDeleteLegacyResponseValidator = responseValidationFactory(
     [
@@ -89481,7 +89421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = teamsDeleteLegacyResponseValidator(status, body)
@@ -89543,7 +89483,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListDiscussionsLegacyResponseValidator(status, body)
@@ -89604,7 +89544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCreateDiscussionLegacyResponseValidator(status, body)
@@ -89658,7 +89598,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetDiscussionLegacyResponseValidator(status, body)
@@ -89673,7 +89613,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const teamsUpdateDiscussionLegacyBodySchema = z
-    .object({ title: z.string().optional(), body: z.string().optional() })
+    .object({title: z.string().optional(), body: z.string().optional()})
     .optional()
 
   const teamsUpdateDiscussionLegacyResponseValidator =
@@ -89718,7 +89658,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsUpdateDiscussionLegacyResponseValidator(status, body)
@@ -89770,7 +89710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsDeleteDiscussionLegacyResponseValidator(status, body)
@@ -89835,7 +89775,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListDiscussionCommentsLegacyResponseValidator(
@@ -89898,7 +89838,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCreateDiscussionCommentLegacyResponseValidator(
@@ -89954,7 +89894,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetDiscussionCommentLegacyResponseValidator(status, body)
@@ -90015,7 +89955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsUpdateDiscussionCommentLegacyResponseValidator(
@@ -90071,7 +90011,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsDeleteDiscussionCommentLegacyResponseValidator(
@@ -90153,7 +90093,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForTeamDiscussionCommentLegacyResponseValidator(
@@ -90231,7 +90171,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForTeamDiscussionCommentLegacyResponseValidator(
@@ -90307,7 +90247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsListForTeamDiscussionLegacyResponseValidator(
@@ -90379,7 +90319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reactionsCreateForTeamDiscussionLegacyResponseValidator(
@@ -90445,7 +90385,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListPendingInvitationsLegacyResponseValidator(
@@ -90517,7 +90457,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListMembersLegacyResponseValidator(status, body)
@@ -90577,7 +90517,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetMemberLegacyResponseValidator(status, body)
@@ -90645,7 +90585,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddMemberLegacyResponseValidator(status, body)
@@ -90705,7 +90645,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveMemberLegacyResponseValidator(status, body)
@@ -90766,7 +90706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsGetMembershipForUserLegacyResponseValidator(status, body)
@@ -90845,7 +90785,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddOrUpdateMembershipForUserLegacyResponseValidator(
@@ -90909,7 +90849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveMembershipForUserLegacyResponseValidator(
@@ -90980,7 +90920,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListProjectsLegacyResponseValidator(status, body)
@@ -91041,7 +90981,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCheckPermissionsForProjectLegacyResponseValidator(
@@ -91059,7 +90999,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const teamsAddOrUpdateProjectPermissionsLegacyBodySchema = z
-    .object({ permission: z.enum(["read", "write", "admin"]).optional() })
+    .object({permission: z.enum(["read", "write", "admin"]).optional()})
     .optional()
 
   const teamsAddOrUpdateProjectPermissionsLegacyResponseValidator =
@@ -91130,7 +91070,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddOrUpdateProjectPermissionsLegacyResponseValidator(
@@ -91197,7 +91137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveProjectLegacyResponseValidator(status, body)
@@ -91206,9 +91146,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const teamsListReposLegacyParamSchema = z.object({
-    team_id: z.coerce.number(),
-  })
+  const teamsListReposLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsListReposLegacyQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -91265,7 +91203,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListReposLegacyResponseValidator(status, body)
@@ -91331,7 +91269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsCheckPermissionsForRepoLegacyResponseValidator(
@@ -91350,7 +91288,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const teamsAddOrUpdateRepoPermissionsLegacyBodySchema = z
-    .object({ permission: z.enum(["pull", "push", "admin"]).optional() })
+    .object({permission: z.enum(["pull", "push", "admin"]).optional()})
     .optional()
 
   const teamsAddOrUpdateRepoPermissionsLegacyResponseValidator =
@@ -91408,7 +91346,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsAddOrUpdateRepoPermissionsLegacyResponseValidator(
@@ -91466,7 +91404,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsRemoveRepoLegacyResponseValidator(status, body)
@@ -91475,9 +91413,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const teamsListChildLegacyParamSchema = z.object({
-    team_id: z.coerce.number(),
-  })
+  const teamsListChildLegacyParamSchema = z.object({team_id: z.coerce.number()})
 
   const teamsListChildLegacyQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -91542,7 +91478,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListChildLegacyResponseValidator(status, body)
@@ -91598,7 +91534,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersGetAuthenticatedResponseValidator(status, body)
@@ -91678,7 +91614,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersUpdateAuthenticatedResponseValidator(status, body)
@@ -91750,7 +91686,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListBlockedByAuthenticatedUserResponseValidator(
@@ -91762,7 +91698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersCheckBlockedParamSchema = z.object({ username: z.string() })
+  const usersCheckBlockedParamSchema = z.object({username: z.string()})
 
   const usersCheckBlockedResponseValidator = responseValidationFactory(
     [
@@ -91822,7 +91758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersCheckBlockedResponseValidator(status, body)
@@ -91831,7 +91767,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersBlockParamSchema = z.object({ username: z.string() })
+  const usersBlockParamSchema = z.object({username: z.string()})
 
   const usersBlockResponseValidator = responseValidationFactory(
     [
@@ -91892,7 +91828,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersBlockResponseValidator(status, body)
@@ -91900,7 +91836,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const usersUnblockParamSchema = z.object({ username: z.string() })
+  const usersUnblockParamSchema = z.object({username: z.string()})
 
   const usersUnblockResponseValidator = responseValidationFactory(
     [
@@ -91957,7 +91893,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersUnblockResponseValidator(status, body)
@@ -92043,7 +91979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesListForAuthenticatedUserResponseValidator(
@@ -92162,7 +92098,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesCreateForAuthenticatedUserResponseValidator(
@@ -92231,7 +92167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesListSecretsForAuthenticatedUserResponseValidator(
@@ -92280,7 +92216,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetPublicKeyForAuthenticatedUserResponseValidator(
@@ -92334,7 +92270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetSecretForAuthenticatedUserResponseValidator(
@@ -92347,7 +92283,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codespacesCreateOrUpdateSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string() })
+    z.object({secret_name: z.string()})
 
   const codespacesCreateOrUpdateSecretForAuthenticatedUserBodySchema = z.object(
     {
@@ -92430,7 +92366,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -92485,7 +92421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesDeleteSecretForAuthenticatedUserResponseValidator(
@@ -92498,7 +92434,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codespacesListRepositoriesForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string() })
+    z.object({secret_name: z.string()})
 
   const codespacesListRepositoriesForSecretForAuthenticatedUserResponseValidator =
     responseValidationFactory(
@@ -92573,7 +92509,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -92587,10 +92523,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codespacesSetRepositoriesForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string() })
+    z.object({secret_name: z.string()})
 
   const codespacesSetRepositoriesForSecretForAuthenticatedUserBodySchema =
-    z.object({ selected_repository_ids: z.array(z.coerce.number()) })
+    z.object({selected_repository_ids: z.array(z.coerce.number())})
 
   const codespacesSetRepositoriesForSecretForAuthenticatedUserResponseValidator =
     responseValidationFactory(
@@ -92660,7 +92596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -92674,7 +92610,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codespacesAddRepositoryForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string(), repository_id: z.coerce.number() })
+    z.object({secret_name: z.string(), repository_id: z.coerce.number()})
 
   const codespacesAddRepositoryForSecretForAuthenticatedUserResponseValidator =
     responseValidationFactory(
@@ -92740,7 +92676,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -92754,7 +92690,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const codespacesRemoveRepositoryForSecretForAuthenticatedUserParamSchema =
-    z.object({ secret_name: z.string(), repository_id: z.coerce.number() })
+    z.object({secret_name: z.string(), repository_id: z.coerce.number()})
 
   const codespacesRemoveRepositoryForSecretForAuthenticatedUserResponseValidator =
     responseValidationFactory(
@@ -92820,7 +92756,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -92900,7 +92836,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesGetForAuthenticatedUserResponseValidator(
@@ -92983,7 +92919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesUpdateForAuthenticatedUserResponseValidator(
@@ -93064,7 +93000,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesDeleteForAuthenticatedUserResponseValidator(
@@ -93143,7 +93079,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesExportForAuthenticatedUserResponseValidator(
@@ -93212,7 +93148,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -93306,7 +93242,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -93391,7 +93327,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesPublishForAuthenticatedUserResponseValidator(
@@ -93482,7 +93418,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesStartForAuthenticatedUserResponseValidator(
@@ -93557,7 +93493,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = codespacesStopForAuthenticatedUserResponseValidator(
@@ -93608,7 +93544,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -93622,7 +93558,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const usersSetPrimaryEmailVisibilityForAuthenticatedUserBodySchema = z.object(
-    { visibility: z.enum(["public", "private"]) },
+    {visibility: z.enum(["public", "private"])},
   )
 
   const usersSetPrimaryEmailVisibilityForAuthenticatedUserResponseValidator =
@@ -93693,7 +93629,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -93770,7 +93706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListEmailsForAuthenticatedUserResponseValidator(
@@ -93784,7 +93720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const usersAddEmailForAuthenticatedUserBodySchema = z
     .union([
-      z.object({ emails: z.array(z.string()).min(1) }),
+      z.object({emails: z.array(z.string()).min(1)}),
       z.array(z.string()).min(1),
       z.string(),
     ])
@@ -93853,7 +93789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersAddEmailForAuthenticatedUserResponseValidator(
@@ -93866,7 +93802,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const usersDeleteEmailForAuthenticatedUserBodySchema = z.union([
-    z.object({ emails: z.array(z.string()).min(1) }),
+    z.object({emails: z.array(z.string()).min(1)}),
     z.array(z.string()).min(1),
     z.string(),
   ])
@@ -93934,7 +93870,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteEmailForAuthenticatedUserResponseValidator(
@@ -94006,7 +93942,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListFollowersForAuthenticatedUserResponseValidator(
@@ -94078,7 +94014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListFollowedByAuthenticatedUserResponseValidator(
@@ -94153,7 +94089,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersCheckPersonIsFollowedByAuthenticatedResponseValidator(
@@ -94165,7 +94101,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersFollowParamSchema = z.object({ username: z.string() })
+  const usersFollowParamSchema = z.object({username: z.string()})
 
   const usersFollowResponseValidator = responseValidationFactory(
     [
@@ -94226,7 +94162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersFollowResponseValidator(status, body)
@@ -94234,7 +94170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const usersUnfollowParamSchema = z.object({ username: z.string() })
+  const usersUnfollowParamSchema = z.object({username: z.string()})
 
   const usersUnfollowResponseValidator = responseValidationFactory(
     [
@@ -94294,7 +94230,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersUnfollowResponseValidator(status, body)
@@ -94367,7 +94303,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListGpgKeysForAuthenticatedUserResponseValidator(
@@ -94447,7 +94383,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersCreateGpgKeyForAuthenticatedUserResponseValidator(
@@ -94522,7 +94458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersGetGpgKeyForAuthenticatedUserResponseValidator(
@@ -94601,7 +94537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteGpgKeyForAuthenticatedUserResponseValidator(
@@ -94682,7 +94618,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListInstallationsForAuthenticatedUserResponseValidator(
@@ -94778,7 +94714,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListInstallationReposForAuthenticatedUserResponseValidator(
@@ -94855,7 +94791,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsAddRepoToInstallationForAuthenticatedUserResponseValidator(
@@ -94937,7 +94873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -95000,7 +94936,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -95068,7 +95004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -95120,7 +95056,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -95145,7 +95081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional()
       .default("created"),
     direction: z.enum(["asc", "desc"]).optional().default("desc"),
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -95201,7 +95137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = issuesListForAuthenticatedUserResponseValidator(status, body)
@@ -95274,7 +95210,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListPublicSshKeysForAuthenticatedUserResponseValidator(
@@ -95363,7 +95299,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersCreatePublicSshKeyForAuthenticatedUserResponseValidator(
@@ -95438,7 +95374,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersGetPublicSshKeyForAuthenticatedUserResponseValidator(
@@ -95518,7 +95454,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeletePublicSshKeyForAuthenticatedUserResponseValidator(
@@ -95590,7 +95526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsListSubscriptionsForAuthenticatedUserResponseValidator(
@@ -95663,7 +95599,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -95741,7 +95677,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListMembershipsForAuthenticatedUserResponseValidator(
@@ -95808,7 +95744,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsGetMembershipForAuthenticatedUserResponseValidator(
@@ -95887,7 +95823,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsUpdateMembershipForAuthenticatedUserResponseValidator(
@@ -95959,7 +95895,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsListForAuthenticatedUserResponseValidator(
@@ -96042,7 +95978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsStartForAuthenticatedUserResponseValidator(
@@ -96130,7 +96066,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsGetStatusForAuthenticatedUserResponseValidator(
@@ -96201,7 +96137,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsGetArchiveForAuthenticatedUserResponseValidator(
@@ -96281,7 +96217,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsDeleteArchiveForAuthenticatedUserResponseValidator(
@@ -96357,7 +96293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsUnlockRepoForAuthenticatedUserResponseValidator(
@@ -96429,7 +96365,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = migrationsListReposForAuthenticatedUserResponseValidator(
@@ -96501,7 +96437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = orgsListForAuthenticatedUserResponseValidator(status, body)
@@ -96571,7 +96507,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesListPackagesForAuthenticatedUserResponseValidator(
@@ -96633,7 +96569,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesGetPackageForAuthenticatedUserResponseValidator(
@@ -96712,7 +96648,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesDeletePackageForAuthenticatedUserResponseValidator(
@@ -96799,7 +96735,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesRestorePackageForAuthenticatedUserResponseValidator(
@@ -96895,7 +96831,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -96964,7 +96900,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesGetPackageVersionForAuthenticatedUserResponseValidator(
@@ -97049,7 +96985,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -97137,7 +97073,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -97214,7 +97150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsCreateForAuthenticatedUserResponseValidator(
@@ -97290,7 +97226,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListPublicEmailsForAuthenticatedUserResponseValidator(
@@ -97319,8 +97255,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
     direction: z.enum(["asc", "desc"]).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
-    since: z.string().datetime({ offset: true }).optional(),
-    before: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
+    before: z.string().datetime({offset: true}).optional(),
   })
 
   const reposListForAuthenticatedUserResponseValidator =
@@ -97382,7 +97318,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListForAuthenticatedUserResponseValidator(status, body)
@@ -97488,7 +97424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposCreateForAuthenticatedUserResponseValidator(status, body)
@@ -97561,7 +97497,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListInvitationsForAuthenticatedUserResponseValidator(
@@ -97636,7 +97572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposAcceptInvitationForAuthenticatedUserResponseValidator(
@@ -97711,7 +97647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposDeclineInvitationForAuthenticatedUserResponseValidator(
@@ -97792,7 +97728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListSocialAccountsForAuthenticatedUserResponseValidator(
@@ -97871,7 +97807,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersAddSocialAccountForAuthenticatedUserResponseValidator(
@@ -97955,7 +97891,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteSocialAccountForAuthenticatedUserResponseValidator(
@@ -98036,7 +97972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListSshSigningKeysForAuthenticatedUserResponseValidator(
@@ -98127,7 +98063,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersCreateSshSigningKeyForAuthenticatedUserResponseValidator(
@@ -98202,7 +98138,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersGetSshSigningKeyForAuthenticatedUserResponseValidator(
@@ -98282,7 +98218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteSshSigningKeyForAuthenticatedUserResponseValidator(
@@ -98361,7 +98297,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListReposStarredByAuthenticatedUserResponseValidator(
@@ -98442,7 +98378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityCheckRepoIsStarredByAuthenticatedUserResponseValidator(
@@ -98518,7 +98454,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityStarRepoForAuthenticatedUserResponseValidator(
@@ -98594,7 +98530,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityUnstarRepoForAuthenticatedUserResponseValidator(
@@ -98671,7 +98607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListWatchedReposForAuthenticatedUserResponseValidator(
@@ -98743,7 +98679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = teamsListForAuthenticatedUserResponseValidator(status, body)
@@ -98752,7 +98688,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersGetByIdParamSchema = z.object({ account_id: z.coerce.number() })
+  const usersGetByIdParamSchema = z.object({account_id: z.coerce.number()})
 
   const usersGetByIdResponseValidator = responseValidationFactory(
     [
@@ -98797,7 +98733,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersGetByIdResponseValidator(status, body)
@@ -98853,7 +98789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersListResponseValidator(status, body)
@@ -98861,7 +98797,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const usersGetByUsernameParamSchema = z.object({ username: z.string() })
+  const usersGetByUsernameParamSchema = z.object({username: z.string()})
 
   const usersGetByUsernameResponseValidator = responseValidationFactory(
     [
@@ -98906,7 +98842,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = usersGetByUsernameResponseValidator(status, body)
@@ -98914,9 +98850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const usersListAttestationsBulkParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListAttestationsBulkParamSchema = z.object({username: z.string()})
 
   const usersListAttestationsBulkQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -99037,7 +98971,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListAttestationsBulkResponseValidator(status, body)
@@ -99051,8 +98985,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const usersDeleteAttestationsBulkBodySchema = z.union([
-    z.object({ subject_digests: z.array(z.string()).min(1).max(1024) }),
-    z.object({ attestation_ids: z.array(z.coerce.number()).min(1).max(1024) }),
+    z.object({subject_digests: z.array(z.string()).min(1).max(1024)}),
+    z.object({attestation_ids: z.array(z.coerce.number()).min(1).max(1024)}),
   ])
 
   const usersDeleteAttestationsBulkResponseValidator =
@@ -99106,7 +99040,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteAttestationsBulkResponseValidator(status, body)
@@ -99171,7 +99105,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteAttestationsBySubjectDigestResponseValidator(
@@ -99243,7 +99177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersDeleteAttestationsByIdResponseValidator(status, body)
@@ -99355,7 +99289,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListAttestationsResponseValidator(status, body)
@@ -99365,7 +99299,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const packagesListDockerMigrationConflictingPackagesForUserParamSchema =
-    z.object({ username: z.string() })
+    z.object({username: z.string()})
 
   const packagesListDockerMigrationConflictingPackagesForUserResponseValidator =
     responseValidationFactory(
@@ -99423,7 +99357,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -99487,7 +99421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListEventsForAuthenticatedUserResponseValidator(
@@ -99551,7 +99485,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListOrgEventsForAuthenticatedUserResponseValidator(
@@ -99614,7 +99548,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListPublicEventsForUserResponseValidator(status, body)
@@ -99623,9 +99557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersListFollowersForUserParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListFollowersForUserParamSchema = z.object({username: z.string()})
 
   const usersListFollowersForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -99676,7 +99608,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListFollowersForUserResponseValidator(status, body)
@@ -99685,9 +99617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersListFollowingForUserParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListFollowingForUserParamSchema = z.object({username: z.string()})
 
   const usersListFollowingForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -99738,7 +99668,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListFollowingForUserResponseValidator(status, body)
@@ -99798,7 +99728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersCheckFollowingForUserResponseValidator(status, body)
@@ -99807,10 +99737,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const gistsListForUserParamSchema = z.object({ username: z.string() })
+  const gistsListForUserParamSchema = z.object({username: z.string()})
 
   const gistsListForUserQuerySchema = z.object({
-    since: z.string().datetime({ offset: true }).optional(),
+    since: z.string().datetime({offset: true}).optional(),
     per_page: z.coerce.number().optional().default(30),
     page: z.coerce.number().optional().default(1),
   })
@@ -99865,7 +99795,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = gistsListForUserResponseValidator(status, body)
@@ -99874,7 +99804,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersListGpgKeysForUserParamSchema = z.object({ username: z.string() })
+  const usersListGpgKeysForUserParamSchema = z.object({username: z.string()})
 
   const usersListGpgKeysForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -99925,7 +99855,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListGpgKeysForUserResponseValidator(status, body)
@@ -99934,7 +99864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersGetContextForUserParamSchema = z.object({ username: z.string() })
+  const usersGetContextForUserParamSchema = z.object({username: z.string()})
 
   const usersGetContextForUserQuerySchema = z.object({
     subject_type: z
@@ -99997,7 +99927,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersGetContextForUserResponseValidator(status, body)
@@ -100006,7 +99936,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const appsGetUserInstallationParamSchema = z.object({ username: z.string() })
+  const appsGetUserInstallationParamSchema = z.object({username: z.string()})
 
   const appsGetUserInstallationResponseValidator = responseValidationFactory(
     [["200", s_installation]],
@@ -100048,7 +99978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = appsGetUserInstallationResponseValidator(status, body)
@@ -100057,9 +99987,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const usersListPublicKeysForUserParamSchema = z.object({
-    username: z.string(),
-  })
+  const usersListPublicKeysForUserParamSchema = z.object({username: z.string()})
 
   const usersListPublicKeysForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -100110,7 +100038,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListPublicKeysForUserResponseValidator(status, body)
@@ -100119,7 +100047,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const orgsListForUserParamSchema = z.object({ username: z.string() })
+  const orgsListForUserParamSchema = z.object({username: z.string()})
 
   const orgsListForUserQuerySchema = z.object({
     per_page: z.coerce.number().optional().default(30),
@@ -100167,7 +100095,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = orgsListForUserResponseValidator(status, body)
@@ -100252,7 +100180,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesListPackagesForUserResponseValidator(status, body)
@@ -100314,7 +100242,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesGetPackageForUserResponseValidator(status, body)
@@ -100391,7 +100319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesDeletePackageForUserResponseValidator(status, body)
@@ -100476,7 +100404,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesRestorePackageForUserResponseValidator(status, body)
@@ -100559,7 +100487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -100624,7 +100552,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesGetPackageVersionForUserResponseValidator(status, body)
@@ -100702,7 +100630,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesDeletePackageVersionForUserResponseValidator(
@@ -100783,7 +100711,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = packagesRestorePackageVersionForUserResponseValidator(
@@ -100795,7 +100723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const projectsListForUserParamSchema = z.object({ username: z.string() })
+  const projectsListForUserParamSchema = z.object({username: z.string()})
 
   const projectsListForUserQuerySchema = z.object({
     state: z.enum(["open", "closed", "all"]).optional().default("open"),
@@ -100853,7 +100781,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = projectsListForUserResponseValidator(status, body)
@@ -100913,7 +100841,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListReceivedEventsForUserResponseValidator(
@@ -100976,7 +100904,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListReceivedPublicEventsForUserResponseValidator(
@@ -100988,7 +100916,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const reposListForUserParamSchema = z.object({ username: z.string() })
+  const reposListForUserParamSchema = z.object({username: z.string()})
 
   const reposListForUserQuerySchema = z.object({
     type: z.enum(["all", "owner", "member"]).optional().default("owner"),
@@ -101045,7 +100973,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = reposListForUserResponseValidator(status, body)
@@ -101096,7 +101024,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetGithubActionsBillingUserResponseValidator(
@@ -101150,7 +101078,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetGithubPackagesBillingUserResponseValidator(
@@ -101204,7 +101132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetSharedStorageBillingUserResponseValidator(
@@ -101301,7 +101229,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = billingGetGithubBillingUsageReportUserResponseValidator(
@@ -101364,7 +101292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListSocialAccountsForUserResponseValidator(status, body)
@@ -101424,7 +101352,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = usersListSshSigningKeysForUserResponseValidator(status, body)
@@ -101496,7 +101424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListReposStarredByUserResponseValidator(status, body)
@@ -101559,7 +101487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = activityListReposWatchedByUserResponseValidator(status, body)
@@ -101607,7 +101535,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = metaGetAllVersionsResponseValidator(status, body)
@@ -101648,7 +101576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = metaGetZenResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_actions_billing_usage = {
   included_minutes: number

--- a/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/api.github.com.yaml/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -44,8 +44,8 @@ export const s_actions_cache_list = z.object({
       ref: z.string().optional(),
       key: z.string().optional(),
       version: z.string().optional(),
-      last_accessed_at: z.string().datetime({ offset: true }).optional(),
-      created_at: z.string().datetime({ offset: true }).optional(),
+      last_accessed_at: z.string().datetime({offset: true}).optional(),
+      created_at: z.string().datetime({offset: true}).optional(),
       size_in_bytes: z.coerce.number().optional(),
     }),
   ),
@@ -101,15 +101,15 @@ export const s_actions_public_key = z.object({
 
 export const s_actions_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_actions_variable = z.object({
   name: z.string(),
   value: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_actions_workflow_access_to_repository = z.object({
@@ -127,17 +127,17 @@ export const s_actor = z.object({
 
 export const s_alert_auto_dismissed_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
   .nullable()
 
-export const s_alert_created_at = z.string().datetime({ offset: true })
+export const s_alert_created_at = z.string().datetime({offset: true})
 
 export const s_alert_dismissed_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
   .nullable()
 
-export const s_alert_fixed_at = z.string().datetime({ offset: true }).nullable()
+export const s_alert_fixed_at = z.string().datetime({offset: true}).nullable()
 
 export const s_alert_html_url = z.string()
 
@@ -145,7 +145,7 @@ export const s_alert_instances_url = z.string()
 
 export const s_alert_number = z.coerce.number()
 
-export const s_alert_updated_at = z.string().datetime({ offset: true })
+export const s_alert_updated_at = z.string().datetime({offset: true})
 
 export const s_alert_url = z.string()
 
@@ -309,9 +309,9 @@ export const s_artifact = z.object({
   url: z.string(),
   archive_download_url: z.string(),
   expired: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  expires_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  expires_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   digest: z.string().nullable().optional(),
   workflow_run: z
     .object({
@@ -499,7 +499,7 @@ export const s_branch_restriction_policy = z.object({
 
 export const s_branch_short = z.object({
   name: z.string(),
-  commit: z.object({ sha: z.string(), url: z.string() }),
+  commit: z.object({sha: z.string(), url: z.string()}),
   protected: PermissiveBoolean,
 })
 
@@ -644,7 +644,7 @@ export const s_code_scanning_analysis_commit_sha = z
 
 export const s_code_scanning_analysis_created_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
 
 export const s_code_scanning_analysis_deletion = z.object({
   next_analysis_url: z.string().nullable(),
@@ -666,7 +666,7 @@ export const s_code_scanning_analysis_tool_version = z.string().nullable()
 export const s_code_scanning_analysis_url = z.string()
 
 export const s_code_scanning_autofix_commits = z
-  .object({ target_ref: z.string().optional(), message: z.string().optional() })
+  .object({target_ref: z.string().optional(), message: z.string().optional()})
   .nullable()
 
 export const s_code_scanning_autofix_commits_response = z.object({
@@ -678,7 +678,7 @@ export const s_code_scanning_autofix_description = z.string().nullable()
 
 export const s_code_scanning_autofix_started_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
 
 export const s_code_scanning_autofix_status = z.enum([
   "pending",
@@ -710,7 +710,7 @@ export const s_code_scanning_default_setup = z.object({
   runner_label: z.string().nullable().optional(),
   query_suite: z.enum(["default", "extended"]).optional(),
   threat_model: z.enum(["remote", "remote_and_local"]).optional(),
-  updated_at: z.string().datetime({ offset: true }).nullable().optional(),
+  updated_at: z.string().datetime({offset: true}).nullable().optional(),
   schedule: z.enum(["weekly"]).nullable().optional(),
 })
 
@@ -779,7 +779,7 @@ export const s_code_scanning_variant_analysis_repository = z.object({
   full_name: z.string(),
   private: PermissiveBoolean,
   stargazers_count: z.coerce.number(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_code_scanning_variant_analysis_status = z.enum([
@@ -804,7 +804,7 @@ export const s_code_security_configuration = z.object({
     .enum(["enabled", "disabled", "not_set"])
     .optional(),
   dependency_graph_autosubmit_action_options: z
-    .object({ labeled_runners: PermissiveBoolean.optional() })
+    .object({labeled_runners: PermissiveBoolean.optional()})
     .optional(),
   dependabot_alerts: z.enum(["enabled", "disabled", "not_set"]).optional(),
   dependabot_security_updates: z
@@ -864,8 +864,8 @@ export const s_code_security_configuration = z.object({
   enforcement: z.enum(["enforced", "unenforced"]).optional(),
   url: z.string().optional(),
   html_url: z.string().optional(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_codeowners_errors = z.object({
@@ -884,7 +884,7 @@ export const s_codeowners_errors = z.object({
 
 export const s_codespace_export_details = z.object({
   state: z.string().nullable().optional(),
-  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  completed_at: z.string().datetime({offset: true}).nullable().optional(),
   branch: z.string().nullable().optional(),
   sha: z.string().nullable().optional(),
   id: z.string().optional(),
@@ -904,8 +904,8 @@ export const s_codespace_machine = z.object({
 
 export const s_codespaces_org_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -925,8 +925,8 @@ export const s_codespaces_public_key = z.object({
 
 export const s_codespaces_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string(),
 })
@@ -1311,8 +1311,8 @@ export const s_dependabot_public_key = z.object({
 
 export const s_dependabot_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_dependency_graph_diff = z.array(
@@ -1462,8 +1462,8 @@ export const s_enterprise = z.object({
   node_id: z.string(),
   name: z.string(),
   slug: z.string(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   avatar_url: z.string(),
 })
 
@@ -1479,8 +1479,8 @@ export const s_enterprise_team = z.object({
   group_name: z.string().nullable().optional(),
   html_url: z.string(),
   members_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_file_commit = z.object({
@@ -1525,7 +1525,7 @@ export const s_file_commit = z.object({
       .optional(),
     message: z.string().optional(),
     tree: z
-      .object({ url: z.string().optional(), sha: z.string().optional() })
+      .object({url: z.string().optional(), sha: z.string().optional()})
       .optional(),
     parents: z
       .array(
@@ -1553,19 +1553,19 @@ export const s_git_commit = z.object({
   node_id: z.string(),
   url: z.string(),
   author: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   committer: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   message: z.string(),
-  tree: z.object({ sha: z.string(), url: z.string() }),
+  tree: z.object({sha: z.string(), url: z.string()}),
   parents: z.array(
-    z.object({ sha: z.string(), url: z.string(), html_url: z.string() }),
+    z.object({sha: z.string(), url: z.string(), html_url: z.string()}),
   ),
   verification: z.object({
     verified: PermissiveBoolean,
@@ -1650,8 +1650,8 @@ export const s_gpg_key = z.object({
   can_encrypt_comms: PermissiveBoolean,
   can_encrypt_storage: PermissiveBoolean,
   can_certify: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }),
-  expires_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  expires_at: z.string().datetime({offset: true}).nullable(),
   revoked: PermissiveBoolean,
   raw_key: z.string().nullable(),
 })
@@ -1659,7 +1659,7 @@ export const s_gpg_key = z.object({
 export const s_hook_delivery = z.object({
   id: z.coerce.number(),
   guid: z.string(),
-  delivered_at: z.string().datetime({ offset: true }),
+  delivered_at: z.string().datetime({offset: true}),
   redelivery: PermissiveBoolean,
   duration: z.coerce.number(),
   status: z.string(),
@@ -1668,7 +1668,7 @@ export const s_hook_delivery = z.object({
   action: z.string().nullable(),
   installation_id: z.coerce.number().nullable(),
   repository_id: z.coerce.number().nullable(),
-  throttled_at: z.string().datetime({ offset: true }).nullable().optional(),
+  throttled_at: z.string().datetime({offset: true}).nullable().optional(),
   url: z.string().optional(),
   request: z.object({
     headers: z.record(z.unknown()).nullable(),
@@ -1683,7 +1683,7 @@ export const s_hook_delivery = z.object({
 export const s_hook_delivery_item = z.object({
   id: z.coerce.number(),
   guid: z.string(),
-  delivered_at: z.string().datetime({ offset: true }),
+  delivered_at: z.string().datetime({offset: true}),
   redelivery: PermissiveBoolean,
   duration: z.coerce.number(),
   status: z.string(),
@@ -1692,7 +1692,7 @@ export const s_hook_delivery_item = z.object({
   action: z.string().nullable(),
   installation_id: z.coerce.number().nullable(),
   repository_id: z.coerce.number().nullable(),
-  throttled_at: z.string().datetime({ offset: true }).nullable().optional(),
+  throttled_at: z.string().datetime({offset: true}).nullable().optional(),
 })
 
 export const s_hook_response = z.object({
@@ -1702,7 +1702,7 @@ export const s_hook_response = z.object({
 })
 
 export const s_hovercard = z.object({
-  contexts: z.array(z.object({ message: z.string(), octicon: z.string() })),
+  contexts: z.array(z.object({message: z.string(), octicon: z.string()})),
 })
 
 export const s_import = z.object({
@@ -1782,7 +1782,7 @@ export const s_issue_event_label = z.object({
   color: z.string().nullable(),
 })
 
-export const s_issue_event_milestone = z.object({ title: z.string() })
+export const s_issue_event_milestone = z.object({title: z.string()})
 
 export const s_issue_event_project_card = z.object({
   url: z.string(),
@@ -1793,10 +1793,7 @@ export const s_issue_event_project_card = z.object({
   previous_column_name: z.string().optional(),
 })
 
-export const s_issue_event_rename = z.object({
-  from: z.string(),
-  to: z.string(),
-})
+export const s_issue_event_rename = z.object({from: z.string(), to: z.string()})
 
 export const s_issue_type = z
   .object({
@@ -1817,8 +1814,8 @@ export const s_issue_type = z
       ])
       .nullable()
       .optional(),
-    created_at: z.string().datetime({ offset: true }).optional(),
-    updated_at: z.string().datetime({ offset: true }).optional(),
+    created_at: z.string().datetime({offset: true}).optional(),
+    updated_at: z.string().datetime({offset: true}).optional(),
     is_enabled: PermissiveBoolean.optional(),
   })
   .nullable()
@@ -1851,9 +1848,9 @@ export const s_job = z.object({
       "action_required",
     ])
     .nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  started_at: z.string().datetime({ offset: true }),
-  completed_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  started_at: z.string().datetime({offset: true}),
+  completed_at: z.string().datetime({offset: true}).nullable(),
   name: z.string(),
   steps: z
     .array(
@@ -1862,12 +1859,8 @@ export const s_job = z.object({
         conclusion: z.string().nullable(),
         name: z.string(),
         number: z.coerce.number(),
-        started_at: z.string().datetime({ offset: true }).nullable().optional(),
-        completed_at: z
-          .string()
-          .datetime({ offset: true })
-          .nullable()
-          .optional(),
+        started_at: z.string().datetime({offset: true}).nullable().optional(),
+        completed_at: z.string().datetime({offset: true}).nullable().optional(),
       }),
     )
     .optional(),
@@ -1886,7 +1879,7 @@ export const s_key = z.object({
   id: z.coerce.number(),
   url: z.string(),
   title: z.string(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   verified: PermissiveBoolean,
   read_only: PermissiveBoolean,
 })
@@ -1894,7 +1887,7 @@ export const s_key = z.object({
 export const s_key_simple = z.object({
   id: z.coerce.number(),
   key: z.string(),
-  created_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_label = z.object({
@@ -1934,9 +1927,9 @@ export const s_license_simple = z.object({
   html_url: z.string().optional(),
 })
 
-export const s_link = z.object({ href: z.string() })
+export const s_link = z.object({href: z.string()})
 
-export const s_link_with_type = z.object({ href: z.string(), type: z.string() })
+export const s_link_with_type = z.object({href: z.string(), type: z.string()})
 
 export const s_marketplace_account = z.object({
   url: z.string(),
@@ -1979,7 +1972,7 @@ export const s_network_configuration = z.object({
   name: z.string(),
   compute_service: z.enum(["none", "actions", "codespaces"]).optional(),
   network_settings_ids: z.array(z.string()).optional(),
-  created_on: z.string().datetime({ offset: true }).nullable(),
+  created_on: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_network_settings = z.object({
@@ -2001,7 +1994,7 @@ export const s_nullable_actions_hosted_runner_pool_image = z
 
 export const s_nullable_alert_updated_at = z
   .string()
-  .datetime({ offset: true })
+  .datetime({offset: true})
   .nullable()
 
 export const s_nullable_code_of_conduct_simple = z
@@ -2062,7 +2055,7 @@ export const s_nullable_collaborator = z
   .nullable()
 
 export const s_nullable_community_health_file = z
-  .object({ url: z.string(), html_url: z.string() })
+  .object({url: z.string(), html_url: z.string()})
   .nullable()
 
 export const s_nullable_git_user = z
@@ -2106,12 +2099,10 @@ export const s_nullable_simple_commit = z
     id: z.string(),
     tree_id: z.string(),
     message: z.string(),
-    timestamp: z.string().datetime({ offset: true }),
-    author: z
-      .object({ name: z.string(), email: z.string().email() })
-      .nullable(),
+    timestamp: z.string().datetime({offset: true}),
+    author: z.object({name: z.string(), email: z.string().email()}).nullable(),
     committer: z
-      .object({ name: z.string(), email: z.string().email() })
+      .object({name: z.string(), email: z.string().email()})
       .nullable(),
   })
   .nullable()
@@ -2184,8 +2175,8 @@ export const s_org_hook = z.object({
     content_type: z.string().optional(),
     secret: z.string().optional(),
   }),
-  updated_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
   type: z.string(),
 })
 
@@ -2194,8 +2185,8 @@ export const s_org_private_registry_configuration = z.object({
   registry_type: z.enum(["maven_repository", "nuget_feed", "goproxy_server"]),
   username: z.string().nullable().optional(),
   visibility: z.enum(["all", "private", "selected"]),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_org_private_registry_configuration_with_selected_repositories =
@@ -2205,14 +2196,14 @@ export const s_org_private_registry_configuration_with_selected_repositories =
     username: z.string().optional(),
     visibility: z.enum(["all", "private", "selected"]),
     selected_repository_ids: z.array(z.coerce.number()).optional(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
   })
 
 export const s_organization_actions_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -2220,8 +2211,8 @@ export const s_organization_actions_secret = z.object({
 export const s_organization_actions_variable = z.object({
   name: z.string(),
   value: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -2247,8 +2238,8 @@ export const s_organization_create_issue_type = z.object({
 
 export const s_organization_dependabot_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   visibility: z.enum(["all", "private", "selected"]),
   selected_repositories_url: z.string().optional(),
 })
@@ -2329,9 +2320,9 @@ export const s_organization_full = z.object({
   secret_scanning_push_protection_custom_link_enabled:
     PermissiveBoolean.optional(),
   secret_scanning_push_protection_custom_link: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  archived_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  archived_at: z.string().datetime({offset: true}).nullable(),
   deploy_keys_enabled_for_repositories: PermissiveBoolean.optional(),
 })
 
@@ -2377,9 +2368,9 @@ export const s_package_version = z.object({
   html_url: z.string().optional(),
   license: z.string().optional(),
   description: z.string().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  deleted_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  deleted_at: z.string().datetime({offset: true}).optional(),
   metadata: z
     .object({
       package_type: z.enum([
@@ -2390,8 +2381,8 @@ export const s_package_version = z.object({
         "nuget",
         "container",
       ]),
-      container: z.object({ tags: z.array(z.string()) }).optional(),
-      docker: z.object({ tag: z.array(z.string()).optional() }).optional(),
+      container: z.object({tags: z.array(z.string())}).optional(),
+      docker: z.object({tag: z.array(z.string()).optional()}).optional(),
     })
     .optional(),
 })
@@ -2584,8 +2575,8 @@ export const s_private_user = z.object({
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
   following: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   private_gists: z.coerce.number(),
   total_private_repos: z.coerce.number(),
   owned_private_repos: z.coerce.number(),
@@ -2611,8 +2602,8 @@ export const s_project_column = z.object({
   id: z.coerce.number(),
   node_id: z.string(),
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_protected_branch_admin_enforced = z.object({
@@ -2625,7 +2616,7 @@ export const s_protected_branch_required_status_check = z.object({
   enforcement_level: z.string().optional(),
   contexts: z.array(z.string()),
   checks: z.array(
-    z.object({ context: z.string(), app_id: z.coerce.number().nullable() }),
+    z.object({context: z.string(), app_id: z.coerce.number().nullable()}),
   ),
   contexts_url: z.string().optional(),
   strict: PermissiveBoolean.optional(),
@@ -2670,8 +2661,8 @@ export const s_public_user = z.object({
   public_gists: z.coerce.number(),
   followers: z.coerce.number(),
   following: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   plan: z
     .object({
       collaborators: z.coerce.number(),
@@ -2700,20 +2691,12 @@ export const s_pull_request_minimal = z.object({
   head: z.object({
     ref: z.string(),
     sha: z.string(),
-    repo: z.object({
-      id: z.coerce.number(),
-      url: z.string(),
-      name: z.string(),
-    }),
+    repo: z.object({id: z.coerce.number(), url: z.string(), name: z.string()}),
   }),
   base: z.object({
     ref: z.string(),
     sha: z.string(),
-    repo: z.object({
-      id: z.coerce.number(),
-      url: z.string(),
-      name: z.string(),
-    }),
+    repo: z.object({id: z.coerce.number(), url: z.string(), name: z.string()}),
   }),
 })
 
@@ -2756,8 +2739,8 @@ export const s_release_notes_content = z.object({
 
 export const s_repo_codespaces_secret = z.object({
   name: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_repository_rule_branch_name_pattern = z.object({
@@ -2808,13 +2791,9 @@ export const s_repository_rule_committer_email_pattern = z.object({
     .optional(),
 })
 
-export const s_repository_rule_creation = z.object({
-  type: z.enum(["creation"]),
-})
+export const s_repository_rule_creation = z.object({type: z.enum(["creation"])})
 
-export const s_repository_rule_deletion = z.object({
-  type: z.enum(["deletion"]),
-})
+export const s_repository_rule_deletion = z.object({type: z.enum(["deletion"])})
 
 export const s_repository_rule_enforcement = z.enum([
   "disabled",
@@ -2825,28 +2804,26 @@ export const s_repository_rule_enforcement = z.enum([
 export const s_repository_rule_file_extension_restriction = z.object({
   type: z.enum(["file_extension_restriction"]),
   parameters: z
-    .object({ restricted_file_extensions: z.array(z.string()) })
+    .object({restricted_file_extensions: z.array(z.string())})
     .optional(),
 })
 
 export const s_repository_rule_file_path_restriction = z.object({
   type: z.enum(["file_path_restriction"]),
-  parameters: z
-    .object({ restricted_file_paths: z.array(z.string()) })
-    .optional(),
+  parameters: z.object({restricted_file_paths: z.array(z.string())}).optional(),
 })
 
 export const s_repository_rule_max_file_path_length = z.object({
   type: z.enum(["max_file_path_length"]),
   parameters: z
-    .object({ max_file_path_length: z.coerce.number().min(1).max(32767) })
+    .object({max_file_path_length: z.coerce.number().min(1).max(32767)})
     .optional(),
 })
 
 export const s_repository_rule_max_file_size = z.object({
   type: z.enum(["max_file_size"]),
   parameters: z
-    .object({ max_file_size: z.coerce.number().min(1).max(100) })
+    .object({max_file_size: z.coerce.number().min(1).max(100)})
     .optional(),
 })
 
@@ -2913,7 +2890,7 @@ export const s_repository_rule_pull_request = z.object({
 export const s_repository_rule_required_deployments = z.object({
   type: z.enum(["required_deployments"]),
   parameters: z
-    .object({ required_deployment_environments: z.array(z.string()) })
+    .object({required_deployment_environments: z.array(z.string())})
     .optional(),
 })
 
@@ -2946,7 +2923,7 @@ export const s_repository_rule_tag_name_pattern = z.object({
 export const s_repository_rule_update = z.object({
   type: z.enum(["update"]),
   parameters: z
-    .object({ update_allows_fetch_and_merge: PermissiveBoolean })
+    .object({update_allows_fetch_and_merge: PermissiveBoolean})
     .optional(),
 })
 
@@ -2996,7 +2973,7 @@ export const s_repository_subscription = z.object({
   subscribed: PermissiveBoolean,
   ignored: PermissiveBoolean,
   reason: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   url: z.string(),
   repository_url: z.string(),
 })
@@ -3057,7 +3034,7 @@ export const s_rule_suite = z.object({
   ref: z.string().optional(),
   repository_id: z.coerce.number().optional(),
   repository_name: z.string().optional(),
-  pushed_at: z.string().datetime({ offset: true }).optional(),
+  pushed_at: z.string().datetime({offset: true}).optional(),
   result: z.enum(["pass", "fail", "bypass"]).optional(),
   evaluation_result: z.enum(["pass", "fail", "bypass"]).nullable().optional(),
   rule_evaluations: z
@@ -3091,7 +3068,7 @@ export const s_rule_suites = z.array(
     ref: z.string().optional(),
     repository_id: z.coerce.number().optional(),
     repository_name: z.string().optional(),
-    pushed_at: z.string().datetime({ offset: true }).optional(),
+    pushed_at: z.string().datetime({offset: true}).optional(),
     result: z.enum(["pass", "fail", "bypass"]).optional(),
     evaluation_result: z.enum(["pass", "fail", "bypass"]).optional(),
   }),
@@ -3103,7 +3080,7 @@ export const s_ruleset_version = z.object({
     id: z.coerce.number().optional(),
     type: z.string().optional(),
   }),
-  updated_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_runner_application = z.object({
@@ -3252,8 +3229,8 @@ export const s_secret_scanning_push_protection_bypass_reason = z.enum([
 export const s_secret_scanning_scan = z.object({
   type: z.string().optional(),
   status: z.string().optional(),
-  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
-  started_at: z.string().datetime({ offset: true }).nullable().optional(),
+  completed_at: z.string().datetime({offset: true}).nullable().optional(),
+  started_at: z.string().datetime({offset: true}).nullable().optional(),
 })
 
 export const s_security_advisory_credit_types = z.enum([
@@ -3295,25 +3272,25 @@ export const s_security_advisory_epss = z
 export const s_security_and_analysis = z
   .object({
     advanced_security: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     code_security: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     dependabot_security_updates: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning_push_protection: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning_non_provider_patterns: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
     secret_scanning_ai_detection: z
-      .object({ status: z.enum(["enabled", "disabled"]).optional() })
+      .object({status: z.enum(["enabled", "disabled"]).optional()})
       .optional(),
   })
   .nullable()
@@ -3326,7 +3303,7 @@ export const s_selected_actions = z.object({
 
 export const s_selected_actions_url = z.string()
 
-export const s_short_blob = z.object({ url: z.string(), sha: z.string() })
+export const s_short_blob = z.object({url: z.string(), sha: z.string()})
 
 export const s_simple_classroom = z.object({
   id: z.coerce.number(),
@@ -3364,11 +3341,9 @@ export const s_simple_commit = z.object({
   id: z.string(),
   tree_id: z.string(),
   message: z.string(),
-  timestamp: z.string().datetime({ offset: true }),
-  author: z.object({ name: z.string(), email: z.string().email() }).nullable(),
-  committer: z
-    .object({ name: z.string(), email: z.string().email() })
-    .nullable(),
+  timestamp: z.string().datetime({offset: true}),
+  author: z.object({name: z.string(), email: z.string().email()}).nullable(),
+  committer: z.object({name: z.string(), email: z.string().email()}).nullable(),
 })
 
 export const s_simple_commit_status = z.object({
@@ -3381,8 +3356,8 @@ export const s_simple_commit_status = z.object({
   required: PermissiveBoolean.nullable().optional(),
   avatar_url: z.string().nullable(),
   url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_simple_user = z.object({
@@ -3419,7 +3394,7 @@ export const s_ssh_signing_key = z.object({
   key: z.string(),
   id: z.coerce.number(),
   title: z.string(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
 })
 
 export const s_status_check_policy = z.object({
@@ -3427,7 +3402,7 @@ export const s_status_check_policy = z.object({
   strict: PermissiveBoolean,
   contexts: z.array(z.string()),
   checks: z.array(
-    z.object({ context: z.string(), app_id: z.coerce.number().nullable() }),
+    z.object({context: z.string(), app_id: z.coerce.number().nullable()}),
   ),
   contexts_url: z.string(),
 })
@@ -3440,7 +3415,7 @@ export const s_sub_issues_summary = z.object({
 
 export const s_tag = z.object({
   name: z.string(),
-  commit: z.object({ sha: z.string(), url: z.string() }),
+  commit: z.object({sha: z.string(), url: z.string()}),
   zipball_url: z.string(),
   tarball_url: z.string(),
   node_id: z.string(),
@@ -3487,7 +3462,7 @@ export const s_team_organization = z.object({
   followers: z.coerce.number(),
   following: z.coerce.number(),
   html_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   type: z.string(),
   total_private_repos: z.coerce.number().optional(),
   owned_private_repos: z.coerce.number().optional(),
@@ -3517,8 +3492,8 @@ export const s_team_organization = z.object({
   members_can_fork_private_repositories:
     PermissiveBoolean.nullable().optional(),
   web_commit_signoff_required: PermissiveBoolean.optional(),
-  updated_at: z.string().datetime({ offset: true }),
-  archived_at: z.string().datetime({ offset: true }).nullable(),
+  updated_at: z.string().datetime({offset: true}),
+  archived_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_team_simple = z.object({
@@ -3541,7 +3516,7 @@ export const s_thread_subscription = z.object({
   subscribed: PermissiveBoolean,
   ignored: PermissiveBoolean,
   reason: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
   url: z.string(),
   thread_url: z.string().optional(),
   repository_url: z.string().optional(),
@@ -3553,19 +3528,19 @@ export const s_timeline_committed_event = z.object({
   node_id: z.string(),
   url: z.string(),
   author: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   committer: z.object({
-    date: z.string().datetime({ offset: true }),
+    date: z.string().datetime({offset: true}),
     email: z.string(),
     name: z.string(),
   }),
   message: z.string(),
-  tree: z.object({ sha: z.string(), url: z.string() }),
+  tree: z.object({sha: z.string(), url: z.string()}),
   parents: z.array(
-    z.object({ sha: z.string(), url: z.string(), html_url: z.string() }),
+    z.object({sha: z.string(), url: z.string(), html_url: z.string()}),
   ),
   verification: z.object({
     verified: PermissiveBoolean,
@@ -3577,10 +3552,10 @@ export const s_timeline_committed_event = z.object({
   html_url: z.string(),
 })
 
-export const s_topic = z.object({ names: z.array(z.string()) })
+export const s_topic = z.object({names: z.array(z.string())})
 
 export const s_traffic = z.object({
-  timestamp: z.string().datetime({ offset: true }),
+  timestamp: z.string().datetime({offset: true}),
   uniques: z.coerce.number(),
   count: z.coerce.number(),
 })
@@ -3647,12 +3622,12 @@ export const s_workflow = z.object({
     "disabled_inactivity",
     "disabled_manually",
   ]),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   html_url: z.string(),
   badge_url: z.string(),
-  deleted_at: z.string().datetime({ offset: true }).optional(),
+  deleted_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_workflow_run_usage = z.object({
@@ -3705,9 +3680,9 @@ export const s_workflow_run_usage = z.object({
 
 export const s_workflow_usage = z.object({
   billable: z.object({
-    UBUNTU: z.object({ total_ms: z.coerce.number().optional() }).optional(),
-    MACOS: z.object({ total_ms: z.coerce.number().optional() }).optional(),
-    WINDOWS: z.object({ total_ms: z.coerce.number().optional() }).optional(),
+    UBUNTU: z.object({total_ms: z.coerce.number().optional()}).optional(),
+    MACOS: z.object({total_ms: z.coerce.number().optional()}).optional(),
+    WINDOWS: z.object({total_ms: z.coerce.number().optional()}).optional(),
   }),
 })
 
@@ -3727,7 +3702,7 @@ export const s_actions_hosted_runner = z.object({
   maximum_runners: z.coerce.number().optional().default(10),
   public_ip_enabled: PermissiveBoolean,
   public_ips: z.array(s_public_ip).optional(),
-  last_active_on: z.string().datetime({ offset: true }).nullable().optional(),
+  last_active_on: z.string().datetime({offset: true}).nullable().optional(),
 })
 
 export const s_actions_organization_permissions = z.object({
@@ -3756,7 +3731,7 @@ export const s_activity = z.object({
   before: z.string(),
   after: z.string(),
   ref: z.string(),
-  timestamp: z.string().datetime({ offset: true }),
+  timestamp: z.string().datetime({offset: true}),
   activity_type: z.enum([
     "push",
     "force_push",
@@ -3797,8 +3772,8 @@ export const s_base_gist = z.object({
     }),
   ),
   public: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   description: z.string().nullable(),
   comments: z.coerce.number(),
   comments_enabled: PermissiveBoolean.optional(),
@@ -3831,7 +3806,7 @@ export const s_code_scanning_alert_instance = z.object({
   category: s_code_scanning_analysis_category.optional(),
   state: s_code_scanning_alert_state.optional(),
   commit_sha: z.string().optional(),
-  message: z.object({ text: z.string().optional() }).optional(),
+  message: z.object({text: z.string().optional()}).optional(),
   location: s_code_scanning_alert_location.optional(),
   html_url: z.string().optional(),
   classifications: z.array(s_code_scanning_alert_classification).optional(),
@@ -3856,8 +3831,8 @@ export const s_code_scanning_codeql_database = z.object({
   uploader: s_simple_user,
   content_type: z.string(),
   size: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   commit_oid: z.string().nullable().optional(),
 })
@@ -3907,7 +3882,7 @@ export const s_commit = z.object({
     committer: s_nullable_git_user,
     message: z.string(),
     comment_count: z.coerce.number(),
-    tree: z.object({ sha: z.string(), url: z.string() }),
+    tree: z.object({sha: z.string(), url: z.string()}),
     verification: s_verification.optional(),
   }),
   author: z.union([s_simple_user, s_empty_object]).nullable(),
@@ -3940,8 +3915,8 @@ export const s_commit_comment = z.object({
   line: z.coerce.number().nullable(),
   commit_id: z.string(),
   user: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   author_association: s_author_association,
   reactions: s_reaction_rollup.optional(),
 })
@@ -3959,7 +3934,7 @@ export const s_community_profile = z.object({
     issue_template: s_nullable_community_health_file,
     pull_request_template: s_nullable_community_health_file,
   }),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   content_reports_enabled: PermissiveBoolean.optional(),
 })
 
@@ -4011,7 +3986,7 @@ export const s_dependabot_alert_security_vulnerability = z.object({
   package: s_dependabot_alert_package,
   severity: z.enum(["low", "medium", "high", "critical"]),
   vulnerable_version_range: z.string(),
-  first_patched_version: z.object({ identifier: z.string() }).nullable(),
+  first_patched_version: z.object({identifier: z.string()}).nullable(),
 })
 
 export const s_dependency = z.object({
@@ -4037,8 +4012,8 @@ export const s_environment_approvals = z.object({
       name: z.string().optional(),
       url: z.string().optional(),
       html_url: z.string().optional(),
-      created_at: z.string().datetime({ offset: true }).optional(),
-      updated_at: z.string().datetime({ offset: true }).optional(),
+      created_at: z.string().datetime({offset: true}).optional(),
+      updated_at: z.string().datetime({offset: true}).optional(),
     }),
   ),
   state: z.enum(["approved", "rejected", "pending"]),
@@ -4077,8 +4052,8 @@ export const s_gist_comment = z.object({
   url: z.string(),
   body: z.string().max(65535),
   user: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   author_association: s_author_association,
 })
 
@@ -4091,13 +4066,13 @@ export const s_gist_commit = z.object({
     additions: z.coerce.number().optional(),
     deletions: z.coerce.number().optional(),
   }),
-  committed_at: z.string().datetime({ offset: true }),
+  committed_at: z.string().datetime({offset: true}),
 })
 
 export const s_gist_history = z.object({
   user: s_nullable_simple_user.optional(),
   version: z.string().optional(),
-  committed_at: z.string().datetime({ offset: true }).optional(),
+  committed_at: z.string().datetime({offset: true}).optional(),
   change_status: z
     .object({
       total: z.coerce.number().optional(),
@@ -4114,8 +4089,8 @@ export const s_git_tag = z.object({
   sha: z.string(),
   url: z.string(),
   message: z.string(),
-  tagger: z.object({ date: z.string(), email: z.string(), name: z.string() }),
-  object: z.object({ sha: z.string(), type: z.string(), url: z.string() }),
+  tagger: z.object({date: z.string(), email: z.string(), name: z.string()}),
+  object: z.object({sha: z.string(), type: z.string(), url: z.string()}),
   verification: s_verification.optional(),
 })
 
@@ -4132,14 +4107,14 @@ export const s_installation = z.object({
   target_type: z.string(),
   permissions: s_app_permissions,
   events: z.array(z.string()),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   single_file_name: z.string().nullable(),
   has_multiple_single_files: PermissiveBoolean.optional(),
   single_file_paths: z.array(z.string()).optional(),
   app_slug: z.string(),
   suspended_by: s_nullable_simple_user,
-  suspended_at: z.string().datetime({ offset: true }).nullable(),
+  suspended_at: z.string().datetime({offset: true}).nullable(),
   contact_email: z.string().nullable().optional(),
 })
 
@@ -4154,8 +4129,8 @@ export const s_integration = z
     description: z.string().nullable(),
     external_url: z.string(),
     html_url: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
     permissions: z.intersection(
       z.object({
         issues: z.string().optional(),
@@ -4176,7 +4151,7 @@ export const s_integration_installation_request = z.object({
   node_id: z.string().optional(),
   account: z.union([s_simple_user, s_enterprise]),
   requester: s_simple_user,
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
 })
 
 export const s_interaction_limit = z.object({
@@ -4187,7 +4162,7 @@ export const s_interaction_limit = z.object({
 export const s_interaction_limit_response = z.object({
   limit: s_interaction_group,
   origin: z.string(),
-  expires_at: z.string().datetime({ offset: true }),
+  expires_at: z.string().datetime({offset: true}),
 })
 
 export const s_label_search_result_item = z.object({
@@ -4264,10 +4239,10 @@ export const s_milestone = z.object({
   creator: s_nullable_simple_user,
   open_issues: z.coerce.number(),
   closed_issues: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  due_on: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  due_on: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_minimal_repository = z.object({
@@ -4341,9 +4316,9 @@ export const s_minimal_repository = z.object({
   archived: PermissiveBoolean.optional(),
   disabled: PermissiveBoolean.optional(),
   visibility: z.string().optional(),
-  pushed_at: z.string().datetime({ offset: true }).nullable().optional(),
-  created_at: z.string().datetime({ offset: true }).nullable().optional(),
-  updated_at: z.string().datetime({ offset: true }).nullable().optional(),
+  pushed_at: z.string().datetime({offset: true}).nullable().optional(),
+  created_at: z.string().datetime({offset: true}).nullable().optional(),
+  updated_at: z.string().datetime({offset: true}).nullable().optional(),
   permissions: z
     .object({
       admin: PermissiveBoolean.optional(),
@@ -4389,8 +4364,8 @@ export const s_nullable_integration = z
     description: z.string().nullable(),
     external_url: z.string(),
     html_url: z.string(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
     permissions: z.intersection(
       z.object({
         issues: z.string().optional(),
@@ -4420,10 +4395,10 @@ export const s_nullable_milestone = z
     creator: s_nullable_simple_user,
     open_issues: z.coerce.number(),
     closed_issues: z.coerce.number(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
-    closed_at: z.string().datetime({ offset: true }).nullable(),
-    due_on: z.string().datetime({ offset: true }).nullable(),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
+    closed_at: z.string().datetime({offset: true}).nullable(),
+    due_on: z.string().datetime({offset: true}).nullable(),
   })
   .nullable()
 
@@ -4499,9 +4474,9 @@ export const s_nullable_minimal_repository = z
     archived: PermissiveBoolean.optional(),
     disabled: PermissiveBoolean.optional(),
     visibility: z.string().optional(),
-    pushed_at: z.string().datetime({ offset: true }).nullable().optional(),
-    created_at: z.string().datetime({ offset: true }).nullable().optional(),
-    updated_at: z.string().datetime({ offset: true }).nullable().optional(),
+    pushed_at: z.string().datetime({offset: true}).nullable().optional(),
+    created_at: z.string().datetime({offset: true}).nullable().optional(),
+    updated_at: z.string().datetime({offset: true}).nullable().optional(),
     permissions: z
       .object({
         admin: PermissiveBoolean.optional(),
@@ -4620,9 +4595,9 @@ export const s_nullable_repository = z
     archived: PermissiveBoolean.default(false),
     disabled: PermissiveBoolean,
     visibility: z.string().optional().default("public"),
-    pushed_at: z.string().datetime({ offset: true }).nullable(),
-    created_at: z.string().datetime({ offset: true }).nullable(),
-    updated_at: z.string().datetime({ offset: true }).nullable(),
+    pushed_at: z.string().datetime({offset: true}).nullable(),
+    created_at: z.string().datetime({offset: true}).nullable(),
+    updated_at: z.string().datetime({offset: true}).nullable(),
     allow_rebase_merge: PermissiveBoolean.optional().default(true),
     temp_clone_token: z.string().optional(),
     allow_squash_merge: PermissiveBoolean.optional().default(true),
@@ -4743,9 +4718,7 @@ export const s_org_membership = z.object({
   organization_url: z.string(),
   organization: s_organization_simple,
   user: s_nullable_simple_user,
-  permissions: z
-    .object({ can_create_repository: PermissiveBoolean })
-    .optional(),
+  permissions: z.object({can_create_repository: PermissiveBoolean}).optional(),
 })
 
 export const s_org_repo_custom_property_values = z.object({
@@ -4821,8 +4794,8 @@ export const s_organization_role = z.object({
     .optional(),
   permissions: z.array(z.string()),
   organization: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_page = z.object({
@@ -4835,7 +4808,7 @@ export const s_page = z.object({
     .optional(),
   pending_domain_unverified_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   custom_404: PermissiveBoolean.default(false),
@@ -4850,12 +4823,12 @@ export const s_page = z.object({
 export const s_page_build = z.object({
   url: z.string(),
   status: z.string(),
-  error: z.object({ message: z.string().nullable() }),
+  error: z.object({message: z.string().nullable()}),
   pusher: s_nullable_simple_user,
   commit: z.string(),
   duration: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_private_vulnerability_report_create = z.object({
@@ -4893,8 +4866,8 @@ export const s_project = z.object({
   number: z.coerce.number(),
   state: z.string(),
   creator: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   organization_permission: z
     .enum(["read", "write", "admin", "none"])
     .optional(),
@@ -4907,8 +4880,8 @@ export const s_project_card = z.object({
   node_id: z.string(),
   note: z.string().nullable(),
   creator: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   archived: PermissiveBoolean.optional(),
   column_name: z.string().optional(),
   project_id: z.string().optional(),
@@ -4931,10 +4904,10 @@ export const s_pull_request_review = z.object({
   html_url: z.string(),
   pull_request_url: z.string(),
   _links: z.object({
-    html: z.object({ href: z.string() }),
-    pull_request: z.object({ href: z.string() }),
+    html: z.object({href: z.string()}),
+    pull_request: z.object({href: z.string()}),
   }),
-  submitted_at: z.string().datetime({ offset: true }).optional(),
+  submitted_at: z.string().datetime({offset: true}).optional(),
   commit_id: z.string().nullable(),
   body_html: z.string().optional(),
   body_text: z.string().optional(),
@@ -4955,15 +4928,15 @@ export const s_pull_request_review_comment = z.object({
   in_reply_to_id: z.coerce.number().optional(),
   user: s_simple_user,
   body: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   html_url: z.string(),
   pull_request_url: z.string(),
   author_association: s_author_association,
   _links: z.object({
-    self: z.object({ href: z.string() }),
-    html: z.object({ href: z.string() }),
-    pull_request: z.object({ href: z.string() }),
+    self: z.object({href: z.string()}),
+    html: z.object({href: z.string()}),
+    pull_request: z.object({href: z.string()}),
   }),
   start_line: z.coerce.number().nullable().optional(),
   original_start_line: z.coerce.number().nullable().optional(),
@@ -5009,7 +4982,7 @@ export const s_reaction = z.object({
     "rocket",
     "eyes",
   ]),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
 })
 
 export const s_release_asset = z.object({
@@ -5024,8 +4997,8 @@ export const s_release_asset = z.object({
   size: z.coerce.number(),
   digest: z.string().nullable(),
   download_count: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   uploader: s_nullable_simple_user,
 })
 
@@ -5040,9 +5013,9 @@ export const s_repo_search_result_item = z.object({
   description: z.string().nullable(),
   fork: PermissiveBoolean,
   url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  pushed_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  pushed_at: z.string().datetime({offset: true}),
   homepage: z.string().nullable(),
   size: z.coerce.number(),
   stargazers_count: z.coerce.number(),
@@ -5211,9 +5184,9 @@ export const s_repository = z.object({
   archived: PermissiveBoolean.default(false),
   disabled: PermissiveBoolean,
   visibility: z.string().optional().default("public"),
-  pushed_at: z.string().datetime({ offset: true }).nullable(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  pushed_at: z.string().datetime({offset: true}).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   allow_rebase_merge: PermissiveBoolean.optional().default(true),
   temp_clone_token: z.string().optional(),
   allow_squash_merge: PermissiveBoolean.optional().default(true),
@@ -5263,7 +5236,7 @@ export const s_repository_advisory_create = z.object({
   cwe_ids: z.array(z.string()).nullable().optional(),
   credits: z
     .array(
-      z.object({ login: z.string(), type: s_security_advisory_credit_types }),
+      z.object({login: z.string(), type: s_security_advisory_credit_types}),
     )
     .nullable()
     .optional(),
@@ -5298,7 +5271,7 @@ export const s_repository_advisory_update = z.object({
   cwe_ids: z.array(z.string()).nullable().optional(),
   credits: z
     .array(
-      z.object({ login: z.string(), type: s_security_advisory_credit_types }),
+      z.object({login: z.string(), type: s_security_advisory_credit_types}),
     )
     .nullable()
     .optional(),
@@ -5408,12 +5381,12 @@ export const s_review_comment = z.object({
   in_reply_to_id: z.coerce.number().optional(),
   user: s_nullable_simple_user,
   body: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   html_url: z.string(),
   pull_request_url: z.string(),
   author_association: s_author_association,
-  _links: z.object({ self: s_link, html: s_link, pull_request: s_link }),
+  _links: z.object({self: s_link, html: s_link, pull_request: s_link}),
   body_text: z.string().optional(),
   body_html: z.string().optional(),
   reactions: s_reaction_rollup.optional(),
@@ -5427,7 +5400,7 @@ export const s_review_comment = z.object({
 })
 
 export const s_ruleset_version_with_state = s_ruleset_version.merge(
-  z.object({ state: z.object({}) }),
+  z.object({state: z.object({})}),
 )
 
 export const s_runner = z.object({
@@ -5480,7 +5453,7 @@ export const s_secret_scanning_location = z.object({
 
 export const s_secret_scanning_push_protection_bypass = z.object({
   reason: s_secret_scanning_push_protection_bypass_reason.optional(),
-  expire_at: z.string().datetime({ offset: true }).nullable().optional(),
+  expire_at: z.string().datetime({offset: true}).nullable().optional(),
   token_type: z.string().optional(),
 })
 
@@ -5517,7 +5490,7 @@ export const s_simple_classroom_assignment = z.object({
   submitted: z.coerce.number(),
   passing: z.coerce.number(),
   language: z.string(),
-  deadline: z.string().datetime({ offset: true }).nullable(),
+  deadline: z.string().datetime({offset: true}).nullable(),
   classroom: s_simple_classroom,
 })
 
@@ -5571,7 +5544,7 @@ export const s_simple_repository = z.object({
 })
 
 export const s_stargazer = z.object({
-  starred_at: z.string().datetime({ offset: true }),
+  starred_at: z.string().datetime({offset: true}),
   user: s_nullable_simple_user,
 })
 
@@ -5621,8 +5594,8 @@ export const s_team_discussion = z.object({
   body_version: z.string(),
   comments_count: z.coerce.number(),
   comments_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  last_edited_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  last_edited_at: z.string().datetime({offset: true}).nullable(),
   html_url: z.string(),
   node_id: z.string(),
   number: z.coerce.number(),
@@ -5630,7 +5603,7 @@ export const s_team_discussion = z.object({
   private: PermissiveBoolean,
   team_url: z.string(),
   title: z.string(),
-  updated_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   reactions: s_reaction_rollup.optional(),
 })
@@ -5640,13 +5613,13 @@ export const s_team_discussion_comment = z.object({
   body: z.string(),
   body_html: z.string(),
   body_version: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  last_edited_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  last_edited_at: z.string().datetime({offset: true}).nullable(),
   discussion_url: z.string(),
   html_url: z.string(),
   node_id: z.string(),
   number: z.coerce.number(),
-  updated_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
   url: z.string(),
   reactions: s_reaction_rollup.optional(),
 })
@@ -5669,8 +5642,8 @@ export const s_team_full = z.object({
   parent: s_nullable_team_simple.optional(),
   members_count: z.coerce.number(),
   repos_count: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   organization: s_team_organization,
   ldap_dn: z.string().optional(),
 })
@@ -5780,9 +5753,9 @@ export const s_team_repository = z.object({
   archived: PermissiveBoolean.default(false),
   disabled: PermissiveBoolean,
   visibility: z.string().optional().default("public"),
-  pushed_at: z.string().datetime({ offset: true }).nullable(),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  pushed_at: z.string().datetime({offset: true}).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   allow_rebase_merge: PermissiveBoolean.optional().default(true),
   temp_clone_token: z.string().optional(),
   allow_squash_merge: PermissiveBoolean.optional().default(true),
@@ -5834,10 +5807,10 @@ export const s_timeline_reviewed_event = z.object({
   html_url: z.string(),
   pull_request_url: z.string(),
   _links: z.object({
-    html: z.object({ href: z.string() }),
-    pull_request: z.object({ href: z.string() }),
+    html: z.object({href: z.string()}),
+    pull_request: z.object({href: z.string()}),
   }),
-  submitted_at: z.string().datetime({ offset: true }).optional(),
+  submitted_at: z.string().datetime({offset: true}).optional(),
   commit_id: z.string(),
   body_html: z.string().optional(),
   body_text: z.string().optional(),
@@ -5851,8 +5824,8 @@ export const s_topic_search_result_item = z.object({
   description: z.string().nullable(),
   created_by: z.string().nullable(),
   released: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   featured: PermissiveBoolean,
   curated: PermissiveBoolean,
   score: z.coerce.number(),
@@ -5893,11 +5866,11 @@ export const s_topic_search_result_item = z.object({
 
 export const s_user_marketplace_purchase = z.object({
   billing_cycle: z.string(),
-  next_billing_date: z.string().datetime({ offset: true }).nullable(),
+  next_billing_date: z.string().datetime({offset: true}).nullable(),
   unit_count: z.coerce.number().nullable(),
   on_free_trial: PermissiveBoolean,
-  free_trial_ends_on: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  free_trial_ends_on: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   account: s_marketplace_account,
   plan: s_marketplace_listing_plan,
 })
@@ -5952,8 +5925,8 @@ export const s_user_search_result_item = z.object({
   public_gists: z.coerce.number().optional(),
   followers: z.coerce.number().optional(),
   following: z.coerce.number().optional(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
   name: z.string().nullable().optional(),
   bio: z.string().nullable().optional(),
   email: z.string().email().nullable().optional(),
@@ -5963,7 +5936,7 @@ export const s_user_search_result_item = z.object({
   text_matches: s_search_result_text_matches.optional(),
   blog: z.string().nullable().optional(),
   company: z.string().nullable().optional(),
-  suspended_at: z.string().datetime({ offset: true }).nullable().optional(),
+  suspended_at: z.string().datetime({offset: true}).nullable().optional(),
   user_view_type: z.string().optional(),
 })
 
@@ -6030,7 +6003,7 @@ export const s_assigned_issue_event = z.object({
 
 export const s_authentication_token = z.object({
   token: z.string(),
-  expires_at: z.string().datetime({ offset: true }),
+  expires_at: z.string().datetime({offset: true}),
   permissions: z.object({}).optional(),
   repositories: z.array(s_repository).optional(),
   single_file: z.string().nullable().optional(),
@@ -6044,28 +6017,28 @@ export const s_authorization = z.object({
   token: z.string(),
   token_last_eight: z.string().nullable(),
   hashed_token: z.string().nullable(),
-  app: z.object({ client_id: z.string(), name: z.string(), url: z.string() }),
+  app: z.object({client_id: z.string(), name: z.string(), url: z.string()}),
   note: z.string().nullable(),
   note_url: z.string().nullable(),
-  updated_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
   fingerprint: z.string().nullable(),
   user: s_nullable_simple_user.optional(),
   installation: s_nullable_scoped_installation.optional(),
-  expires_at: z.string().datetime({ offset: true }).nullable(),
+  expires_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_campaign_summary = z.object({
   number: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   name: z.string().optional(),
   description: z.string(),
   managers: z.array(s_simple_user),
   team_managers: z.array(s_team).optional(),
-  published_at: z.string().datetime({ offset: true }).optional(),
-  ends_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  published_at: z.string().datetime({offset: true}).optional(),
+  ends_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable().optional(),
   state: s_campaign_state,
   contact_link: z.string().nullable(),
   alert_stats: z
@@ -6111,8 +6084,8 @@ export const s_check_suite = z.object({
   pull_requests: z.array(s_pull_request_minimal).nullable(),
   app: s_nullable_integration,
   repository: s_minimal_repository,
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
   head_commit: s_simple_commit,
   latest_check_runs_count: z.coerce.number(),
   check_runs_url: z.string(),
@@ -6123,9 +6096,7 @@ export const s_check_suite = z.object({
 export const s_check_suite_preference = z.object({
   preferences: z.object({
     auto_trigger_checks: z
-      .array(
-        z.object({ app_id: z.coerce.number(), setting: PermissiveBoolean }),
-      )
+      .array(z.object({app_id: z.coerce.number(), setting: PermissiveBoolean}))
       .optional(),
   }),
   repository: s_minimal_repository,
@@ -6159,7 +6130,7 @@ export const s_classroom_assignment = z.object({
   submitted: z.coerce.number(),
   passing: z.coerce.number(),
   language: z.string(),
-  deadline: z.string().datetime({ offset: true }).nullable(),
+  deadline: z.string().datetime({offset: true}).nullable(),
   starter_code_repository: s_simple_classroom_repository,
   classroom: s_classroom,
 })
@@ -6246,9 +6217,9 @@ export const s_code_scanning_variant_analysis = z.object({
   actor: s_simple_user,
   query_language: s_code_scanning_variant_analysis_language,
   query_pack_url: z.string(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
-  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
+  completed_at: z.string().datetime({offset: true}).nullable().optional(),
   status: z.enum(["in_progress", "succeeded", "failed", "cancelled"]),
   actions_workflow_run_id: z.coerce.number().optional(),
   failure_reason: z
@@ -6301,7 +6272,7 @@ export const s_code_search_result_item = z.object({
   score: z.coerce.number(),
   file_size: z.coerce.number().optional(),
   language: z.string().nullable().optional(),
-  last_modified_at: z.string().datetime({ offset: true }).optional(),
+  last_modified_at: z.string().datetime({offset: true}).optional(),
   line_numbers: z.array(z.string()).optional(),
   text_matches: s_search_result_text_matches.optional(),
 })
@@ -6333,9 +6304,9 @@ export const s_codespace = z.object({
   machine: s_nullable_codespace_machine,
   devcontainer_path: z.string().nullable().optional(),
   prebuild: PermissiveBoolean.nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  last_used_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  last_used_at: z.string().datetime({offset: true}),
   state: z.enum([
     "Unknown",
     "Created",
@@ -6383,7 +6354,7 @@ export const s_codespace = z.object({
   retention_period_minutes: z.coerce.number().nullable().optional(),
   retention_expires_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   last_known_stop_notice: z.string().nullable().optional(),
@@ -6424,12 +6395,12 @@ export const s_commit_search_result_item = z.object({
     author: z.object({
       name: z.string(),
       email: z.string(),
-      date: z.string().datetime({ offset: true }),
+      date: z.string().datetime({offset: true}),
     }),
     committer: s_nullable_git_user,
     comment_count: z.coerce.number(),
     message: z.string(),
-    tree: z.object({ sha: z.string(), url: z.string() }),
+    tree: z.object({sha: z.string(), url: z.string()}),
     url: z.string(),
     verification: s_verification.optional(),
   }),
@@ -6475,10 +6446,10 @@ export const s_copilot_seat_details = z.object({
   organization: s_nullable_organization_simple.optional(),
   assigning_team: z.union([s_team, s_enterprise_team]).nullable().optional(),
   pending_cancellation_date: z.string().nullable().optional(),
-  last_activity_at: z.string().datetime({ offset: true }).nullable().optional(),
+  last_activity_at: z.string().datetime({offset: true}).nullable().optional(),
   last_activity_editor: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}).optional(),
   plan_type: z.enum(["business", "enterprise", "unknown"]).optional(),
 })
 
@@ -6492,7 +6463,7 @@ export const s_demilestoned_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  milestone: z.object({ title: z.string() }),
+  milestone: z.object({title: z.string()}),
 })
 
 export const s_dependabot_alert_security_advisory = z.object({
@@ -6508,14 +6479,14 @@ export const s_dependabot_alert_security_advisory = z.object({
   }),
   cvss_severities: s_cvss_severities.optional(),
   epss: s_security_advisory_epss.optional(),
-  cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })),
+  cwes: z.array(z.object({cwe_id: z.string(), name: z.string()})),
   identifiers: z.array(
-    z.object({ type: z.enum(["CVE", "GHSA"]), value: z.string() }),
+    z.object({type: z.enum(["CVE", "GHSA"]), value: z.string()}),
   ),
-  references: z.array(z.object({ url: z.string() })),
-  published_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  withdrawn_at: z.string().datetime({ offset: true }).nullable(),
+  references: z.array(z.object({url: z.string()})),
+  published_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  withdrawn_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_dependabot_repository_access_details = z.object({
@@ -6535,8 +6506,8 @@ export const s_deployment = z.object({
   environment: z.string(),
   description: z.string().nullable(),
   creator: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   statuses_url: z.string(),
   repository_url: z.string(),
   transient_environment: PermissiveBoolean.optional(),
@@ -6552,8 +6523,8 @@ export const s_deployment_simple = z.object({
   original_environment: z.string().optional(),
   environment: z.string(),
   description: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   statuses_url: z.string(),
   repository_url: z.string(),
   transient_environment: PermissiveBoolean.optional(),
@@ -6578,8 +6549,8 @@ export const s_deployment_status = z.object({
   description: z.string().max(140).default(""),
   environment: z.string().optional().default(""),
   target_url: z.string().default(""),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   deployment_url: z.string(),
   repository_url: z.string(),
   environment_url: z.string().optional().default(""),
@@ -6593,8 +6564,8 @@ export const s_environment = z.object({
   name: z.string(),
   url: z.string(),
   html_url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   protection_rules: z
     .array(
       z.union([
@@ -6700,9 +6671,9 @@ export const s_full_repository = z.object({
   archived: PermissiveBoolean,
   disabled: PermissiveBoolean,
   visibility: z.string().optional(),
-  pushed_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  pushed_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   permissions: z
     .object({
       admin: PermissiveBoolean,
@@ -6754,8 +6725,8 @@ export const s_gist_simple = z.object({
         id: z.string().optional(),
         url: z.string().optional(),
         user: s_public_user.optional(),
-        created_at: z.string().datetime({ offset: true }).optional(),
-        updated_at: z.string().datetime({ offset: true }).optional(),
+        created_at: z.string().datetime({offset: true}).optional(),
+        updated_at: z.string().datetime({offset: true}).optional(),
       }),
     )
     .nullable()
@@ -6781,8 +6752,8 @@ export const s_gist_simple = z.object({
         }),
       ),
       public: PermissiveBoolean,
-      created_at: z.string().datetime({ offset: true }),
-      updated_at: z.string().datetime({ offset: true }),
+      created_at: z.string().datetime({offset: true}),
+      updated_at: z.string().datetime({offset: true}),
       description: z.string().nullable(),
       comments: z.coerce.number(),
       comments_enabled: PermissiveBoolean.optional(),
@@ -6843,14 +6814,14 @@ export const s_global_advisory = z.object({
   severity: z.enum(["critical", "high", "medium", "low", "unknown"]),
   source_code_location: z.string().nullable(),
   identifiers: z
-    .array(z.object({ type: z.enum(["CVE", "GHSA"]), value: z.string() }))
+    .array(z.object({type: z.enum(["CVE", "GHSA"]), value: z.string()}))
     .nullable(),
   references: z.array(z.string()).nullable(),
-  published_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  github_reviewed_at: z.string().datetime({ offset: true }).nullable(),
-  nvd_published_at: z.string().datetime({ offset: true }).nullable(),
-  withdrawn_at: z.string().datetime({ offset: true }).nullable(),
+  published_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  github_reviewed_at: z.string().datetime({offset: true}).nullable(),
+  nvd_published_at: z.string().datetime({offset: true}).nullable(),
+  withdrawn_at: z.string().datetime({offset: true}).nullable(),
   vulnerabilities: z.array(s_vulnerability).nullable(),
   cvss: z
     .object({
@@ -6860,10 +6831,10 @@ export const s_global_advisory = z.object({
     .nullable(),
   cvss_severities: s_cvss_severities.optional(),
   epss: s_security_advisory_epss.optional(),
-  cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })).nullable(),
+  cwes: z.array(z.object({cwe_id: z.string(), name: z.string()})).nullable(),
   credits: z
     .array(
-      z.object({ user: s_simple_user, type: s_security_advisory_credit_types }),
+      z.object({user: s_simple_user, type: s_security_advisory_credit_types}),
     )
     .nullable(),
 })
@@ -6875,8 +6846,8 @@ export const s_hook = z.object({
   active: PermissiveBoolean,
   events: z.array(z.string()),
   config: s_webhook_config,
-  updated_at: z.string().datetime({ offset: true }),
-  created_at: z.string().datetime({ offset: true }),
+  updated_at: z.string().datetime({offset: true}),
+  created_at: z.string().datetime({offset: true}),
   url: z.string(),
   test_url: z.string(),
   ping_url: z.string(),
@@ -6935,16 +6906,16 @@ export const s_issue = z.object({
   comments: z.coerce.number(),
   pull_request: z
     .object({
-      merged_at: z.string().datetime({ offset: true }).nullable().optional(),
+      merged_at: z.string().datetime({offset: true}).nullable().optional(),
       diff_url: z.string().nullable(),
       html_url: z.string().nullable(),
       patch_url: z.string().nullable(),
       url: z.string().nullable(),
     })
     .optional(),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   draft: PermissiveBoolean.optional(),
   closed_by: s_nullable_simple_user.optional(),
   body_html: z.string().optional(),
@@ -6967,8 +6938,8 @@ export const s_issue_comment = z.object({
   body_html: z.string().optional(),
   html_url: z.string(),
   user: s_nullable_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   issue_url: z.string(),
   author_association: s_author_association,
   performed_via_github_app: s_nullable_integration.optional(),
@@ -7013,13 +6984,13 @@ export const s_issue_search_result_item = z.object({
   assignee: s_nullable_simple_user,
   milestone: s_nullable_milestone,
   comments: z.coerce.number(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
   text_matches: s_search_result_text_matches.optional(),
   pull_request: z
     .object({
-      merged_at: z.string().datetime({ offset: true }).nullable().optional(),
+      merged_at: z.string().datetime({offset: true}).nullable().optional(),
       diff_url: z.string().nullable(),
       html_url: z.string().nullable(),
       patch_url: z.string().nullable(),
@@ -7049,7 +7020,7 @@ export const s_labeled_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  label: z.object({ name: z.string(), color: z.string() }),
+  label: z.object({name: z.string(), color: z.string()}),
 })
 
 export const s_locked_issue_event = z.object({
@@ -7067,7 +7038,7 @@ export const s_locked_issue_event = z.object({
 
 export const s_manifest = z.object({
   name: z.string(),
-  file: z.object({ source_location: z.string().optional() }).optional(),
+  file: z.object({source_location: z.string().optional()}).optional(),
   metadata: s_metadata.optional(),
   resolved: z.record(s_dependency).optional(),
 })
@@ -7086,8 +7057,8 @@ export const s_migration = z.object({
   org_metadata_only: PermissiveBoolean,
   repositories: z.array(s_repository),
   url: z.string(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   node_id: z.string(),
   archive_url: z.string().optional(),
   exclude: z.array(z.string()).optional(),
@@ -7103,7 +7074,7 @@ export const s_milestoned_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  milestone: z.object({ title: z.string() }),
+  milestone: z.object({title: z.string()}),
 })
 
 export const s_moved_column_in_project_issue_event = z.object({
@@ -7169,16 +7140,16 @@ export const s_nullable_issue = z
     comments: z.coerce.number(),
     pull_request: z
       .object({
-        merged_at: z.string().datetime({ offset: true }).nullable().optional(),
+        merged_at: z.string().datetime({offset: true}).nullable().optional(),
         diff_url: z.string().nullable(),
         html_url: z.string().nullable(),
         patch_url: z.string().nullable(),
         url: z.string().nullable(),
       })
       .optional(),
-    closed_at: z.string().datetime({ offset: true }).nullable(),
-    created_at: z.string().datetime({ offset: true }),
-    updated_at: z.string().datetime({ offset: true }),
+    closed_at: z.string().datetime({offset: true}).nullable(),
+    created_at: z.string().datetime({offset: true}),
+    updated_at: z.string().datetime({offset: true}),
     draft: PermissiveBoolean.optional(),
     closed_by: s_nullable_simple_user.optional(),
     body_html: z.string().optional(),
@@ -7214,7 +7185,7 @@ export const s_organization_secret_scanning_alert = z.object({
   locations_url: z.string().optional(),
   state: s_secret_scanning_alert_state.optional(),
   resolution: s_secret_scanning_alert_resolution.optional(),
-  resolved_at: z.string().datetime({ offset: true }).nullable().optional(),
+  resolved_at: z.string().datetime({offset: true}).nullable().optional(),
   resolved_by: s_nullable_simple_user.optional(),
   secret_type: z.string().optional(),
   secret_type_display_name: z.string().optional(),
@@ -7224,7 +7195,7 @@ export const s_organization_secret_scanning_alert = z.object({
   push_protection_bypassed_by: s_nullable_simple_user.optional(),
   push_protection_bypassed_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   push_protection_bypass_request_reviewer: s_nullable_simple_user.optional(),
@@ -7261,8 +7232,8 @@ export const s_package = z.object({
   visibility: z.enum(["private", "public"]),
   owner: s_nullable_simple_user.optional(),
   repository: s_nullable_minimal_repository.optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
 })
 
 export const s_pending_deployment = z.object({
@@ -7274,7 +7245,7 @@ export const s_pending_deployment = z.object({
     html_url: z.string().optional(),
   }),
   wait_timer: z.coerce.number(),
-  wait_timer_started_at: z.string().datetime({ offset: true }).nullable(),
+  wait_timer_started_at: z.string().datetime({offset: true}).nullable(),
   current_user_can_approve: PermissiveBoolean,
   reviewers: z.array(
     z.object({
@@ -7314,24 +7285,24 @@ export const s_protected_branch = z.object({
     })
     .optional(),
   required_signatures: z
-    .object({ url: z.string(), enabled: PermissiveBoolean })
+    .object({url: z.string(), enabled: PermissiveBoolean})
     .optional(),
   enforce_admins: z
-    .object({ url: z.string(), enabled: PermissiveBoolean })
+    .object({url: z.string(), enabled: PermissiveBoolean})
     .optional(),
-  required_linear_history: z.object({ enabled: PermissiveBoolean }).optional(),
-  allow_force_pushes: z.object({ enabled: PermissiveBoolean }).optional(),
-  allow_deletions: z.object({ enabled: PermissiveBoolean }).optional(),
+  required_linear_history: z.object({enabled: PermissiveBoolean}).optional(),
+  allow_force_pushes: z.object({enabled: PermissiveBoolean}).optional(),
+  allow_deletions: z.object({enabled: PermissiveBoolean}).optional(),
   restrictions: s_branch_restriction_policy.optional(),
   required_conversation_resolution: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
-  block_creations: z.object({ enabled: PermissiveBoolean }).optional(),
+  block_creations: z.object({enabled: PermissiveBoolean}).optional(),
   lock_branch: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
   allow_fork_syncing: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
 })
 
@@ -7392,10 +7363,10 @@ export const s_pull_request = z.object({
   ),
   milestone: s_nullable_milestone,
   active_lock_reason: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  merged_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  merged_at: z.string().datetime({offset: true}).nullable(),
   merge_commit_sha: z.string().nullable(),
   assignee: s_nullable_simple_user,
   assignees: z.array(s_simple_user).nullable().optional(),
@@ -7479,10 +7450,10 @@ export const s_pull_request_simple = z.object({
   ),
   milestone: s_nullable_milestone,
   active_lock_reason: z.string().nullable().optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  merged_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  merged_at: z.string().datetime({offset: true}).nullable(),
   merge_commit_sha: z.string().nullable(),
   assignee: s_nullable_simple_user,
   assignees: z.array(s_simple_user).nullable().optional(),
@@ -7532,8 +7503,8 @@ export const s_release = z.object({
   body: z.string().nullable().optional(),
   draft: PermissiveBoolean,
   prerelease: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }),
-  published_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}),
+  published_at: z.string().datetime({offset: true}).nullable(),
   author: s_simple_user,
   assets: z.array(s_release_asset),
   body_html: z.string().optional(),
@@ -7575,7 +7546,7 @@ export const s_renamed_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  rename: z.object({ from: z.string(), to: z.string() }),
+  rename: z.object({from: z.string(), to: z.string()}),
 })
 
 export const s_repository_advisory = z.object({
@@ -7589,15 +7560,15 @@ export const s_repository_advisory = z.object({
   author: s_simple_user.nullable(),
   publisher: s_simple_user.nullable(),
   identifiers: z.array(
-    z.object({ type: z.enum(["CVE", "GHSA"]), value: z.string() }),
+    z.object({type: z.enum(["CVE", "GHSA"]), value: z.string()}),
   ),
   state: z.enum(["published", "closed", "withdrawn", "draft", "triage"]),
-  created_at: z.string().datetime({ offset: true }).nullable(),
-  updated_at: z.string().datetime({ offset: true }).nullable(),
-  published_at: z.string().datetime({ offset: true }).nullable(),
-  closed_at: z.string().datetime({ offset: true }).nullable(),
-  withdrawn_at: z.string().datetime({ offset: true }).nullable(),
-  submission: z.object({ accepted: PermissiveBoolean }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
+  updated_at: z.string().datetime({offset: true}).nullable(),
+  published_at: z.string().datetime({offset: true}).nullable(),
+  closed_at: z.string().datetime({offset: true}).nullable(),
+  withdrawn_at: z.string().datetime({offset: true}).nullable(),
+  submission: z.object({accepted: PermissiveBoolean}).nullable(),
   vulnerabilities: z.array(s_repository_advisory_vulnerability).nullable(),
   cvss: z
     .object({
@@ -7606,7 +7577,7 @@ export const s_repository_advisory = z.object({
     })
     .nullable(),
   cvss_severities: s_cvss_severities.optional(),
-  cwes: z.array(z.object({ cwe_id: z.string(), name: z.string() })).nullable(),
+  cwes: z.array(z.object({cwe_id: z.string(), name: z.string()})).nullable(),
   cwe_ids: z.array(z.string()).nullable(),
   credits: z
     .array(
@@ -7628,7 +7599,7 @@ export const s_repository_invitation = z.object({
   invitee: s_nullable_simple_user,
   inviter: s_nullable_simple_user,
   permissions: z.enum(["read", "write", "admin", "triage", "maintain"]),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   expired: PermissiveBoolean.optional(),
   url: z.string(),
   html_url: z.string(),
@@ -7752,7 +7723,7 @@ export const s_secret_scanning_alert = z.object({
   locations_url: z.string().optional(),
   state: s_secret_scanning_alert_state.optional(),
   resolution: s_secret_scanning_alert_resolution.optional(),
-  resolved_at: z.string().datetime({ offset: true }).nullable().optional(),
+  resolved_at: z.string().datetime({offset: true}).nullable().optional(),
   resolved_by: s_nullable_simple_user.optional(),
   resolution_comment: z.string().nullable().optional(),
   secret_type: z.string().optional(),
@@ -7762,7 +7733,7 @@ export const s_secret_scanning_alert = z.object({
   push_protection_bypassed_by: s_nullable_simple_user.optional(),
   push_protection_bypassed_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
   push_protection_bypass_request_reviewer: s_nullable_simple_user.optional(),
@@ -7782,7 +7753,7 @@ export const s_secret_scanning_alert = z.object({
 })
 
 export const s_starred_repository = z.object({
-  starred_at: z.string().datetime({ offset: true }),
+  starred_at: z.string().datetime({offset: true}),
   repo: s_repository,
 })
 
@@ -7840,8 +7811,8 @@ export const s_timeline_comment_event = z.object({
   body_html: z.string().optional(),
   html_url: z.string(),
   user: s_simple_user,
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   issue_url: z.string(),
   author_association: s_author_association,
   performed_via_github_app: s_nullable_integration.optional(),
@@ -7898,7 +7869,7 @@ export const s_unlabeled_issue_event = z.object({
   commit_url: z.string().nullable(),
   created_at: z.string(),
   performed_via_github_app: s_nullable_integration,
-  label: z.object({ name: z.string(), color: z.string() }),
+  label: z.object({name: z.string(), color: z.string()}),
 })
 
 export const s_workflow_run = z.object({
@@ -7920,11 +7891,11 @@ export const s_workflow_run = z.object({
   url: z.string(),
   html_url: z.string(),
   pull_requests: z.array(s_pull_request_minimal).nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
   actor: s_simple_user.optional(),
   triggering_actor: s_simple_user.optional(),
-  run_started_at: z.string().datetime({ offset: true }).optional(),
+  run_started_at: z.string().datetime({offset: true}).optional(),
   jobs_url: z.string(),
   logs_url: z.string(),
   check_suite_url: z.string(),
@@ -7949,30 +7920,26 @@ export const s_branch_protection = z.object({
     s_protected_branch_pull_request_review.optional(),
   restrictions: s_branch_restriction_policy.optional(),
   required_linear_history: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
   allow_force_pushes: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
-  allow_deletions: z
-    .object({ enabled: PermissiveBoolean.optional() })
-    .optional(),
-  block_creations: z
-    .object({ enabled: PermissiveBoolean.optional() })
-    .optional(),
+  allow_deletions: z.object({enabled: PermissiveBoolean.optional()}).optional(),
+  block_creations: z.object({enabled: PermissiveBoolean.optional()}).optional(),
   required_conversation_resolution: z
-    .object({ enabled: PermissiveBoolean.optional() })
+    .object({enabled: PermissiveBoolean.optional()})
     .optional(),
   name: z.string().optional(),
   protection_url: z.string().optional(),
   required_signatures: z
-    .object({ url: z.string(), enabled: PermissiveBoolean })
+    .object({url: z.string(), enabled: PermissiveBoolean})
     .optional(),
   lock_branch: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
   allow_fork_syncing: z
-    .object({ enabled: PermissiveBoolean.optional().default(false) })
+    .object({enabled: PermissiveBoolean.optional().default(false)})
     .optional(),
 })
 
@@ -8003,8 +7970,8 @@ export const s_check_run = z.object({
       "action_required",
     ])
     .nullable(),
-  started_at: z.string().datetime({ offset: true }).nullable(),
-  completed_at: z.string().datetime({ offset: true }).nullable(),
+  started_at: z.string().datetime({offset: true}).nullable(),
+  completed_at: z.string().datetime({offset: true}).nullable(),
   output: z.object({
     title: z.string().nullable(),
     summary: z.string().nullable(),
@@ -8013,7 +7980,7 @@ export const s_check_run = z.object({
     annotations_url: z.string(),
   }),
   name: z.string(),
-  check_suite: z.object({ id: z.coerce.number() }).nullable(),
+  check_suite: z.object({id: z.coerce.number()}).nullable(),
   app: s_nullable_integration,
   pull_requests: z.array(s_pull_request_minimal),
   deployment: s_deployment_simple.optional(),
@@ -8030,9 +7997,9 @@ export const s_codespace_with_full_repository = z.object({
   machine: s_nullable_codespace_machine,
   devcontainer_path: z.string().nullable().optional(),
   prebuild: PermissiveBoolean.nullable(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  last_used_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  last_used_at: z.string().datetime({offset: true}),
   state: z.enum([
     "Unknown",
     "Created",
@@ -8080,7 +8047,7 @@ export const s_codespace_with_full_repository = z.object({
   retention_period_minutes: z.coerce.number().nullable().optional(),
   retention_expires_at: z
     .string()
-    .datetime({ offset: true })
+    .datetime({offset: true})
     .nullable()
     .optional(),
 })
@@ -8158,7 +8125,7 @@ export const s_event = z.object({
   id: z.string(),
   type: z.string().nullable(),
   actor: s_actor,
-  repo: z.object({ id: z.coerce.number(), name: z.string(), url: z.string() }),
+  repo: z.object({id: z.coerce.number(), name: z.string(), url: z.string()}),
   org: s_actor.optional(),
   payload: z.object({
     action: z.string().optional(),
@@ -8178,7 +8145,7 @@ export const s_event = z.object({
       .optional(),
   }),
   public: PermissiveBoolean,
-  created_at: z.string().datetime({ offset: true }).nullable(),
+  created_at: z.string().datetime({offset: true}).nullable(),
 })
 
 export const s_issue_event = z.object({
@@ -8189,7 +8156,7 @@ export const s_issue_event = z.object({
   event: z.string(),
   commit_id: z.string().nullable(),
   commit_url: z.string().nullable(),
-  created_at: z.string().datetime({ offset: true }),
+  created_at: z.string().datetime({offset: true}),
   issue: s_nullable_issue.optional(),
   label: s_issue_event_label.optional(),
   assignee: s_nullable_simple_user.optional(),
@@ -8238,8 +8205,8 @@ export const s_repository_ruleset = z.object({
   node_id: z.string().optional(),
   _links: z
     .object({
-      self: z.object({ href: z.string().optional() }).optional(),
-      html: z.object({ href: z.string().optional() }).nullable().optional(),
+      self: z.object({href: z.string().optional()}).optional(),
+      html: z.object({href: z.string().optional()}).nullable().optional(),
     })
     .optional(),
   conditions: z
@@ -8247,8 +8214,8 @@ export const s_repository_ruleset = z.object({
     .nullable()
     .optional(),
   rules: z.array(s_repository_rule).optional(),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
+  created_at: z.string().datetime({offset: true}).optional(),
+  updated_at: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_snapshot = z.object({
@@ -8260,28 +8227,24 @@ export const s_snapshot = z.object({
   }),
   sha: z.string().min(40).max(40),
   ref: z.string().regex(new RegExp("^refs/")),
-  detector: z.object({
-    name: z.string(),
-    version: z.string(),
-    url: z.string(),
-  }),
+  detector: z.object({name: z.string(), version: z.string(), url: z.string()}),
   metadata: s_metadata.optional(),
   manifests: z.record(s_manifest).optional(),
-  scanned: z.string().datetime({ offset: true }),
+  scanned: z.string().datetime({offset: true}),
 })
 
 export const s_timeline_cross_referenced_event = z.object({
   event: z.string(),
   actor: s_simple_user.optional(),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  source: z.object({ type: z.string().optional(), issue: s_issue.optional() }),
+  created_at: z.string().datetime({offset: true}),
+  updated_at: z.string().datetime({offset: true}),
+  source: z.object({type: z.string().optional(), issue: s_issue.optional()}),
 })
 
 export const s_branch_with_protection = z.object({
   name: z.string(),
   commit: s_commit,
-  _links: z.object({ html: z.string(), self: z.string() }),
+  _links: z.object({html: z.string(), self: z.string()}),
   protected: PermissiveBoolean,
   protection: s_branch_protection,
   protection_url: z.string(),
@@ -8291,7 +8254,7 @@ export const s_branch_with_protection = z.object({
 
 export const s_short_branch = z.object({
   name: z.string(),
-  commit: z.object({ sha: z.string(), url: z.string() }),
+  commit: z.object({sha: z.string(), url: z.string()}),
   protected: PermissiveBoolean,
   protection: s_branch_protection.optional(),
   protection_url: z.string().optional(),

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/generated.ts
@@ -96,7 +96,7 @@ import {
   s_WidgetRepairRequest,
   s_WidgetRepairState,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -115,8 +115,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetServiceStatusResponder = {
   with200(): KoaRuntimeResponse<{
@@ -795,7 +795,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const getServiceStatusResponseValidator = responseValidationFactory(
-    [["200", z.object({ statusString: z.string() })]],
+    [["200", z.object({statusString: z.string()})]],
     s_Azure_Core_Foundations_ErrorResponse,
   )
 
@@ -842,7 +842,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getServiceStatusResponseValidator(status, body)
@@ -851,10 +851,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusParamSchema =
-    z.object({ widgetName: z.string(), operationId: z.string() })
+    z.object({widgetName: z.string(), operationId: z.string()})
 
   const widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusQuerySchema =
-    z.object({ "api-version": z.string().min(1) })
+    z.object({"api-version": z.string().min(1)})
 
   const widgetsGetWidgetOperationStatusWidgetsGetWidgetDeleteOperationStatusResponseValidator =
     responseValidationFactory(
@@ -940,7 +940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -1037,7 +1037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetsCreateOrUpdateWidgetResponseValidator(status, body)
@@ -1046,7 +1046,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const widgetsGetWidgetParamSchema = z.object({ widgetName: z.string() })
+  const widgetsGetWidgetParamSchema = z.object({widgetName: z.string()})
 
   const widgetsGetWidgetQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1110,7 +1110,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = widgetsGetWidgetResponseValidator(status, body)
@@ -1118,7 +1118,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const widgetsDeleteWidgetParamSchema = z.object({ widgetName: z.string() })
+  const widgetsDeleteWidgetParamSchema = z.object({widgetName: z.string()})
 
   const widgetsDeleteWidgetQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1200,7 +1200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetsDeleteWidgetResponseValidator(status, body)
@@ -1272,7 +1272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = widgetsListWidgetsResponseValidator(status, body)
@@ -1280,7 +1280,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const widgetsGetAnalyticsParamSchema = z.object({ widgetName: z.string() })
+  const widgetsGetAnalyticsParamSchema = z.object({widgetName: z.string()})
 
   const widgetsGetAnalyticsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1347,7 +1347,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetsGetAnalyticsResponseValidator(status, body)
@@ -1356,7 +1356,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const widgetsUpdateAnalyticsParamSchema = z.object({ widgetName: z.string() })
+  const widgetsUpdateAnalyticsParamSchema = z.object({widgetName: z.string()})
 
   const widgetsUpdateAnalyticsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1437,7 +1437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetsUpdateAnalyticsResponseValidator(status, body)
@@ -1519,7 +1519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetsGetRepairStatusResponseValidator(status, body)
@@ -1528,7 +1528,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const widgetsScheduleRepairsParamSchema = z.object({ widgetName: z.string() })
+  const widgetsScheduleRepairsParamSchema = z.object({widgetName: z.string()})
 
   const widgetsScheduleRepairsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -1553,10 +1553,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           result: z
             .object({
               requestState: s_WidgetRepairState,
-              scheduledDateTime: z.string().datetime({ offset: true }),
-              createdDateTime: z.string().datetime({ offset: true }),
-              updatedDateTime: z.string().datetime({ offset: true }),
-              completedDateTime: z.string().datetime({ offset: true }),
+              scheduledDateTime: z.string().datetime({offset: true}),
+              createdDateTime: z.string().datetime({offset: true}),
+              updatedDateTime: z.string().datetime({offset: true}),
+              completedDateTime: z.string().datetime({offset: true}),
             })
             .optional(),
         }),
@@ -1628,7 +1628,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetsScheduleRepairsResponseValidator(status, body)
@@ -1712,7 +1712,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetPartsGetWidgetPartOperationStatusResponseValidator(
@@ -1802,7 +1802,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetPartsCreateWidgetPartResponseValidator(status, body)
@@ -1876,7 +1876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetPartsListWidgetPartsResponseValidator(status, body)
@@ -1955,7 +1955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetPartsGetWidgetPartResponseValidator(status, body)
@@ -2037,7 +2037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetPartsDeleteWidgetPartResponseValidator(status, body)
@@ -2046,9 +2046,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const widgetPartsReorderPartsParamSchema = z.object({
-    widgetName: z.string(),
-  })
+  const widgetPartsReorderPartsParamSchema = z.object({widgetName: z.string()})
 
   const widgetPartsReorderPartsQuerySchema = z.object({
     "api-version": z.string().min(1),
@@ -2132,7 +2130,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = widgetPartsReorderPartsResponseValidator(status, body)
@@ -2220,7 +2218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = manufacturersGetManufacturerOperationStatusResponseValidator(
@@ -2316,7 +2314,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = manufacturersCreateOrReplaceManufacturerResponseValidator(
@@ -2398,7 +2396,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = manufacturersGetManufacturerResponseValidator(status, body)
@@ -2492,7 +2490,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = manufacturersDeleteManufacturerResponseValidator(status, body)
@@ -2559,7 +2557,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = manufacturersListManufacturersResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-core-data-plane-service.tsp/schemas.ts
@@ -7,7 +7,7 @@ import {
   t_Azure_Core_Foundations_ErrorResponse,
   t_Azure_Core_Foundations_InnerError,
 } from "./models"
-import { z } from "zod"
+import {z} from "zod"
 
 export const s_Azure_Core_Foundations_OperationState = z.union([
   z.enum(["NotStarted", "Running", "Succeeded", "Failed", "Canceled"]),
@@ -34,7 +34,7 @@ export const s_WidgetColor = z.union([
   z.enum(["Black", "White", "Red", "Green", "Blue"]),
 ])
 
-export const s_WidgetPartReorderRequest = z.object({ signedOffBy: z.string() })
+export const s_WidgetPartReorderRequest = z.object({signedOffBy: z.string()})
 
 export const s_WidgetRepairState = z.union([
   z.string(),
@@ -69,10 +69,10 @@ export const s_WidgetPart = z.object({
 
 export const s_WidgetRepairRequest = z.object({
   requestState: s_WidgetRepairState,
-  scheduledDateTime: z.string().datetime({ offset: true }),
-  createdDateTime: z.string().datetime({ offset: true }),
-  updatedDateTime: z.string().datetime({ offset: true }),
-  completedDateTime: z.string().datetime({ offset: true }),
+  scheduledDateTime: z.string().datetime({offset: true}),
+  createdDateTime: z.string().datetime({offset: true}),
+  updatedDateTime: z.string().datetime({offset: true}),
+  completedDateTime: z.string().datetime({offset: true}),
 })
 
 export const s_PagedManufacturer = z.object({
@@ -94,7 +94,7 @@ export const s_Azure_Core_Foundations_ErrorResponse: z.ZodType<
   t_Azure_Core_Foundations_ErrorResponse,
   z.ZodTypeDef,
   unknown
-> = z.object({ error: z.lazy(() => s_Azure_Core_Foundations_Error) })
+> = z.object({error: z.lazy(() => s_Azure_Core_Foundations_Error)})
 
 export const s_Azure_Core_Foundations_Error: z.ZodType<
   t_Azure_Core_Foundations_Error,

--- a/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/generated.ts
@@ -39,7 +39,7 @@ import {
   s_MoveResponse,
   s_OperationListResult,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -58,8 +58,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type OperationsListResponder = {
   with200(): KoaRuntimeResponse<t_OperationListResult>
@@ -293,9 +293,7 @@ export type Implementation = {
 export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
-  const operationsListQuerySchema = z.object({
-    "api-version": z.string().min(1),
-  })
+  const operationsListQuerySchema = z.object({"api-version": z.string().min(1)})
 
   const operationsListResponseValidator = responseValidationFactory(
     [["200", s_OperationListResult]],
@@ -342,7 +340,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = operationsListResponseValidator(status, body)
@@ -361,7 +359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     employeeName: z.string().regex(new RegExp("^[a-zA-Z0-9-]{3,24}$")),
   })
 
-  const employeesGetQuerySchema = z.object({ "api-version": z.string().min(1) })
+  const employeesGetQuerySchema = z.object({"api-version": z.string().min(1)})
 
   const employeesGetResponseValidator = responseValidationFactory(
     [["200", s_Employee]],
@@ -412,7 +410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesGetResponseValidator(status, body)
@@ -496,7 +494,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesCreateOrUpdateResponseValidator(status, body)
@@ -574,7 +572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesUpdateResponseValidator(status, body)
@@ -652,7 +650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesDeleteResponseValidator(status, body)
@@ -730,7 +728,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesCheckExistenceResponseValidator(status, body)
@@ -802,7 +800,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesListByResourceGroupResponseValidator(status, body)
@@ -869,7 +867,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesListBySubscriptionResponseValidator(status, body)
@@ -888,9 +886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     employeeName: z.string().regex(new RegExp("^[a-zA-Z0-9-]{3,24}$")),
   })
 
-  const employeesMoveQuerySchema = z.object({
-    "api-version": z.string().min(1),
-  })
+  const employeesMoveQuerySchema = z.object({"api-version": z.string().min(1)})
 
   const employeesMoveBodySchema = s_MoveRequest
 
@@ -947,7 +943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = employeesMoveResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/models.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_Azure_Core_armResourceType = string
 

--- a/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/azure-resource-manager.tsp/schemas.ts
@@ -6,7 +6,7 @@ import {
   t_Azure_ResourceManager_CommonTypes_ErrorDetail,
   t_Azure_ResourceManager_CommonTypes_ErrorResponse,
 } from "./models"
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -27,7 +27,7 @@ export const s_Azure_ResourceManager_CommonTypes_ActionType = z.union([
 ])
 
 export const s_Azure_ResourceManager_CommonTypes_ErrorAdditionalInfo = z.object(
-  { type: z.string().optional(), info: z.object({}).optional() },
+  {type: z.string().optional(), info: z.object({}).optional()},
 )
 
 export const s_Azure_ResourceManager_CommonTypes_OperationDisplay = z.object({
@@ -53,9 +53,9 @@ export const s_EmployeeUpdateProperties = z.object({
   profile: z.string().optional(),
 })
 
-export const s_MoveRequest = z.object({ from: z.string(), to: z.string() })
+export const s_MoveRequest = z.object({from: z.string(), to: z.string()})
 
-export const s_MoveResponse = z.object({ movingStatus: z.string() })
+export const s_MoveResponse = z.object({movingStatus: z.string()})
 
 export const s_Azure_ResourceManager_CommonTypes_Operation = z.object({
   name: z.string().optional(),
@@ -68,11 +68,11 @@ export const s_Azure_ResourceManager_CommonTypes_Operation = z.object({
 export const s_Azure_ResourceManager_CommonTypes_SystemData = z.object({
   createdBy: z.string().optional(),
   createdByType: s_Azure_ResourceManager_CommonTypes_createdByType.optional(),
-  createdAt: z.string().datetime({ offset: true }).optional(),
+  createdAt: z.string().datetime({offset: true}).optional(),
   lastModifiedBy: z.string().optional(),
   lastModifiedByType:
     s_Azure_ResourceManager_CommonTypes_createdByType.optional(),
-  lastModifiedAt: z.string().datetime({ offset: true }).optional(),
+  lastModifiedAt: z.string().datetime({offset: true}).optional(),
 })
 
 export const s_EmployeeUpdate = z.object({

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/generated.ts
@@ -67,7 +67,7 @@ import {
   s_UpdateAppAuthenticatorEnrollmentRequest,
   s_UpdateAuthenticatorEnrollmentRequest,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -86,8 +86,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type CreateAppAuthenticatorEnrollmentResponder = {
   with200(): KoaRuntimeResponse<t_AppAuthenticatorEnrollment>
@@ -1015,7 +1015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = createAppAuthenticatorEnrollmentResponseValidator(status, body)
@@ -1091,7 +1091,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -1170,7 +1170,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = updateAppAuthenticatorEnrollmentResponseValidator(status, body)
@@ -1238,7 +1238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteAppAuthenticatorEnrollmentResponseValidator(status, body)
@@ -1248,7 +1248,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const listAppAuthenticatorPendingPushNotificationChallengesParamSchema =
-    z.object({ enrollmentId: z.string() })
+    z.object({enrollmentId: z.string()})
 
   const listAppAuthenticatorPendingPushNotificationChallengesResponseValidator =
     responseValidationFactory(
@@ -1302,7 +1302,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -1369,7 +1369,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = listAuthenticatorsResponseValidator(status, body)
@@ -1378,11 +1378,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getAuthenticatorParamSchema = z.object({ authenticatorId: z.string() })
+  const getAuthenticatorParamSchema = z.object({authenticatorId: z.string()})
 
-  const getAuthenticatorQuerySchema = z.object({
-    expand: z.string().optional(),
-  })
+  const getAuthenticatorQuerySchema = z.object({expand: z.string().optional()})
 
   const getAuthenticatorResponseValidator = responseValidationFactory(
     [
@@ -1442,7 +1440,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAuthenticatorResponseValidator(status, body)
@@ -1451,7 +1449,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const listEnrollmentsParamSchema = z.object({ authenticatorId: z.string() })
+  const listEnrollmentsParamSchema = z.object({authenticatorId: z.string()})
 
   const listEnrollmentsResponseValidator = responseValidationFactory(
     [
@@ -1507,7 +1505,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = listEnrollmentsResponseValidator(status, body)
@@ -1575,7 +1573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getEnrollmentResponseValidator(status, body)
@@ -1649,7 +1647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = updateEnrollmentResponseValidator(status, body)
@@ -1697,7 +1695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = listEmailsResponseValidator(status, body)
@@ -1706,7 +1704,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const createEmailBodySchema = z.object({
-    profile: z.object({ email: z.string().email() }),
+    profile: z.object({email: z.string().email()}),
     sendEmail: PermissiveBoolean.optional().default(true),
     state: z.string().optional(),
     role: z.enum(["PRIMARY", "SECONDARY"]).optional(),
@@ -1767,7 +1765,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = createEmailResponseValidator(status, body)
@@ -1775,7 +1773,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getEmailParamSchema = z.object({ id: z.string() })
+  const getEmailParamSchema = z.object({id: z.string()})
 
   const getEmailResponseValidator = responseValidationFactory(
     [
@@ -1820,7 +1818,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getEmailResponseValidator(status, body)
@@ -1828,7 +1826,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteEmailParamSchema = z.object({ id: z.string() })
+  const deleteEmailParamSchema = z.object({id: z.string()})
 
   const deleteEmailResponseValidator = responseValidationFactory(
     [
@@ -1884,7 +1882,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteEmailResponseValidator(status, body)
@@ -1893,9 +1891,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const sendEmailChallengeParamSchema = z.object({ id: z.string() })
+  const sendEmailChallengeParamSchema = z.object({id: z.string()})
 
-  const sendEmailChallengeBodySchema = z.object({ state: z.string() })
+  const sendEmailChallengeBodySchema = z.object({state: z.string()})
 
   const sendEmailChallengeResponseValidator = responseValidationFactory(
     [
@@ -1905,15 +1903,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
           id: z.string().min(1),
           status: z.enum(["VERIFIED", "UNVERIFIED"]),
           expiresAt: z.string().min(1),
-          profile: z.object({ email: z.string().min(1) }),
+          profile: z.object({email: z.string().min(1)}),
           _links: z.object({
             verify: z.object({
               href: z.string().min(1),
-              hints: z.object({ allow: z.array(z.enum(["POST"])) }),
+              hints: z.object({allow: z.array(z.enum(["POST"]))}),
             }),
             poll: z.object({
               href: z.string().min(1),
-              hints: z.object({ allow: z.array(z.enum(["GET"])) }),
+              hints: z.object({allow: z.array(z.enum(["GET"]))}),
             }),
           }),
         }),
@@ -1994,7 +1992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = sendEmailChallengeResponseValidator(status, body)
@@ -2017,7 +2015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             id: z.string().min(1),
             status: z.enum(["VERIFIED", "UNVERIFIED"]),
             expiresAt: z.string().min(1),
-            profile: z.object({ email: z.string().min(1) }),
+            profile: z.object({email: z.string().min(1)}),
             _links: z.object({
               verify: z.object({
                 href: z.string().min(1),
@@ -2102,7 +2100,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = pollChallengeForEmailMagicLinkResponseValidator(status, body)
@@ -2116,7 +2114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     challengeId: z.string(),
   })
 
-  const verifyEmailOtpBodySchema = z.object({ verificationCode: z.string() })
+  const verifyEmailOtpBodySchema = z.object({verificationCode: z.string()})
 
   const verifyEmailOtpResponseValidator = responseValidationFactory(
     [
@@ -2176,7 +2174,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = verifyEmailOtpResponseValidator(status, body)
@@ -2227,7 +2225,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = listOktaApplicationsResponseValidator(status, body)
@@ -2278,7 +2276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getOrganizationResponseValidator(status, body)
@@ -2326,7 +2324,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPasswordResponseValidator(status, body)
@@ -2335,7 +2333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const createPasswordBodySchema = z.object({
-    profile: z.object({ password: z.string() }),
+    profile: z.object({password: z.string()}),
   })
 
   const createPasswordResponseValidator = responseValidationFactory(
@@ -2392,7 +2390,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = createPasswordResponseValidator(status, body)
@@ -2402,7 +2400,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const replacePasswordBodySchema = z.object({
-    profile: z.object({ password: z.string() }),
+    profile: z.object({password: z.string()}),
   })
 
   const replacePasswordResponseValidator = responseValidationFactory(
@@ -2459,7 +2457,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = replacePasswordResponseValidator(status, body)
@@ -2514,7 +2512,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deletePasswordResponseValidator(status, body)
@@ -2562,7 +2560,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = listPhonesResponseValidator(status, body)
@@ -2571,7 +2569,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const createPhoneBodySchema = z.object({
-    profile: z.object({ phoneNumber: z.string().optional() }),
+    profile: z.object({phoneNumber: z.string().optional()}),
     sendCode: PermissiveBoolean.optional().default(true),
     method: z.enum(["SMS", "CALL"]).optional(),
   })
@@ -2635,7 +2633,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = createPhoneResponseValidator(status, body)
@@ -2643,7 +2641,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPhoneParamSchema = z.object({ id: z.string() })
+  const getPhoneParamSchema = z.object({id: z.string()})
 
   const getPhoneResponseValidator = responseValidationFactory(
     [
@@ -2692,7 +2690,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPhoneResponseValidator(status, body)
@@ -2700,7 +2698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deletePhoneParamSchema = z.object({ id: z.string() })
+  const deletePhoneParamSchema = z.object({id: z.string()})
 
   const deletePhoneResponseValidator = responseValidationFactory(
     [
@@ -2756,7 +2754,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deletePhoneResponseValidator(status, body)
@@ -2765,7 +2763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const sendPhoneChallengeParamSchema = z.object({ id: z.string() })
+  const sendPhoneChallengeParamSchema = z.object({id: z.string()})
 
   const sendPhoneChallengeBodySchema = z.object({
     method: z.enum(["SMS", "CALL"]),
@@ -2782,7 +2780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               verify: z
                 .object({
                   href: z.string().min(1),
-                  hints: z.object({ allow: z.array(z.enum(["GET"])) }),
+                  hints: z.object({allow: z.array(z.enum(["GET"]))}),
                 })
                 .optional(),
             })
@@ -2861,7 +2859,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = sendPhoneChallengeResponseValidator(status, body)
@@ -2870,7 +2868,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const verifyPhoneChallengeParamSchema = z.object({ id: z.string() })
+  const verifyPhoneChallengeParamSchema = z.object({id: z.string()})
 
   const verifyPhoneChallengeBodySchema = z.object({
     verificationCode: z.string(),
@@ -2942,7 +2940,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = verifyPhoneChallengeResponseValidator(status, body)
@@ -2990,7 +2988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getProfileResponseValidator(status, body)
@@ -2998,9 +2996,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const replaceProfileBodySchema = z.object({
-    profile: z.object({}).optional(),
-  })
+  const replaceProfileBodySchema = z.object({profile: z.object({}).optional()})
 
   const replaceProfileResponseValidator = responseValidationFactory(
     [
@@ -3049,7 +3045,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = replaceProfileResponseValidator(status, body)
@@ -3099,7 +3095,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getProfileSchemaResponseValidator(status, body)
@@ -3154,7 +3150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteSessionsResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_AppAuthenticatorEnrollment = {
   readonly authenticatorId?: string

--- a/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.idp.yaml/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -15,25 +15,25 @@ export const PermissiveBoolean = z.preprocess((value) => {
 
 export const s_AppAuthenticatorEnrollment = z.object({
   authenticatorId: z.string().optional(),
-  createdDate: z.string().datetime({ offset: true }).optional(),
+  createdDate: z.string().datetime({offset: true}).optional(),
   device: z
     .object({
       id: z.string().optional(),
       status: z.enum(["ACTIVE"]).optional(),
-      createdDate: z.string().datetime({ offset: true }).optional(),
-      lastUpdated: z.string().datetime({ offset: true }).optional(),
+      createdDate: z.string().datetime({offset: true}).optional(),
+      lastUpdated: z.string().datetime({offset: true}).optional(),
       clientInstanceId: z.string().optional(),
     })
     .optional(),
   id: z.string().optional(),
-  lastUpdated: z.string().datetime({ offset: true }).optional(),
+  lastUpdated: z.string().datetime({offset: true}).optional(),
   links: z
     .object({
       self: z
         .object({
           href: z.string().min(1).optional(),
           hints: z
-            .object({ allow: z.array(z.enum(["PATCH", "DELETE"])).optional() })
+            .object({allow: z.array(z.enum(["PATCH", "DELETE"])).optional()})
             .optional(),
         })
         .optional(),
@@ -44,15 +44,15 @@ export const s_AppAuthenticatorEnrollment = z.object({
       push: z
         .object({
           id: z.string().optional(),
-          createdDate: z.string().datetime({ offset: true }).optional(),
-          lastUpdated: z.string().datetime({ offset: true }).optional(),
+          createdDate: z.string().datetime({offset: true}).optional(),
+          lastUpdated: z.string().datetime({offset: true}).optional(),
           links: z
             .object({
               pending: z
                 .object({
                   href: z.string().min(1).optional(),
                   hints: z
-                    .object({ allow: z.array(z.enum(["GET"])).optional() })
+                    .object({allow: z.array(z.enum(["GET"])).optional()})
                     .optional(),
                 })
                 .optional(),
@@ -63,7 +63,7 @@ export const s_AppAuthenticatorEnrollment = z.object({
     })
     .optional(),
   user: z
-    .object({ id: z.string().optional(), username: z.string().optional() })
+    .object({id: z.string().optional(), username: z.string().optional()})
     .optional(),
 })
 
@@ -91,7 +91,7 @@ export const s_AuthenticatorKey = z.enum([
 
 export const s_Email = z.object({
   id: z.string().min(1),
-  profile: z.object({ email: z.string().min(1) }),
+  profile: z.object({email: z.string().min(1)}),
   roles: z.array(z.enum(["PRIMARY", "SECONDARY"])),
   status: z.enum(["VERIFIED", "UNVERIFIED"]),
   _links: z
@@ -148,7 +148,7 @@ export const s_Email = z.object({
 
 export const s_Error = z.object({
   errorCauses: z
-    .array(z.object({ errorSummary: z.string().optional() }))
+    .array(z.object({errorSummary: z.string().optional()}))
     .optional(),
   errorCode: z.string().optional(),
   errorId: z.string().optional(),
@@ -192,7 +192,7 @@ export const s_Organization = z.object({
         .object({
           href: z.string().min(1).optional(),
           hints: z
-            .object({ allow: z.array(z.enum(["GET"])).optional() })
+            .object({allow: z.array(z.enum(["GET"])).optional()})
             .optional(),
         })
         .optional(),
@@ -223,7 +223,7 @@ export const s_PasswordResponse = z.object({
 
 export const s_Phone = z.object({
   id: z.string().min(1),
-  profile: z.object({ phoneNumber: z.string().min(1) }),
+  profile: z.object({phoneNumber: z.string().min(1)}),
   status: z.enum(["VERIFIED", "UNVERIFIED"]),
   _links: z
     .object({
@@ -266,13 +266,13 @@ export const s_Phone = z.object({
 })
 
 export const s_Profile = z.object({
-  createdAt: z.string().datetime({ offset: true }).optional(),
-  modifiedAt: z.string().datetime({ offset: true }).optional(),
+  createdAt: z.string().datetime({offset: true}).optional(),
+  modifiedAt: z.string().datetime({offset: true}).optional(),
   profile: z.object({}).optional(),
   _links: z
     .object({
-      self: z.object({ href: z.string().optional() }).optional(),
-      describedBy: z.object({ href: z.string().optional() }).optional(),
+      self: z.object({href: z.string().optional()}).optional(),
+      describedBy: z.object({href: z.string().optional()}).optional(),
     })
     .optional(),
 })
@@ -291,8 +291,8 @@ export const s_Schema = z.object({
   properties: z.object({}).optional(),
   _links: z
     .object({
-      self: z.object({ href: z.string().optional() }).optional(),
-      user: z.object({ href: z.string().optional() }).optional(),
+      self: z.object({href: z.string().optional()}).optional(),
+      user: z.object({href: z.string().optional()}).optional(),
     })
     .optional(),
 })
@@ -302,7 +302,7 @@ export const s_UpdateAuthenticatorEnrollmentRequest = z.object({
 })
 
 export const s_HrefObject = z.object({
-  hints: z.object({ allow: z.array(s_HttpMethod).optional() }).optional(),
+  hints: z.object({allow: z.array(s_HttpMethod).optional()}).optional(),
   href: z.string(),
   name: z.string().optional(),
   type: z.string().optional(),
@@ -364,9 +364,7 @@ export const s_UpdateAppAuthenticatorEnrollmentRequest = z.object({
       push: z
         .object({
           pushToken: z.string().optional(),
-          keys: z
-            .object({ userVerification: s_KeyObject.optional() })
-            .optional(),
+          keys: z.object({userVerification: s_KeyObject.optional()}).optional(),
           capabilities: s_AppAuthenticatorMethodCapabilities.optional(),
         })
         .optional(),
@@ -380,7 +378,7 @@ export const s_Authenticator = z.object({
   key: s_AuthenticatorKey.optional(),
   name: z.string().optional(),
   _embedded: z
-    .object({ enrollments: z.array(s_AuthenticatorEnrollment).optional() })
+    .object({enrollments: z.array(s_AuthenticatorEnrollment).optional()})
     .optional(),
   _links: z
     .object({

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/generated.ts
@@ -109,7 +109,7 @@ import {
   s_TokenResponse,
   s_UserInfo,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -128,8 +128,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetWellKnownOpenIdConfigurationResponder = {
   with200(): KoaRuntimeResponse<t_OidcMetadata>
@@ -1129,7 +1129,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getWellKnownOpenIdConfigurationResponseValidator(status, body)
@@ -1198,7 +1198,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = authorizeResponseValidator(status, body)
@@ -1248,7 +1248,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = authorizeWithPostResponseValidator(status, body)
@@ -1310,7 +1310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = bcAuthorizeResponseValidator(status, body)
@@ -1375,7 +1375,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = challengeResponseValidator(status, body)
@@ -1436,7 +1436,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = listClientsResponseValidator(status, body)
@@ -1497,7 +1497,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = createClientResponseValidator(status, body)
@@ -1505,7 +1505,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getClientParamSchema = z.object({ clientId: z.string() })
+  const getClientParamSchema = z.object({clientId: z.string()})
 
   const getClientResponseValidator = responseValidationFactory(
     [
@@ -1558,7 +1558,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getClientResponseValidator(status, body)
@@ -1566,7 +1566,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const replaceClientParamSchema = z.object({ clientId: z.string() })
+  const replaceClientParamSchema = z.object({clientId: z.string()})
 
   const replaceClientBodySchema = s_Client
 
@@ -1632,7 +1632,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = replaceClientResponseValidator(status, body)
@@ -1641,7 +1641,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const deleteClientParamSchema = z.object({ clientId: z.string() })
+  const deleteClientParamSchema = z.object({clientId: z.string()})
 
   const deleteClientResponseValidator = responseValidationFactory(
     [
@@ -1697,7 +1697,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteClientResponseValidator(status, body)
@@ -1706,7 +1706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const generateNewClientSecretParamSchema = z.object({ clientId: z.string() })
+  const generateNewClientSecretParamSchema = z.object({clientId: z.string()})
 
   const generateNewClientSecretResponseValidator = responseValidationFactory(
     [
@@ -1762,7 +1762,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = generateNewClientSecretResponseValidator(status, body)
@@ -1827,7 +1827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deviceAuthorizeResponseValidator(status, body)
@@ -1892,7 +1892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = globalTokenRevocationResponseValidator(status, body)
@@ -1954,7 +1954,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = introspectResponseValidator(status, body)
@@ -1962,7 +1962,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const oauthKeysQuerySchema = z.object({ client_id: z.string().optional() })
+  const oauthKeysQuerySchema = z.object({client_id: z.string().optional()})
 
   const oauthKeysResponseValidator = responseValidationFactory(
     [
@@ -2007,7 +2007,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = oauthKeysResponseValidator(status, body)
@@ -2064,7 +2064,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = logoutResponseValidator(status, body)
@@ -2117,7 +2117,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = logoutWithPostResponseValidator(status, body)
@@ -2185,7 +2185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = oobAuthenticateResponseValidator(status, body)
@@ -2194,7 +2194,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const parOptionsHeaderSchema = z.object({ origin: z.string().optional() })
+  const parOptionsHeaderSchema = z.object({origin: z.string().optional()})
 
   const parOptionsResponseValidator = responseValidationFactory(
     [
@@ -2239,7 +2239,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = parOptionsResponseValidator(status, body)
@@ -2304,7 +2304,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = parResponseValidator(status, body)
@@ -2365,7 +2365,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = revokeResponseValidator(status, body)
@@ -2373,7 +2373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const tokenOptionsHeaderSchema = z.object({ origin: z.string().optional() })
+  const tokenOptionsHeaderSchema = z.object({origin: z.string().optional()})
 
   const tokenOptionsResponseValidator = responseValidationFactory(
     [
@@ -2418,7 +2418,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = tokenOptionsResponseValidator(status, body)
@@ -2479,7 +2479,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = tokenResponseValidator(status, body)
@@ -2534,7 +2534,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = userinfoResponseValidator(status, body)
@@ -2605,7 +2605,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getWellKnownOAuthConfigurationCustomAsResponseValidator(
@@ -2680,7 +2680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getWellKnownOpenIdConfigurationCustomAsResponseValidator(
@@ -2763,7 +2763,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = authorizeCustomAsResponseValidator(status, body)
@@ -2822,7 +2822,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = authorizeCustomAsWithPostResponseValidator(status, body)
@@ -2895,7 +2895,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = bcAuthorizeCustomAsResponseValidator(status, body)
@@ -2972,7 +2972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = challengeCustomAsResponseValidator(status, body)
@@ -3045,7 +3045,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deviceAuthorizeCustomAsResponseValidator(status, body)
@@ -3118,7 +3118,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = introspectCustomAsResponseValidator(status, body)
@@ -3177,7 +3177,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = oauthKeysCustomAsResponseValidator(status, body)
@@ -3246,7 +3246,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = logoutCustomAsResponseValidator(status, body)
@@ -3311,7 +3311,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = logoutCustomAsWithPostResponseValidator(status, body)
@@ -3388,7 +3388,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = oobAuthenticateCustomAsResponseValidator(status, body)
@@ -3455,7 +3455,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = parOptionsCustomAsResponseValidator(status, body)
@@ -3464,7 +3464,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const parCustomAsParamSchema = z.object({ authorizationServerId: z.string() })
+  const parCustomAsParamSchema = z.object({authorizationServerId: z.string()})
 
   const parCustomAsBodySchema = s_ParRequest
 
@@ -3530,7 +3530,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = parCustomAsResponseValidator(status, body)
@@ -3603,7 +3603,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = revokeCustomAsResponseValidator(status, body)
@@ -3670,7 +3670,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = tokenOptionsCustomAsResponseValidator(status, body)
@@ -3679,9 +3679,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const tokenCustomAsParamSchema = z.object({
-    authorizationServerId: z.string(),
-  })
+  const tokenCustomAsParamSchema = z.object({authorizationServerId: z.string()})
 
   const tokenCustomAsBodySchema = s_TokenRequest
 
@@ -3743,7 +3741,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = tokenCustomAsResponseValidator(status, body)
@@ -3810,7 +3808,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = userinfoCustomAsResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/okta.oauth.yaml/schemas.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -97,7 +97,7 @@ export const s_EndpointAuthMethod = z.enum([
 
 export const s_Error = z.object({
   errorCauses: z
-    .array(z.object({ errorSummary: z.string().optional() }))
+    .array(z.object({errorSummary: z.string().optional()}))
     .optional(),
   errorCode: z.string().optional(),
   errorId: z.string().optional(),
@@ -257,7 +257,7 @@ export const s_TokenTypeHintRevoke = z.enum([
 ])
 
 export const s_UserInfo = z.intersection(
-  z.object({ sub: z.string().optional() }),
+  z.object({sub: z.string().optional()}),
   z.record(z.unknown()),
 )
 
@@ -385,7 +385,7 @@ export const s_RevokeRequest = z.object({
   token_type_hint: s_TokenTypeHintRevoke.optional(),
 })
 
-export const s_TokenRequest = z.object({ grant_type: s_GrantType.optional() })
+export const s_TokenRequest = z.object({grant_type: s_GrantType.optional()})
 
 export const s_TokenResponse = z.object({
   access_token: z.string().optional(),
@@ -409,7 +409,7 @@ export const s_Client = z.object({
   frontchannel_logout_uri: z.string().nullable().optional(),
   grant_types: z.array(s_GrantType).optional(),
   initiate_login_uri: z.string().optional(),
-  jwks: z.object({ keys: z.array(s_JsonWebKey).optional() }).optional(),
+  jwks: z.object({keys: z.array(s_JsonWebKey).optional()}).optional(),
   jwks_uri: z.string().optional(),
   logo_uri: z.string().nullable().optional(),
   policy_uri: z.string().nullable().optional(),
@@ -421,7 +421,7 @@ export const s_Client = z.object({
   tos_uri: z.string().nullable().optional(),
 })
 
-export const s_OAuthKeys = z.object({ keys: z.array(s_JsonWebKey).optional() })
+export const s_OAuthKeys = z.object({keys: z.array(s_JsonWebKey).optional()})
 
 export const s_OidcMetadata = s_OAuthMetadata.merge(
   z.object({

--- a/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/generated.ts
@@ -10,8 +10,8 @@ import {
   t_FindPetsQuerySchema,
   t_Pet,
 } from "./models"
-import { s_Error, s_NewPet, s_Pet } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import {s_Error, s_NewPet, s_Pet} from "./schemas"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -30,8 +30,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type FindPetsResponder = {
   with200(): KoaRuntimeResponse<t_Pet[]>
@@ -161,7 +161,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = findPetsResponseValidator(status, body)
@@ -211,7 +211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = addPetResponseValidator(status, body)
@@ -219,7 +219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const findPetByIdParamSchema = z.object({ id: z.coerce.number() })
+  const findPetByIdParamSchema = z.object({id: z.coerce.number()})
 
   const findPetByIdResponseValidator = responseValidationFactory(
     [["200", s_Pet]],
@@ -261,7 +261,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = findPetByIdResponseValidator(status, body)
@@ -269,7 +269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deletePetParamSchema = z.object({ id: z.coerce.number() })
+  const deletePetParamSchema = z.object({id: z.coerce.number()})
 
   const deletePetResponseValidator = responseValidationFactory(
     [["204", z.undefined()]],
@@ -311,7 +311,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = deletePetResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/petstore-expanded.yaml/schemas.ts
@@ -2,16 +2,10 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
-export const s_Error = z.object({
-  code: z.coerce.number(),
-  message: z.string(),
-})
+export const s_Error = z.object({code: z.coerce.number(), message: z.string()})
 
-export const s_NewPet = z.object({
-  name: z.string(),
-  tag: z.string().optional(),
-})
+export const s_NewPet = z.object({name: z.string(), tag: z.string().optional()})
 
-export const s_Pet = s_NewPet.merge(z.object({ id: z.coerce.number() }))
+export const s_Pet = s_NewPet.merge(z.object({id: z.coerce.number()}))

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/generated.ts
@@ -1527,7 +1527,7 @@ import {
   s_treasury_transaction_entry,
   s_webhook_endpoint,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -1546,8 +1546,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetAccountResponder = {
   with200(): KoaRuntimeResponse<t_account>
@@ -16122,7 +16122,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getAccountResponseValidator(status, body)
@@ -16185,7 +16185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postAccountLinksResponseValidator(status, body)
@@ -16247,10 +16247,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       documents: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
       financial_account: z
         .object({
@@ -16369,22 +16366,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       payouts_list: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
       tax_registrations: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
       tax_settings: z
-        .object({
-          enabled: PermissiveBoolean,
-          features: z.object({}).optional(),
-        })
+        .object({enabled: PermissiveBoolean, features: z.object({}).optional()})
         .optional(),
     }),
     expand: z.array(z.string().max(5000)).optional(),
@@ -16433,7 +16421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountSessionsResponseValidator(status, body)
@@ -16526,7 +16514,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getAccountsResponseValidator(status, body)
@@ -16551,7 +16539,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string().max(500)).optional() })
+                  .object({files: z.array(z.string().max(500)).optional()})
                   .optional(),
               })
               .optional(),
@@ -16584,7 +16572,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             )
             .optional(),
           monthly_estimated_revenue: z
-            .object({ amount: z.coerce.number(), currency: z.string() })
+            .object({amount: z.coerce.number(), currency: z.string()})
             .optional(),
           name: z.string().max(5000).optional(),
           product_description: z.string().max(40000).optional(),
@@ -16610,181 +16598,181 @@ export function createRouter(implementation: Implementation): KoaRouter {
       capabilities: z
         .object({
           acss_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           affirm_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           afterpay_clearpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           alma_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           amazon_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           au_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bacs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bancontact_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           billie_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           blik_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           boleto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_issuing: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cartes_bancaires_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cashapp_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           crypto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           eps_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           fpx_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           gb_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           giropay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           grabpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           ideal_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           india_international_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jcb_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jp_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kakao_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           klarna_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           konbini_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kr_card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           legacy_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           link_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mobilepay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           multibanco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mx_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           naver_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           nz_bank_account_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           oxxo_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           p24_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pay_by_bank_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           payco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           paynow_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pix_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           promptpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           revolut_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           samsung_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           satispay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sofort_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           swish_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_k: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_misc: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           transfers: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           treasury: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           twint_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_account_ach_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           zip_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
         })
         .optional(),
@@ -16909,14 +16897,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
       controller: z
         .object({
           fees: z
-            .object({ payer: z.enum(["account", "application"]).optional() })
+            .object({payer: z.enum(["account", "application"]).optional()})
             .optional(),
           losses: z
-            .object({ payments: z.enum(["application", "stripe"]).optional() })
+            .object({payments: z.enum(["application", "stripe"]).optional()})
             .optional(),
           requirement_collection: z.enum(["application", "stripe"]).optional(),
           stripe_dashboard: z
-            .object({ type: z.enum(["express", "full", "none"]).optional() })
+            .object({type: z.enum(["express", "full", "none"]).optional()})
             .optional(),
         })
         .optional(),
@@ -16925,31 +16913,31 @@ export function createRouter(implementation: Implementation): KoaRouter {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_license: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_memorandum_of_association: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_ministerial_decree: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_registration_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_tax_id_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_address: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_registration: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_ultimate_beneficial_ownership: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -17068,7 +17056,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       settings: z
         .object({
           bacs_debit_payments: z
-            .object({ display_name: z.string().optional() })
+            .object({display_name: z.string().optional()})
             .optional(),
           branding: z
             .object({
@@ -17231,7 +17219,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postAccountsResponseValidator(status, body)
@@ -17292,7 +17280,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteAccountsAccountResponseValidator(status, body)
@@ -17367,7 +17355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountResponseValidator(status, body)
@@ -17406,7 +17394,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             )
             .optional(),
           monthly_estimated_revenue: z
-            .object({ amount: z.coerce.number(), currency: z.string() })
+            .object({amount: z.coerce.number(), currency: z.string()})
             .optional(),
           name: z.string().max(5000).optional(),
           product_description: z.string().max(40000).optional(),
@@ -17432,181 +17420,181 @@ export function createRouter(implementation: Implementation): KoaRouter {
       capabilities: z
         .object({
           acss_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           affirm_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           afterpay_clearpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           alma_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           amazon_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           au_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bacs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bancontact_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           billie_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           blik_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           boleto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_issuing: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cartes_bancaires_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           cashapp_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           crypto_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           eps_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           fpx_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           gb_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           giropay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           grabpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           ideal_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           india_international_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jcb_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           jp_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kakao_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           klarna_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           konbini_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           kr_card_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           legacy_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           link_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mobilepay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           multibanco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           mx_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           naver_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           nz_bank_account_becs_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           oxxo_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           p24_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pay_by_bank_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           payco_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           paynow_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           pix_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           promptpay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           revolut_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           samsung_pay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           satispay_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sepa_debit_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           sofort_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           swish_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_k: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           tax_reporting_us_1099_misc: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           transfers: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           treasury: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           twint_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_account_ach_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           us_bank_transfer_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
           zip_payments: z
-            .object({ requested: PermissiveBoolean.optional() })
+            .object({requested: PermissiveBoolean.optional()})
             .optional(),
         })
         .optional(),
@@ -17732,31 +17720,31 @@ export function createRouter(implementation: Implementation): KoaRouter {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_license: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_memorandum_of_association: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_ministerial_decree: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_registration_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           company_tax_id_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_address: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_registration: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
           proof_of_ultimate_beneficial_ownership: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -17875,7 +17863,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       settings: z
         .object({
           bacs_debit_payments: z
-            .object({ display_name: z.string().optional() })
+            .object({display_name: z.string().optional()})
             .optional(),
           branding: z
             .object({
@@ -18047,7 +18035,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountResponseValidator(status, body)
@@ -18076,7 +18064,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string().max(500)).optional() })
+                  .object({files: z.array(z.string().max(500)).optional()})
                   .optional(),
               })
               .optional(),
@@ -18138,7 +18126,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountBankAccountsResponseValidator(status, body)
@@ -18199,7 +18187,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteAccountsAccountBankAccountsIdResponseValidator(
@@ -18276,7 +18264,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountBankAccountsIdResponseValidator(status, body)
@@ -18305,7 +18293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -18362,7 +18350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountBankAccountsIdResponseValidator(
@@ -18456,7 +18444,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountCapabilitiesResponseValidator(status, body)
@@ -18532,7 +18520,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountCapabilitiesCapabilityResponseValidator(
@@ -18601,7 +18589,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountCapabilitiesCapabilityResponseValidator(
@@ -18701,7 +18689,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountExternalAccountsResponseValidator(
@@ -18733,7 +18721,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             documents: z
               .object({
                 bank_account_ownership_verification: z
-                  .object({ files: z.array(z.string().max(500)).optional() })
+                  .object({files: z.array(z.string().max(500)).optional()})
                   .optional(),
               })
               .optional(),
@@ -18795,7 +18783,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountExternalAccountsResponseValidator(
@@ -18861,7 +18849,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteAccountsAccountExternalAccountsIdResponseValidator(
@@ -18938,7 +18926,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountExternalAccountsIdResponseValidator(
@@ -18970,7 +18958,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -19027,7 +19015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountExternalAccountsIdResponseValidator(
@@ -19044,7 +19032,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postAccountsAccountLoginLinksBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postAccountsAccountLoginLinksResponseValidator =
@@ -19092,7 +19080,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountLoginLinksResponseValidator(status, body)
@@ -19195,7 +19183,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountPeopleResponseValidator(status, body)
@@ -19459,7 +19447,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountPeopleResponseValidator(status, body)
@@ -19520,7 +19508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteAccountsAccountPeoplePersonResponseValidator(
@@ -19597,7 +19585,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountPeoplePersonResponseValidator(status, body)
@@ -19860,7 +19848,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountPeoplePersonResponseValidator(status, body)
@@ -19963,7 +19951,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountPersonsResponseValidator(status, body)
@@ -20227,7 +20215,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountPersonsResponseValidator(status, body)
@@ -20288,7 +20276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteAccountsAccountPersonsPersonResponseValidator(
@@ -20365,7 +20353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAccountsAccountPersonsPersonResponseValidator(status, body)
@@ -20628,7 +20616,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountPersonsPersonResponseValidator(status, body)
@@ -20693,7 +20681,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAccountsAccountRejectResponseValidator(status, body)
@@ -20779,7 +20767,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getApplePayDomainsResponseValidator(status, body)
@@ -20836,7 +20824,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postApplePayDomainsResponseValidator(status, body)
@@ -20896,7 +20884,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteApplePayDomainsDomainResponseValidator(status, body)
@@ -20971,7 +20959,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getApplePayDomainsDomainResponseValidator(status, body)
@@ -21068,7 +21056,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getApplicationFeesResponseValidator(status, body)
@@ -21142,7 +21130,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getApplicationFeesFeeRefundsIdResponseValidator(status, body)
@@ -21208,7 +21196,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postApplicationFeesFeeRefundsIdResponseValidator(status, body)
@@ -21217,7 +21205,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getApplicationFeesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getApplicationFeesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getApplicationFeesIdQuerySchema = z.object({
     expand: z
@@ -21281,7 +21269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getApplicationFeesIdResponseValidator(status, body)
@@ -21347,7 +21335,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postApplicationFeesIdRefundResponseValidator(status, body)
@@ -21441,7 +21429,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getApplicationFeesIdRefundsResponseValidator(status, body)
@@ -21507,7 +21495,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postApplicationFeesIdRefundsResponseValidator(status, body)
@@ -21593,7 +21581,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getAppsSecretsResponseValidator(status, body)
@@ -21652,7 +21640,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postAppsSecretsResponseValidator(status, body)
@@ -21712,7 +21700,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postAppsSecretsDeleteResponseValidator(status, body)
@@ -21784,7 +21772,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getAppsSecretsFindResponseValidator(status, body)
@@ -21848,7 +21836,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getBalanceResponseValidator(status, body)
@@ -21947,7 +21935,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getBalanceHistoryResponseValidator(status, body)
@@ -21955,7 +21943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getBalanceHistoryIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getBalanceHistoryIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getBalanceHistoryIdQuerySchema = z.object({
     expand: z
@@ -22019,7 +22007,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBalanceHistoryIdResponseValidator(status, body)
@@ -22122,7 +22110,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBalanceTransactionsResponseValidator(status, body)
@@ -22197,7 +22185,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBalanceTransactionsIdResponseValidator(status, body)
@@ -22281,7 +22269,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getBillingAlertsResponseValidator(status, body)
@@ -22350,7 +22338,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postBillingAlertsResponseValidator(status, body)
@@ -22358,7 +22346,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getBillingAlertsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getBillingAlertsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getBillingAlertsIdQuerySchema = z.object({
     expand: z
@@ -22422,7 +22410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingAlertsIdResponseValidator(status, body)
@@ -22436,7 +22424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingAlertsIdActivateBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingAlertsIdActivateResponseValidator =
@@ -22484,7 +22472,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingAlertsIdActivateResponseValidator(status, body)
@@ -22498,7 +22486,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingAlertsIdArchiveBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingAlertsIdArchiveResponseValidator = responseValidationFactory(
@@ -22548,7 +22536,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingAlertsIdArchiveResponseValidator(status, body)
@@ -22562,7 +22550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingAlertsIdDeactivateBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingAlertsIdDeactivateResponseValidator =
@@ -22610,7 +22598,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingAlertsIdDeactivateResponseValidator(status, body)
@@ -22631,7 +22619,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       applicability_scope: z
         .object({
           price_type: z.enum(["metered"]).optional(),
-          prices: z.array(z.object({ id: z.string().max(5000) })).optional(),
+          prices: z.array(z.object({id: z.string().max(5000)})).optional(),
         })
         .optional(),
       credit_grant: z.string().max(5000).optional(),
@@ -22689,7 +22677,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingCreditBalanceSummaryResponseValidator(status, body)
@@ -22780,7 +22768,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingCreditBalanceTransactionsResponseValidator(
@@ -22863,7 +22851,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingCreditBalanceTransactionsIdResponseValidator(
@@ -22955,7 +22943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingCreditGrantsResponseValidator(status, body)
@@ -22967,14 +22955,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postBillingCreditGrantsBodySchema = z.object({
     amount: z.object({
       monetary: z
-        .object({ currency: z.string(), value: z.coerce.number() })
+        .object({currency: z.string(), value: z.coerce.number()})
         .optional(),
       type: z.enum(["monetary"]),
     }),
     applicability_config: z.object({
       scope: z.object({
         price_type: z.enum(["metered"]).optional(),
-        prices: z.array(z.object({ id: z.string().max(5000) })).optional(),
+        prices: z.array(z.object({id: z.string().max(5000)})).optional(),
       }),
     }),
     category: z.enum(["paid", "promotional"]),
@@ -23030,7 +23018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingCreditGrantsResponseValidator(status, body)
@@ -23105,7 +23093,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingCreditGrantsIdResponseValidator(status, body)
@@ -23173,7 +23161,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingCreditGrantsIdResponseValidator(status, body)
@@ -23187,7 +23175,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingCreditGrantsIdExpireBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingCreditGrantsIdExpireResponseValidator =
@@ -23235,7 +23223,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingCreditGrantsIdExpireResponseValidator(status, body)
@@ -23249,7 +23237,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingCreditGrantsIdVoidBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingCreditGrantsIdVoidResponseValidator =
@@ -23297,7 +23285,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingCreditGrantsIdVoidResponseValidator(status, body)
@@ -23307,7 +23295,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postBillingMeterEventAdjustmentsBodySchema = z.object({
-    cancel: z.object({ identifier: z.string().max(100).optional() }).optional(),
+    cancel: z.object({identifier: z.string().max(100).optional()}).optional(),
     event_name: z.string().max(100),
     expand: z.array(z.string().max(5000)).optional(),
     type: z.enum(["cancel"]),
@@ -23357,7 +23345,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingMeterEventAdjustmentsResponseValidator(status, body)
@@ -23417,7 +23405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingMeterEventsResponseValidator(status, body)
@@ -23500,7 +23488,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getBillingMetersResponseValidator(status, body)
@@ -23510,20 +23498,15 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postBillingMetersBodySchema = z.object({
     customer_mapping: z
-      .object({
-        event_payload_key: z.string().max(100),
-        type: z.enum(["by_id"]),
-      })
+      .object({event_payload_key: z.string().max(100), type: z.enum(["by_id"])})
       .optional(),
-    default_aggregation: z.object({
-      formula: z.enum(["count", "last", "sum"]),
-    }),
+    default_aggregation: z.object({formula: z.enum(["count", "last", "sum"])}),
     display_name: z.string().max(250),
     event_name: z.string().max(100),
     event_time_window: z.enum(["day", "hour"]).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     value_settings: z
-      .object({ event_payload_key: z.string().max(100) })
+      .object({event_payload_key: z.string().max(100)})
       .optional(),
   })
 
@@ -23567,7 +23550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postBillingMetersResponseValidator(status, body)
@@ -23575,7 +23558,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getBillingMetersIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getBillingMetersIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getBillingMetersIdQuerySchema = z.object({
     expand: z
@@ -23639,7 +23622,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingMetersIdResponseValidator(status, body)
@@ -23648,7 +23631,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postBillingMetersIdParamSchema = z.object({ id: z.string().max(5000) })
+  const postBillingMetersIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postBillingMetersIdBodySchema = z
     .object({
@@ -23704,7 +23687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingMetersIdResponseValidator(status, body)
@@ -23718,7 +23701,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingMetersIdDeactivateBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingMetersIdDeactivateResponseValidator =
@@ -23766,7 +23749,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingMetersIdDeactivateResponseValidator(status, body)
@@ -23867,7 +23850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingMetersIdEventSummariesResponseValidator(status, body)
@@ -23881,7 +23864,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postBillingMetersIdReactivateBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postBillingMetersIdReactivateResponseValidator =
@@ -23929,7 +23912,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingMetersIdReactivateResponseValidator(status, body)
@@ -24020,7 +24003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingPortalConfigurationsResponseValidator(status, body)
@@ -24060,10 +24043,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           enabled: PermissiveBoolean,
         })
         .optional(),
-      invoice_history: z.object({ enabled: PermissiveBoolean }).optional(),
-      payment_method_update: z
-        .object({ enabled: PermissiveBoolean })
-        .optional(),
+      invoice_history: z.object({enabled: PermissiveBoolean}).optional(),
+      payment_method_update: z.object({enabled: PermissiveBoolean}).optional(),
       subscription_cancel: z
         .object({
           cancellation_reason: z
@@ -24133,7 +24114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
     }),
-    login_page: z.object({ enabled: PermissiveBoolean }).optional(),
+    login_page: z.object({enabled: PermissiveBoolean}).optional(),
     metadata: z.record(z.string()).optional(),
   })
 
@@ -24181,7 +24162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingPortalConfigurationsResponseValidator(status, body)
@@ -24264,7 +24245,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getBillingPortalConfigurationsConfigurationResponseValidator(
@@ -24314,9 +24295,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
               enabled: PermissiveBoolean.optional(),
             })
             .optional(),
-          invoice_history: z.object({ enabled: PermissiveBoolean }).optional(),
+          invoice_history: z.object({enabled: PermissiveBoolean}).optional(),
           payment_method_update: z
-            .object({ enabled: PermissiveBoolean })
+            .object({enabled: PermissiveBoolean})
             .optional(),
           subscription_cancel: z
             .object({
@@ -24393,7 +24374,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      login_page: z.object({ enabled: PermissiveBoolean }).optional(),
+      login_page: z.object({enabled: PermissiveBoolean}).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     })
     .optional()
@@ -24451,7 +24432,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingPortalConfigurationsConfigurationResponseValidator(
@@ -24472,9 +24453,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         after_completion: z
           .object({
             hosted_confirmation: z
-              .object({ custom_message: z.string().max(500).optional() })
+              .object({custom_message: z.string().max(500).optional()})
               .optional(),
-            redirect: z.object({ return_url: z.string() }).optional(),
+            redirect: z.object({return_url: z.string()}).optional(),
             type: z.enum([
               "hosted_confirmation",
               "portal_homepage",
@@ -24486,7 +24467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .object({
             retention: z
               .object({
-                coupon_offer: z.object({ coupon: z.string().max(5000) }),
+                coupon_offer: z.object({coupon: z.string().max(5000)}),
                 type: z.enum(["coupon_offer"]),
               })
               .optional(),
@@ -24494,7 +24475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           })
           .optional(),
         subscription_update: z
-          .object({ subscription: z.string().max(5000) })
+          .object({subscription: z.string().max(5000)})
           .optional(),
         subscription_update_confirm: z
           .object({
@@ -24622,7 +24603,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postBillingPortalSessionsResponseValidator(status, body)
@@ -24718,7 +24699,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getChargesResponseValidator(status, body)
@@ -24768,7 +24749,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       on_behalf_of: z.string().max(5000).optional(),
       radar_options: z
-        .object({ session: z.string().max(5000).optional() })
+        .object({session: z.string().max(5000).optional()})
         .optional(),
       receipt_email: z.string().optional(),
       shipping: z
@@ -24840,7 +24821,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postChargesResponseValidator(status, body)
@@ -24925,7 +24906,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getChargesSearchResponseValidator(status, body)
@@ -24933,7 +24914,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getChargesChargeParamSchema = z.object({ charge: z.string().max(5000) })
+  const getChargesChargeParamSchema = z.object({charge: z.string().max(5000)})
 
   const getChargesChargeQuerySchema = z.object({
     expand: z
@@ -24994,7 +24975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getChargesChargeResponseValidator(status, body)
@@ -25002,9 +24983,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postChargesChargeParamSchema = z.object({
-    charge: z.string().max(5000),
-  })
+  const postChargesChargeParamSchema = z.object({charge: z.string().max(5000)})
 
   const postChargesChargeBodySchema = z
     .object({
@@ -25012,7 +24991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       description: z.string().max(40000).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       fraud_details: z
-        .object({ user_report: z.enum(["", "fraudulent", "safe"]) })
+        .object({user_report: z.enum(["", "fraudulent", "safe"])})
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       receipt_email: z.string().max(5000).optional(),
@@ -25080,7 +25059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postChargesChargeResponseValidator(status, body)
@@ -25102,7 +25081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
       transfer_group: z.string().optional(),
     })
@@ -25155,7 +25134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postChargesChargeCaptureResponseValidator(status, body)
@@ -25230,7 +25209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getChargesChargeDisputeResponseValidator(status, body)
@@ -25362,7 +25341,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   })
                   .optional(),
                 visa_compliance: z
-                  .object({ fee_acknowledged: PermissiveBoolean.optional() })
+                  .object({fee_acknowledged: PermissiveBoolean.optional()})
                   .optional(),
               }),
               z.enum([""]),
@@ -25437,7 +25416,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postChargesChargeDisputeResponseValidator(status, body)
@@ -25451,7 +25430,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postChargesChargeDisputeCloseBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postChargesChargeDisputeCloseResponseValidator =
@@ -25499,7 +25478,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postChargesChargeDisputeCloseResponseValidator(status, body)
@@ -25574,7 +25553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postChargesChargeRefundResponseValidator(status, body)
@@ -25583,7 +25562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getChargesChargeRefundsParamSchema = z.object({ charge: z.string() })
+  const getChargesChargeRefundsParamSchema = z.object({charge: z.string()})
 
   const getChargesChargeRefundsQuerySchema = z.object({
     ending_before: z.string().optional(),
@@ -25665,7 +25644,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getChargesChargeRefundsResponseValidator(status, body)
@@ -25743,7 +25722,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postChargesChargeRefundsResponseValidator(status, body)
@@ -25817,7 +25796,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getChargesChargeRefundsRefundResponseValidator(status, body)
@@ -25883,7 +25862,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postChargesChargeRefundsRefundResponseValidator(status, body)
@@ -25905,7 +25884,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       ])
       .optional(),
     customer: z.string().max(5000).optional(),
-    customer_details: z.object({ email: z.string() }).optional(),
+    customer_details: z.object({email: z.string()}).optional(),
     ending_before: z.string().max(5000).optional(),
     expand: z
       .preprocess(
@@ -25985,7 +25964,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCheckoutSessionsResponseValidator(status, body)
@@ -25997,7 +25976,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postCheckoutSessionsBodySchema = z
     .object({
       adaptive_pricing: z
-        .object({ enabled: PermissiveBoolean.optional() })
+        .object({enabled: PermissiveBoolean.optional()})
         .optional(),
       after_expiration: z
         .object({
@@ -26027,7 +26006,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       consent_collection: z
         .object({
           payment_method_reuse_agreement: z
-            .object({ position: z.enum(["auto", "hidden"]) })
+            .object({position: z.enum(["auto", "hidden"])})
             .optional(),
           promotions: z.enum(["auto", "none"]).optional(),
           terms_of_service: z.enum(["none", "required"]).optional(),
@@ -26075,16 +26054,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
       custom_text: z
         .object({
           after_submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           shipping_address: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           terms_of_service_acceptance: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
         })
         .optional(),
@@ -26332,13 +26311,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           affirm: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           afterpay_clearpay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           alipay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           amazon_pay: z
             .object({
@@ -26367,7 +26346,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           bancontact: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           boleto: z
             .object({
@@ -26380,7 +26359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           card: z
             .object({
               installments: z
-                .object({ enabled: PermissiveBoolean.optional() })
+                .object({enabled: PermissiveBoolean.optional()})
                 .optional(),
               request_extended_authorization: z
                 .enum(["if_available", "never"])
@@ -26428,7 +26407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               bank_transfer: z
                 .object({
                   eu_bank_transfer: z
-                    .object({ country: z.string().max(5000) })
+                    .object({country: z.string().max(5000)})
                     .optional(),
                   requested_address_types: z
                     .array(
@@ -26457,19 +26436,19 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           eps: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           fpx: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           giropay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           grabpay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           ideal: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           kakao_pay: z
             .object({
@@ -26517,10 +26496,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           mobilepay: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           multibanco: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           naver_pay: z
             .object({
@@ -26542,10 +26521,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           pay_by_bank: z.object({}).optional(),
           payco: z
-            .object({ capture_method: z.enum(["manual"]).optional() })
+            .object({capture_method: z.enum(["manual"]).optional()})
             .optional(),
           paynow: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           paypal: z
             .object({
@@ -26583,7 +26562,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           pix: z
-            .object({ expires_after_seconds: z.coerce.number().optional() })
+            .object({expires_after_seconds: z.coerce.number().optional()})
             .optional(),
           revolut_pay: z
             .object({
@@ -26591,7 +26570,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           samsung_pay: z
-            .object({ capture_method: z.enum(["manual"]).optional() })
+            .object({capture_method: z.enum(["manual"]).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -26609,10 +26588,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           sofort: z
-            .object({ setup_future_usage: z.enum(["none"]).optional() })
+            .object({setup_future_usage: z.enum(["none"]).optional()})
             .optional(),
           swish: z
-            .object({ reference: z.string().max(5000).optional() })
+            .object({reference: z.string().max(5000).optional()})
             .optional(),
           us_bank_account: z
             .object({
@@ -26710,7 +26689,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       phone_number_collection: z
-        .object({ enabled: PermissiveBoolean })
+        .object({enabled: PermissiveBoolean})
         .optional(),
       redirect_on_completion: z
         .enum(["always", "if_required", "never"])
@@ -27048,7 +27027,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           application_fee_percent: z.coerce.number().optional(),
           billing_cycle_anchor: z.coerce.number().optional(),
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           default_tax_rates: z.array(z.string().max(5000)).optional(),
           description: z.string().max(500).optional(),
@@ -27097,7 +27076,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       wallet_options: z
         .object({
           link: z
-            .object({ display: z.enum(["auto", "never"]).optional() })
+            .object({display: z.enum(["auto", "never"]).optional()})
             .optional(),
         })
         .optional(),
@@ -27147,7 +27126,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCheckoutSessionsResponseValidator(status, body)
@@ -27222,7 +27201,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCheckoutSessionsSessionResponseValidator(status, body)
@@ -27369,7 +27348,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCheckoutSessionsSessionResponseValidator(status, body)
@@ -27383,7 +27362,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postCheckoutSessionsSessionExpireBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postCheckoutSessionsSessionExpireResponseValidator =
@@ -27431,7 +27410,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCheckoutSessionsSessionExpireResponseValidator(
@@ -27528,7 +27507,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCheckoutSessionsSessionLineItemsResponseValidator(
@@ -27613,7 +27592,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getClimateOrdersResponseValidator(status, body)
@@ -27623,7 +27602,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postClimateOrdersBodySchema = z.object({
     amount: z.coerce.number().optional(),
-    beneficiary: z.object({ public_name: z.string().max(5000) }).optional(),
+    beneficiary: z.object({public_name: z.string().max(5000)}).optional(),
     currency: z.string().max(5000).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
@@ -27671,7 +27650,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postClimateOrdersResponseValidator(status, body)
@@ -27745,7 +27724,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getClimateOrdersOrderResponseValidator(status, body)
@@ -27820,7 +27799,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postClimateOrdersOrderResponseValidator(status, body)
@@ -27834,7 +27813,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postClimateOrdersOrderCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postClimateOrdersOrderCancelResponseValidator =
@@ -27882,7 +27861,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postClimateOrdersOrderCancelResponseValidator(status, body)
@@ -27967,7 +27946,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getClimateProductsResponseValidator(status, body)
@@ -28042,7 +28021,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getClimateProductsProductResponseValidator(status, body)
@@ -28127,7 +28106,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getClimateSuppliersResponseValidator(status, body)
@@ -28200,7 +28179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getClimateSuppliersSupplierResponseValidator(status, body)
@@ -28275,7 +28254,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getConfirmationTokensConfirmationTokenResponseValidator(
@@ -28360,7 +28339,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getCountrySpecsResponseValidator(status, body)
@@ -28434,7 +28413,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCountrySpecsCountryResponseValidator(status, body)
@@ -28527,7 +28506,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getCouponsResponseValidator(status, body)
@@ -28539,11 +28518,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
     .object({
       amount_off: z.coerce.number().optional(),
       applies_to: z
-        .object({ products: z.array(z.string().max(5000)).optional() })
+        .object({products: z.array(z.string().max(5000)).optional()})
         .optional(),
       currency: z.string().optional(),
       currency_options: z
-        .record(z.object({ amount_off: z.coerce.number() }))
+        .record(z.object({amount_off: z.coerce.number()}))
         .optional(),
       duration: z.enum(["forever", "once", "repeating"]).optional(),
       duration_in_months: z.coerce.number().optional(),
@@ -28597,7 +28576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postCouponsResponseValidator(status, body)
@@ -28658,7 +28637,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCouponsCouponResponseValidator(status, body)
@@ -28667,7 +28646,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getCouponsCouponParamSchema = z.object({ coupon: z.string().max(5000) })
+  const getCouponsCouponParamSchema = z.object({coupon: z.string().max(5000)})
 
   const getCouponsCouponQuerySchema = z.object({
     expand: z
@@ -28728,7 +28707,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getCouponsCouponResponseValidator(status, body)
@@ -28736,14 +28715,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postCouponsCouponParamSchema = z.object({
-    coupon: z.string().max(5000),
-  })
+  const postCouponsCouponParamSchema = z.object({coupon: z.string().max(5000)})
 
   const postCouponsCouponBodySchema = z
     .object({
       currency_options: z
-        .record(z.object({ amount_off: z.coerce.number() }))
+        .record(z.object({amount_off: z.coerce.number()}))
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
@@ -28795,7 +28772,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postCouponsCouponResponseValidator(status, body)
@@ -28889,7 +28866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getCreditNotesResponseValidator(status, body)
@@ -28953,7 +28930,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       )
       .optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().max(5000).optional() })
+      .object({shipping_rate: z.string().max(5000).optional()})
       .optional(),
   })
 
@@ -28997,7 +28974,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postCreditNotesResponseValidator(status, body)
@@ -29072,7 +29049,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       )
       .optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().max(5000).optional() })
+      .object({shipping_rate: z.string().max(5000).optional()})
       .optional(),
   })
 
@@ -29125,7 +29102,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCreditNotesPreviewResponseValidator(status, body)
@@ -29203,7 +29180,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       )
       .optional(),
     shipping_cost: z
-      .object({ shipping_rate: z.string().max(5000).optional() })
+      .object({shipping_rate: z.string().max(5000).optional()})
       .optional(),
     starting_after: z.string().max(5000).optional(),
   })
@@ -29272,7 +29249,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCreditNotesPreviewLinesResponseValidator(status, body)
@@ -29366,7 +29343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCreditNotesCreditNoteLinesResponseValidator(status, body)
@@ -29375,7 +29352,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getCreditNotesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getCreditNotesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getCreditNotesIdQuerySchema = z.object({
     expand: z
@@ -29436,7 +29413,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getCreditNotesIdResponseValidator(status, body)
@@ -29444,7 +29421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postCreditNotesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const postCreditNotesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postCreditNotesIdBodySchema = z
     .object({
@@ -29501,7 +29478,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCreditNotesIdResponseValidator(status, body)
@@ -29510,12 +29487,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postCreditNotesIdVoidParamSchema = z.object({
-    id: z.string().max(5000),
-  })
+  const postCreditNotesIdVoidParamSchema = z.object({id: z.string().max(5000)})
 
   const postCreditNotesIdVoidBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postCreditNotesIdVoidResponseValidator = responseValidationFactory(
@@ -29565,7 +29540,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCreditNotesIdVoidResponseValidator(status, body)
@@ -29576,7 +29551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postCustomerSessionsBodySchema = z.object({
     components: z.object({
-      buy_button: z.object({ enabled: PermissiveBoolean }).optional(),
+      buy_button: z.object({enabled: PermissiveBoolean}).optional(),
       payment_element: z
         .object({
           enabled: PermissiveBoolean,
@@ -29598,7 +29573,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      pricing_table: z.object({ enabled: PermissiveBoolean }).optional(),
+      pricing_table: z.object({enabled: PermissiveBoolean}).optional(),
     }),
     customer: z.string().max(5000),
     expand: z.array(z.string().max(5000)).optional(),
@@ -29647,7 +29622,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomerSessionsResponseValidator(status, body)
@@ -29742,7 +29717,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getCustomersResponseValidator(status, body)
@@ -30003,7 +29978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postCustomersResponseValidator(status, body)
@@ -30091,7 +30066,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersSearchResponseValidator(status, body)
@@ -30153,7 +30128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCustomersCustomerResponseValidator(status, body)
@@ -30228,7 +30203,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerResponseValidator(status, body)
@@ -30420,7 +30395,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerResponseValidator(status, body)
@@ -30516,7 +30491,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerBalanceTransactionsResponseValidator(
@@ -30588,7 +30563,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerBalanceTransactionsResponseValidator(
@@ -30601,7 +30576,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string().max(5000), transaction: z.string() })
+    z.object({customer: z.string().max(5000), transaction: z.string()})
 
   const getCustomersCustomerBalanceTransactionsTransactionQuerySchema =
     z.object({
@@ -30674,7 +30649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -30754,7 +30729,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -30852,7 +30827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerBankAccountsResponseValidator(status, body)
@@ -30953,7 +30928,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerBankAccountsResponseValidator(
@@ -30971,7 +30946,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const deleteCustomersCustomerBankAccountsIdBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteCustomersCustomerBankAccountsIdResponseValidator =
@@ -31029,7 +31004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCustomersCustomerBankAccountsIdResponseValidator(
@@ -31106,7 +31081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerBankAccountsIdResponseValidator(
@@ -31215,7 +31190,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerBankAccountsIdResponseValidator(
@@ -31284,7 +31259,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerBankAccountsIdVerifyResponseValidator(
@@ -31380,7 +31355,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerCardsResponseValidator(status, body)
@@ -31483,7 +31458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerCardsResponseValidator(status, body)
@@ -31498,7 +31473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const deleteCustomersCustomerCardsIdBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteCustomersCustomerCardsIdResponseValidator =
@@ -31556,7 +31531,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCustomersCustomerCardsIdResponseValidator(status, body)
@@ -31630,7 +31605,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerCardsIdResponseValidator(status, body)
@@ -31736,7 +31711,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerCardsIdResponseValidator(status, body)
@@ -31809,7 +31784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerCashBalanceResponseValidator(status, body)
@@ -31880,7 +31855,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerCashBalanceResponseValidator(status, body)
@@ -31981,7 +31956,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerCashBalanceTransactionsResponseValidator(
@@ -31994,7 +31969,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getCustomersCustomerCashBalanceTransactionsTransactionParamSchema =
-    z.object({ customer: z.string().max(5000), transaction: z.string() })
+    z.object({customer: z.string().max(5000), transaction: z.string()})
 
   const getCustomersCustomerCashBalanceTransactionsTransactionQuerySchema =
     z.object({
@@ -32069,7 +32044,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -32133,7 +32108,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCustomersCustomerDiscountResponseValidator(status, body)
@@ -32206,7 +32181,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerDiscountResponseValidator(status, body)
@@ -32221,7 +32196,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postCustomersCustomerFundingInstructionsBodySchema = z.object({
     bank_transfer: z.object({
-      eu_bank_transfer: z.object({ country: z.string().max(5000) }).optional(),
+      eu_bank_transfer: z.object({country: z.string().max(5000)}).optional(),
       requested_address_types: z
         .array(z.enum(["iban", "sort_code", "spei", "zengin"]))
         .optional(),
@@ -32283,7 +32258,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerFundingInstructionsResponseValidator(
@@ -32433,7 +32408,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerPaymentMethodsResponseValidator(
@@ -32517,7 +32492,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -32622,7 +32597,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerSourcesResponseValidator(status, body)
@@ -32723,7 +32698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerSourcesResponseValidator(status, body)
@@ -32738,7 +32713,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const deleteCustomersCustomerSourcesIdBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteCustomersCustomerSourcesIdResponseValidator =
@@ -32796,7 +32771,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCustomersCustomerSourcesIdResponseValidator(status, body)
@@ -32870,7 +32845,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerSourcesIdResponseValidator(status, body)
@@ -32976,7 +32951,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerSourcesIdResponseValidator(status, body)
@@ -33042,7 +33017,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerSourcesIdVerifyResponseValidator(
@@ -33139,7 +33114,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerSubscriptionsResponseValidator(
@@ -33255,7 +33230,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
               .optional(),
             discounts: z
               .union([
@@ -33374,7 +33349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -33557,7 +33532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerSubscriptionsResponseValidator(
@@ -33633,7 +33608,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -33720,7 +33695,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -33855,7 +33830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
               .optional(),
             clear_usage: PermissiveBoolean.optional(),
             deleted: PermissiveBoolean.optional(),
@@ -33986,7 +33961,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -34177,7 +34152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -34249,7 +34224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -34335,7 +34310,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -34432,7 +34407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerTaxIdsResponseValidator(status, body)
@@ -34607,7 +34582,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postCustomersCustomerTaxIdsResponseValidator(status, body)
@@ -34668,7 +34643,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteCustomersCustomerTaxIdsIdResponseValidator(status, body)
@@ -34742,7 +34717,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getCustomersCustomerTaxIdsIdResponseValidator(status, body)
@@ -34837,7 +34812,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getDisputesResponseValidator(status, body)
@@ -34911,7 +34886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getDisputesDisputeResponseValidator(status, body)
@@ -35043,7 +35018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   })
                   .optional(),
                 visa_compliance: z
-                  .object({ fee_acknowledged: PermissiveBoolean.optional() })
+                  .object({fee_acknowledged: PermissiveBoolean.optional()})
                   .optional(),
               }),
               z.enum([""]),
@@ -35118,7 +35093,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postDisputesDisputeResponseValidator(status, body)
@@ -35132,7 +35107,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postDisputesDisputeCloseBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postDisputesDisputeCloseResponseValidator = responseValidationFactory(
@@ -35182,7 +35157,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postDisputesDisputeCloseResponseValidator(status, body)
@@ -35269,7 +35244,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getEntitlementsActiveEntitlementsResponseValidator(
@@ -35348,7 +35323,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getEntitlementsActiveEntitlementsIdResponseValidator(
@@ -35441,7 +35416,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getEntitlementsFeaturesResponseValidator(status, body)
@@ -35500,7 +35475,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postEntitlementsFeaturesResponseValidator(status, body)
@@ -35575,7 +35550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getEntitlementsFeaturesIdResponseValidator(status, body)
@@ -35644,7 +35619,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postEntitlementsFeaturesIdResponseValidator(status, body)
@@ -35703,7 +35678,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postEphemeralKeysResponseValidator(status, body)
@@ -35716,7 +35691,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const deleteEphemeralKeysKeyBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const deleteEphemeralKeysKeyResponseValidator = responseValidationFactory(
@@ -35766,7 +35741,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteEphemeralKeysKeyResponseValidator(status, body)
@@ -35867,7 +35842,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getEventsResponseValidator(status, body)
@@ -35875,7 +35850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getEventsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getEventsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getEventsIdQuerySchema = z.object({
     expand: z
@@ -35936,7 +35911,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getEventsIdResponseValidator(status, body)
@@ -36017,7 +35992,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getExchangeRatesResponseValidator(status, body)
@@ -36091,7 +36066,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getExchangeRatesRateIdResponseValidator(status, body)
@@ -36100,7 +36075,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postExternalAccountsIdParamSchema = z.object({ id: z.string() })
+  const postExternalAccountsIdParamSchema = z.object({id: z.string()})
 
   const postExternalAccountsIdBodySchema = z
     .object({
@@ -36117,7 +36092,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       documents: z
         .object({
           bank_account_ownership_verification: z
-            .object({ files: z.array(z.string().max(500)).optional() })
+            .object({files: z.array(z.string().max(500)).optional()})
             .optional(),
         })
         .optional(),
@@ -36176,7 +36151,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postExternalAccountsIdResponseValidator(status, body)
@@ -36271,7 +36246,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getFileLinksResponseValidator(status, body)
@@ -36326,7 +36301,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postFileLinksResponseValidator(status, body)
@@ -36334,7 +36309,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getFileLinksLinkParamSchema = z.object({ link: z.string() })
+  const getFileLinksLinkParamSchema = z.object({link: z.string()})
 
   const getFileLinksLinkQuerySchema = z.object({
     expand: z
@@ -36395,7 +36370,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getFileLinksLinkResponseValidator(status, body)
@@ -36403,7 +36378,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postFileLinksLinkParamSchema = z.object({ link: z.string() })
+  const postFileLinksLinkParamSchema = z.object({link: z.string()})
 
   const postFileLinksLinkBodySchema = z
     .object({
@@ -36462,7 +36437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postFileLinksLinkResponseValidator(status, body)
@@ -36576,7 +36551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getFilesResponseValidator(status, body)
@@ -36649,7 +36624,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postFilesResponseValidator(status, body)
@@ -36657,7 +36632,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getFilesFileParamSchema = z.object({ file: z.string().max(5000) })
+  const getFilesFileParamSchema = z.object({file: z.string().max(5000)})
 
   const getFilesFileQuerySchema = z.object({
     expand: z
@@ -36718,7 +36693,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getFilesFileResponseValidator(status, body)
@@ -36813,7 +36788,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getFinancialConnectionsAccountsResponseValidator(status, body)
@@ -36891,7 +36866,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getFinancialConnectionsAccountsAccountResponseValidator(
@@ -36904,11 +36879,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postFinancialConnectionsAccountsAccountDisconnectParamSchema = z.object(
-    { account: z.string().max(5000) },
+    {account: z.string().max(5000)},
   )
 
   const postFinancialConnectionsAccountsAccountDisconnectBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postFinancialConnectionsAccountsAccountDisconnectResponseValidator =
@@ -36964,7 +36939,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37070,7 +37045,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getFinancialConnectionsAccountsAccountOwnersResponseValidator(
@@ -37144,7 +37119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37219,7 +37194,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37233,7 +37208,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postFinancialConnectionsAccountsAccountUnsubscribeParamSchema =
-    z.object({ account: z.string().max(5000) })
+    z.object({account: z.string().max(5000)})
 
   const postFinancialConnectionsAccountsAccountUnsubscribeBodySchema = z.object(
     {
@@ -37295,7 +37270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37384,7 +37359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postFinancialConnectionsSessionsResponseValidator(status, body)
@@ -37462,7 +37437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getFinancialConnectionsSessionsSessionResponseValidator(
@@ -37496,7 +37471,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.coerce.number(),
       ])
       .optional(),
-    transaction_refresh: z.object({ after: z.string().max(5000) }).optional(),
+    transaction_refresh: z.object({after: z.string().max(5000)}).optional(),
   })
 
   const getFinancialConnectionsTransactionsBodySchema = z.object({}).optional()
@@ -37567,7 +37542,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getFinancialConnectionsTransactionsResponseValidator(
@@ -37655,7 +37630,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -37752,7 +37727,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getForwardingRequestsResponseValidator(status, body)
@@ -37779,10 +37754,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         body: z.string().max(5000).optional(),
         headers: z
           .array(
-            z.object({
-              name: z.string().max(5000),
-              value: z.string().max(5000),
-            }),
+            z.object({name: z.string().max(5000), value: z.string().max(5000)}),
           )
           .optional(),
       })
@@ -37833,7 +37805,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postForwardingRequestsResponseValidator(status, body)
@@ -37908,7 +37880,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getForwardingRequestsIdResponseValidator(status, body)
@@ -38011,7 +37983,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIdentityVerificationReportsResponseValidator(status, body)
@@ -38087,7 +38059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIdentityVerificationReportsReportResponseValidator(
@@ -38195,7 +38167,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIdentityVerificationSessionsResponseValidator(status, body)
@@ -38227,11 +38199,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       provided_details: z
-        .object({ email: z.string().optional(), phone: z.string().optional() })
+        .object({email: z.string().optional(), phone: z.string().optional()})
         .optional(),
       related_customer: z.string().max(5000).optional(),
       related_person: z
-        .object({ account: z.string().max(5000), person: z.string().max(5000) })
+        .object({account: z.string().max(5000), person: z.string().max(5000)})
         .optional(),
       return_url: z.string().optional(),
       type: z.enum(["document", "id_number"]).optional(),
@@ -38283,7 +38255,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIdentityVerificationSessionsResponseValidator(status, body)
@@ -38361,7 +38333,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIdentityVerificationSessionsSessionResponseValidator(
@@ -38399,7 +38371,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       provided_details: z
-        .object({ email: z.string().optional(), phone: z.string().optional() })
+        .object({email: z.string().optional(), phone: z.string().optional()})
         .optional(),
       type: z.enum(["document", "id_number"]).optional(),
     })
@@ -38453,7 +38425,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIdentityVerificationSessionsSessionResponseValidator(
@@ -38470,7 +38442,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postIdentityVerificationSessionsSessionCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postIdentityVerificationSessionsSessionCancelResponseValidator =
@@ -38526,7 +38498,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIdentityVerificationSessionsSessionCancelResponseValidator(
@@ -38543,7 +38515,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postIdentityVerificationSessionsSessionRedactBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postIdentityVerificationSessionsSessionRedactResponseValidator =
@@ -38599,7 +38571,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIdentityVerificationSessionsSessionRedactResponseValidator(
@@ -38695,7 +38667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoicePaymentsResponseValidator(status, body)
@@ -38768,7 +38740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoicePaymentsInvoicePaymentResponseValidator(status, body)
@@ -38855,7 +38827,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoiceRenderingTemplatesResponseValidator(status, body)
@@ -38929,7 +38901,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoiceRenderingTemplatesTemplateResponseValidator(
@@ -38946,7 +38918,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postInvoiceRenderingTemplatesTemplateArchiveBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoiceRenderingTemplatesTemplateArchiveResponseValidator =
@@ -38999,7 +38971,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoiceRenderingTemplatesTemplateArchiveResponseValidator(
@@ -39016,7 +38988,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postInvoiceRenderingTemplatesTemplateUnarchiveBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoiceRenderingTemplatesTemplateUnarchiveResponseValidator =
@@ -39069,7 +39041,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -39169,7 +39141,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getInvoiceitemsResponseValidator(status, body)
@@ -39199,7 +39171,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     invoice: z.string().max(5000).optional(),
     metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
     period: z
-      .object({ end: z.coerce.number(), start: z.coerce.number() })
+      .object({end: z.coerce.number(), start: z.coerce.number()})
       .optional(),
     price_data: z
       .object({
@@ -39212,7 +39184,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         unit_amount_decimal: z.string().optional(),
       })
       .optional(),
-    pricing: z.object({ price: z.string().max(5000).optional() }).optional(),
+    pricing: z.object({price: z.string().max(5000).optional()}).optional(),
     quantity: z.coerce.number().optional(),
     subscription: z.string().max(5000).optional(),
     tax_behavior: z.enum(["exclusive", "inclusive", "unspecified"]).optional(),
@@ -39261,7 +39233,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postInvoiceitemsResponseValidator(status, body)
@@ -39320,7 +39292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteInvoiceitemsInvoiceitemResponseValidator(status, body)
@@ -39395,7 +39367,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoiceitemsInvoiceitemResponseValidator(status, body)
@@ -39428,7 +39400,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       period: z
-        .object({ end: z.coerce.number(), start: z.coerce.number() })
+        .object({end: z.coerce.number(), start: z.coerce.number()})
         .optional(),
       price_data: z
         .object({
@@ -39441,7 +39413,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           unit_amount_decimal: z.string().optional(),
         })
         .optional(),
-      pricing: z.object({ price: z.string().max(5000).optional() }).optional(),
+      pricing: z.object({price: z.string().max(5000).optional()}).optional(),
       quantity: z.coerce.number().optional(),
       tax_behavior: z
         .enum(["exclusive", "inclusive", "unspecified"])
@@ -39499,7 +39471,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoiceitemsInvoiceitemResponseValidator(status, body)
@@ -39611,7 +39583,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getInvoicesResponseValidator(status, body)
@@ -39645,7 +39617,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       custom_fields: z
         .union([
           z.array(
-            z.object({ name: z.string().max(40), value: z.string().max(140) }),
+            z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
           z.enum([""]),
         ])
@@ -39673,7 +39645,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       footer: z.string().max(5000).optional(),
       from_invoice: z
-        .object({ action: z.enum(["revision"]), invoice: z.string().max(5000) })
+        .object({action: z.enum(["revision"]), invoice: z.string().max(5000)})
         .optional(),
       issuer: z
         .object({
@@ -39753,7 +39725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -39860,7 +39832,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .enum(["", "exclude_tax", "include_inclusive_tax"])
             .optional(),
           pdf: z
-            .object({ page_size: z.enum(["a4", "auto", "letter"]).optional() })
+            .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
             .optional(),
           template: z.string().max(5000).optional(),
           template_version: z
@@ -39945,10 +39917,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       statement_descriptor: z.string().max(22).optional(),
       subscription: z.string().max(5000).optional(),
       transfer_data: z
-        .object({
-          amount: z.coerce.number().optional(),
-          destination: z.string(),
-        })
+        .object({amount: z.coerce.number().optional(), destination: z.string()})
         .optional(),
     })
     .optional()
@@ -39993,7 +39962,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postInvoicesResponseValidator(status, body)
@@ -40210,7 +40179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             invoiceitem: z.string().max(5000).optional(),
             metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
             period: z
-              .object({ end: z.coerce.number(), start: z.coerce.number() })
+              .object({end: z.coerce.number(), start: z.coerce.number()})
               .optional(),
             price: z.string().max(5000).optional(),
             price_data: z
@@ -40249,7 +40218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       schedule_details: z
         .object({
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           end_behavior: z.enum(["cancel", "release"]).optional(),
           phases: z
@@ -40353,7 +40322,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   z.object({
                     billing_thresholds: z
                       .union([
-                        z.object({ usage_gte: z.coerce.number() }),
+                        z.object({usage_gte: z.coerce.number()}),
                         z.enum([""]),
                       ])
                       .optional(),
@@ -40426,7 +40395,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .union([z.enum(["now", "unchanged"]), z.coerce.number()])
             .optional(),
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           cancel_at: z.union([z.coerce.number(), z.enum([""])]).optional(),
           cancel_at_period_end: PermissiveBoolean.optional(),
@@ -40439,7 +40408,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               z.object({
                 billing_thresholds: z
                   .union([
-                    z.object({ usage_gte: z.coerce.number() }),
+                    z.object({usage_gte: z.coerce.number()}),
                     z.enum([""]),
                   ])
                   .optional(),
@@ -40539,7 +40508,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesCreatePreviewResponseValidator(status, body)
@@ -40625,7 +40594,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getInvoicesSearchResponseValidator(status, body)
@@ -40686,7 +40655,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteInvoicesInvoiceResponseValidator(status, body)
@@ -40761,7 +40730,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoicesInvoiceResponseValidator(status, body)
@@ -40799,7 +40768,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       custom_fields: z
         .union([
           z.array(
-            z.object({ name: z.string().max(40), value: z.string().max(140) }),
+            z.object({name: z.string().max(40), value: z.string().max(140)}),
           ),
           z.enum([""]),
         ])
@@ -40905,7 +40874,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -41011,7 +40980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .enum(["", "exclude_tax", "include_inclusive_tax"])
             .optional(),
           pdf: z
-            .object({ page_size: z.enum(["a4", "auto", "letter"]).optional() })
+            .object({page_size: z.enum(["a4", "auto", "letter"]).optional()})
             .optional(),
           template: z.string().max(5000).optional(),
           template_version: z
@@ -41159,7 +41128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceResponseValidator(status, body)
@@ -41195,7 +41164,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         invoice_item: z.string().max(5000).optional(),
         metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
         period: z
-          .object({ end: z.coerce.number(), start: z.coerce.number() })
+          .object({end: z.coerce.number(), start: z.coerce.number()})
           .optional(),
         price_data: z
           .object({
@@ -41217,9 +41186,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             unit_amount_decimal: z.string().optional(),
           })
           .optional(),
-        pricing: z
-          .object({ price: z.string().max(5000).optional() })
-          .optional(),
+        pricing: z.object({price: z.string().max(5000).optional()}).optional(),
         quantity: z.coerce.number().optional(),
         tax_amounts: z
           .union([
@@ -41340,7 +41307,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceAddLinesResponseValidator(status, body)
@@ -41405,7 +41372,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceAttachPaymentResponseValidator(status, body)
@@ -41470,7 +41437,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceFinalizeResponseValidator(status, body)
@@ -41563,7 +41530,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getInvoicesInvoiceLinesResponseValidator(status, body)
@@ -41597,7 +41564,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       period: z
-        .object({ end: z.coerce.number(), start: z.coerce.number() })
+        .object({end: z.coerce.number(), start: z.coerce.number()})
         .optional(),
       price_data: z
         .object({
@@ -41619,7 +41586,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           unit_amount_decimal: z.string().optional(),
         })
         .optional(),
-      pricing: z.object({ price: z.string().max(5000).optional() }).optional(),
+      pricing: z.object({price: z.string().max(5000).optional()}).optional(),
       quantity: z.coerce.number().optional(),
       tax_amounts: z
         .union([
@@ -41739,7 +41706,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceLinesLineItemIdResponseValidator(
@@ -41756,7 +41723,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postInvoicesInvoiceMarkUncollectibleBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoicesInvoiceMarkUncollectibleResponseValidator =
@@ -41804,7 +41771,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceMarkUncollectibleResponseValidator(
@@ -41879,7 +41846,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoicePayResponseValidator(status, body)
@@ -41948,7 +41915,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceRemoveLinesResponseValidator(status, body)
@@ -41962,7 +41929,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postInvoicesInvoiceSendBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoicesInvoiceSendResponseValidator = responseValidationFactory(
@@ -42012,7 +41979,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceSendResponseValidator(status, body)
@@ -42048,7 +42015,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         id: z.string().max(5000),
         metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
         period: z
-          .object({ end: z.coerce.number(), start: z.coerce.number() })
+          .object({end: z.coerce.number(), start: z.coerce.number()})
           .optional(),
         price_data: z
           .object({
@@ -42070,9 +42037,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             unit_amount_decimal: z.string().optional(),
           })
           .optional(),
-        pricing: z
-          .object({ price: z.string().max(5000).optional() })
-          .optional(),
+        pricing: z.object({price: z.string().max(5000).optional()}).optional(),
         quantity: z.coerce.number().optional(),
         tax_amounts: z
           .union([
@@ -42193,7 +42158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceUpdateLinesResponseValidator(status, body)
@@ -42207,7 +42172,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postInvoicesInvoiceVoidBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postInvoicesInvoiceVoidResponseValidator = responseValidationFactory(
@@ -42257,7 +42222,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postInvoicesInvoiceVoidResponseValidator(status, body)
@@ -42359,7 +42324,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingAuthorizationsResponseValidator(status, body)
@@ -42434,7 +42399,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingAuthorizationsAuthorizationResponseValidator(
@@ -42502,7 +42467,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingAuthorizationsAuthorizationResponseValidator(
@@ -42576,7 +42541,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingAuthorizationsAuthorizationApproveResponseValidator(
@@ -42649,7 +42614,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingAuthorizationsAuthorizationDeclineResponseValidator(
@@ -42755,7 +42720,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingCardholdersResponseValidator(status, body)
@@ -42775,7 +42740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         state: z.string().max(5000).optional(),
       }),
     }),
-    company: z.object({ tax_id: z.string().max(5000).optional() }).optional(),
+    company: z.object({tax_id: z.string().max(5000).optional()}).optional(),
     email: z.string().optional(),
     expand: z.array(z.string().max(5000)).optional(),
     individual: z
@@ -43792,7 +43757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingCardholdersResponseValidator(status, body)
@@ -43865,7 +43830,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingCardholdersCardholderResponseValidator(status, body)
@@ -43892,7 +43857,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           }),
         })
         .optional(),
-      company: z.object({ tax_id: z.string().max(5000).optional() }).optional(),
+      company: z.object({tax_id: z.string().max(5000).optional()}).optional(),
       email: z.string().optional(),
       expand: z.array(z.string().max(5000)).optional(),
       individual: z
@@ -44910,7 +44875,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingCardholdersCardholderResponseValidator(status, body)
@@ -45010,7 +44975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getIssuingCardsResponseValidator(status, body)
@@ -45026,7 +44991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     metadata: z.record(z.string()).optional(),
     personalization_design: z.string().max(5000).optional(),
     pin: z
-      .object({ encrypted_number: z.string().max(5000).optional() })
+      .object({encrypted_number: z.string().max(5000).optional()})
       .optional(),
     replacement_for: z.string().max(5000).optional(),
     replacement_reason: z
@@ -45053,7 +45018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           })
           .optional(),
         customs: z
-          .object({ eori_number: z.string().max(5000).optional() })
+          .object({eori_number: z.string().max(5000).optional()})
           .optional(),
         name: z.string().max(5000),
         phone_number: z.string().optional(),
@@ -46030,7 +45995,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postIssuingCardsResponseValidator(status, body)
@@ -46038,9 +46003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getIssuingCardsCardParamSchema = z.object({
-    card: z.string().max(5000),
-  })
+  const getIssuingCardsCardParamSchema = z.object({card: z.string().max(5000)})
 
   const getIssuingCardsCardQuerySchema = z.object({
     expand: z
@@ -46104,7 +46067,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingCardsCardResponseValidator(status, body)
@@ -46113,9 +46076,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postIssuingCardsCardParamSchema = z.object({
-    card: z.string().max(5000),
-  })
+  const postIssuingCardsCardParamSchema = z.object({card: z.string().max(5000)})
 
   const postIssuingCardsCardBodySchema = z
     .object({
@@ -46124,7 +46085,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       personalization_design: z.string().max(5000).optional(),
       pin: z
-        .object({ encrypted_number: z.string().max(5000).optional() })
+        .object({encrypted_number: z.string().max(5000).optional()})
         .optional(),
       shipping: z
         .object({
@@ -46146,7 +46107,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           customs: z
-            .object({ eori_number: z.string().max(5000).optional() })
+            .object({eori_number: z.string().max(5000).optional()})
             .optional(),
           name: z.string().max(5000),
           phone_number: z.string().optional(),
@@ -47130,7 +47091,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingCardsCardResponseValidator(status, body)
@@ -47230,7 +47191,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingDisputesResponseValidator(status, body)
@@ -47423,7 +47384,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       metadata: z.record(z.string()).optional(),
       transaction: z.string().max(5000).optional(),
-      treasury: z.object({ received_debit: z.string().max(5000) }).optional(),
+      treasury: z.object({received_debit: z.string().max(5000)}).optional(),
     })
     .optional()
 
@@ -47470,7 +47431,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingDisputesResponseValidator(status, body)
@@ -47545,7 +47506,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingDisputesDisputeResponseValidator(status, body)
@@ -47791,7 +47752,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingDisputesDisputeResponseValidator(status, body)
@@ -47856,7 +47817,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingDisputesDisputeSubmitResponseValidator(status, body)
@@ -47958,7 +47919,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingPersonalizationDesignsResponseValidator(status, body)
@@ -47982,7 +47943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     metadata: z.record(z.string()).optional(),
     name: z.string().max(200).optional(),
     physical_bundle: z.string().max(5000),
-    preferences: z.object({ is_default: PermissiveBoolean }).optional(),
+    preferences: z.object({is_default: PermissiveBoolean}).optional(),
     transfer_lookup_key: PermissiveBoolean.optional(),
   })
 
@@ -48030,7 +47991,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingPersonalizationDesignsResponseValidator(
@@ -48043,7 +48004,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const getIssuingPersonalizationDesignsPersonalizationDesignQuerySchema =
     z.object({
@@ -48116,7 +48077,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -48130,7 +48091,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postIssuingPersonalizationDesignsPersonalizationDesignParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postIssuingPersonalizationDesignsPersonalizationDesignBodySchema = z
     .object({
@@ -48159,7 +48120,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       metadata: z.record(z.string()).optional(),
       name: z.union([z.string().max(200), z.enum([""])]).optional(),
       physical_bundle: z.string().max(5000).optional(),
-      preferences: z.object({ is_default: PermissiveBoolean }).optional(),
+      preferences: z.object({is_default: PermissiveBoolean}).optional(),
       transfer_lookup_key: PermissiveBoolean.optional(),
     })
     .optional()
@@ -48217,7 +48178,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -48311,7 +48272,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingPhysicalBundlesResponseValidator(status, body)
@@ -48386,7 +48347,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingPhysicalBundlesPhysicalBundleResponseValidator(
@@ -48462,7 +48423,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingSettlementsSettlementResponseValidator(status, body)
@@ -48527,7 +48488,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingSettlementsSettlementResponseValidator(status, body)
@@ -48622,7 +48583,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getIssuingTokensResponseValidator(status, body)
@@ -48696,7 +48657,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingTokensTokenResponseValidator(status, body)
@@ -48761,7 +48722,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingTokensTokenResponseValidator(status, body)
@@ -48863,7 +48824,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingTransactionsResponseValidator(status, body)
@@ -48936,7 +48897,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getIssuingTransactionsTransactionResponseValidator(
@@ -49004,7 +48965,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postIssuingTransactionsTransactionResponseValidator(
@@ -49091,7 +49052,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postLinkAccountSessionsResponseValidator(status, body)
@@ -49167,7 +49128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getLinkAccountSessionsSessionResponseValidator(status, body)
@@ -49259,7 +49220,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getLinkedAccountsResponseValidator(status, body)
@@ -49333,7 +49294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getLinkedAccountsAccountResponseValidator(status, body)
@@ -49347,7 +49308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postLinkedAccountsAccountDisconnectBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postLinkedAccountsAccountDisconnectResponseValidator =
@@ -49398,7 +49359,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postLinkedAccountsAccountDisconnectResponseValidator(
@@ -49496,7 +49457,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getLinkedAccountsAccountOwnersResponseValidator(status, body)
@@ -49562,7 +49523,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postLinkedAccountsAccountRefreshResponseValidator(status, body)
@@ -49571,7 +49532,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getMandatesMandateParamSchema = z.object({ mandate: z.string() })
+  const getMandatesMandateParamSchema = z.object({mandate: z.string()})
 
   const getMandatesMandateQuerySchema = z.object({
     expand: z
@@ -49635,7 +49596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getMandatesMandateResponseValidator(status, body)
@@ -49729,7 +49690,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPaymentIntentsResponseValidator(status, body)
@@ -49836,7 +49797,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           })
           .optional(),
         blik: z.object({}).optional(),
-        boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+        boleto: z.object({tax_id: z.string().max(5000)}).optional(),
         cashapp: z.object({}).optional(),
         crypto: z.object({}).optional(),
         customer_balance: z.object({}).optional(),
@@ -49951,7 +49912,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         mobilepay: z.object({}).optional(),
         multibanco: z.object({}).optional(),
         naver_pay: z
-          .object({ funding: z.enum(["card", "points"]).optional() })
+          .object({funding: z.enum(["card", "points"]).optional()})
           .optional(),
         nz_bank_account: z
           .object({
@@ -50005,14 +49966,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
         pix: z.object({}).optional(),
         promptpay: z.object({}).optional(),
         radar_options: z
-          .object({ session: z.string().max(5000).optional() })
+          .object({session: z.string().max(5000).optional()})
           .optional(),
         revolut_pay: z.object({}).optional(),
         samsung_pay: z.object({}).optional(),
         satispay: z.object({}).optional(),
-        sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+        sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
         sofort: z
-          .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+          .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
           .optional(),
         swish: z.object({}).optional(),
         twint: z.object({}).optional(),
@@ -50138,7 +50099,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         alma: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50195,7 +50156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         billie: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50358,7 +50319,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         crypto: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50368,7 +50329,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               bank_transfer: z
                 .object({
                   eu_bank_transfer: z
-                    .object({ country: z.string().max(5000) })
+                    .object({country: z.string().max(5000)})
                     .optional(),
                   requested_address_types: z
                     .array(
@@ -50400,25 +50361,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         eps: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         fpx: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         giropay: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         grabpay: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50586,7 +50547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         multibanco: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50633,13 +50594,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
         pay_by_bank: z.union([z.object({}), z.enum([""])]).optional(),
         payco: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         paynow: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50693,7 +50654,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         promptpay: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50710,13 +50671,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         samsung_pay: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
         satispay: z
           .union([
-            z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+            z.object({capture_method: z.enum(["", "manual"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50764,7 +50725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         twint: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50797,7 +50758,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -50832,7 +50793,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           .optional(),
         zip: z
           .union([
-            z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+            z.object({setup_future_usage: z.enum(["none"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -50840,7 +50801,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     payment_method_types: z.array(z.string().max(5000)).optional(),
     radar_options: z
-      .object({ session: z.string().max(5000).optional() })
+      .object({session: z.string().max(5000).optional()})
       .optional(),
     receipt_email: z.string().optional(),
     return_url: z.string().optional(),
@@ -50864,7 +50825,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     statement_descriptor: z.string().max(22).optional(),
     statement_descriptor_suffix: z.string().max(22).optional(),
     transfer_data: z
-      .object({ amount: z.coerce.number().optional(), destination: z.string() })
+      .object({amount: z.coerce.number().optional(), destination: z.string()})
       .optional(),
     transfer_group: z.string().optional(),
     use_stripe_sdk: PermissiveBoolean.optional(),
@@ -50913,7 +50874,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsResponseValidator(status, body)
@@ -51002,7 +50963,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentIntentsSearchResponseValidator(status, body)
@@ -51078,7 +51039,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentIntentsIntentResponseValidator(status, body)
@@ -51160,7 +51121,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -51275,7 +51236,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -51329,14 +51290,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -51464,7 +51425,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           alma: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -51521,7 +51482,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           billie: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -51688,7 +51649,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           crypto: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -51698,7 +51659,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 bank_transfer: z
                   .object({
                     eu_bank_transfer: z
-                      .object({ country: z.string().max(5000) })
+                      .object({country: z.string().max(5000)})
                       .optional(),
                     requested_address_types: z
                       .array(
@@ -51730,25 +51691,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           eps: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           fpx: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           giropay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           grabpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -51918,7 +51879,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           multibanco: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -51965,13 +51926,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pay_by_bank: z.union([z.object({}), z.enum([""])]).optional(),
           payco: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           paynow: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52025,7 +51986,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           promptpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52042,13 +52003,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           samsung_pay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           satispay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52096,7 +52057,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           twint: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52129,9 +52090,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   })
                   .optional(),
                 mandate_options: z
-                  .object({
-                    collection_method: z.enum(["", "paper"]).optional(),
-                  })
+                  .object({collection_method: z.enum(["", "paper"]).optional()})
                   .optional(),
                 networks: z
                   .object({
@@ -52166,7 +52125,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           zip: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52197,7 +52156,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
       transfer_group: z.string().optional(),
     })
@@ -52250,7 +52209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsIntentResponseValidator(status, body)
@@ -52321,7 +52280,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsIntentApplyCustomerBalanceResponseValidator(
@@ -52391,7 +52350,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsIntentCancelResponseValidator(status, body)
@@ -52414,7 +52373,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       statement_descriptor: z.string().max(22).optional(),
       statement_descriptor_suffix: z.string().max(22).optional(),
       transfer_data: z
-        .object({ amount: z.coerce.number().optional() })
+        .object({amount: z.coerce.number().optional()})
         .optional(),
     })
     .optional()
@@ -52464,7 +52423,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsIntentCaptureResponseValidator(status, body)
@@ -52571,7 +52530,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -52686,7 +52645,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -52740,14 +52699,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -52875,7 +52834,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           alma: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -52932,7 +52891,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           billie: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53099,7 +53058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           crypto: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53109,7 +53068,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 bank_transfer: z
                   .object({
                     eu_bank_transfer: z
-                      .object({ country: z.string().max(5000) })
+                      .object({country: z.string().max(5000)})
                       .optional(),
                     requested_address_types: z
                       .array(
@@ -53141,25 +53100,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           eps: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           fpx: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           giropay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           grabpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53329,7 +53288,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           multibanco: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53376,13 +53335,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pay_by_bank: z.union([z.object({}), z.enum([""])]).optional(),
           payco: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           paynow: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53436,7 +53395,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           promptpay: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53453,13 +53412,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           samsung_pay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
           satispay: z
             .union([
-              z.object({ capture_method: z.enum(["", "manual"]).optional() }),
+              z.object({capture_method: z.enum(["", "manual"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53507,7 +53466,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           twint: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53540,9 +53499,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   })
                   .optional(),
                 mandate_options: z
-                  .object({
-                    collection_method: z.enum(["", "paper"]).optional(),
-                  })
+                  .object({collection_method: z.enum(["", "paper"]).optional()})
                   .optional(),
                 networks: z
                   .object({
@@ -53577,7 +53534,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           zip: z
             .union([
-              z.object({ setup_future_usage: z.enum(["none"]).optional() }),
+              z.object({setup_future_usage: z.enum(["none"]).optional()}),
               z.enum([""]),
             ])
             .optional(),
@@ -53585,7 +53542,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .optional(),
       payment_method_types: z.array(z.string().max(5000)).optional(),
       radar_options: z
-        .object({ session: z.string().max(5000).optional() })
+        .object({session: z.string().max(5000).optional()})
         .optional(),
       receipt_email: z.union([z.string(), z.enum([""])]).optional(),
       return_url: z.string().optional(),
@@ -53658,7 +53615,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsIntentConfirmResponseValidator(status, body)
@@ -53678,9 +53635,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     expand: z.array(z.string().max(5000)).optional(),
     metadata: z.record(z.string()).optional(),
     statement_descriptor: z.string().max(22).optional(),
-    transfer_data: z
-      .object({ amount: z.coerce.number().optional() })
-      .optional(),
+    transfer_data: z.object({amount: z.coerce.number().optional()}).optional(),
   })
 
   const postPaymentIntentsIntentIncrementAuthorizationResponseValidator =
@@ -53733,7 +53688,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -53809,7 +53764,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentIntentsIntentVerifyMicrodepositsResponseValidator(
@@ -53895,7 +53850,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPaymentLinksResponseValidator(status, body)
@@ -53907,9 +53862,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
     after_completion: z
       .object({
         hosted_confirmation: z
-          .object({ custom_message: z.string().max(500).optional() })
+          .object({custom_message: z.string().max(500).optional()})
           .optional(),
-        redirect: z.object({ url: z.string() }).optional(),
+        redirect: z.object({url: z.string()}).optional(),
         type: z.enum(["hosted_confirmation", "redirect"]),
       })
       .optional(),
@@ -53931,7 +53886,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     consent_collection: z
       .object({
         payment_method_reuse_agreement: z
-          .object({ position: z.enum(["auto", "hidden"]) })
+          .object({position: z.enum(["auto", "hidden"])})
           .optional(),
         promotions: z.enum(["auto", "none"]).optional(),
         terms_of_service: z.enum(["none", "required"]).optional(),
@@ -53979,16 +53934,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
     custom_text: z
       .object({
         after_submit: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
         shipping_address: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
         submit: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
         terms_of_service_acceptance: z
-          .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+          .union([z.object({message: z.string().max(1200)}), z.enum([""])])
           .optional(),
       })
       .optional(),
@@ -54124,11 +54079,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ]),
       )
       .optional(),
-    phone_number_collection: z
-      .object({ enabled: PermissiveBoolean })
-      .optional(),
+    phone_number_collection: z.object({enabled: PermissiveBoolean}).optional(),
     restrictions: z
-      .object({ completed_sessions: z.object({ limit: z.coerce.number() }) })
+      .object({completed_sessions: z.object({limit: z.coerce.number()})})
       .optional(),
     shipping_address_collection: z
       .object({
@@ -54377,7 +54330,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     shipping_options: z
-      .array(z.object({ shipping_rate: z.string().max(5000).optional() }))
+      .array(z.object({shipping_rate: z.string().max(5000).optional()}))
       .optional(),
     submit_type: z
       .enum(["auto", "book", "donate", "pay", "subscribe"])
@@ -54417,7 +54370,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     transfer_data: z
-      .object({ amount: z.coerce.number().optional(), destination: z.string() })
+      .object({amount: z.coerce.number().optional(), destination: z.string()})
       .optional(),
   })
 
@@ -54461,7 +54414,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPaymentLinksResponseValidator(status, body)
@@ -54535,7 +54488,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentLinksPaymentLinkResponseValidator(status, body)
@@ -54554,9 +54507,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
       after_completion: z
         .object({
           hosted_confirmation: z
-            .object({ custom_message: z.string().max(500).optional() })
+            .object({custom_message: z.string().max(500).optional()})
             .optional(),
-          redirect: z.object({ url: z.string() }).optional(),
+          redirect: z.object({url: z.string()}).optional(),
           type: z.enum(["hosted_confirmation", "redirect"]),
         })
         .optional(),
@@ -54617,16 +54570,16 @@ export function createRouter(implementation: Implementation): KoaRouter {
       custom_text: z
         .object({
           after_submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           shipping_address: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           submit: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
           terms_of_service_acceptance: z
-            .union([z.object({ message: z.string().max(1200) }), z.enum([""])])
+            .union([z.object({message: z.string().max(1200)}), z.enum([""])])
             .optional(),
         })
         .optional(),
@@ -54756,13 +54709,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       phone_number_collection: z
-        .object({ enabled: PermissiveBoolean })
+        .object({enabled: PermissiveBoolean})
         .optional(),
       restrictions: z
         .union([
-          z.object({
-            completed_sessions: z.object({ limit: z.coerce.number() }),
-          }),
+          z.object({completed_sessions: z.object({limit: z.coerce.number()})}),
           z.enum([""]),
         ])
         .optional(),
@@ -55104,7 +55055,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentLinksPaymentLinkResponseValidator(status, body)
@@ -55198,7 +55149,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentLinksPaymentLinkLineItemsResponseValidator(
@@ -55291,7 +55242,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentMethodConfigurationsResponseValidator(status, body)
@@ -55305,133 +55256,133 @@ export function createRouter(implementation: Implementation): KoaRouter {
       acss_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       affirm: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       afterpay_clearpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alipay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alma: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       amazon_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay_later: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       au_becs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bacs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bancontact: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       billie: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       blik: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       boleto: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cartes_bancaires: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cashapp: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       customer_balance: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       eps: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -55439,91 +55390,91 @@ export function createRouter(implementation: Implementation): KoaRouter {
       fpx: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       giropay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       google_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       grabpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       ideal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       jcb: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kakao_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       klarna: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       konbini: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kr_card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       link: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       mobilepay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       multibanco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -55531,28 +55482,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
       naver_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       nz_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       oxxo: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       p24: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -55560,112 +55511,112 @@ export function createRouter(implementation: Implementation): KoaRouter {
       pay_by_bank: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       payco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paynow: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paypal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       pix: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       promptpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       revolut_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       samsung_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       satispay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sepa_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sofort: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       swish: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       twint: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       us_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       wechat_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       zip: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -55716,7 +55667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodConfigurationsResponseValidator(status, body)
@@ -55799,7 +55750,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentMethodConfigurationsConfigurationResponseValidator(
@@ -55820,7 +55771,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       acss_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -55828,126 +55779,126 @@ export function createRouter(implementation: Implementation): KoaRouter {
       affirm: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       afterpay_clearpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alipay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       alma: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       amazon_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       apple_pay_later: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       au_becs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bacs_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       bancontact: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       billie: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       blik: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       boleto: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cartes_bancaires: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       cashapp: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       customer_balance: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       eps: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -55955,91 +55906,91 @@ export function createRouter(implementation: Implementation): KoaRouter {
       fpx: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       giropay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       google_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       grabpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       ideal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       jcb: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kakao_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       klarna: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       konbini: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       kr_card: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       link: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       mobilepay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       multibanco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56047,140 +55998,140 @@ export function createRouter(implementation: Implementation): KoaRouter {
       naver_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       nz_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       oxxo: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       p24: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       pay_by_bank: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       payco: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paynow: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       paypal: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       pix: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       promptpay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       revolut_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       samsung_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       satispay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sepa_debit: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       sofort: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       swish: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       twint: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       us_bank_account: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       wechat_pay: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
       zip: z
         .object({
           display_preference: z
-            .object({ preference: z.enum(["none", "off", "on"]).optional() })
+            .object({preference: z.enum(["none", "off", "on"]).optional()})
             .optional(),
         })
         .optional(),
@@ -56240,7 +56191,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodConfigurationsConfigurationResponseValidator(
@@ -56333,7 +56284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentMethodDomainsResponseValidator(status, body)
@@ -56391,7 +56342,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodDomainsResponseValidator(status, body)
@@ -56466,7 +56417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentMethodDomainsPaymentMethodDomainResponseValidator(
@@ -56539,7 +56490,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodDomainsPaymentMethodDomainResponseValidator(
@@ -56552,10 +56503,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateParamSchema =
-    z.object({ payment_method_domain: z.string().max(5000) })
+    z.object({payment_method_domain: z.string().max(5000)})
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postPaymentMethodDomainsPaymentMethodDomainValidateResponseValidator =
@@ -56608,7 +56559,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -56747,7 +56698,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPaymentMethodsResponseValidator(status, body)
@@ -56806,7 +56757,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         })
         .optional(),
       blik: z.object({}).optional(),
-      boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+      boleto: z.object({tax_id: z.string().max(5000)}).optional(),
       card: z
         .union([
           z.object({
@@ -56822,7 +56773,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               .optional(),
             number: z.string().max(5000),
           }),
-          z.object({ token: z.string().max(5000) }),
+          z.object({token: z.string().max(5000)}),
         ])
         .optional(),
       cashapp: z.object({}).optional(),
@@ -56941,7 +56892,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       mobilepay: z.object({}).optional(),
       multibanco: z.object({}).optional(),
       naver_pay: z
-        .object({ funding: z.enum(["card", "points"]).optional() })
+        .object({funding: z.enum(["card", "points"]).optional()})
         .optional(),
       nz_bank_account: z
         .object({
@@ -56996,14 +56947,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
       pix: z.object({}).optional(),
       promptpay: z.object({}).optional(),
       radar_options: z
-        .object({ session: z.string().max(5000).optional() })
+        .object({session: z.string().max(5000).optional()})
         .optional(),
       revolut_pay: z.object({}).optional(),
       samsung_pay: z.object({}).optional(),
       satispay: z.object({}).optional(),
-      sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+      sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
       sofort: z
-        .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+        .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
         .optional(),
       swish: z.object({}).optional(),
       twint: z.object({}).optional(),
@@ -57116,7 +57067,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodsResponseValidator(status, body)
@@ -57189,7 +57140,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPaymentMethodsPaymentMethodResponseValidator(status, body)
@@ -57297,7 +57248,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodsPaymentMethodResponseValidator(status, body)
@@ -57360,7 +57311,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodsPaymentMethodAttachResponseValidator(
@@ -57377,7 +57328,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postPaymentMethodsPaymentMethodDetachBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postPaymentMethodsPaymentMethodDetachResponseValidator =
@@ -57425,7 +57376,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPaymentMethodsPaymentMethodDetachResponseValidator(
@@ -57534,7 +57485,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPayoutsResponseValidator(status, body)
@@ -57594,7 +57545,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPayoutsResponseValidator(status, body)
@@ -57602,7 +57553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPayoutsPayoutParamSchema = z.object({ payout: z.string().max(5000) })
+  const getPayoutsPayoutParamSchema = z.object({payout: z.string().max(5000)})
 
   const getPayoutsPayoutQuerySchema = z.object({
     expand: z
@@ -57663,7 +57614,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPayoutsPayoutResponseValidator(status, body)
@@ -57671,9 +57622,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPayoutsPayoutParamSchema = z.object({
-    payout: z.string().max(5000),
-  })
+  const postPayoutsPayoutParamSchema = z.object({payout: z.string().max(5000)})
 
   const postPayoutsPayoutBodySchema = z
     .object({
@@ -57726,7 +57675,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPayoutsPayoutResponseValidator(status, body)
@@ -57739,7 +57688,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postPayoutsPayoutCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postPayoutsPayoutCancelResponseValidator = responseValidationFactory(
@@ -57789,7 +57738,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPayoutsPayoutCancelResponseValidator(status, body)
@@ -57856,7 +57805,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPayoutsPayoutReverseResponseValidator(status, body)
@@ -57951,7 +57900,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPlansResponseValidator(status, body)
@@ -57999,7 +57948,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .optional(),
     tiers_mode: z.enum(["graduated", "volume"]).optional(),
     transform_usage: z
-      .object({ divide_by: z.coerce.number(), round: z.enum(["down", "up"]) })
+      .object({divide_by: z.coerce.number(), round: z.enum(["down", "up"])})
       .optional(),
     trial_period_days: z.coerce.number().optional(),
     usage_type: z.enum(["licensed", "metered"]).optional(),
@@ -58045,7 +57994,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPlansResponseValidator(status, body)
@@ -58053,7 +58002,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deletePlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
+  const deletePlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
   const deletePlansPlanBodySchema = z.object({}).optional()
 
@@ -58101,7 +58050,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = deletePlansPlanResponseValidator(status, body)
@@ -58109,7 +58058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
+  const getPlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
   const getPlansPlanQuerySchema = z.object({
     expand: z
@@ -58170,7 +58119,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPlansPlanResponseValidator(status, body)
@@ -58178,7 +58127,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPlansPlanParamSchema = z.object({ plan: z.string().max(5000) })
+  const postPlansPlanParamSchema = z.object({plan: z.string().max(5000)})
 
   const postPlansPlanBodySchema = z
     .object({
@@ -58235,7 +58184,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPlansPlanResponseValidator(status, body)
@@ -58344,7 +58293,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPricesResponseValidator(status, body)
@@ -58433,7 +58382,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     tiers_mode: z.enum(["graduated", "volume"]).optional(),
     transfer_lookup_key: PermissiveBoolean.optional(),
     transform_quantity: z
-      .object({ divide_by: z.coerce.number(), round: z.enum(["down", "up"]) })
+      .object({divide_by: z.coerce.number(), round: z.enum(["down", "up"])})
       .optional(),
     unit_amount: z.coerce.number().optional(),
     unit_amount_decimal: z.string().optional(),
@@ -58479,7 +58428,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPricesResponseValidator(status, body)
@@ -58564,7 +58513,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPricesSearchResponseValidator(status, body)
@@ -58572,7 +58521,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getPricesPriceParamSchema = z.object({ price: z.string().max(5000) })
+  const getPricesPriceParamSchema = z.object({price: z.string().max(5000)})
 
   const getPricesPriceQuerySchema = z.object({
     expand: z
@@ -58633,7 +58582,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPricesPriceResponseValidator(status, body)
@@ -58641,7 +58590,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postPricesPriceParamSchema = z.object({ price: z.string().max(5000) })
+  const postPricesPriceParamSchema = z.object({price: z.string().max(5000)})
 
   const postPricesPriceBodySchema = z
     .object({
@@ -58734,7 +58683,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postPricesPriceResponseValidator(status, body)
@@ -58835,7 +58784,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getProductsResponseValidator(status, body)
@@ -58905,7 +58854,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     id: z.string().max(5000).optional(),
     images: z.array(z.string()).optional(),
     marketing_features: z
-      .array(z.object({ name: z.string().max(5000) }))
+      .array(z.object({name: z.string().max(5000)}))
       .optional(),
     metadata: z.record(z.string()).optional(),
     name: z.string().max(5000),
@@ -58964,7 +58913,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postProductsResponseValidator(status, body)
@@ -59049,7 +58998,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getProductsSearchResponseValidator(status, body)
@@ -59057,7 +59006,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteProductsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const deleteProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const deleteProductsIdBodySchema = z.object({}).optional()
 
@@ -59105,7 +59054,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = deleteProductsIdResponseValidator(status, body)
@@ -59113,7 +59062,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getProductsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getProductsIdQuerySchema = z.object({
     expand: z
@@ -59174,7 +59123,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getProductsIdResponseValidator(status, body)
@@ -59182,7 +59131,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postProductsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const postProductsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postProductsIdBodySchema = z
     .object({
@@ -59192,10 +59141,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       images: z.union([z.array(z.string()), z.enum([""])]).optional(),
       marketing_features: z
-        .union([
-          z.array(z.object({ name: z.string().max(5000) })),
-          z.enum([""]),
-        ])
+        .union([z.array(z.object({name: z.string().max(5000)})), z.enum([""])])
         .optional(),
       metadata: z.union([z.record(z.string()), z.enum([""])]).optional(),
       name: z.string().max(5000).optional(),
@@ -59262,7 +59208,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postProductsIdResponseValidator(status, body)
@@ -59354,7 +59300,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getProductsProductFeaturesResponseValidator(status, body)
@@ -59417,7 +59363,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postProductsProductFeaturesResponseValidator(status, body)
@@ -59478,7 +59424,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteProductsProductFeaturesIdResponseValidator(status, body)
@@ -59552,7 +59498,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getProductsProductFeaturesIdResponseValidator(status, body)
@@ -59649,7 +59595,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getPromotionCodesResponseValidator(status, body)
@@ -59669,7 +59615,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     restrictions: z
       .object({
         currency_options: z
-          .record(z.object({ minimum_amount: z.coerce.number().optional() }))
+          .record(z.object({minimum_amount: z.coerce.number().optional()}))
           .optional(),
         first_time_transaction: PermissiveBoolean.optional(),
         minimum_amount: z.coerce.number().optional(),
@@ -59721,7 +59667,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPromotionCodesResponseValidator(status, body)
@@ -59794,7 +59740,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getPromotionCodesPromotionCodeResponseValidator(status, body)
@@ -59815,7 +59761,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       restrictions: z
         .object({
           currency_options: z
-            .record(z.object({ minimum_amount: z.coerce.number().optional() }))
+            .record(z.object({minimum_amount: z.coerce.number().optional()}))
             .optional(),
         })
         .optional(),
@@ -59867,7 +59813,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postPromotionCodesPromotionCodeResponseValidator(status, body)
@@ -59952,7 +59898,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getQuotesResponseValidator(status, body)
@@ -60065,7 +60011,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       subscription_data: z
         .object({
           billing_mode: z
-            .object({ type: z.enum(["classic", "flexible"]) })
+            .object({type: z.enum(["classic", "flexible"])})
             .optional(),
           description: z.string().max(500).optional(),
           effective_date: z
@@ -60135,7 +60081,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postQuotesResponseValidator(status, body)
@@ -60143,7 +60089,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getQuotesQuoteParamSchema = z.object({ quote: z.string().max(5000) })
+  const getQuotesQuoteParamSchema = z.object({quote: z.string().max(5000)})
 
   const getQuotesQuoteQuerySchema = z.object({
     expand: z
@@ -60204,7 +60150,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getQuotesQuoteResponseValidator(status, body)
@@ -60212,7 +60158,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postQuotesQuoteParamSchema = z.object({ quote: z.string().max(5000) })
+  const postQuotesQuoteParamSchema = z.object({quote: z.string().max(5000)})
 
   const postQuotesQuoteBodySchema = z
     .object({
@@ -60384,7 +60330,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postQuotesQuoteResponseValidator(status, body)
@@ -60397,7 +60343,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postQuotesQuoteAcceptBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postQuotesQuoteAcceptResponseValidator = responseValidationFactory(
@@ -60447,7 +60393,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postQuotesQuoteAcceptResponseValidator(status, body)
@@ -60461,7 +60407,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postQuotesQuoteCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postQuotesQuoteCancelResponseValidator = responseValidationFactory(
@@ -60511,7 +60457,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postQuotesQuoteCancelResponseValidator(status, body)
@@ -60607,7 +60553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getQuotesQuoteComputedUpfrontLineItemsResponseValidator(
@@ -60677,7 +60623,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postQuotesQuoteFinalizeResponseValidator(status, body)
@@ -60770,7 +60716,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getQuotesQuoteLineItemsResponseValidator(status, body)
@@ -60779,7 +60725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getQuotesQuotePdfParamSchema = z.object({ quote: z.string().max(5000) })
+  const getQuotesQuotePdfParamSchema = z.object({quote: z.string().max(5000)})
 
   const getQuotesQuotePdfQuerySchema = z.object({
     expand: z
@@ -60843,7 +60789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getQuotesQuotePdfResponseValidator(status, body)
@@ -60944,7 +60890,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getRadarEarlyFraudWarningsResponseValidator(status, body)
@@ -61024,7 +60970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getRadarEarlyFraudWarningsEarlyFraudWarningResponseValidator(
@@ -61128,7 +61074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getRadarValueListItemsResponseValidator(status, body)
@@ -61186,7 +61132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postRadarValueListItemsResponseValidator(status, body)
@@ -61249,7 +61195,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteRadarValueListItemsItemResponseValidator(status, body)
@@ -61324,7 +61270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getRadarValueListItemsItemResponseValidator(status, body)
@@ -61422,7 +61368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getRadarValueListsResponseValidator(status, body)
@@ -61495,7 +61441,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postRadarValueListsResponseValidator(status, body)
@@ -61555,7 +61501,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteRadarValueListsValueListResponseValidator(status, body)
@@ -61628,7 +61574,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getRadarValueListsValueListResponseValidator(status, body)
@@ -61695,7 +61641,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postRadarValueListsValueListResponseValidator(status, body)
@@ -61790,7 +61736,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getRefundsResponseValidator(status, body)
@@ -61857,7 +61803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postRefundsResponseValidator(status, body)
@@ -61865,7 +61811,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getRefundsRefundParamSchema = z.object({ refund: z.string() })
+  const getRefundsRefundParamSchema = z.object({refund: z.string()})
 
   const getRefundsRefundQuerySchema = z.object({
     expand: z
@@ -61926,7 +61872,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getRefundsRefundResponseValidator(status, body)
@@ -61934,7 +61880,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postRefundsRefundParamSchema = z.object({ refund: z.string() })
+  const postRefundsRefundParamSchema = z.object({refund: z.string()})
 
   const postRefundsRefundBodySchema = z
     .object({
@@ -61987,7 +61933,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postRefundsRefundResponseValidator(status, body)
@@ -61995,10 +61941,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postRefundsRefundCancelParamSchema = z.object({ refund: z.string() })
+  const postRefundsRefundCancelParamSchema = z.object({refund: z.string()})
 
   const postRefundsRefundCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postRefundsRefundCancelResponseValidator = responseValidationFactory(
@@ -62048,7 +61994,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postRefundsRefundCancelResponseValidator(status, body)
@@ -62147,7 +62093,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getReportingReportRunsResponseValidator(status, body)
@@ -62857,7 +62803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postReportingReportRunsResponseValidator(status, body)
@@ -62930,7 +62876,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getReportingReportRunsReportRunResponseValidator(status, body)
@@ -63012,7 +62958,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getReportingReportTypesResponseValidator(status, body)
@@ -63085,7 +63031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getReportingReportTypesReportTypeResponseValidator(
@@ -63181,7 +63127,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getReviewsResponseValidator(status, body)
@@ -63189,7 +63135,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getReviewsReviewParamSchema = z.object({ review: z.string().max(5000) })
+  const getReviewsReviewParamSchema = z.object({review: z.string().max(5000)})
 
   const getReviewsReviewQuerySchema = z.object({
     expand: z
@@ -63250,7 +63196,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getReviewsReviewResponseValidator(status, body)
@@ -63263,7 +63209,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postReviewsReviewApproveBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postReviewsReviewApproveResponseValidator = responseValidationFactory(
@@ -63313,7 +63259,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postReviewsReviewApproveResponseValidator(status, body)
@@ -63407,7 +63353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getSetupAttemptsResponseValidator(status, body)
@@ -63502,7 +63448,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getSetupIntentsResponseValidator(status, body)
@@ -63600,7 +63546,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -63715,7 +63661,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -63769,14 +63715,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -64034,7 +63980,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().max(5000).optional() })
+            .object({billing_agreement_id: z.string().max(5000).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -64075,7 +64021,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -64094,7 +64040,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       payment_method_types: z.array(z.string().max(5000)).optional(),
       return_url: z.string().optional(),
       single_use: z
-        .object({ amount: z.coerce.number(), currency: z.string() })
+        .object({amount: z.coerce.number(), currency: z.string()})
         .optional(),
       usage: z.enum(["off_session", "on_session"]).optional(),
       use_stripe_sdk: PermissiveBoolean.optional(),
@@ -64141,7 +64087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postSetupIntentsResponseValidator(status, body)
@@ -64216,7 +64162,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSetupIntentsIntentResponseValidator(status, body)
@@ -64292,7 +64238,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -64407,7 +64353,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -64461,14 +64407,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -64726,7 +64672,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().max(5000).optional() })
+            .object({billing_agreement_id: z.string().max(5000).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -64767,7 +64713,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -64834,7 +64780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSetupIntentsIntentResponseValidator(status, body)
@@ -64901,7 +64847,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSetupIntentsIntentCancelResponseValidator(status, body)
@@ -65000,7 +64946,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -65115,7 +65061,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -65169,14 +65115,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -65434,7 +65380,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
           link: z.object({}).optional(),
           paypal: z
-            .object({ billing_agreement_id: z.string().max(5000).optional() })
+            .object({billing_agreement_id: z.string().max(5000).optional()})
             .optional(),
           sepa_debit: z
             .object({
@@ -65475,7 +65421,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                 })
                 .optional(),
               mandate_options: z
-                .object({ collection_method: z.enum(["", "paper"]).optional() })
+                .object({collection_method: z.enum(["", "paper"]).optional()})
                 .optional(),
               networks: z
                 .object({
@@ -65541,7 +65487,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSetupIntentsIntentConfirmResponseValidator(status, body)
@@ -65608,7 +65554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSetupIntentsIntentVerifyMicrodepositsResponseValidator(
@@ -65706,7 +65652,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getShippingRatesResponseValidator(status, body)
@@ -65795,7 +65741,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postShippingRatesResponseValidator(status, body)
@@ -65867,7 +65813,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getShippingRatesShippingRateTokenResponseValidator(
@@ -65953,7 +65899,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postShippingRatesShippingRateTokenResponseValidator(
@@ -66024,7 +65970,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSigmaSavedQueriesIdResponseValidator(status, body)
@@ -66112,7 +66058,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSigmaScheduledQueryRunsResponseValidator(status, body)
@@ -66192,7 +66138,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSigmaScheduledQueryRunsScheduledQueryRunResponseValidator(
@@ -66219,7 +66165,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              offline: z.object({ contact_email: z.string() }).optional(),
+              offline: z.object({contact_email: z.string()}).optional(),
               online: z
                 .object({
                   date: z.coerce.number().optional(),
@@ -66272,7 +66218,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      redirect: z.object({ return_url: z.string() }).optional(),
+      redirect: z.object({return_url: z.string()}).optional(),
       source_order: z
         .object({
           items: z
@@ -66352,7 +66298,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postSourcesResponseValidator(status, body)
@@ -66360,7 +66306,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getSourcesSourceParamSchema = z.object({ source: z.string().max(5000) })
+  const getSourcesSourceParamSchema = z.object({source: z.string().max(5000)})
 
   const getSourcesSourceQuerySchema = z.object({
     client_secret: z.string().max(5000).optional(),
@@ -66422,7 +66368,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getSourcesSourceResponseValidator(status, body)
@@ -66430,9 +66376,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postSourcesSourceParamSchema = z.object({
-    source: z.string().max(5000),
-  })
+  const postSourcesSourceParamSchema = z.object({source: z.string().max(5000)})
 
   const postSourcesSourceBodySchema = z
     .object({
@@ -66444,7 +66388,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .object({
               date: z.coerce.number().optional(),
               ip: z.string().optional(),
-              offline: z.object({ contact_email: z.string() }).optional(),
+              offline: z.object({contact_email: z.string()}).optional(),
               online: z
                 .object({
                   date: z.coerce.number().optional(),
@@ -66568,7 +66512,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postSourcesSourceResponseValidator(status, body)
@@ -66650,7 +66594,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -66748,7 +66692,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSourcesSourceSourceTransactionsResponseValidator(
@@ -66834,7 +66778,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -66903,7 +66847,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSourcesSourceVerifyResponseValidator(status, body)
@@ -66992,7 +66936,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSubscriptionItemsResponseValidator(status, body)
@@ -67003,7 +66947,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
 
   const postSubscriptionItemsBodySchema = z.object({
     billing_thresholds: z
-      .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+      .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
       .optional(),
     discounts: z
       .union([
@@ -67097,7 +67041,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionItemsResponseValidator(status, body)
@@ -67165,7 +67109,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteSubscriptionItemsItemResponseValidator(status, body)
@@ -67240,7 +67184,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSubscriptionItemsItemResponseValidator(status, body)
@@ -67256,7 +67200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postSubscriptionItemsItemBodySchema = z
     .object({
       billing_thresholds: z
-        .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+        .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
         .optional(),
       discounts: z
         .union([
@@ -67355,7 +67299,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionItemsItemResponseValidator(status, body)
@@ -67489,7 +67433,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSubscriptionSchedulesResponseValidator(status, body)
@@ -67501,7 +67445,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postSubscriptionSchedulesBodySchema = z
     .object({
       billing_mode: z
-        .object({ type: z.enum(["classic", "flexible"]) })
+        .object({type: z.enum(["classic", "flexible"])})
         .optional(),
       customer: z.string().max(5000).optional(),
       default_settings: z
@@ -67663,7 +67607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               z.object({
                 billing_thresholds: z
                   .union([
-                    z.object({ usage_gte: z.coerce.number() }),
+                    z.object({usage_gte: z.coerce.number()}),
                     z.enum([""]),
                   ])
                   .optional(),
@@ -67766,7 +67710,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionSchedulesResponseValidator(status, body)
@@ -67839,7 +67783,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSubscriptionSchedulesScheduleResponseValidator(status, body)
@@ -68011,7 +67955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
               z.object({
                 billing_thresholds: z
                   .union([
-                    z.object({ usage_gte: z.coerce.number() }),
+                    z.object({usage_gte: z.coerce.number()}),
                     z.enum([""]),
                   ])
                   .optional(),
@@ -68121,7 +68065,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionSchedulesScheduleResponseValidator(
@@ -68190,7 +68134,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionSchedulesScheduleCancelResponseValidator(
@@ -68258,7 +68202,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionSchedulesScheduleReleaseResponseValidator(
@@ -68271,7 +68215,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getSubscriptionsQuerySchema = z.object({
-    automatic_tax: z.object({ enabled: PermissiveBoolean }).optional(),
+    automatic_tax: z.object({enabled: PermissiveBoolean}).optional(),
     collection_method: z
       .enum(["charge_automatically", "send_invoice"])
       .optional(),
@@ -68397,7 +68341,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getSubscriptionsResponseValidator(status, body)
@@ -68462,9 +68406,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         second: z.coerce.number().optional(),
       })
       .optional(),
-    billing_mode: z
-      .object({ type: z.enum(["classic", "flexible"]) })
-      .optional(),
+    billing_mode: z.object({type: z.enum(["classic", "flexible"])}).optional(),
     billing_thresholds: z
       .union([
         z.object({
@@ -68518,7 +68460,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .array(
         z.object({
           billing_thresholds: z
-            .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+            .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
             .optional(),
           discounts: z
             .union([
@@ -68638,7 +68580,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                   bank_transfer: z
                     .object({
                       eu_bank_transfer: z
-                        .object({ country: z.string().max(5000) })
+                        .object({country: z.string().max(5000)})
                         .optional(),
                       type: z.string().optional(),
                     })
@@ -68811,7 +68753,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postSubscriptionsResponseValidator(status, body)
@@ -68899,7 +68841,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSubscriptionsSearchResponseValidator(status, body)
@@ -68983,7 +68925,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteSubscriptionsSubscriptionExposedIdResponseValidator(
@@ -69061,7 +69003,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getSubscriptionsSubscriptionExposedIdResponseValidator(
@@ -69194,7 +69136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         .array(
           z.object({
             billing_thresholds: z
-              .union([z.object({ usage_gte: z.coerce.number() }), z.enum([""])])
+              .union([z.object({usage_gte: z.coerce.number()}), z.enum([""])])
               .optional(),
             clear_usage: PermissiveBoolean.optional(),
             deleted: PermissiveBoolean.optional(),
@@ -69326,7 +69268,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
                     bank_transfer: z
                       .object({
                         eu_bank_transfer: z
-                          .object({ country: z.string().max(5000) })
+                          .object({country: z.string().max(5000)})
                           .optional(),
                         type: z.string().optional(),
                       })
@@ -69512,7 +69454,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionsSubscriptionExposedIdResponseValidator(
@@ -69582,7 +69524,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -69600,7 +69542,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postSubscriptionsSubscriptionMigrateBodySchema = z.object({
-    billing_mode: z.object({ type: z.enum(["flexible"]) }),
+    billing_mode: z.object({type: z.enum(["flexible"])}),
     expand: z.array(z.string().max(5000)).optional(),
   })
 
@@ -69649,7 +69591,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionsSubscriptionMigrateResponseValidator(
@@ -69721,7 +69663,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postSubscriptionsSubscriptionResumeResponseValidator(
@@ -69954,7 +69896,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTaxCalculationsResponseValidator(status, body)
@@ -70027,7 +69969,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxCalculationsCalculationResponseValidator(status, body)
@@ -70126,7 +70068,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxCalculationsCalculationLineItemsResponseValidator(
@@ -70215,7 +70157,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxRegistrationsResponseValidator(status, body)
@@ -70228,10 +70170,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
     active_from: z.union([z.enum(["now"]), z.coerce.number()]),
     country: z.string().max(5000),
     country_options: z.object({
-      ae: z.object({ type: z.enum(["standard"]) }).optional(),
-      al: z.object({ type: z.enum(["standard"]) }).optional(),
-      am: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ao: z.object({ type: z.enum(["standard"]) }).optional(),
+      ae: z.object({type: z.enum(["standard"])}).optional(),
+      al: z.object({type: z.enum(["standard"])}).optional(),
+      am: z.object({type: z.enum(["simplified"])}).optional(),
+      ao: z.object({type: z.enum(["standard"])}).optional(),
       at: z
         .object({
           standard: z
@@ -70242,12 +70184,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      au: z.object({ type: z.enum(["standard"]) }).optional(),
-      aw: z.object({ type: z.enum(["standard"]) }).optional(),
-      az: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ba: z.object({ type: z.enum(["standard"]) }).optional(),
-      bb: z.object({ type: z.enum(["standard"]) }).optional(),
-      bd: z.object({ type: z.enum(["standard"]) }).optional(),
+      au: z.object({type: z.enum(["standard"])}).optional(),
+      aw: z.object({type: z.enum(["standard"])}).optional(),
+      az: z.object({type: z.enum(["simplified"])}).optional(),
+      ba: z.object({type: z.enum(["standard"])}).optional(),
+      bb: z.object({type: z.enum(["standard"])}).optional(),
+      bd: z.object({type: z.enum(["standard"])}).optional(),
       be: z
         .object({
           standard: z
@@ -70258,7 +70200,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      bf: z.object({ type: z.enum(["standard"]) }).optional(),
+      bf: z.object({type: z.enum(["standard"])}).optional(),
       bg: z
         .object({
           standard: z
@@ -70269,25 +70211,25 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      bh: z.object({ type: z.enum(["standard"]) }).optional(),
-      bj: z.object({ type: z.enum(["simplified"]) }).optional(),
-      bs: z.object({ type: z.enum(["standard"]) }).optional(),
-      by: z.object({ type: z.enum(["simplified"]) }).optional(),
+      bh: z.object({type: z.enum(["standard"])}).optional(),
+      bj: z.object({type: z.enum(["simplified"])}).optional(),
+      bs: z.object({type: z.enum(["standard"])}).optional(),
+      by: z.object({type: z.enum(["simplified"])}).optional(),
       ca: z
         .object({
           province_standard: z
-            .object({ province: z.string().max(5000) })
+            .object({province: z.string().max(5000)})
             .optional(),
           type: z.enum(["province_standard", "simplified", "standard"]),
         })
         .optional(),
-      cd: z.object({ type: z.enum(["standard"]) }).optional(),
-      ch: z.object({ type: z.enum(["standard"]) }).optional(),
-      cl: z.object({ type: z.enum(["simplified"]) }).optional(),
-      cm: z.object({ type: z.enum(["simplified"]) }).optional(),
-      co: z.object({ type: z.enum(["simplified"]) }).optional(),
-      cr: z.object({ type: z.enum(["simplified"]) }).optional(),
-      cv: z.object({ type: z.enum(["simplified"]) }).optional(),
+      cd: z.object({type: z.enum(["standard"])}).optional(),
+      ch: z.object({type: z.enum(["standard"])}).optional(),
+      cl: z.object({type: z.enum(["simplified"])}).optional(),
+      cm: z.object({type: z.enum(["simplified"])}).optional(),
+      co: z.object({type: z.enum(["simplified"])}).optional(),
+      cr: z.object({type: z.enum(["simplified"])}).optional(),
+      cv: z.object({type: z.enum(["simplified"])}).optional(),
       cy: z
         .object({
           standard: z
@@ -70328,7 +70270,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      ec: z.object({ type: z.enum(["simplified"]) }).optional(),
+      ec: z.object({type: z.enum(["simplified"])}).optional(),
       ee: z
         .object({
           standard: z
@@ -70339,7 +70281,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      eg: z.object({ type: z.enum(["simplified"]) }).optional(),
+      eg: z.object({type: z.enum(["simplified"])}).optional(),
       es: z
         .object({
           standard: z
@@ -70350,7 +70292,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      et: z.object({ type: z.enum(["standard"]) }).optional(),
+      et: z.object({type: z.enum(["standard"])}).optional(),
       fi: z
         .object({
           standard: z
@@ -70371,9 +70313,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      gb: z.object({ type: z.enum(["standard"]) }).optional(),
-      ge: z.object({ type: z.enum(["simplified"]) }).optional(),
-      gn: z.object({ type: z.enum(["standard"]) }).optional(),
+      gb: z.object({type: z.enum(["standard"])}).optional(),
+      ge: z.object({type: z.enum(["simplified"])}).optional(),
+      gn: z.object({type: z.enum(["standard"])}).optional(),
       gr: z
         .object({
           standard: z
@@ -70404,7 +70346,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      id: z.object({ type: z.enum(["simplified"]) }).optional(),
+      id: z.object({type: z.enum(["simplified"])}).optional(),
       ie: z
         .object({
           standard: z
@@ -70415,8 +70357,8 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      in: z.object({ type: z.enum(["simplified"]) }).optional(),
-      is: z.object({ type: z.enum(["standard"]) }).optional(),
+      in: z.object({type: z.enum(["simplified"])}).optional(),
+      is: z.object({type: z.enum(["standard"])}).optional(),
       it: z
         .object({
           standard: z
@@ -70427,13 +70369,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      jp: z.object({ type: z.enum(["standard"]) }).optional(),
-      ke: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kg: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kh: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kr: z.object({ type: z.enum(["simplified"]) }).optional(),
-      kz: z.object({ type: z.enum(["simplified"]) }).optional(),
-      la: z.object({ type: z.enum(["simplified"]) }).optional(),
+      jp: z.object({type: z.enum(["standard"])}).optional(),
+      ke: z.object({type: z.enum(["simplified"])}).optional(),
+      kg: z.object({type: z.enum(["simplified"])}).optional(),
+      kh: z.object({type: z.enum(["simplified"])}).optional(),
+      kr: z.object({type: z.enum(["simplified"])}).optional(),
+      kz: z.object({type: z.enum(["simplified"])}).optional(),
+      la: z.object({type: z.enum(["simplified"])}).optional(),
       lt: z
         .object({
           standard: z
@@ -70464,11 +70406,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      ma: z.object({ type: z.enum(["simplified"]) }).optional(),
-      md: z.object({ type: z.enum(["simplified"]) }).optional(),
-      me: z.object({ type: z.enum(["standard"]) }).optional(),
-      mk: z.object({ type: z.enum(["standard"]) }).optional(),
-      mr: z.object({ type: z.enum(["standard"]) }).optional(),
+      ma: z.object({type: z.enum(["simplified"])}).optional(),
+      md: z.object({type: z.enum(["simplified"])}).optional(),
+      me: z.object({type: z.enum(["standard"])}).optional(),
+      mk: z.object({type: z.enum(["standard"])}).optional(),
+      mr: z.object({type: z.enum(["standard"])}).optional(),
       mt: z
         .object({
           standard: z
@@ -70479,9 +70421,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      mx: z.object({ type: z.enum(["simplified"]) }).optional(),
-      my: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ng: z.object({ type: z.enum(["simplified"]) }).optional(),
+      mx: z.object({type: z.enum(["simplified"])}).optional(),
+      my: z.object({type: z.enum(["simplified"])}).optional(),
+      ng: z.object({type: z.enum(["simplified"])}).optional(),
       nl: z
         .object({
           standard: z
@@ -70492,12 +70434,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      no: z.object({ type: z.enum(["standard"]) }).optional(),
-      np: z.object({ type: z.enum(["simplified"]) }).optional(),
-      nz: z.object({ type: z.enum(["standard"]) }).optional(),
-      om: z.object({ type: z.enum(["standard"]) }).optional(),
-      pe: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ph: z.object({ type: z.enum(["simplified"]) }).optional(),
+      no: z.object({type: z.enum(["standard"])}).optional(),
+      np: z.object({type: z.enum(["simplified"])}).optional(),
+      nz: z.object({type: z.enum(["standard"])}).optional(),
+      om: z.object({type: z.enum(["standard"])}).optional(),
+      pe: z.object({type: z.enum(["simplified"])}).optional(),
+      ph: z.object({type: z.enum(["simplified"])}).optional(),
       pl: z
         .object({
           standard: z
@@ -70528,9 +70470,9 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      rs: z.object({ type: z.enum(["standard"]) }).optional(),
-      ru: z.object({ type: z.enum(["simplified"]) }).optional(),
-      sa: z.object({ type: z.enum(["simplified"]) }).optional(),
+      rs: z.object({type: z.enum(["standard"])}).optional(),
+      ru: z.object({type: z.enum(["simplified"])}).optional(),
+      sa: z.object({type: z.enum(["simplified"])}).optional(),
       se: z
         .object({
           standard: z
@@ -70541,7 +70483,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      sg: z.object({ type: z.enum(["standard"]) }).optional(),
+      sg: z.object({type: z.enum(["standard"])}).optional(),
       si: z
         .object({
           standard: z
@@ -70562,21 +70504,21 @@ export function createRouter(implementation: Implementation): KoaRouter {
           type: z.enum(["ioss", "oss_non_union", "oss_union", "standard"]),
         })
         .optional(),
-      sn: z.object({ type: z.enum(["simplified"]) }).optional(),
-      sr: z.object({ type: z.enum(["standard"]) }).optional(),
-      th: z.object({ type: z.enum(["simplified"]) }).optional(),
-      tj: z.object({ type: z.enum(["simplified"]) }).optional(),
-      tr: z.object({ type: z.enum(["simplified"]) }).optional(),
-      tz: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ua: z.object({ type: z.enum(["simplified"]) }).optional(),
-      ug: z.object({ type: z.enum(["simplified"]) }).optional(),
+      sn: z.object({type: z.enum(["simplified"])}).optional(),
+      sr: z.object({type: z.enum(["standard"])}).optional(),
+      th: z.object({type: z.enum(["simplified"])}).optional(),
+      tj: z.object({type: z.enum(["simplified"])}).optional(),
+      tr: z.object({type: z.enum(["simplified"])}).optional(),
+      tz: z.object({type: z.enum(["simplified"])}).optional(),
+      ua: z.object({type: z.enum(["simplified"])}).optional(),
+      ug: z.object({type: z.enum(["simplified"])}).optional(),
       us: z
         .object({
           local_amusement_tax: z
-            .object({ jurisdiction: z.string().max(5000) })
+            .object({jurisdiction: z.string().max(5000)})
             .optional(),
           local_lease_tax: z
-            .object({ jurisdiction: z.string().max(5000) })
+            .object({jurisdiction: z.string().max(5000)})
             .optional(),
           state: z.string().max(5000),
           state_sales_tax: z
@@ -70602,12 +70544,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
           ]),
         })
         .optional(),
-      uy: z.object({ type: z.enum(["standard"]) }).optional(),
-      uz: z.object({ type: z.enum(["simplified"]) }).optional(),
-      vn: z.object({ type: z.enum(["simplified"]) }).optional(),
-      za: z.object({ type: z.enum(["standard"]) }).optional(),
-      zm: z.object({ type: z.enum(["simplified"]) }).optional(),
-      zw: z.object({ type: z.enum(["standard"]) }).optional(),
+      uy: z.object({type: z.enum(["standard"])}).optional(),
+      uz: z.object({type: z.enum(["simplified"])}).optional(),
+      vn: z.object({type: z.enum(["simplified"])}).optional(),
+      za: z.object({type: z.enum(["standard"])}).optional(),
+      zm: z.object({type: z.enum(["simplified"])}).optional(),
+      zw: z.object({type: z.enum(["standard"])}).optional(),
     }),
     expand: z.array(z.string().max(5000)).optional(),
     expires_at: z.coerce.number().optional(),
@@ -70656,7 +70598,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTaxRegistrationsResponseValidator(status, body)
@@ -70665,9 +70607,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const getTaxRegistrationsIdParamSchema = z.object({
-    id: z.string().max(5000),
-  })
+  const getTaxRegistrationsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getTaxRegistrationsIdQuerySchema = z.object({
     expand: z
@@ -70731,7 +70671,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxRegistrationsIdResponseValidator(status, body)
@@ -70740,9 +70680,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     },
   )
 
-  const postTaxRegistrationsIdParamSchema = z.object({
-    id: z.string().max(5000),
-  })
+  const postTaxRegistrationsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const postTaxRegistrationsIdBodySchema = z
     .object({
@@ -70801,7 +70739,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTaxRegistrationsIdResponseValidator(status, body)
@@ -70865,7 +70803,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTaxSettingsResponseValidator(status, body)
@@ -70939,7 +70877,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTaxSettingsResponseValidator(status, body)
@@ -70996,7 +70934,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTaxTransactionsCreateFromCalculationResponseValidator(
@@ -71028,7 +70966,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     original_transaction: z.string().max(5000),
     reference: z.string().max(500),
     shipping_cost: z
-      .object({ amount: z.coerce.number(), amount_tax: z.coerce.number() })
+      .object({amount: z.coerce.number(), amount_tax: z.coerce.number()})
       .optional(),
   })
 
@@ -71073,7 +71011,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTaxTransactionsCreateReversalResponseValidator(
@@ -71149,7 +71087,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxTransactionsTransactionResponseValidator(status, body)
@@ -71248,7 +71186,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxTransactionsTransactionLineItemsResponseValidator(
@@ -71333,7 +71271,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTaxCodesResponseValidator(status, body)
@@ -71341,7 +71279,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTaxCodesIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getTaxCodesIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getTaxCodesIdQuerySchema = z.object({
     expand: z
@@ -71402,7 +71340,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTaxCodesIdResponseValidator(status, body)
@@ -71490,7 +71428,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTaxIdsResponseValidator(status, body)
@@ -71662,7 +71600,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTaxIdsResponseValidator(status, body)
@@ -71670,7 +71608,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteTaxIdsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const deleteTaxIdsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const deleteTaxIdsIdBodySchema = z.object({}).optional()
 
@@ -71718,7 +71656,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = deleteTaxIdsIdResponseValidator(status, body)
@@ -71726,7 +71664,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTaxIdsIdParamSchema = z.object({ id: z.string().max(5000) })
+  const getTaxIdsIdParamSchema = z.object({id: z.string().max(5000)})
 
   const getTaxIdsIdQuerySchema = z.object({
     expand: z
@@ -71787,7 +71725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTaxIdsIdResponseValidator(status, body)
@@ -71881,7 +71819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTaxRatesResponseValidator(status, body)
@@ -71960,7 +71898,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTaxRatesResponseValidator(status, body)
@@ -72034,7 +71972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTaxRatesTaxRateResponseValidator(status, body)
@@ -72125,7 +72063,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTaxRatesTaxRateResponseValidator(status, body)
@@ -72214,7 +72152,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTerminalConfigurationsResponseValidator(status, body)
@@ -72226,22 +72164,18 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTerminalConfigurationsBodySchema = z
     .object({
       bbpos_wisepos_e: z
-        .object({
-          splashscreen: z.union([z.string(), z.enum([""])]).optional(),
-        })
+        .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       name: z.string().max(100).optional(),
       offline: z
-        .union([z.object({ enabled: PermissiveBoolean }), z.enum([""])])
+        .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
         .optional(),
       reboot_window: z
-        .object({ end_hour: z.coerce.number(), start_hour: z.coerce.number() })
+        .object({end_hour: z.coerce.number(), start_hour: z.coerce.number()})
         .optional(),
       stripe_s700: z
-        .object({
-          splashscreen: z.union([z.string(), z.enum([""])]).optional(),
-        })
+        .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
         .optional(),
       tipping: z
         .union([
@@ -72363,9 +72297,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       verifone_p400: z
-        .object({
-          splashscreen: z.union([z.string(), z.enum([""])]).optional(),
-        })
+        .object({splashscreen: z.union([z.string(), z.enum([""])]).optional()})
         .optional(),
       wifi: z
         .union([
@@ -72448,7 +72380,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalConfigurationsResponseValidator(status, body)
@@ -72513,7 +72445,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteTerminalConfigurationsConfigurationResponseValidator(
@@ -72604,7 +72536,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTerminalConfigurationsConfigurationResponseValidator(
@@ -72633,7 +72565,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       name: z.string().max(100).optional(),
       offline: z
-        .union([z.object({ enabled: PermissiveBoolean }), z.enum([""])])
+        .union([z.object({enabled: PermissiveBoolean}), z.enum([""])])
         .optional(),
       reboot_window: z
         .union([
@@ -72875,7 +72807,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalConfigurationsConfigurationResponseValidator(
@@ -72935,7 +72867,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalConnectionTokensResponseValidator(status, body)
@@ -73023,7 +72955,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTerminalLocationsResponseValidator(status, body)
@@ -73090,7 +73022,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalLocationsResponseValidator(status, body)
@@ -73150,7 +73082,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteTerminalLocationsLocationResponseValidator(status, body)
@@ -73228,7 +73160,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTerminalLocationsLocationResponseValidator(status, body)
@@ -73312,7 +73244,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalLocationsLocationResponseValidator(status, body)
@@ -73413,7 +73345,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTerminalReadersResponseValidator(status, body)
@@ -73473,7 +73405,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersResponseValidator(status, body)
@@ -73533,7 +73465,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteTerminalReadersReaderResponseValidator(status, body)
@@ -73615,7 +73547,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTerminalReadersReaderResponseValidator(status, body)
@@ -73690,7 +73622,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderResponseValidator(status, body)
@@ -73704,7 +73636,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTerminalReadersReaderCancelActionBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTerminalReadersReaderCancelActionResponseValidator =
@@ -73752,7 +73684,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderCancelActionResponseValidator(
@@ -73857,7 +73789,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderCollectInputsResponseValidator(
@@ -73882,7 +73814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         enable_customer_cancellation: PermissiveBoolean.optional(),
         skip_tipping: PermissiveBoolean.optional(),
         tipping: z
-          .object({ amount_eligible: z.coerce.number().optional() })
+          .object({amount_eligible: z.coerce.number().optional()})
           .optional(),
       })
       .optional(),
@@ -73940,7 +73872,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderCollectPaymentMethodResponseValidator(
@@ -73957,7 +73889,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTerminalReadersReaderConfirmPaymentIntentBodySchema = z.object({
-    confirm_config: z.object({ return_url: z.string().optional() }).optional(),
+    confirm_config: z.object({return_url: z.string().optional()}).optional(),
     expand: z.array(z.string().max(5000)).optional(),
     payment_intent: z.string().max(5000),
   })
@@ -74012,7 +73944,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderConfirmPaymentIntentResponseValidator(
@@ -74040,7 +73972,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return_url: z.string().optional(),
         skip_tipping: PermissiveBoolean.optional(),
         tipping: z
-          .object({ amount_eligible: z.coerce.number().optional() })
+          .object({amount_eligible: z.coerce.number().optional()})
           .optional(),
       })
       .optional(),
@@ -74096,7 +74028,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderProcessPaymentIntentResponseValidator(
@@ -74116,7 +74048,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     allow_redisplay: z.enum(["always", "limited", "unspecified"]),
     expand: z.array(z.string().max(5000)).optional(),
     process_config: z
-      .object({ enable_customer_cancellation: PermissiveBoolean.optional() })
+      .object({enable_customer_cancellation: PermissiveBoolean.optional()})
       .optional(),
     setup_intent: z.string().max(5000),
   })
@@ -74171,7 +74103,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderProcessSetupIntentResponseValidator(
@@ -74196,7 +74128,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       payment_intent: z.string().max(5000).optional(),
       refund_application_fee: PermissiveBoolean.optional(),
       refund_payment_config: z
-        .object({ enable_customer_cancellation: PermissiveBoolean.optional() })
+        .object({enable_customer_cancellation: PermissiveBoolean.optional()})
         .optional(),
       reverse_transfer: PermissiveBoolean.optional(),
     })
@@ -74247,7 +74179,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderRefundPaymentResponseValidator(
@@ -74327,7 +74259,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTerminalReadersReaderSetReaderDisplayResponseValidator(
@@ -74396,7 +74328,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             })
             .optional(),
           blik: z.object({}).optional(),
-          boleto: z.object({ tax_id: z.string().max(5000) }).optional(),
+          boleto: z.object({tax_id: z.string().max(5000)}).optional(),
           cashapp: z.object({}).optional(),
           crypto: z.object({}).optional(),
           customer_balance: z.object({}).optional(),
@@ -74511,7 +74443,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
           mobilepay: z.object({}).optional(),
           multibanco: z.object({}).optional(),
           naver_pay: z
-            .object({ funding: z.enum(["card", "points"]).optional() })
+            .object({funding: z.enum(["card", "points"]).optional()})
             .optional(),
           nz_bank_account: z
             .object({
@@ -74565,14 +74497,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
           pix: z.object({}).optional(),
           promptpay: z.object({}).optional(),
           radar_options: z
-            .object({ session: z.string().max(5000).optional() })
+            .object({session: z.string().max(5000).optional()})
             .optional(),
           revolut_pay: z.object({}).optional(),
           samsung_pay: z.object({}).optional(),
           satispay: z.object({}).optional(),
-          sepa_debit: z.object({ iban: z.string().max(5000) }).optional(),
+          sepa_debit: z.object({iban: z.string().max(5000)}).optional(),
           sofort: z
-            .object({ country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"]) })
+            .object({country: z.enum(["AT", "BE", "DE", "ES", "IT", "NL"])})
             .optional(),
           swish: z.object({}).optional(),
           twint: z.object({}).optional(),
@@ -74715,7 +74647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersConfirmationTokensResponseValidator(
@@ -74793,7 +74725,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -74841,10 +74773,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
         reported_breakdown: z
           .object({
             fuel: z
-              .object({ gross_amount_decimal: z.string().optional() })
+              .object({gross_amount_decimal: z.string().optional()})
               .optional(),
             non_fuel: z
-              .object({ gross_amount_decimal: z.string().optional() })
+              .object({gross_amount_decimal: z.string().optional()})
               .optional(),
             tax: z
               .object({
@@ -75201,7 +75133,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       })
       .optional(),
     network_data: z
-      .object({ acquiring_institution_id: z.string().max(5000).optional() })
+      .object({acquiring_institution_id: z.string().max(5000).optional()})
       .optional(),
     verification_data: z
       .object({
@@ -75279,7 +75211,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersIssuingAuthorizationsResponseValidator(
@@ -75292,7 +75224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationCaptureBodySchema = z
     .object({
@@ -75322,10 +75254,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
               reported_breakdown: z
                 .object({
                   fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   non_fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   tax: z
                     .object({
@@ -75460,7 +75392,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75474,10 +75406,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingAuthorizationsAuthorizationExpireResponseValidator =
@@ -75530,7 +75462,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75544,7 +75476,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmountBodySchema =
     z.object({
@@ -75571,10 +75503,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
           reported_breakdown: z
             .object({
               fuel: z
-                .object({ gross_amount_decimal: z.string().optional() })
+                .object({gross_amount_decimal: z.string().optional()})
                 .optional(),
               non_fuel: z
-                .object({ gross_amount_decimal: z.string().optional() })
+                .object({gross_amount_decimal: z.string().optional()})
                 .optional(),
               tax: z
                 .object({
@@ -75669,7 +75601,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75683,7 +75615,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespondParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespondBodySchema =
     z.object({
@@ -75741,7 +75673,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75755,7 +75687,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationIncrementBodySchema =
     z.object({
@@ -75814,7 +75746,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75828,7 +75760,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingAuthorizationsAuthorizationReverseParamSchema =
-    z.object({ authorization: z.string().max(5000) })
+    z.object({authorization: z.string().max(5000)})
 
   const postTestHelpersIssuingAuthorizationsAuthorizationReverseBodySchema = z
     .object({
@@ -75887,7 +75819,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75905,7 +75837,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersIssuingCardsCardShippingDeliverBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingDeliverResponseValidator =
@@ -75958,7 +75890,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -75976,7 +75908,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersIssuingCardsCardShippingFailBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingFailResponseValidator =
@@ -76029,7 +75961,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersIssuingCardsCardShippingFailResponseValidator(
@@ -76046,7 +75978,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersIssuingCardsCardShippingReturnBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingReturnResponseValidator =
@@ -76099,7 +76031,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersIssuingCardsCardShippingReturnResponseValidator(
@@ -76116,7 +76048,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersIssuingCardsCardShippingShipBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingShipResponseValidator =
@@ -76169,7 +76101,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersIssuingCardsCardShippingShipResponseValidator(
@@ -76186,7 +76118,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersIssuingCardsCardShippingSubmitBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingCardsCardShippingSubmitResponseValidator =
@@ -76239,7 +76171,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersIssuingCardsCardShippingSubmitResponseValidator(
@@ -76252,10 +76184,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivateResponseValidator =
     responseValidationFactory(
@@ -76310,7 +76242,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -76324,10 +76256,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivateResponseValidator =
     responseValidationFactory(
@@ -76382,7 +76314,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -76396,7 +76328,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectParamSchema =
-    z.object({ personalization_design: z.string().max(5000) })
+    z.object({personalization_design: z.string().max(5000)})
 
   const postTestHelpersIssuingPersonalizationDesignsPersonalizationDesignRejectBodySchema =
     z.object({
@@ -76485,7 +76417,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -76552,7 +76484,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersIssuingSettlementsResponseValidator(
@@ -76565,10 +76497,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingSettlementsSettlementCompleteParamSchema =
-    z.object({ settlement: z.string().max(5000) })
+    z.object({settlement: z.string().max(5000)})
 
   const postTestHelpersIssuingSettlementsSettlementCompleteBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersIssuingSettlementsSettlementCompleteResponseValidator =
@@ -76621,7 +76553,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -76973,10 +76905,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
               reported_breakdown: z
                 .object({
                   fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   non_fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   tax: z
                     .object({
@@ -77106,7 +77038,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -77458,10 +77390,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
               reported_breakdown: z
                 .object({
                   fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   non_fuel: z
-                    .object({ gross_amount_decimal: z.string().optional() })
+                    .object({gross_amount_decimal: z.string().optional()})
                     .optional(),
                   tax: z
                     .object({
@@ -77591,7 +77523,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -77605,7 +77537,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersIssuingTransactionsTransactionRefundParamSchema =
-    z.object({ transaction: z.string().max(5000) })
+    z.object({transaction: z.string().max(5000)})
 
   const postTestHelpersIssuingTransactionsTransactionRefundBodySchema = z
     .object({
@@ -77664,7 +77596,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -77682,7 +77614,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersRefundsRefundExpireBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersRefundsRefundExpireResponseValidator =
@@ -77730,7 +77662,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersRefundsRefundExpireResponseValidator(
@@ -77743,17 +77675,17 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTerminalReadersReaderPresentPaymentMethodParamSchema =
-    z.object({ reader: z.string().max(5000) })
+    z.object({reader: z.string().max(5000)})
 
   const postTestHelpersTerminalReadersReaderPresentPaymentMethodBodySchema = z
     .object({
       amount_tip: z.coerce.number().optional(),
       card_present: z
-        .object({ number: z.string().max(5000).optional() })
+        .object({number: z.string().max(5000).optional()})
         .optional(),
       expand: z.array(z.string().max(5000)).optional(),
       interac_present: z
-        .object({ number: z.string().max(5000).optional() })
+        .object({number: z.string().max(5000).optional()})
         .optional(),
       type: z.enum(["card_present", "interac_present"]).optional(),
     })
@@ -77809,7 +77741,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -77823,7 +77755,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTerminalReadersReaderSucceedInputCollectionParamSchema =
-    z.object({ reader: z.string().max(5000) })
+    z.object({reader: z.string().max(5000)})
 
   const postTestHelpersTerminalReadersReaderSucceedInputCollectionBodySchema = z
     .object({
@@ -77882,7 +77814,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -77896,10 +77828,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTerminalReadersReaderTimeoutInputCollectionParamSchema =
-    z.object({ reader: z.string().max(5000) })
+    z.object({reader: z.string().max(5000)})
 
   const postTestHelpersTerminalReadersReaderTimeoutInputCollectionBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTerminalReadersReaderTimeoutInputCollectionResponseValidator =
@@ -77952,7 +77884,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -78044,7 +77976,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTestHelpersTestClocksResponseValidator(status, body)
@@ -78102,7 +78034,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTestClocksResponseValidator(status, body)
@@ -78165,7 +78097,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteTestHelpersTestClocksTestClockResponseValidator(
@@ -78241,7 +78173,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTestHelpersTestClocksTestClockResponseValidator(
@@ -78307,7 +78239,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTestClocksTestClockAdvanceResponseValidator(
@@ -78400,7 +78332,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTreasuryInboundTransfersIdFailResponseValidator(
@@ -78417,7 +78349,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersTreasuryInboundTransfersIdReturnBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryInboundTransfersIdReturnResponseValidator =
@@ -78470,7 +78402,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -78488,7 +78420,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryInboundTransfersIdSucceedResponseValidator =
@@ -78541,7 +78473,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -78561,7 +78493,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const postTestHelpersTreasuryOutboundPaymentsIdBodySchema = z.object({
     expand: z.array(z.string().max(5000)).optional(),
     tracking_details: z.object({
-      ach: z.object({ trace_id: z.string().max(5000) }).optional(),
+      ach: z.object({trace_id: z.string().max(5000)}).optional(),
       type: z.enum(["ach", "us_domestic_wire"]),
       us_domestic_wire: z
         .object({
@@ -78618,7 +78550,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTreasuryOutboundPaymentsIdResponseValidator(
@@ -78635,7 +78567,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryOutboundPaymentsIdFailResponseValidator =
@@ -78688,7 +78620,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTreasuryOutboundPaymentsIdFailResponseValidator(
@@ -78705,7 +78637,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTestHelpersTreasuryOutboundPaymentsIdPostResponseValidator =
@@ -78758,7 +78690,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTreasuryOutboundPaymentsIdPostResponseValidator(
@@ -78848,7 +78780,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -78862,13 +78794,13 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferBodySchema =
     z.object({
       expand: z.array(z.string().max(5000)).optional(),
       tracking_details: z.object({
-        ach: z.object({ trace_id: z.string().max(5000) }).optional(),
+        ach: z.object({trace_id: z.string().max(5000)}).optional(),
         type: z.enum(["ach", "us_domestic_wire"]),
         us_domestic_wire: z
           .object({
@@ -78930,7 +78862,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -78944,10 +78876,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferFailResponseValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
@@ -78999,7 +78931,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -79013,10 +78945,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostBodySchema =
-    z.object({ expand: z.array(z.string().max(5000)).optional() }).optional()
+    z.object({expand: z.array(z.string().max(5000)).optional()}).optional()
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferPostResponseValidator =
     responseValidationFactory([["200", s_treasury_outbound_transfer]], s_error)
@@ -79068,7 +79000,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -79082,7 +79014,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTestHelpersTreasuryOutboundTransfersOutboundTransferReturnBodySchema =
     z
@@ -79159,7 +79091,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -79234,7 +79166,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTreasuryReceivedCreditsResponseValidator(
@@ -79308,7 +79240,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTestHelpersTreasuryReceivedDebitsResponseValidator(
@@ -79594,7 +79526,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         ])
         .optional(),
       customer: z.string().max(5000).optional(),
-      cvc_update: z.object({ cvc: z.string().max(5000) }).optional(),
+      cvc_update: z.object({cvc: z.string().max(5000)}).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       person: z
         .object({
@@ -79797,7 +79729,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
             .optional(),
         })
         .optional(),
-      pii: z.object({ id_number: z.string().max(5000).optional() }).optional(),
+      pii: z.object({id_number: z.string().max(5000).optional()}).optional(),
     })
     .optional()
 
@@ -79841,7 +79773,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTokensResponseValidator(status, body)
@@ -79849,7 +79781,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTokensTokenParamSchema = z.object({ token: z.string().max(5000) })
+  const getTokensTokenParamSchema = z.object({token: z.string().max(5000)})
 
   const getTokensTokenQuerySchema = z.object({
     expand: z
@@ -79910,7 +79842,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTokensTokenResponseValidator(status, body)
@@ -80014,7 +79946,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTopupsResponseValidator(status, body)
@@ -80073,7 +80005,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTopupsResponseValidator(status, body)
@@ -80081,7 +80013,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTopupsTopupParamSchema = z.object({ topup: z.string().max(5000) })
+  const getTopupsTopupParamSchema = z.object({topup: z.string().max(5000)})
 
   const getTopupsTopupQuerySchema = z.object({
     expand: z
@@ -80142,7 +80074,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTopupsTopupResponseValidator(status, body)
@@ -80150,7 +80082,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const postTopupsTopupParamSchema = z.object({ topup: z.string().max(5000) })
+  const postTopupsTopupParamSchema = z.object({topup: z.string().max(5000)})
 
   const postTopupsTopupBodySchema = z
     .object({
@@ -80204,7 +80136,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTopupsTopupResponseValidator(status, body)
@@ -80217,7 +80149,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTopupsTopupCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTopupsTopupCancelResponseValidator = responseValidationFactory(
@@ -80267,7 +80199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTopupsTopupCancelResponseValidator(status, body)
@@ -80362,7 +80294,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTransfersResponseValidator(status, body)
@@ -80422,7 +80354,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = postTransfersResponseValidator(status, body)
@@ -80514,7 +80446,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTransfersIdReversalsResponseValidator(status, body)
@@ -80584,7 +80516,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTransfersIdReversalsResponseValidator(status, body)
@@ -80659,7 +80591,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTransfersTransferResponseValidator(status, body)
@@ -80727,7 +80659,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTransfersTransferResponseValidator(status, body)
@@ -80801,7 +80733,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTransfersTransferReversalsIdResponseValidator(status, body)
@@ -80867,7 +80799,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTransfersTransferReversalsIdResponseValidator(status, body)
@@ -80955,7 +80887,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryCreditReversalsResponseValidator(status, body)
@@ -81011,7 +80943,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryCreditReversalsResponseValidator(status, body)
@@ -81086,7 +81018,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryCreditReversalsCreditReversalResponseValidator(
@@ -81178,7 +81110,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryDebitReversalsResponseValidator(status, body)
@@ -81236,7 +81168,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryDebitReversalsResponseValidator(status, body)
@@ -81311,7 +81243,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryDebitReversalsDebitReversalResponseValidator(
@@ -81415,7 +81347,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryFinancialAccountsResponseValidator(status, body)
@@ -81428,36 +81360,28 @@ export function createRouter(implementation: Implementation): KoaRouter {
     expand: z.array(z.string().max(5000)).optional(),
     features: z
       .object({
-        card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
-        deposit_insurance: z
-          .object({ requested: PermissiveBoolean })
-          .optional(),
+        card_issuing: z.object({requested: PermissiveBoolean}).optional(),
+        deposit_insurance: z.object({requested: PermissiveBoolean}).optional(),
         financial_addresses: z
-          .object({
-            aba: z.object({ requested: PermissiveBoolean }).optional(),
-          })
+          .object({aba: z.object({requested: PermissiveBoolean}).optional()})
           .optional(),
         inbound_transfers: z
-          .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
-          })
+          .object({ach: z.object({requested: PermissiveBoolean}).optional()})
           .optional(),
-        intra_stripe_flows: z
-          .object({ requested: PermissiveBoolean })
-          .optional(),
+        intra_stripe_flows: z.object({requested: PermissiveBoolean}).optional(),
         outbound_payments: z
           .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
+            ach: z.object({requested: PermissiveBoolean}).optional(),
             us_domestic_wire: z
-              .object({ requested: PermissiveBoolean })
+              .object({requested: PermissiveBoolean})
               .optional(),
           })
           .optional(),
         outbound_transfers: z
           .object({
-            ach: z.object({ requested: PermissiveBoolean }).optional(),
+            ach: z.object({requested: PermissiveBoolean}).optional(),
             us_domestic_wire: z
-              .object({ requested: PermissiveBoolean })
+              .object({requested: PermissiveBoolean})
               .optional(),
           })
           .optional(),
@@ -81515,7 +81439,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryFinancialAccountsResponseValidator(status, body)
@@ -81595,7 +81519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryFinancialAccountsFinancialAccountResponseValidator(
@@ -81616,36 +81540,32 @@ export function createRouter(implementation: Implementation): KoaRouter {
       expand: z.array(z.string().max(5000)).optional(),
       features: z
         .object({
-          card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
+          card_issuing: z.object({requested: PermissiveBoolean}).optional(),
           deposit_insurance: z
-            .object({ requested: PermissiveBoolean })
+            .object({requested: PermissiveBoolean})
             .optional(),
           financial_addresses: z
-            .object({
-              aba: z.object({ requested: PermissiveBoolean }).optional(),
-            })
+            .object({aba: z.object({requested: PermissiveBoolean}).optional()})
             .optional(),
           inbound_transfers: z
-            .object({
-              ach: z.object({ requested: PermissiveBoolean }).optional(),
-            })
+            .object({ach: z.object({requested: PermissiveBoolean}).optional()})
             .optional(),
           intra_stripe_flows: z
-            .object({ requested: PermissiveBoolean })
+            .object({requested: PermissiveBoolean})
             .optional(),
           outbound_payments: z
             .object({
-              ach: z.object({ requested: PermissiveBoolean }).optional(),
+              ach: z.object({requested: PermissiveBoolean}).optional(),
               us_domestic_wire: z
-                .object({ requested: PermissiveBoolean })
+                .object({requested: PermissiveBoolean})
                 .optional(),
             })
             .optional(),
           outbound_transfers: z
             .object({
-              ach: z.object({ requested: PermissiveBoolean }).optional(),
+              ach: z.object({requested: PermissiveBoolean}).optional(),
               us_domestic_wire: z
-                .object({ requested: PermissiveBoolean })
+                .object({requested: PermissiveBoolean})
                 .optional(),
             })
             .optional(),
@@ -81719,7 +81639,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryFinancialAccountsFinancialAccountResponseValidator(
@@ -81732,7 +81652,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryFinancialAccountsFinancialAccountCloseParamSchema =
-    z.object({ financial_account: z.string().max(5000) })
+    z.object({financial_account: z.string().max(5000)})
 
   const postTreasuryFinancialAccountsFinancialAccountCloseBodySchema = z
     .object({
@@ -81797,7 +81717,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -81811,7 +81731,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
-    z.object({ financial_account: z.string().max(5000) })
+    z.object({financial_account: z.string().max(5000)})
 
   const getTreasuryFinancialAccountsFinancialAccountFeaturesQuerySchema =
     z.object({
@@ -81886,7 +81806,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -81900,34 +81820,30 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesParamSchema =
-    z.object({ financial_account: z.string().max(5000) })
+    z.object({financial_account: z.string().max(5000)})
 
   const postTreasuryFinancialAccountsFinancialAccountFeaturesBodySchema = z
     .object({
-      card_issuing: z.object({ requested: PermissiveBoolean }).optional(),
-      deposit_insurance: z.object({ requested: PermissiveBoolean }).optional(),
+      card_issuing: z.object({requested: PermissiveBoolean}).optional(),
+      deposit_insurance: z.object({requested: PermissiveBoolean}).optional(),
       expand: z.array(z.string().max(5000)).optional(),
       financial_addresses: z
-        .object({ aba: z.object({ requested: PermissiveBoolean }).optional() })
+        .object({aba: z.object({requested: PermissiveBoolean}).optional()})
         .optional(),
       inbound_transfers: z
-        .object({ ach: z.object({ requested: PermissiveBoolean }).optional() })
+        .object({ach: z.object({requested: PermissiveBoolean}).optional()})
         .optional(),
-      intra_stripe_flows: z.object({ requested: PermissiveBoolean }).optional(),
+      intra_stripe_flows: z.object({requested: PermissiveBoolean}).optional(),
       outbound_payments: z
         .object({
-          ach: z.object({ requested: PermissiveBoolean }).optional(),
-          us_domestic_wire: z
-            .object({ requested: PermissiveBoolean })
-            .optional(),
+          ach: z.object({requested: PermissiveBoolean}).optional(),
+          us_domestic_wire: z.object({requested: PermissiveBoolean}).optional(),
         })
         .optional(),
       outbound_transfers: z
         .object({
-          ach: z.object({ requested: PermissiveBoolean }).optional(),
-          us_domestic_wire: z
-            .object({ requested: PermissiveBoolean })
-            .optional(),
+          ach: z.object({requested: PermissiveBoolean}).optional(),
+          us_domestic_wire: z.object({requested: PermissiveBoolean}).optional(),
         })
         .optional(),
     })
@@ -81988,7 +81904,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -82082,7 +81998,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryInboundTransfersResponseValidator(status, body)
@@ -82143,7 +82059,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryInboundTransfersResponseValidator(status, body)
@@ -82216,7 +82132,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryInboundTransfersIdResponseValidator(status, body)
@@ -82226,11 +82142,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryInboundTransfersInboundTransferCancelParamSchema = z.object(
-    { inbound_transfer: z.string().max(5000) },
+    {inbound_transfer: z.string().max(5000)},
   )
 
   const postTreasuryInboundTransfersInboundTransferCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTreasuryInboundTransfersInboundTransferCancelResponseValidator =
@@ -82283,7 +82199,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -82392,7 +82308,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryOutboundPaymentsResponseValidator(status, body)
@@ -82447,16 +82363,14 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .object({
         us_bank_account: z
           .union([
-            z.object({
-              network: z.enum(["ach", "us_domestic_wire"]).optional(),
-            }),
+            z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
       })
       .optional(),
     end_user_details: z
-      .object({ ip_address: z.string().optional(), present: PermissiveBoolean })
+      .object({ip_address: z.string().optional(), present: PermissiveBoolean})
       .optional(),
     expand: z.array(z.string().max(5000)).optional(),
     financial_account: z.string(),
@@ -82505,7 +82419,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryOutboundPaymentsResponseValidator(status, body)
@@ -82578,7 +82492,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryOutboundPaymentsIdResponseValidator(status, body)
@@ -82592,7 +82506,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   })
 
   const postTreasuryOutboundPaymentsIdCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTreasuryOutboundPaymentsIdCancelResponseValidator =
@@ -82640,7 +82554,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryOutboundPaymentsIdCancelResponseValidator(
@@ -82733,7 +82647,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryOutboundTransfersResponseValidator(status, body)
@@ -82757,9 +82671,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       .object({
         us_bank_account: z
           .union([
-            z.object({
-              network: z.enum(["ach", "us_domestic_wire"]).optional(),
-            }),
+            z.object({network: z.enum(["ach", "us_domestic_wire"]).optional()}),
             z.enum([""]),
           ])
           .optional(),
@@ -82812,7 +82724,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postTreasuryOutboundTransfersResponseValidator(status, body)
@@ -82892,7 +82804,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryOutboundTransfersOutboundTransferResponseValidator(
@@ -82905,10 +82817,10 @@ export function createRouter(implementation: Implementation): KoaRouter {
   )
 
   const postTreasuryOutboundTransfersOutboundTransferCancelParamSchema =
-    z.object({ outbound_transfer: z.string().max(5000) })
+    z.object({outbound_transfer: z.string().max(5000)})
 
   const postTreasuryOutboundTransfersOutboundTransferCancelBodySchema = z
-    .object({ expand: z.array(z.string().max(5000)).optional() })
+    .object({expand: z.array(z.string().max(5000)).optional()})
     .optional()
 
   const postTreasuryOutboundTransfersOutboundTransferCancelResponseValidator =
@@ -82961,7 +82873,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body =
@@ -83063,7 +82975,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryReceivedCreditsResponseValidator(status, body)
@@ -83136,7 +83048,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryReceivedCreditsIdResponseValidator(status, body)
@@ -83223,7 +83135,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryReceivedDebitsResponseValidator(status, body)
@@ -83296,7 +83208,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryReceivedDebitsIdResponseValidator(status, body)
@@ -83410,7 +83322,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryTransactionEntriesResponseValidator(status, body)
@@ -83483,7 +83395,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryTransactionEntriesIdResponseValidator(status, body)
@@ -83597,7 +83509,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryTransactionsResponseValidator(status, body)
@@ -83672,7 +83584,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getTreasuryTransactionsIdResponseValidator(status, body)
@@ -83757,7 +83669,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getWebhookEndpointsResponseValidator(status, body)
@@ -84181,7 +84093,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postWebhookEndpointsResponseValidator(status, body)
@@ -84243,7 +84155,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = deleteWebhookEndpointsWebhookEndpointResponseValidator(
@@ -84319,7 +84231,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = getWebhookEndpointsWebhookEndpointResponseValidator(
@@ -84639,7 +84551,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = postWebhookEndpointsWebhookEndpointResponseValidator(

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/models.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/models.ts
@@ -2,7 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type EmptyObject = { [key: string]: never }
+export type EmptyObject = {[key: string]: never}
 
 export type t_account = {
   business_profile?: t_account_business_profile | null

--- a/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/stripe.yaml/schemas.ts
@@ -200,7 +200,7 @@ import {
   t_treasury_transaction_entry,
   t_treasury_transactions_resource_flow_details,
 } from "./models"
-import { z } from "zod"
+import {z} from "zod"
 
 export const PermissiveBoolean = z.preprocess((value) => {
   if (typeof value === "string" && (value === "true" || value === "false")) {
@@ -475,7 +475,7 @@ export const s_account_unification_account_controller_losses = z.object({
 })
 
 export const s_account_unification_account_controller_stripe_dashboard =
-  z.object({ type: z.enum(["express", "full", "none"]) })
+  z.object({type: z.enum(["express", "full", "none"])})
 
 export const s_address = z.object({
   city: z.string().max(5000).nullable().optional(),
@@ -507,10 +507,10 @@ export const s_balance_amount_by_source_type = z.object({
 })
 
 export const s_bank_connections_resource_balance_api_resource_cash_balance =
-  z.object({ available: z.record(z.coerce.number()).nullable().optional() })
+  z.object({available: z.record(z.coerce.number()).nullable().optional()})
 
 export const s_bank_connections_resource_balance_api_resource_credit_balance =
-  z.object({ used: z.record(z.coerce.number()).nullable().optional() })
+  z.object({used: z.record(z.coerce.number()).nullable().optional()})
 
 export const s_bank_connections_resource_balance_refresh = z.object({
   last_attempted_at: z.coerce.number(),
@@ -567,16 +567,16 @@ export const s_billing_bill_resource_invoicing_lines_common_credited_items =
   })
 
 export const s_billing_bill_resource_invoicing_parents_invoice_quote_parent =
-  z.object({ quote: z.string().max(5000) })
+  z.object({quote: z.string().max(5000)})
 
 export const s_billing_bill_resource_invoicing_pricing_pricing_price_details =
-  z.object({ price: z.string().max(5000), product: z.string().max(5000) })
+  z.object({price: z.string().max(5000), product: z.string().max(5000)})
 
 export const s_billing_bill_resource_invoicing_taxes_tax_rate_details =
-  z.object({ tax_rate: z.string().max(5000) })
+  z.object({tax_rate: z.string().max(5000)})
 
 export const s_billing_clocks_resource_status_details_advancing_status_details =
-  z.object({ target_frozen_time: z.coerce.number() })
+  z.object({target_frozen_time: z.coerce.number()})
 
 export const s_billing_credit_grants_resource_applicable_price = z.object({
   id: z.string().max(5000).nullable().optional(),
@@ -612,10 +612,10 @@ export const s_billing_meter_resource_aggregation_settings = z.object({
 })
 
 export const s_billing_meter_resource_billing_meter_event_adjustment_cancel =
-  z.object({ identifier: z.string().max(100).nullable().optional() })
+  z.object({identifier: z.string().max(100).nullable().optional()})
 
 export const s_billing_meter_resource_billing_meter_status_transitions =
-  z.object({ deactivated_at: z.coerce.number().nullable().optional() })
+  z.object({deactivated_at: z.coerce.number().nullable().optional()})
 
 export const s_billing_meter_resource_billing_meter_value = z.object({
   event_payload_key: z.string().max(5000),
@@ -783,10 +783,10 @@ export const s_checkout_payco_payment_method_options = z.object({
 })
 
 export const s_checkout_payment_method_options_mandate_options_bacs_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_checkout_payment_method_options_mandate_options_sepa_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_checkout_paynow_payment_method_options = z.object({
   setup_future_usage: z.enum(["none"]).optional(),
@@ -865,7 +865,7 @@ export const s_connect_embedded_financial_account_features = z.object({
 })
 
 export const s_connect_embedded_financial_account_transactions_features =
-  z.object({ card_spend_dispute_management: PermissiveBoolean })
+  z.object({card_spend_dispute_management: PermissiveBoolean})
 
 export const s_connect_embedded_issuing_card_features = z.object({
   card_management: PermissiveBoolean,
@@ -955,7 +955,7 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_funde
   })
 
 export const s_customer_session_resource_components_resource_buy_button =
-  z.object({ enabled: PermissiveBoolean })
+  z.object({enabled: PermissiveBoolean})
 
 export const s_customer_session_resource_components_resource_payment_element_resource_features =
   z.object({
@@ -973,7 +973,7 @@ export const s_customer_session_resource_components_resource_payment_element_res
   })
 
 export const s_customer_session_resource_components_resource_pricing_table =
-  z.object({ enabled: PermissiveBoolean })
+  z.object({enabled: PermissiveBoolean})
 
 export const s_customer_tax_location = z.object({
   country: z.string().max(5000),
@@ -1445,7 +1445,7 @@ export const s_invoice_payment_method_options_bancontact = z.object({
 })
 
 export const s_invoice_payment_method_options_customer_balance_bank_transfer_eu_bank_transfer =
-  z.object({ country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"]) })
+  z.object({country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"])})
 
 export const s_invoice_payment_method_options_konbini = z.object({})
 
@@ -2656,7 +2656,7 @@ export const s_mandate_acss_debit = z.object({
 
 export const s_mandate_amazon_pay = z.object({})
 
-export const s_mandate_au_becs_debit = z.object({ url: z.string().max(5000) })
+export const s_mandate_au_becs_debit = z.object({url: z.string().max(5000)})
 
 export const s_mandate_bacs_debit = z.object({
   network_status: z.enum(["accepted", "pending", "refused", "revoked"]),
@@ -2734,10 +2734,10 @@ export const s_online_acceptance = z.object({
 })
 
 export const s_outbound_payments_payment_method_details_financial_account =
-  z.object({ id: z.string().max(5000), network: z.enum(["stripe"]) })
+  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
 
 export const s_outbound_transfers_payment_method_details_financial_account =
-  z.object({ id: z.string().max(5000), network: z.enum(["stripe"]) })
+  z.object({id: z.string().max(5000), network: z.enum(["stripe"])})
 
 export const s_package_dimensions = z.object({
   height: z.coerce.number(),
@@ -2775,10 +2775,10 @@ export const s_payment_flows_private_payment_methods_alipay_details = z.object({
 })
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_extended_authorization_extended_authorization =
-  z.object({ status: z.enum(["disabled", "enabled"]) })
+  z.object({status: z.enum(["disabled", "enabled"])})
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_incremental_authorization_incremental_authorization =
-  z.object({ status: z.enum(["available", "unavailable"]) })
+  z.object({status: z.enum(["available", "unavailable"])})
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_overcapture_overcapture =
   z.object({
@@ -2787,7 +2787,7 @@ export const s_payment_flows_private_payment_methods_card_details_api_resource_e
   })
 
 export const s_payment_flows_private_payment_methods_card_details_api_resource_multicapture =
-  z.object({ status: z.enum(["available", "unavailable"]) })
+  z.object({status: z.enum(["available", "unavailable"])})
 
 export const s_payment_flows_private_payment_methods_card_present_common_wallet =
   z.object({
@@ -2818,10 +2818,10 @@ export const s_payment_flows_private_payment_methods_naver_pay_payment_method_op
   })
 
 export const s_payment_flows_private_payment_methods_payco_payment_method_options =
-  z.object({ capture_method: z.enum(["manual"]).optional() })
+  z.object({capture_method: z.enum(["manual"]).optional()})
 
 export const s_payment_flows_private_payment_methods_samsung_pay_payment_method_options =
-  z.object({ capture_method: z.enum(["manual"]).optional() })
+  z.object({capture_method: z.enum(["manual"]).optional()})
 
 export const s_payment_intent_next_action_alipay_handle_redirect = z.object({
   native_data: z.string().max(5000).nullable().optional(),
@@ -2947,7 +2947,7 @@ export const s_payment_intent_next_action_wechat_pay_redirect_to_android_app =
   })
 
 export const s_payment_intent_next_action_wechat_pay_redirect_to_ios_app =
-  z.object({ native_url: z.string().max(5000) })
+  z.object({native_url: z.string().max(5000)})
 
 export const s_payment_intent_payment_method_options_au_becs_debit = z.object({
   setup_future_usage: z.enum(["none", "off_session", "on_session"]).optional(),
@@ -2979,10 +2979,10 @@ export const s_payment_intent_payment_method_options_mandate_options_acss_debit 
   })
 
 export const s_payment_intent_payment_method_options_mandate_options_bacs_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_payment_intent_payment_method_options_mandate_options_sepa_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_payment_intent_payment_method_options_mobilepay = z.object({
   capture_method: z.enum(["manual"]).optional(),
@@ -3014,7 +3014,7 @@ export const s_payment_links_resource_completed_sessions = z.object({
 })
 
 export const s_payment_links_resource_completion_behavior_confirmation_page =
-  z.object({ custom_message: z.string().max(5000).nullable().optional() })
+  z.object({custom_message: z.string().max(5000).nullable().optional()})
 
 export const s_payment_links_resource_completion_behavior_redirect = z.object({
   url: z.string().max(5000),
@@ -3070,7 +3070,7 @@ export const s_payment_links_resource_payment_intent_data = z.object({
 })
 
 export const s_payment_links_resource_payment_method_reuse_agreement = z.object(
-  { position: z.enum(["auto", "hidden"]) },
+  {position: z.enum(["auto", "hidden"])},
 )
 
 export const s_payment_links_resource_phone_number_collection = z.object({
@@ -3361,9 +3361,7 @@ export const s_payment_method_billie = z.object({})
 
 export const s_payment_method_blik = z.object({})
 
-export const s_payment_method_boleto = z.object({
-  tax_id: z.string().max(5000),
-})
+export const s_payment_method_boleto = z.object({tax_id: z.string().max(5000)})
 
 export const s_payment_method_card_checks = z.object({
   address_line1_check: z.string().max(5000).nullable().optional(),
@@ -3784,7 +3782,7 @@ export const s_payment_method_details_wechat_pay = z.object({
 export const s_payment_method_details_zip = z.object({})
 
 export const s_payment_method_domain_resource_payment_method_status_details =
-  z.object({ error_message: z.string().max(5000) })
+  z.object({error_message: z.string().max(5000)})
 
 export const s_payment_method_eps = z.object({
   bank: z
@@ -4029,7 +4027,7 @@ export const s_payment_method_options_crypto = z.object({
 })
 
 export const s_payment_method_options_customer_balance_eu_bank_account =
-  z.object({ country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"]) })
+  z.object({country: z.enum(["BE", "DE", "ES", "FR", "IE", "NL"])})
 
 export const s_payment_method_options_fpx = z.object({
   setup_future_usage: z.enum(["none"]).optional(),
@@ -4126,7 +4124,7 @@ export const s_payment_method_options_twint = z.object({
 })
 
 export const s_payment_method_options_us_bank_account_mandate_options =
-  z.object({ collection_method: z.enum(["paper"]).optional() })
+  z.object({collection_method: z.enum(["paper"]).optional()})
 
 export const s_payment_method_options_wechat_pay = z.object({
   app_id: z.string().max(5000).nullable().optional(),
@@ -4299,7 +4297,7 @@ export const s_payment_pages_checkout_session_optional_item_adjustable_quantity 
   })
 
 export const s_payment_pages_checkout_session_payment_method_reuse_agreement =
-  z.object({ position: z.enum(["auto", "hidden"]) })
+  z.object({position: z.enum(["auto", "hidden"])})
 
 export const s_payment_pages_checkout_session_permissions = z.object({
   update_shipping_details: z
@@ -4309,7 +4307,7 @@ export const s_payment_pages_checkout_session_permissions = z.object({
 })
 
 export const s_payment_pages_checkout_session_phone_number_collection =
-  z.object({ enabled: PermissiveBoolean })
+  z.object({enabled: PermissiveBoolean})
 
 export const s_payment_pages_checkout_session_saved_payment_method_options =
   z.object({
@@ -4843,7 +4841,7 @@ export const s_portal_flows_subscription_update_confirm_item = z.object({
   quantity: z.coerce.number().optional(),
 })
 
-export const s_portal_invoice_list = z.object({ enabled: PermissiveBoolean })
+export const s_portal_invoice_list = z.object({enabled: PermissiveBoolean})
 
 export const s_portal_login_page = z.object({
   enabled: PermissiveBoolean,
@@ -4855,7 +4853,7 @@ export const s_portal_payment_method_update = z.object({
 })
 
 export const s_portal_resource_schedule_update_at_period_end_condition =
-  z.object({ type: z.enum(["decreasing_item_amount", "shortening_interval"]) })
+  z.object({type: z.enum(["decreasing_item_amount", "shortening_interval"])})
 
 export const s_portal_subscription_cancellation_reason = z.object({
   enabled: PermissiveBoolean,
@@ -5143,10 +5141,10 @@ export const s_setup_intent_payment_method_options_mandate_options_acss_debit =
   })
 
 export const s_setup_intent_payment_method_options_mandate_options_bacs_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_setup_intent_payment_method_options_mandate_options_sepa_debit =
-  z.object({ reference_prefix: z.string().max(5000).optional() })
+  z.object({reference_prefix: z.string().max(5000).optional()})
 
 export const s_setup_intent_payment_method_options_paypal = z.object({
   billing_agreement_id: z.string().max(5000).nullable().optional(),
@@ -5533,25 +5531,25 @@ export const s_tax_id_verification = z.object({
 })
 
 export const s_tax_product_registrations_resource_country_options_ca_province_standard =
-  z.object({ province: z.string().max(5000) })
+  z.object({province: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_default =
-  z.object({ type: z.enum(["standard"]) })
+  z.object({type: z.enum(["standard"])})
 
 export const s_tax_product_registrations_resource_country_options_default_inbound_goods =
-  z.object({ type: z.enum(["standard"]) })
+  z.object({type: z.enum(["standard"])})
 
 export const s_tax_product_registrations_resource_country_options_eu_standard =
-  z.object({ place_of_supply_scheme: z.enum(["small_seller", "standard"]) })
+  z.object({place_of_supply_scheme: z.enum(["small_seller", "standard"])})
 
 export const s_tax_product_registrations_resource_country_options_simplified =
-  z.object({ type: z.enum(["simplified"]) })
+  z.object({type: z.enum(["simplified"])})
 
 export const s_tax_product_registrations_resource_country_options_us_local_amusement_tax =
-  z.object({ jurisdiction: z.string().max(5000) })
+  z.object({jurisdiction: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_us_local_lease_tax =
-  z.object({ jurisdiction: z.string().max(5000) })
+  z.object({jurisdiction: z.string().max(5000)})
 
 export const s_tax_product_registrations_resource_country_options_us_state_sales_tax_election =
   z.object({
@@ -5736,10 +5734,10 @@ export const s_tax_product_resource_tax_settings_status_details_resource_pending
   })
 
 export const s_tax_product_resource_tax_transaction_line_item_resource_reversal =
-  z.object({ original_line_item: z.string().max(5000) })
+  z.object({original_line_item: z.string().max(5000)})
 
 export const s_tax_product_resource_tax_transaction_resource_reversal =
-  z.object({ original_transaction: z.string().max(5000).nullable().optional() })
+  z.object({original_transaction: z.string().max(5000).nullable().optional()})
 
 export const s_tax_product_resource_tax_transaction_shipping_cost = z.object({
   amount: z.coerce.number(),
@@ -5779,13 +5777,13 @@ export const s_terminal_configuration_configuration_resource_enterprise_tls_wifi
   })
 
 export const s_terminal_configuration_configuration_resource_offline_config =
-  z.object({ enabled: PermissiveBoolean.nullable().optional() })
+  z.object({enabled: PermissiveBoolean.nullable().optional()})
 
 export const s_terminal_configuration_configuration_resource_personal_psk_wifi =
-  z.object({ password: z.string().max(5000), ssid: z.string().max(5000) })
+  z.object({password: z.string().max(5000), ssid: z.string().max(5000)})
 
 export const s_terminal_configuration_configuration_resource_reboot_window =
-  z.object({ end_hour: z.coerce.number(), start_hour: z.coerce.number() })
+  z.object({end_hour: z.coerce.number(), start_hour: z.coerce.number()})
 
 export const s_terminal_connection_token = z.object({
   location: z.string().max(5000).optional(),
@@ -5833,7 +5831,7 @@ export const s_terminal_reader_reader_resource_process_setup_config = z.object({
 })
 
 export const s_terminal_reader_reader_resource_refund_payment_config = z.object(
-  { enable_customer_cancellation: PermissiveBoolean.optional() },
+  {enable_customer_cancellation: PermissiveBoolean.optional()},
 )
 
 export const s_terminal_reader_reader_resource_signature = z.object({
@@ -5929,7 +5927,7 @@ export const s_three_d_secure_details_charge = z.object({
   version: z.enum(["1.0.2", "2.1.0", "2.2.0"]).nullable().optional(),
 })
 
-export const s_three_d_secure_usage = z.object({ supported: PermissiveBoolean })
+export const s_three_d_secure_usage = z.object({supported: PermissiveBoolean})
 
 export const s_token_card_networks = z.object({
   preferred: z.string().max(5000).nullable().optional(),
@@ -6035,7 +6033,7 @@ export const s_treasury_inbound_transfers_resource_failure_details = z.object({
 })
 
 export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_linked_flows =
-  z.object({ received_debit: z.string().max(5000).nullable().optional() })
+  z.object({received_debit: z.string().max(5000).nullable().optional()})
 
 export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions =
   z.object({
@@ -6045,7 +6043,7 @@ export const s_treasury_inbound_transfers_resource_inbound_transfer_resource_sta
   })
 
 export const s_treasury_outbound_payments_resource_ach_tracking_details =
-  z.object({ trace_id: z.string().max(5000) })
+  z.object({trace_id: z.string().max(5000)})
 
 export const s_treasury_outbound_payments_resource_outbound_payment_resource_end_user_details =
   z.object({
@@ -6069,7 +6067,7 @@ export const s_treasury_outbound_payments_resource_us_domestic_wire_tracking_det
   })
 
 export const s_treasury_outbound_transfers_resource_ach_tracking_details =
-  z.object({ trace_id: z.string().max(5000) })
+  z.object({trace_id: z.string().max(5000)})
 
 export const s_treasury_outbound_transfers_resource_status_transitions =
   z.object({
@@ -6101,11 +6099,11 @@ export const s_treasury_received_credits_resource_reversal_details = z.object({
 })
 
 export const s_treasury_received_credits_resource_status_transitions = z.object(
-  { posted_at: z.coerce.number().nullable().optional() },
+  {posted_at: z.coerce.number().nullable().optional()},
 )
 
 export const s_treasury_received_debits_resource_debit_reversal_linked_flows =
-  z.object({ issuing_dispute: z.string().max(5000).nullable().optional() })
+  z.object({issuing_dispute: z.string().max(5000).nullable().optional()})
 
 export const s_treasury_received_debits_resource_linked_flows = z.object({
   debit_reversal: z.string().max(5000).nullable().optional(),
@@ -6612,7 +6610,7 @@ export const s_confirmation_tokens_resource_mandate_data_resource_customer_accep
   })
 
 export const s_confirmation_tokens_resource_payment_method_options_resource_card_resource_installment =
-  z.object({ plan: s_payment_method_details_card_installments_plan.optional() })
+  z.object({plan: s_payment_method_details_card_installments_plan.optional()})
 
 export const s_confirmation_tokens_resource_shipping = z.object({
   address: s_address,
@@ -7773,7 +7771,7 @@ export const s_issuing_card_wallets = z.object({
   primary_account_identifier: z.string().max(5000).nullable().optional(),
 })
 
-export const s_issuing_cardholder_address = z.object({ address: s_address })
+export const s_issuing_cardholder_address = z.object({address: s_address})
 
 export const s_issuing_cardholder_authorization_controls = z.object({
   allowed_categories: z
@@ -8862,7 +8860,7 @@ export const s_payment_pages_checkout_session_after_expiration = z.object({
 })
 
 export const s_payment_pages_checkout_session_checkout_address_details =
-  z.object({ address: s_address, name: z.string().max(5000) })
+  z.object({address: s_address, name: z.string().max(5000)})
 
 export const s_payment_pages_checkout_session_consent_collection = z.object({
   payment_method_reuse_agreement:
@@ -9537,9 +9535,7 @@ export const s_balance_amount_net = z.object({
   source_types: s_balance_amount_by_source_type.optional(),
 })
 
-export const s_balance_detail = z.object({
-  available: z.array(s_balance_amount),
-})
+export const s_balance_detail = z.object({available: z.array(s_balance_amount)})
 
 export const s_balance_detail_ungated = z.object({
   available: z.array(s_balance_amount),
@@ -15448,7 +15444,7 @@ export const s_line_items_discount_amount: z.ZodType<
   t_line_items_discount_amount,
   z.ZodTypeDef,
   unknown
-> = z.object({ amount: z.coerce.number(), discount: z.lazy(() => s_discount) })
+> = z.object({amount: z.coerce.number(), discount: z.lazy(() => s_discount)})
 
 export const s_confirmation_tokens_resource_payment_method_preview: z.ZodType<
   t_confirmation_tokens_resource_payment_method_preview,
@@ -15655,9 +15651,7 @@ export const s_customer_balance_resource_cash_balance_transaction_resource_refun
   t_customer_balance_resource_cash_balance_transaction_resource_refunded_from_payment_transaction,
   z.ZodTypeDef,
   unknown
-> = z.object({
-  refund: z.union([z.string().max(5000), z.lazy(() => s_refund)]),
-})
+> = z.object({refund: z.union([z.string().max(5000), z.lazy(() => s_refund)])})
 
 export const s_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance: z.ZodType<
   t_customer_balance_resource_cash_balance_transaction_resource_transferred_to_balance,
@@ -16789,7 +16783,7 @@ export const s_payment_links_resource_subscription_data_invoice_settings: z.ZodT
   t_payment_links_resource_subscription_data_invoice_settings,
   z.ZodTypeDef,
   unknown
-> = z.object({ issuer: z.lazy(() => s_connect_account_reference) })
+> = z.object({issuer: z.lazy(() => s_connect_account_reference)})
 
 export const s_quotes_resource_recurring: z.ZodType<
   t_quotes_resource_recurring,

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/generated.ts
@@ -23,7 +23,7 @@ import {
   s_TodoList,
   s_UnknownObject,
 } from "./schemas"
-import KoaRouter, { RouterContext } from "@koa/router"
+import KoaRouter, {RouterContext} from "@koa/router"
 import {
   KoaRuntimeError,
   RequestInputType,
@@ -44,8 +44,8 @@ import {
   parseRequestInput,
   responseValidationFactory,
 } from "@nahkies/typescript-koa-runtime/zod"
-import { Next } from "koa"
-import { z } from "zod"
+import {Next} from "koa"
+import {z} from "zod"
 
 export type GetTodoListsResponder = {
   with200(): KoaRuntimeResponse<t_TodoList[]>
@@ -224,7 +224,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
   const router = new KoaRouter()
 
   const getTodoListsQuerySchema = z.object({
-    created: z.string().datetime({ offset: true }).optional(),
+    created: z.string().datetime({offset: true}).optional(),
     statuses: z
       .preprocess(
         (it: unknown) => (Array.isArray(it) || it === undefined ? it : [it]),
@@ -276,7 +276,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTodoListsResponseValidator(status, body)
@@ -284,7 +284,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTodoListByIdParamSchema = z.object({ listId: z.string() })
+  const getTodoListByIdParamSchema = z.object({listId: z.string()})
 
   const getTodoListByIdResponseValidator = responseValidationFactory(
     [
@@ -332,7 +332,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTodoListByIdResponseValidator(status, body)
@@ -340,7 +340,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const updateTodoListByIdParamSchema = z.object({ listId: z.string() })
+  const updateTodoListByIdParamSchema = z.object({listId: z.string()})
 
   const updateTodoListByIdBodySchema = s_CreateUpdateTodoList
 
@@ -394,7 +394,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = updateTodoListByIdResponseValidator(status, body)
@@ -402,7 +402,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const deleteTodoListByIdParamSchema = z.object({ listId: z.string() })
+  const deleteTodoListByIdParamSchema = z.object({listId: z.string()})
 
   const deleteTodoListByIdResponseValidator = responseValidationFactory(
     [
@@ -450,7 +450,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = deleteTodoListByIdResponseValidator(status, body)
@@ -458,7 +458,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const getTodoListItemsParamSchema = z.object({ listId: z.string() })
+  const getTodoListItemsParamSchema = z.object({listId: z.string()})
 
   const getTodoListItemsResponseValidator = responseValidationFactory(
     [
@@ -467,11 +467,11 @@ export function createRouter(implementation: Implementation): KoaRouter {
         z.object({
           id: z.string(),
           content: z.string(),
-          createdAt: z.string().datetime({ offset: true }),
-          completedAt: z.string().datetime({ offset: true }).optional(),
+          createdAt: z.string().datetime({offset: true}),
+          completedAt: z.string().datetime({offset: true}).optional(),
         }),
       ],
-      ["5XX", z.object({ message: z.string(), code: z.string() })],
+      ["5XX", z.object({message: z.string(), code: z.string()})],
     ],
     undefined,
   )
@@ -519,7 +519,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = getTodoListItemsResponseValidator(status, body)
@@ -527,12 +527,12 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const createTodoListItemParamSchema = z.object({ listId: z.string() })
+  const createTodoListItemParamSchema = z.object({listId: z.string()})
 
   const createTodoListItemBodySchema = z.object({
     id: z.string(),
     content: z.string(),
-    completedAt: z.string().datetime({ offset: true }).optional(),
+    completedAt: z.string().datetime({offset: true}).optional(),
   })
 
   const createTodoListItemResponseValidator = responseValidationFactory(
@@ -579,7 +579,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
         return
       }
 
-      const { status, body } =
+      const {status, body} =
         response instanceof KoaRuntimeResponse ? response.unpack() : response
 
       ctx.body = createTodoListItemResponseValidator(status, body)
@@ -621,7 +621,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = listAttachmentsResponseValidator(status, body)
@@ -629,7 +629,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
     return next()
   })
 
-  const uploadAttachmentBodySchema = z.object({ file: z.unknown().optional() })
+  const uploadAttachmentBodySchema = z.object({file: z.unknown().optional()})
 
   const uploadAttachmentResponseValidator = responseValidationFactory(
     [["202", z.undefined()]],
@@ -668,7 +668,7 @@ export function createRouter(implementation: Implementation): KoaRouter {
       return
     }
 
-    const { status, body } =
+    const {status, body} =
       response instanceof KoaRuntimeResponse ? response.unpack() : response
 
     ctx.body = uploadAttachmentResponseValidator(status, body)

--- a/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
+++ b/integration-tests/typescript-koa/src/generated/todo-lists.yaml/schemas.ts
@@ -2,9 +2,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { z } from "zod"
+import {z} from "zod"
 
-export const s_CreateUpdateTodoList = z.object({ name: z.string() })
+export const s_CreateUpdateTodoList = z.object({name: z.string()})
 
 export const s_Error = z.object({
   message: z.string().optional(),
@@ -18,8 +18,8 @@ export const s_TodoList = z.object({
   name: z.string(),
   totalItemCount: z.coerce.number(),
   incompleteItemCount: z.coerce.number(),
-  created: z.string().datetime({ offset: true }),
-  updated: z.string().datetime({ offset: true }),
+  created: z.string().datetime({offset: true}),
+  updated: z.string().datetime({offset: true}),
 })
 
 export const s_UnknownObject = z.record(z.unknown())

--- a/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
@@ -1,5 +1,5 @@
-import * as console from "node:console"
-import path from "node:path"
+// biome-ignore lint/style/useNodejsImportProtocol: <explanation>
+import path from "path"
 import stripJsonComments from "strip-json-comments"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"
 
@@ -22,7 +22,11 @@ export async function loadTypescriptFormatterConfig(
 
   if (biomeConfigFile) {
     const rawConfig = await fsAdaptor.readFile(biomeConfigFile)
-    return {type: "biome", config: JSON.parse(stripJsonComments(rawConfig))}
+
+    return {
+      type: "biome",
+      config: JSON.parse(stripJsonComments(rawConfig)),
+    }
   }
 
   const prettierConfigFile = findConfigFile(
@@ -42,7 +46,7 @@ export async function loadTypescriptFormatterConfig(
 
   if (prettierConfigFile) {
     const prettier = await import("prettier")
-    // TODO: use prettier.resolveConfig to actually load the config
+
     return {
       type: "prettier",
       config: (await prettier.resolveConfig(prettierConfigFile)) ?? {},

--- a/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
@@ -2,6 +2,7 @@
 import path from "path"
 import stripJsonComments from "strip-json-comments"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"
+import {logger} from "../logger"
 
 export type TypescriptFormatterConfig =
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -45,11 +46,15 @@ export async function loadTypescriptFormatterConfig(
   )
 
   if (prettierConfigFile) {
-    const prettier = await import("prettier")
+    try {
+      const prettier = await import("prettier")
 
-    return {
-      type: "prettier",
-      config: (await prettier.resolveConfig(prettierConfigFile)) ?? {},
+      return {
+        type: "prettier",
+        config: (await prettier.resolveConfig(prettierConfigFile)) ?? {},
+      }
+    } catch (err) {
+      logger.error("failed to load prettier config", {err})
     }
   }
 
@@ -68,7 +73,7 @@ function findConfigFile(
   for (const name of names) {
     const fullPath = path.join(searchPath, name)
     if (fileExists(fullPath)) {
-      console.info(`found ${fullPath} in ${searchPath}`)
+      logger.info(`found ${fullPath} in ${searchPath}`)
       return fullPath
     }
   }

--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.biome.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.biome.ts
@@ -1,32 +1,33 @@
-import {Biome, Distribution} from "@biomejs/js-api"
+import * as console from "node:console"
+import {Biome, type Configuration, Distribution} from "@biomejs/js-api"
 import type {IFormatter} from "../../core/interfaces"
 import {logger} from "../../core/logger"
 
+const defaultConfiguration = {
+  organizeImports: {
+    enabled: true,
+  },
+  files: {
+    maxSize: 5 * 1024 * 1024,
+  },
+  formatter: {
+    enabled: true,
+    indentWidth: 2,
+    indentStyle: "space",
+  },
+  linter: {
+    enabled: false,
+  },
+  javascript: {
+    formatter: {
+      bracketSpacing: true,
+      semicolons: "asNeeded",
+    },
+  },
+} as const
+
 export class TypescriptFormatterBiome implements IFormatter {
-  private constructor(private readonly biome: Biome) {
-    biome.applyConfiguration({
-      organizeImports: {
-        enabled: true,
-      },
-      files: {
-        maxSize: 5 * 1024 * 1024,
-      },
-      formatter: {
-        enabled: true,
-        indentWidth: 2,
-        indentStyle: "space",
-      },
-      linter: {
-        enabled: false,
-      },
-      javascript: {
-        formatter: {
-          bracketSpacing: true,
-          semicolons: "asNeeded",
-        },
-      },
-    })
-  }
+  private constructor(private readonly biome: Biome) {}
 
   async format(
     filename: string,
@@ -52,9 +53,19 @@ export class TypescriptFormatterBiome implements IFormatter {
     }
   }
 
-  static async createNodeFormatter(): Promise<TypescriptFormatterBiome> {
+  static async createNodeFormatter(
+    configuration?: Configuration,
+  ): Promise<TypescriptFormatterBiome> {
     const biome = await Biome.create({
       distribution: Distribution.NODE,
+    })
+    console.info(configuration)
+    biome.applyConfiguration({
+      ...(configuration ?? defaultConfiguration),
+      files: {
+        maxSize: 5 * 1024 * 1024,
+      },
+      linter: {enabled: false},
     })
 
     return new TypescriptFormatterBiome(biome)
@@ -64,6 +75,7 @@ export class TypescriptFormatterBiome implements IFormatter {
     const biome = await Biome.create({
       distribution: Distribution.WEB,
     })
+    biome.applyConfiguration(defaultConfiguration)
 
     return new TypescriptFormatterBiome(biome)
   }

--- a/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-formatter.prettier.ts
@@ -1,3 +1,4 @@
+import {resolveConfig} from "prettier"
 import type {IFormatter} from "../../core/interfaces"
 import {logger} from "../../core/logger"
 


### PR DESCRIPTION
- search up from the output path for `prettier` / `biome` configuration files
- load and use the configuration if found, such that the generated code should match the projects formatting conventions
- fall back to previous default configuration if not found
