### PR TITLE
chore: adjust webpack config to allow node: protocol imports

### DIFF
--- a/packages/documentation/next.config.mjs
+++ b/packages/documentation/next.config.mjs
@@ -9,13 +9,27 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  webpack: (config, {buildId, dev, isServer, defaultLoaders, webpack}) => {
+  webpack: (config) => {
     config.experiments = {...config.experiments, syncWebAssembly: true}
-    config.plugins.push(new NodePolyfillPlugin())
-    config.module.rules.push({
-      test: /node:.+/i,
-      use: "null-loader",
+
+    /**
+     * Webpack doesn't support `node:` prefixed imports, so rewrite them to be
+     * plain imports, allowing the NodePolyfillPlugin to do its job correctly.
+     */
+    config.plugins.push({
+      apply(compiler) {
+        compiler.hooks.normalModuleFactory.tap("RewriteNodeProtocol", (nmf) => {
+          nmf.hooks.beforeResolve.tap("RewriteNodeProtocol", (result) => {
+            if (result?.request?.startsWith("node:")) {
+              result.request = result.request.replace(/^node:/, "")
+            }
+          })
+        })
+      },
     })
+
+    config.plugins.push(new NodePolyfillPlugin())
+
     config.module.rules.push({
       test: /@biomejs\/wasm-nodejs/i,
       use: "null-loader",

--- a/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
+++ b/packages/openapi-code-generator/src/core/file-system/node-fs-adaptor.ts
@@ -1,9 +1,6 @@
-// TODO: webpack shouldn't be including this file?
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import {existsSync} from "fs"
+import {existsSync} from "node:fs"
 
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import fs from "fs/promises"
+import fs from "node:fs/promises"
 import type {IFsAdaptor} from "./fs-adaptor"
 
 export class NodeFsAdaptor implements IFsAdaptor {

--- a/packages/openapi-code-generator/src/core/loaders/generic.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/generic.loader.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack doesn't like `node:` prefix
-import path from "path"
+import path from "node:path"
 import yaml from "js-yaml"
 import json5 from "json5"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"

--- a/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/tsconfig.loader.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import path from "path"
+import path from "node:path"
 import json5 from "json5"
 import ts from "typescript"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"

--- a/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
+++ b/packages/openapi-code-generator/src/core/loaders/typescript-formatter-config.loader.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: <explanation>
-import path from "path"
+import path from "node:path"
 import stripJsonComments from "strip-json-comments"
 import type {IFsAdaptor} from "../file-system/fs-adaptor"
 import {logger} from "../logger"

--- a/packages/openapi-code-generator/src/core/logger.ts
+++ b/packages/openapi-code-generator/src/core/logger.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import util from "util"
+import util from "node:util"
 
 export type LoggerMeta = Record<string, unknown>
 

--- a/packages/openapi-code-generator/src/core/openapi-loader.ts
+++ b/packages/openapi-code-generator/src/core/openapi-loader.ts
@@ -1,7 +1,5 @@
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import path from "path"
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import util from "util"
+import path from "node:path"
+import util from "node:util"
 
 import * as console from "node:console"
 import {load} from "js-yaml"

--- a/packages/openapi-code-generator/src/core/utils.ts
+++ b/packages/openapi-code-generator/src/core/utils.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack doesn't like node: prefix
-import path from "path"
+import path from "node:path"
 import _ from "lodash"
 
 export function isDefined<T>(it: T | undefined): it is T {

--- a/packages/openapi-code-generator/src/typescript/common/import-builder.ts
+++ b/packages/openapi-code-generator/src/typescript/common/import-builder.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import path from "path"
+import path from "node:path"
 
 export class ImportBuilder {
   private readonly imports: Record<string, Set<string>> = {}

--- a/packages/openapi-code-generator/src/typescript/common/typescript-emitter.ts
+++ b/packages/openapi-code-generator/src/typescript/common/typescript-emitter.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: webpack doesn't like node: prefix
-import path from "path"
+import path from "node:path"
 import type {IFsAdaptor} from "../../core/file-system/fs-adaptor"
 import type {IFormatter} from "../../core/interfaces"
 import {logger} from "../../core/logger"

--- a/packages/openapi-code-generator/src/typescript/server/typescript-express/typescript-express.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/server/typescript-express/typescript-express.generator.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import path from "path"
+import path from "node:path"
 import {normalizeFilename} from "../../../core/utils"
 import type {OpenapiTypescriptGeneratorConfig} from "../../../templates.types"
 import {CompilationUnit} from "../../common/compilation-units"

--- a/packages/openapi-code-generator/src/typescript/server/typescript-koa/typescript-koa.generator.ts
+++ b/packages/openapi-code-generator/src/typescript/server/typescript-koa/typescript-koa.generator.ts
@@ -1,5 +1,4 @@
-// biome-ignore lint/style/useNodejsImportProtocol: keep webpack happy
-import path from "path"
+import path from "node:path"
 import {normalizeFilename} from "../../../core/utils"
 import type {OpenapiTypescriptGeneratorConfig} from "../../../templates.types"
 import {CompilationUnit} from "../../common/compilation-units"


### PR DESCRIPTION
required in order to use the latest version of `ts-morph` over in #152 